### PR TITLE
fix(calendar): convert Trakt UTC dates to local timezone

### DIFF
--- a/src/lib/trakt/calendar.ts
+++ b/src/lib/trakt/calendar.ts
@@ -9,13 +9,32 @@ export type CalendarEpisode = TraktItem & {
   episodeTitle?: string;
 };
 
+function utcIsoToLocalDate(iso: string): string {
+  if (!iso) return "";
+  if (!iso.includes("T")) return iso.slice(0, 10);
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso.slice(0, 10);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function localDateToday(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 export async function fetchUpcomingEpisodes(days = 14): Promise<CalendarEpisode[]> {
   type Raw = {
     first_aired: string;
     episode: { season: number; number: number; title?: string; ids: { imdb?: string; tmdb?: number; tvdb?: number } };
     show: { title: string; year: number | null; ids: { imdb?: string; tmdb?: number; tvdb?: number } };
   };
-  const today = new Date().toISOString().slice(0, 10);
+  const today = localDateToday();
   const rows = await traktRequest<Raw[]>(
     `/calendars/my/shows/${today}/${days}`,
   ).catch(() => [] as Raw[]);
@@ -24,7 +43,7 @@ export async function fetchUpcomingEpisodes(days = 14): Promise<CalendarEpisode[
     title: r.show.title,
     year: r.show.year,
     ids: r.show.ids,
-    airDate: r.first_aired,
+    airDate: utcIsoToLocalDate(r.first_aired),
     season: r.episode.season,
     number: r.episode.number,
     episodeTitle: r.episode.title,
@@ -36,7 +55,7 @@ export async function fetchUpcomingMovies(days = 30): Promise<TraktItem[]> {
     released: string;
     movie: { title: string; year: number | null; ids: { imdb?: string; tmdb?: number } };
   };
-  const today = new Date().toISOString().slice(0, 10);
+  const today = localDateToday();
   const rows = await traktRequest<Raw[]>(
     `/calendars/my/movies/${today}/${days}`,
   ).catch(() => [] as Raw[]);
@@ -88,7 +107,7 @@ export async function fetchAnticipatedShows(): Promise<AnticipatedShow[]> {
       title: r.show.title,
       year: r.show.year,
       ids: r.show.ids,
-      firstAired: (r.show.first_aired ?? "").slice(0, 10),
+      firstAired: utcIsoToLocalDate(r.show.first_aired ?? ""),
       poster: null,
       overview: r.show.overview ?? "",
     }));
@@ -115,7 +134,7 @@ export async function fetchAnticipatedMovies(): Promise<AnticipatedMovie[]> {
       title: r.movie.title,
       year: r.movie.year,
       ids: r.movie.ids,
-      released: (r.movie.released ?? "").slice(0, 10),
+      released: utcIsoToLocalDate(r.movie.released ?? ""),
       poster: null,
       overview: r.movie.overview ?? "",
     }));


### PR DESCRIPTION
## Description
 
The Calendar's Trakt source was timezone-locked — dates from the Trakt API (which returns UTC datetimes like `"2024-06-15T22:00:00.000Z"`) were used as-is without converting to the user's local timezone. This caused episodes airing at night
UTC to show on the wrong date for users in positive-offset timezones like India (UTC+5:30).
 
## Changes
 
- **`src/lib/trakt/calendar.ts`**
  - Added `utcIsoToLocalDate()` — converts UTC ISO datetime to local YYYY-MM-DD. Safely handles date-only strings as no-op
  - Added `localDateToday()` — returns today's date in local TZ
  - `fetchUpcomingEpisodes`: convert `first_aired` UTC → local
  - `fetchUpcomingMovies`: use local today for API request URL
  - `fetchAnticipatedShows`: convert `first_aired` UTC → local
  - `fetchAnticipatedMovies`: convert `released` UTC → local
 
## Testing
 
Verified with DevTools in Asia/Calcutta timezone (UTC+5:30):
 
2024-06-15T22:00:00.000Z → 2024-06-16  (was 2024-06-15)
2024-06-15T12:00:00.000Z → 2024-06-15 
2024-06-15T18:30:00.000Z → 2024-06-16 
All 6 tests passed