### PR TITLE
feat: Context menu subtitle download and keyboard seek fix

### DIFF
--- a/src/components/context-menu.tsx
+++ b/src/components/context-menu.tsx
@@ -11,6 +11,7 @@ import { useTmdbImdbId } from "@/lib/providers/tmdb";
 import { useIsFavorite, useMediaFavorites } from "@/lib/media-favorites";
 import { useInLocalWatchlist, useLocalWatchlist } from "@/lib/local-watchlist";
 import { clearTitleBackdrop, getTitleBackdrop, setTitleBackdrop } from "@/lib/title-backdrop";
+import { useT } from "@/lib/i18n";
 
 const MENU_WIDTH = 220;
 const MENU_HEIGHT = 120;
@@ -33,6 +34,7 @@ const VIEW_LABELS: Record<ViewSummonable, string> = {
 
 export function ContextMenu() {
   const { state, close, open } = useContextMenu();
+  const t = useT();
   const {
     openMeta,
     setView,
@@ -250,6 +252,19 @@ export function ContextMenu() {
             label="Download Video"
             onClick={() => {
               playerActions.download();
+              close();
+            }}
+          />,
+        );
+      }
+      if (playerActions.canDownloadSubtitle) {
+        items.push(
+          <Item
+            key="download-subtitle"
+            icon={<Download size={14} strokeWidth={2} />}
+            label={t("Download Subtitle")}
+            onClick={() => {
+              playerActions.downloadSubtitle();
               close();
             }}
           />,
@@ -478,3 +493,4 @@ function Item({
 function Separator() {
   return <span aria-hidden className="my-1 h-px bg-edge-soft/60" />;
 }
+

--- a/src/lib/i18n/locales/ar/library.ts
+++ b/src/lib/i18n/locales/ar/library.ts
@@ -128,6 +128,7 @@ const library: Record<string, string> = {
   "Add a TMDB key in Settings to unlock the full discovery feed.":
     "أضف مفتاح TMDB في الإعدادات لفتح موجز الاكتشاف الكامل.",
   "No picks loaded. TMDB might be unreachable.": "لم تُحمّل أي اختيارات. قد يتعذّر الوصول إلى TMDB.",
+
 };
 
 export default library;

--- a/src/lib/i18n/locales/ar/player.ts
+++ b/src/lib/i18n/locales/ar/player.ts
@@ -61,6 +61,7 @@ const player: Record<string, string> = {
   "Thinner outline": "حدود أرفع",
   "No subtitles found.": "لم يُعثر على ترجمات.",
   "Download subtitle to disk": "تنزيل الترجمة إلى القرص",
+  "Download Subtitle": "تحميل الترجمة",
   "Movie's too new. Subtitles haven't been published yet.":
     "الفيلم جديد جدًا. لم تُنشر الترجمات بعد.",
   Forced: "إجباري",

--- a/src/lib/player-actions.ts
+++ b/src/lib/player-actions.ts
@@ -4,6 +4,8 @@ export type PlayerActions = {
   download: () => void;
   toggleFullscreen: () => void;
   canDownload: boolean;
+  downloadSubtitle: () => void;
+  canDownloadSubtitle: boolean;
 };
 
 let current: PlayerActions | null = null;
@@ -16,7 +18,9 @@ export function setPlayerActions(actions: PlayerActions | null) {
     actions &&
     current.download === actions.download &&
     current.toggleFullscreen === actions.toggleFullscreen &&
-    current.canDownload === actions.canDownload
+    current.canDownload === actions.canDownload &&
+    current.downloadSubtitle === actions.downloadSubtitle &&
+    current.canDownloadSubtitle === actions.canDownloadSubtitle
   ) {
     return;
   }

--- a/src/views/player/hooks/use-keyboard-shortcuts.ts
+++ b/src/views/player/hooks/use-keyboard-shortcuts.ts
@@ -138,22 +138,30 @@ export function useKeyboardShortcuts(params: {
       }
       if (match("playerSeekBack10")) {
         e.preventDefault();
-        seekStep(-10);
+        const saved = localStorage.getItem("harbor.seek-step.back");
+        const n = saved ? Number(saved) : NaN;
+        seekStep(-(Number.isFinite(n) && n > 0 ? n : 10));
         return;
       }
       if (match("playerSeekForward10")) {
         e.preventDefault();
-        seekStep(10);
+        const saved = localStorage.getItem("harbor.seek-step.forward");
+        const n = saved ? Number(saved) : NaN;
+        seekStep(Number.isFinite(n) && n > 0 ? n : 10);
         return;
       }
       if (match("playerSeekBack30")) {
         e.preventDefault();
-        seekStep(-30);
+        const saved = localStorage.getItem("harbor.seek-step.back");
+        const n = saved ? Number(saved) : NaN;
+        seekStep(-(Number.isFinite(n) && n > 0 ? n : 30));
         return;
       }
       if (match("playerSeekForward30")) {
         e.preventDefault();
-        seekStep(30);
+        const saved = localStorage.getItem("harbor.seek-step.forward");
+        const n = saved ? Number(saved) : NaN;
+        seekStep(Number.isFinite(n) && n > 0 ? n : 30);
         return;
       }
       if (match("playerFrameForward") && onFrameStep) {

--- a/src/views/player/hooks/use-player-media.ts
+++ b/src/views/player/hooks/use-player-media.ts
@@ -6,6 +6,8 @@ import { clearImportedSubs } from "@/lib/player/imported-subs";
 import { readPlayerVolume } from "@/lib/player-volume";
 import { setPlayerActions } from "@/lib/player-actions";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
+import { fetchAndParse } from "@/lib/subtitles/parser";
+import { toSrt } from "@/lib/subtitles/serialize";
 import { useSettings } from "@/lib/settings";
 import { isLocalEngineUrl } from "@/lib/stremio-server";
 import { useSimklScrobble } from "@/lib/simkl/scrobble-hook";
@@ -137,13 +139,58 @@ export function usePlayerMedia(params: {
   const download = useVideoDownload({ url: src.url, meta: src.meta, episode: src.episode });
 
   useEffect(() => {
+    const doDownloadSubtitle = async () => {
+      const b = bridgeRef.current;
+      if (!b) return;
+
+      // Try URL-based download first (works for all external/addon/opensubtitles tracks)
+      const url = b.getSelectedTrackUrl();
+      if (url && /^https?:/i.test(url)) {
+        try {
+          const res = await fetch(url);
+          if (res.ok) {
+            const text = await res.text();
+            const ext = url.split(/[?#]/)[0].match(/\.([a-z]{2,4})$/i)?.[1]?.toLowerCase() || "srt";
+            const filename = `subtitle.${ext}`;
+            const { downloadText } = await import("@/lib/download-text");
+            await downloadText(filename, text, [ext], "Subtitle");
+            return;
+          }
+        } catch {
+          // fall through to cues-based
+        }
+      }
+
+      // Fallback: get cues from bridge (works for embedded/parsed tracks)
+      let cues = b.getSelectedTrackCues();
+      if ((!cues || cues.length === 0) && url) {
+        try {
+          const readableUrl =
+            /^(https?|blob|data|tauri|asset):/i.test(url) ? url : null;
+          if (readableUrl) {
+            cues = await fetchAndParse(readableUrl);
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+      if (!cues || cues.length === 0) return;
+      const { downloadText } = await import("@/lib/download-text");
+      await downloadText("subtitle.srt", toSrt(cues), ["srt"], "Subtitle");
+    };
+
+    const selectedSub = snap.subtitleTracks.find((t) => t.selected) ?? null;
+    const canSub = selectedSub !== null;
+
     setPlayerActions({
       download: download.start,
       toggleFullscreen,
       canDownload: !!src.url,
+      downloadSubtitle: doDownloadSubtitle,
+      canDownloadSubtitle: canSub,
     });
     return () => setPlayerActions(null);
-  }, [download.start, toggleFullscreen, src.url]);
+  }, [download.start, toggleFullscreen, src.url, snap.subtitleTracks]);
 
   useResumeAutosave({ src, snap, season, episode });
   useStremioSync({ src, snap, authKey, resolvedImdbId, resolvedImdbVerified, resolutionSettled, castActiveRef });


### PR DESCRIPTION
- Added the ability to download subtitles directly from the context menu in the player when a subtitle track is active. Works for external URLs and embedded subtitles.
- Fixed an issue where the keyboard seek shortcuts (left/right arrows) used hardcoded 10-second and 30-second values instead of respecting the user's custom step choices saved in localStorage.


https://github.com/user-attachments/assets/f7b723b2-6ad4-4361-8739-1b44f91091b6

