### PR TITLE
Fix: embedded subtitles ignore the user's preferred language

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: true

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { pickBestTrack } from "@/lib/subtitles/language";
 import {
   emptySnapshot,
   type PlayerBridge,
@@ -50,6 +51,7 @@ export type MpvOptions = {
   anime4kShaders?: string[];
   d3d11Flip?: boolean;
   getEmbedRect?: () => Promise<MpvRect | null> | MpvRect | null;
+  preferredLangs?: string[]; 
 };
 
 export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
@@ -133,6 +135,12 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
         }
         snap.audioTracks = audio;
         snap.subtitleTracks = subs;
+        if (subs.length > 0 && mpvOptions?.preferredLangs?.length) {
+        const best = pickBestTrack(subs, mpvOptions.preferredLangs);
+        if (best) {
+          invoke("mpv_set_property", { name: "sid", value: Number(best.id) }).catch(() => {});
+        }
+      }
       }
       if (name === "sub-delay" && typeof data === "number") snap.subDelaySec = data;
       if (name === "audio-delay" && typeof data === "number") snap.audioDelaySec = data;

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -51,7 +51,8 @@ export type MpvOptions = {
   anime4kShaders?: string[];
   d3d11Flip?: boolean;
   getEmbedRect?: () => Promise<MpvRect | null> | MpvRect | null;
-  preferredLangs?: string[]; 
+  preferredLangs?: string[];
+  subsOff?: boolean;
 };
 
 export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
@@ -137,11 +138,20 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
         }
         snap.audioTracks = audio;
         snap.subtitleTracks = subs;
