### PR TITLE
fix: posters and cast images collapse to 0x0 on some WebView2 installs

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -86,6 +86,7 @@ body {
     border: 0;
     padding: 0;
     cursor: pointer;
+    align-items: stretch;
   }
 
   input {


### PR DESCRIPTION
## Problem

Movie posters, cast headshots, and Continue Watching thumbnails render as **0x0 invisible boxes** on some Windows devices. The `<img>` elements load successfully but their containers collapse, so nothing is visible.

## Root cause

The Chromium/WebView2 **user-agent stylesheet** sets `align-items: flex-start` on all `<button>` elements by default. When Tailwind's `flex` utility sets `display: flex` on a `<button>` (as done in `PickCard`, `ContinueCard`, `CastCard`, `WatchlistCard`, `AnilistEntryCard`, and others), this UA default overrides the expected flexbox `stretch` behavior.

The poster container (the shared `Poster` component and similar aspect-ratio divs) is a **flex child with no explicit width** -- it relies on `align-items: stretch` to fill the button's width, then uses `aspect-ratio` to derive its height. With `align-items: flex-start` from the UA stylesheet, the container doesn't stretch, width collapses to 0, `aspect-ratio` produces 0 height, and the absolutely-positioned `<img>` renders at 0x0.

```
button.group.flex.flex-col  (display:flex, align-items: flex-start -- UA default)
  div.harbor-poster.aspect-[2/3]  (width: auto -> 0, height: 0 via aspect-ratio)
    img.absolute.inset-0.h-full.w-full  (0x0)
```

## Fix

Add `align-items: stretch` to the base `button` reset in `@layer base` (`src/index.css`):

```css
@layer base {
  button {
    /* ...existing resets... */
    align-items: stretch;  /* override UA default flex-start */
  }
}
```

This is a one-line change. Tailwind utilities (`items-start`, `items-center`, etc.) in the higher-priority `@layer utilities` still override this when explicitly applied.

## Verification

Diagnosed and verified via **CDP runtime analysis** (WebView2 remote debugging):

| | Before fix | After fix |
|---|---|---|
| Total `.harbor-poster` elements | 186 | 130 |
| Posters with 0x0 dimensions | **176** | **0** |
| `align-items` on card buttons | `flex-start` (UA) | `stretch` |

All poster types confirmed working: movie cards (`PickCard`), Continue Watching (`ContinueCard`), cast cards (`CastCard`), library cards (`WatchlistCard`, `AnilistEntryCard`), and the person detail page headshot.
