### PR TITLE
Keep subtitle menu open after selecting a subtitle

### DIFF
--- a/src/components/player/subtitle-menu/menu-body.tsx
+++ b/src/components/player/subtitle-menu/menu-body.tsx
@@ -282,7 +282,6 @@ export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
                       selected={t.id === selectedId}
                       onPick={() => {
                         onSelect(t.id);
-                        onClose();
                       }}
                     />
                   ))}


### PR DESCRIPTION
## Summary

Selecting a subtitle currently closes the subtitle menu immediately, making it inconvenient to compare or switch between different subtitle tracks.

This change removes the unconditional onClose() call after selecting a subtitle, allowing the menu to remain open until the user explicitly closes it.

## Testing

- Verified that selecting multiple subtitle tracks keeps the menu open.
- Verified that subtitle switching still works correctly.
- Verified that the dialog still closes via explicit close actions (such as the close button).
- Verified the project builds successfully (`npx tsc --noEmit`).

## Demo

## Before 


https://github.com/user-attachments/assets/cd5881b7-788f-4db5-ab70-529bdea1dcb7


## After 


https://github.com/user-attachments/assets/cdd0155e-e465-439b-92f1-3f49d05e711c