-        if (!userPickedSub && !pickedAutoTrack && subs.length > 0 && mpvOptions?.preferredLangs?.length) {
-          const best = pickBestTrack(subs, mpvOptions.preferredLangs);
-          if (best) {
-            pickedAutoTrack = true;
-            invoke("mpv_set_property", { name: "sid", value: Number(best.id) }).catch(() => {});
+        if (!userPickedSub && !pickedAutoTrack) {
+          if (mpvOptions?.subsOff) {
+            const anySelected = subs.some((t) => t.selected);
+            if (anySelected) {
+              pickedAutoTrack = true;
+              invoke("mpv_set_property", { name: "sid", value: "no" }).catch(() => {});
+              for (const t of subs) t.selected = false;
+            }
+          } else if (subs.length > 0 && mpvOptions?.preferredLangs?.length) {
+            const best = pickBestTrack(subs, mpvOptions.preferredLangs);
+            if (best) {
+              pickedAutoTrack = true;
+              invoke("mpv_set_property", { name: "sid", value: Number(best.id) }).catch(() => {});
+            }
           }
         }
       }

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -68,6 +68,8 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
   let geomTauriUnlisten: Array<() => void> = [];
   let mpvStarted = false;
   let suppressEndFileUntil = 0;
+  let userPickedSub = false;
+  let pickedAutoTrack = false;
 
   const emit = () => {
     const next: PlayerSnapshot = { ...snap };
@@ -135,12 +137,13 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
         }
         snap.audioTracks = audio;
         snap.subtitleTracks = subs;
-        if (subs.length > 0 && mpvOptions?.preferredLangs?.length) {
-        const best = pickBestTrack(subs, mpvOptions.preferredLangs);
-        if (best) {
-          invoke("mpv_set_property", { name: "sid", value: Number(best.id) }).catch(() => {});
+        if (!userPickedSub && !pickedAutoTrack && subs.length > 0 && mpvOptions?.preferredLangs?.length) {
+          const best = pickBestTrack(subs, mpvOptions.preferredLangs);
+          if (best) {
+            pickedAutoTrack = true;
+            invoke("mpv_set_property", { name: "sid", value: Number(best.id) }).catch(() => {});
+          }
         }
-      }
       }
       if (name === "sub-delay" && typeof data === "number") snap.subDelaySec = data;
       if (name === "audio-delay" && typeof data === "number") snap.audioDelaySec = data;
@@ -222,6 +225,8 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       snap.durationSec = 0;
       snap.bufferedSec = 0;
       pendingTracks = {};
+      userPickedSub = false;
+      pickedAutoTrack = false;
       emit();
       if (!unlistenEvent) {
         unlistenEvent = await listen<MpvEvent>("mpv://event", (ev) => handleEvent(ev.payload));
@@ -371,6 +376,8 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       invoke("mpv_set_property", { name: "aid", value: Number(id) || id }).catch(() => {});
     },
     setSubtitleTrack(id) {
+      userPickedSub = true;
+      pickedAutoTrack = true;
       if (id == null) {
         invoke("mpv_set_property", { name: "sid", value: "no" }).catch(() => {});
         snap.subText = "";

--- a/src/lib/subtitles/language.ts
+++ b/src/lib/subtitles/language.ts
@@ -83,11 +83,12 @@ export function pickBestTrack<T extends { lang?: string; default?: boolean; forc
   for (const t of tracks) {
     if (t.forced) continue;
     const ls = langScore(t.lang ?? "", preferred);
+    if (ls < 0) continue;
     const score = ls * 10 + (t.default ? 1 : 0);
     if (score > bestScore) {
       bestScore = score;
       best = t;
     }
   }
-  return best ?? tracks[0];
+  return best;
 }

--- a/src/lib/subtitles/search.ts
+++ b/src/lib/subtitles/search.ts
@@ -92,13 +92,15 @@ function streamMatchScore(r: SubResult, hints: StreamHints | undefined): number 
 
 function sourcePriority(source: SubResult["source"]): number {
   switch (source) {
+    case "embedded":
+      return 5;
+    case "addon":
+      return 4;
     case "opensubtitles":
       return 3;
     case "wyzie":
       return 2;
     case "jimaku":
-      return 2;
-    case "addon":
       return 1;
     default:
       return 0;
@@ -151,14 +153,21 @@ function interleaveBySource(
   const sourceOrder = [...buckets.keys()].sort(
     (a, b) => sourcePriority(b as SubResult["source"]) - sourcePriority(a as SubResult["source"]),
   );
-  const out: SubResult[] = [];
+const out: SubResult[] = [];
   let depth = 0;
   let added = true;
   while (added) {
     added = false;
     for (const src of sourceOrder) {
       const arr = buckets.get(src);
-      if (arr && arr[depth]) {
+      if (arr && arr[depth] && langScore(arr[depth].lang, preferred) > 0) {
+        out.push(arr[depth]);
+        added = true;
+      }
+    }
+    for (const src of sourceOrder) {
+      const arr = buckets.get(src);
+      if (arr && arr[depth] && !out.includes(arr[depth])) {
         out.push(arr[depth]);
         added = true;
       }

--- a/src/lib/subtitles/types.ts
+++ b/src/lib/subtitles/types.ts
@@ -4,7 +4,7 @@ export type SubResult = {
   lang: string;
   langName?: string;
   title?: string;
-  source: "wyzie" | "addon" | "opensubtitles" | "jimaku";
+  source: "wyzie" | "addon" | "opensubtitles" | "jimaku" | "embedded";
   format?: "srt" | "vtt" | "ass" | "ssa" | "sub";
   encoding?: string;
   fps?: number;

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -525,7 +525,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   });
   const gif = useGifRecorder({ src });
 
-  const { resolvedImdbId, resolvedImdbVerified, resolutionSettled } = useTrackAutoload({
+  const { resolvedImdbId, resolvedImdbVerified, resolutionSettled, userPickedSubRef } = useTrackAutoload({
     bridgeRef,
     src,
     snap,
@@ -1233,11 +1233,12 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
           const t = snap.audioTracks.find((x) => x.id === id);
           if (t?.lang) writePlayerPrefs(src.meta.id, { audioLang: t.lang });
         }}
-        onSubtitle={(id) => {
-          bridgeRef.current?.setSubtitleTrack(id);
-          const t = snap.subtitleTracks.find((x) => x.id === id);
-          if (t?.lang) writePlayerPrefs(src.meta.id, { subLang: t.lang });
-        }}
+       onSubtitle={(id) => {
+      userPickedSubRef.current = true;
+      bridgeRef.current?.setSubtitleTrack(id);
+      const t = snap.subtitleTracks.find((x) => x.id === id);
+      if (t?.lang) writePlayerPrefs(src.meta.id, { subLang: t.lang });
+    }}
         onSubDelay={(s) => {
           bridgeRef.current?.setSubDelay(s);
           writePlayerPrefs(src.meta.id, { subDelaySec: s });

--- a/src/views/player/hooks/use-player-bridge.ts
+++ b/src/views/player/hooks/use-player-bridge.ts
@@ -77,6 +77,7 @@ export function usePlayerBridge(params: {
           ? settings.playerAnime4kShaders
           : [],
         getEmbedRect,
+        preferredLangs: settings.preferredSubLangs ?? [],
       });
       if (cancelled) return;
       bridge = choose;

--- a/src/views/player/hooks/use-player-bridge.ts
+++ b/src/views/player/hooks/use-player-bridge.ts
@@ -77,7 +77,7 @@ export function usePlayerBridge(params: {
           ? settings.playerAnime4kShaders
           : [],
         getEmbedRect,
-        preferredLangs: settings.preferredSubLangs ?? [],
+        preferredLangs: settings.subtitlesOffByDefault ? [] : (settings.preferredSubLangs ?? []),
       });
       if (cancelled) return;
       bridge = choose;

--- a/src/views/player/hooks/use-player-bridge.ts
+++ b/src/views/player/hooks/use-player-bridge.ts
@@ -78,6 +78,7 @@ export function usePlayerBridge(params: {
           : [],
         getEmbedRect,
         preferredLangs: settings.subtitlesOffByDefault ? [] : (settings.preferredSubLangs ?? []),
+        subsOff: settings.subtitlesOffByDefault === true,
       });
       if (cancelled) return;
       bridge = choose;

--- a/src/views/player/hooks/use-track-autoload.ts
+++ b/src/views/player/hooks/use-track-autoload.ts
@@ -81,6 +81,7 @@ export function useTrackAutoload(params: {
   }, [authKey]);
 
   const autoSubLoadKeyRef = useRef<string | null>(null);
+  const userPickedSubRef = useRef(false);
   useEffect(() => {
     if (!resolvedImdbId) return;
     if (snap.audioTracks.length === 0 && snap.durationSec === 0) return;
@@ -96,6 +97,7 @@ export function useTrackAutoload(params: {
     );
     const langs = subIsAnime ? rawLangs : rawLangs.filter((l) => !isJapanese(l));
     autoSubLoadKeyRef.current = key;
+    userPickedSubRef.current = false;
     const enabled = settings.subProvidersEnabled ?? {};
     void (async () => {
       console.info("[subs/autoload] starting", {
@@ -148,7 +150,7 @@ export function useTrackAutoload(params: {
         perLang.set(k, n + 1);
         const blocked = snapRef.current.subtitleTracks.some((t) => t.selected);
         const shouldSelect =
-          !settings.subtitlesOffByDefault && !blocked && !firstAdded;
+          !settings.subtitlesOffByDefault && !blocked && !firstAdded && !userPickedSubRef.current;
         attempted++;
         const labeled = labelForTrack(r);
         const ok = await b.addSubtitle(r.url, r.lang, labeled, shouldSelect);
@@ -182,6 +184,7 @@ export function useTrackAutoload(params: {
     if (autoTrackKeyRef.current === key) return;
     if (snap.audioTracks.length === 0 && snap.subtitleTracks.length === 0) return;
     autoTrackKeyRef.current = key;
+    if (userPickedSubRef.current) return;
     if (engine === "mpv") void applySubStyle(settings);
     if (settings.audioNormalize) bridgeRef.current?.setAudioNormalize(true);
 
@@ -211,7 +214,7 @@ export function useTrackAutoload(params: {
       if (want && (!cur || cur.id !== want.id)) bridgeRef.current?.setAudioTrack(want.id);
     }
     const subSelected = snap.subtitleTracks.some((t) => t.selected);
-    if (!subSelected && snap.subtitleTracks.length > 0 && subLangs.length > 0) {
+    if (!subSelected && snap.subtitleTracks.length > 0 && subLangs.length > 0 && !userPickedSubRef.current) {
       const want = pickBestTrack(snap.subtitleTracks, subLangs);
       if (want) bridgeRef.current?.setSubtitleTrack(want.id);
     }
@@ -227,7 +230,7 @@ export function useTrackAutoload(params: {
     }
   }, [engine, src.url, src.meta.id, snap.audioTracks, snap.subtitleTracks, snap.rate, snap.subDelaySec, settings]);
 
-  return { resolvedImdbId, resolvedImdbVerified, resolutionSettled };
+  return { resolvedImdbId, resolvedImdbVerified, resolutionSettled, userPickedSubRef };
 }
 
 function resolveLangPreference(

--- a/src/views/player/hooks/use-track-autoload.ts
+++ b/src/views/player/hooks/use-track-autoload.ts
@@ -201,12 +201,11 @@ export function useTrackAutoload(params: {
     const baseSub = stripJaForNonAnime(
       resolveLangPreference(settings.preferredSubLangs, settings.preferredLanguages),
     );
-    const audioLangs = prefs?.audioLang
-      ? [prefs.audioLang, ...baseAudio.filter((l) => l !== prefs.audioLang)]
-      : baseAudio;
-    const subLangs = prefs?.subLang
-      ? [prefs.subLang, ...baseSub.filter((l) => l !== prefs.subLang)]
-      : baseSub;
+    const audioLangs =
+      prefs?.audioLang && langScore(prefs.audioLang, baseAudio) >= 0
+        ? [prefs.audioLang, ...baseAudio.filter((l) => l !== prefs.audioLang)]
+        : baseAudio;
+    const subLangs = baseSub;
 
     if (snap.audioTracks.length > 0) {
       const want = pickBestTrack(snap.audioTracks, audioLangs);
@@ -214,7 +213,7 @@ export function useTrackAutoload(params: {
       if (want && (!cur || cur.id !== want.id)) bridgeRef.current?.setAudioTrack(want.id);
     }
     const subSelected = snap.subtitleTracks.some((t) => t.selected);
-    if (!subSelected && snap.subtitleTracks.length > 0 && subLangs.length > 0 && !userPickedSubRef.current) {
+    if (!subSelected && snap.subtitleTracks.length > 0 && subLangs.length > 0 && !userPickedSubRef.current && !settings.subtitlesOffByDefault) {
       const want = pickBestTrack(snap.subtitleTracks, subLangs);
       if (want) bridgeRef.current?.setSubtitleTrack(want.id);
     }

--- a/src/views/player/player-utils.ts
+++ b/src/views/player/player-utils.ts
@@ -39,7 +39,8 @@ export async function pickBridge(
     embed?: boolean;
     anime4kShaders?: string[];
     d3d11Flip?: boolean;
-    preferredLangs?: string[]; 
+    preferredLangs?: string[];
+    subsOff?: boolean;
     getEmbedRect?: () =>
       | Promise<{ screenX: number; screenY: number; w: number; h: number } | null>
       | { screenX: number; screenY: number; w: number; h: number }

--- a/src/views/player/player-utils.ts
+++ b/src/views/player/player-utils.ts
@@ -39,6 +39,7 @@ export async function pickBridge(
     embed?: boolean;
     anime4kShaders?: string[];
     d3d11Flip?: boolean;
+    preferredLangs?: string[]; 
     getEmbedRect?: () =>
       | Promise<{ screenX: number; screenY: number; w: number; h: number } | null>
       | { screenX: number; screenY: number; w: number; h: number }


### PR DESCRIPTION
Fixes embedded subtitles not respecting the user’s preferred subtitle language. Before this, the player would sometimes select a random embedded subtitle (Chinese, French, English…) instead of the language set in settings.
Embedded subtitles are now prioritised when they match the user's preferred language.
This also ensures external subtitle sources (addons, OpenSubtitles) respect the preferred language when no matching embedded track is available, following the priority order: embedded, addon, then OpenSubtitles v3.
Fix the off by default subtitles button not working, now making the subtitles to not show when the option its on and only showing the subtitles when you choose one from the player.

I’ve tested this with most subtitle language, files with no embedded track in the preferred language, manual selection, “subtitles off by default”, watched a full episode of a show, and reopening previously watched titles after changing the language setting all working as expected on my end. Would appreciate it if someone else could also test with their own setups, just to make sure I haven’t missed any edge cases.