### PR TITLE
feat: full hero banner, cinematic layout, full quality toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { RoyalTopbar } from "@/chrome/royal-topbar";
 import { SideRail } from "@/chrome/siderail";
 import { StremioRail } from "@/chrome/stremio-rail";
 import { TopDock } from "@/chrome/topdock";
+import { CinematicOverlay } from "@/chrome/cinematic-overlay";
 import { Topbar } from "@/chrome/topbar";
 import { startMaintenance, subscribeMemoryPressure } from "@/lib/maintenance";
 import { exitWindowFullscreen, toggleWindowFullscreen } from "@/lib/fullscreen-state";
@@ -581,10 +582,12 @@ function Shell() {
       {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "forest" && <ForestSidebar />}
       {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "stremio" && <StremioRail />}
       {!settingsTop && !playerActive && !pickerTop && layout === "topdock" && <TopDock />}
+      {!settingsTop && !playerActive && !pickerTop && layout === "cinematic" && <CinematicOverlay />}
       {!settingsTop && !playerActive && !pickerTop && layout === "royal" && <RoyalTopbar />}
       {!settingsTop && !playerActive && !pickerTop && layout === "rail" && <SideRail />}
       {!playerActive && !pickerTop && layout === "minui" && <MinUIDock />}
       {!playerActive && !pickerTop && layout === "topdock" && <FloatingBack offsetTop={92} />}
+      {!playerActive && !pickerTop && layout === "cinematic" && <FloatingBack offsetTop={92} />}
       {!playerActive && !pickerTop && layout === "royal" && <FloatingBack offsetTop={92} />}
       {!playerActive && !pickerTop && layout === "rail" && <FloatingBack offsetLeft={settings.sidebarCollapsed ? 88 : 220} offsetTop={28} />}
       {!playerActive && !pickerTop && layout === "custom" && <FloatingBack offsetLeft={20} offsetTop={20} />}

--- a/src/chrome/cinematic-overlay.tsx
+++ b/src/chrome/cinematic-overlay.tsx
@@ -1,0 +1,450 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  LogOut,
+  Pencil,
+  Search,
+  Settings as SettingsIcon,
+  Users,
+} from "lucide-react";
+import { HarborMark } from "@/components/icons/harbor-mark";
+import { CatAvatar } from "@/components/icons/cat-avatar";
+import { RecordingPill } from "@/chrome/recording-pill";
+import { TogetherButton } from "@/chrome/topbar";
+import { useAuth } from "@/lib/auth";
+import { useT } from "@/lib/i18n";
+import { useProfiles } from "@/lib/profiles";
+import { useSearch } from "@/lib/search-context";
+import { useSettings } from "@/lib/settings";
+import { getThemeById } from "@/lib/theme";
+import { useParental, type LockableTab } from "@/lib/parental";
+import { useView, type View } from "@/lib/view";
+import { ParentalPinModal } from "@/components/parental-pin-modal";
+import { close, minimize, toggleMaximize, useMaximized } from "@/lib/window";
+import { OverflowNav, type NavEntry } from "@/chrome/nav-overflow";
+
+const IS_TAURI =
+  typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+type Tab = {
+  label: string;
+  view: View;
+  parentalKey?: LockableTab;
+};
+
+const PRIMARY: Tab[] = [
+  { label: "Home", view: "home" },
+  { label: "Discover", view: "discover", parentalKey: "discover" },
+  { label: "Movies", view: "movies", parentalKey: "movies" },
+  { label: "Shows", view: "shows", parentalKey: "shows" },
+  { label: "Anime", view: "anime", parentalKey: "anime" },
+  { label: "Live TV", view: "live", parentalKey: "liveTv" },
+  { label: "Playlists", view: "vod" },
+];
+
+const SECONDARY: Tab[] = [
+  { label: "Calendar", view: "calendar", parentalKey: "calendar" },
+  { label: "Library", view: "library", parentalKey: "library" },
+  { label: "Downloads", view: "downloads" },
+  { label: "Addons", view: "addons", parentalKey: "addons" },
+];
+
+export function CinematicOverlay() {
+  const { view, setView, chromeHidden } = useView();
+  const { locked, unlock, hiddenTabs } = useParental();
+  const { settings } = useSettings();
+  const { setOpen: setSearchOpen } = useSearch();
+  const t = useT();
+  const [pinFor, setPinFor] = useState<View | null>(null);
+  const maxed = useMaximized();
+
+  const themePreset =
+    settings.theme.preset !== "custom"
+      ? getThemeById(settings.theme.preset)
+      : null;
+  const customMark = themePreset?.logo?.mark ?? null;
+
+  const navigate = (tab: Tab) => {
+    if (tab.parentalKey && locked && hiddenTabs[tab.parentalKey]) {
+      setPinFor(tab.view);
+      return;
+    }
+    setView(tab.view);
+  };
+
+  const navEntries: NavEntry[] = [...PRIMARY, ...SECONDARY]
+    .filter(
+      (tab) =>
+        (tab.view !== "vod" || settings.showPlaylistsTab) &&
+        (!tab.parentalKey || !locked || !hiddenTabs[tab.parentalKey]),
+    )
+    .map((tab) => {
+      const active = view === tab.view;
+      const label = t(tab.label);
+      return {
+        key: tab.view,
+        label,
+        active,
+        onSelect: () => navigate(tab),
+        node: (
+          <button
+            type="button"
+            onClick={() => navigate(tab)}
+            className={`relative h-9 whitespace-nowrap rounded-full px-3 text-[12.5px] font-medium transition-colors ${
+              active ? "text-ink" : "text-ink-muted hover:text-ink"
+            }`}
+          >
+            {active && (
+              <span
+                aria-hidden
+                className="absolute inset-0 -z-10 rounded-full bg-white/15 ring-1 ring-white/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_4px_12px_-2px_rgba(0,0,0,0.3)] backdrop-blur-md"
+              />
+            )}
+            {label}
+          </button>
+        ),
+      };
+    });
+
+  return (
+    <>
+      <header
+        aria-hidden={chromeHidden}
+        className={`fixed inset-x-0 top-0 z-[60] flex h-24 items-start px-6 pt-3 transition-opacity duration-300 ${
+          chromeHidden ? "pointer-events-none opacity-0" : "opacity-100"
+        }`}
+      >
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-black/85 via-black/45 to-transparent" />
+        <div
+          data-tauri-drag-region
+          className="pointer-events-auto relative flex h-14 w-full items-center gap-2 px-1"
+        >
+          <button
+            type="button"
+            onClick={() => setView("home")}
+            className="flex shrink-0 items-center gap-2 text-ink"
+            aria-label={t("chrome.harborHome")}
+          >
+            {customMark ? (
+              <img
+                src={customMark}
+                alt=""
+                draggable={false}
+                className="h-7 w-7 object-contain"
+              />
+            ) : (
+              <HarborMark className="h-7 w-7" />
+            )}
+            {themePreset?.id === "crunch" && (
+              <span className="font-display text-[22px] font-bold leading-none text-ink">
+                Harbor
+              </span>
+            )}
+          </button>
+
+          <div className="mx-1 h-6 w-px shrink-0 bg-white/15" />
+
+          <OverflowNav
+            entries={navEntries}
+            gapPx={2}
+            className="flex-1"
+            moreClassName="relative flex h-9 items-center gap-1 whitespace-nowrap rounded-full px-3 text-[12.5px] font-medium text-ink-muted transition-colors hover:text-ink"
+          />
+
+          <div className="ms-2 flex shrink-0 items-center gap-1">
+            <RecordingPill />
+            {view !== "live" && (
+              <TogetherButton variant="ghost" connectStyle="tab" />
+            )}
+            <IconBtn
+              onClick={() => setSearchOpen(true)}
+              label={t("common.search")}
+              active={false}
+            >
+              <Search size={15} strokeWidth={2.2} />
+            </IconBtn>
+            <ProfileChipCompact
+              onOpenSettings={() => setView("settings")}
+              settingsActive={view === "settings"}
+            />
+            {IS_TAURI && !settings.useNativeTitleBar && (
+              <div className="ms-1 flex items-center gap-0.5">
+                <WinBtn onClick={minimize} label={t("chrome.minimize")}>
+                  <path
+                    d="M3 6.5h7"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                  />
+                </WinBtn>
+                <WinBtn
+                  onClick={toggleMaximize}
+                  label={maxed ? t("chrome.restore") : t("chrome.maximize")}
+                >
+                  {maxed ? (
+                    <>
+                      <rect
+                        x="2.5"
+                        y="4.5"
+                        width="6"
+                        height="6"
+                        stroke="currentColor"
+                        strokeWidth="1.4"
+                        rx="1"
+                      />
+                      <path
+                        d="M5 4.5V3a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-.5.5H9"
+                        stroke="currentColor"
+                        strokeWidth="1.4"
+                        fill="none"
+                      />
+                    </>
+                  ) : (
+                    <rect
+                      x="3"
+                      y="3"
+                      width="7"
+                      height="7"
+                      stroke="currentColor"
+                      strokeWidth="1.4"
+                      rx="1.2"
+                    />
+                  )}
+                </WinBtn>
+                <WinBtn onClick={close} label={t("common.close")}>
+                  <path
+                    d="M3.5 3.5l6 6M9.5 3.5l-6 6"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                  />
+                </WinBtn>
+              </div>
+            )}
+          </div>
+        </div>
+      </header>
+      {pinFor !== null && (
+        <ParentalPinModal
+          mode={{
+            kind: "unlock",
+            onUnlock: () => {
+              const v = pinFor;
+              setPinFor(null);
+              if (v) setView(v);
+            },
+            onCancel: () => setPinFor(null),
+          }}
+          verify={unlock}
+        />
+      )}
+    </>
+  );
+}
+
+function IconBtn({
+  onClick,
+  label,
+  active,
+  children,
+}: {
+  onClick: () => void;
+  label: string;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors ${
+        active
+          ? "bg-white/20 text-ink ring-1 ring-white/25"
+          : "text-ink-muted hover:bg-white/12 hover:text-ink"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function WinBtn({
+  onClick,
+  label,
+  children,
+}: {
+  onClick: () => void;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className="flex h-8 w-8 items-center justify-center rounded-full text-ink-muted transition-colors hover:bg-white/15 hover:text-ink"
+    >
+      <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+        {children}
+      </svg>
+    </button>
+  );
+}
+
+function ProfileChipCompact({
+  onOpenSettings,
+  settingsActive,
+}: {
+  onOpenSettings: () => void;
+  settingsActive: boolean;
+}) {
+  const { user, signOut } = useAuth();
+  const { settings } = useSettings();
+  const { profiles, activeProfile, openPicker, selectProfile } = useProfiles();
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const name =
+    activeProfile?.name ??
+    user?.fullname ??
+    user?.email?.split("@")[0] ??
+    t("profile.fallback");
+  const color = activeProfile?.color ?? "#7cd6ff";
+  const avatarSrc =
+    activeProfile?.avatar ?? settings.harborAvatar ?? user?.avatar ?? null;
+  const otherProfiles = profiles.filter((p) => p.id !== activeProfile?.id);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        data-open={String(open)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="flex h-9 items-center gap-2 rounded-full ps-1 pe-3 text-[12.5px] font-medium text-ink-muted transition-colors hover:bg-white/12 hover:text-ink"
+      >
+        <span
+          className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-white/25"
+          style={{ background: color }}
+        >
+          {avatarSrc ? (
+            <img
+              src={avatarSrc}
+              alt=""
+              className="h-full w-full object-cover"
+              draggable={false}
+            />
+          ) : (
+            <CatAvatar className="h-full w-full" />
+          )}
+        </span>
+        <span className="hidden max-w-[8rem] truncate sm:inline">{name}</span>
+      </button>
+      {open && (
+        <div className="harbor-profile-dropdown absolute end-0 top-[calc(100%+8px)] z-40 w-60 overflow-hidden rounded-2xl border border-white/15 bg-canvas/95 shadow-[0_20px_50px_-15px_rgba(0,0,0,0.8)] backdrop-blur-2xl">
+          <div className="border-b border-white/10 px-4 py-3">
+            <div className="text-[13.5px] font-semibold text-ink">{name}</div>
+            {user?.email && (
+              <div className="truncate text-[11.5px] text-ink-subtle">
+                {user.email}
+              </div>
+            )}
+          </div>
+          {otherProfiles.length > 0 && (
+            <div className="flex flex-col gap-0.5 border-b border-white/10 p-1.5">
+              <span className="px-2.5 pb-1 pt-1 text-[10px] font-bold uppercase tracking-[0.16em] text-ink-subtle">
+                {t("profile.switch")}
+              </span>
+              {otherProfiles.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => {
+                    setOpen(false);
+                    if (p.passwordHash) {
+                      openPicker({ kind: "unlock", profileId: p.id });
+                    } else {
+                      selectProfile(p.id);
+                    }
+                  }}
+                  className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-start transition-colors hover:bg-white/10"
+                >
+                  <span
+                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-canvas"
+                    style={{ background: p.color }}
+                  >
+                    {p.name.slice(0, 1).toUpperCase()}
+                  </span>
+                  <span className="truncate text-[12.5px] text-ink">
+                    {p.name}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="flex flex-col">
+            <button
+              type="button"
+              onClick={() => {
+                openPicker({ kind: "list" });
+                setOpen(false);
+              }}
+              className="flex items-center gap-2.5 px-4 py-2.5 text-start text-[13px] text-ink-muted transition-colors hover:bg-white/10 hover:text-ink"
+            >
+              <Users size={13} strokeWidth={2.2} /> {t("profile.whoWatching")}
+            </button>
+            {activeProfile && (
+              <button
+                type="button"
+                onClick={() => {
+                  openPicker({ kind: "edit", profileId: activeProfile.id });
+                  setOpen(false);
+                }}
+                className="flex items-center gap-2.5 px-4 py-2.5 text-start text-[13px] text-ink-muted transition-colors hover:bg-white/10 hover:text-ink"
+              >
+                <Pencil size={13} strokeWidth={2.2} /> {t("Edit profile")}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => {
+                onOpenSettings();
+                setOpen(false);
+              }}
+              className={`flex items-center gap-2.5 px-4 py-2.5 text-start text-[13px] transition-colors hover:bg-white/10 ${
+                settingsActive ? "text-ink" : "text-ink-muted hover:text-ink"
+              }`}
+            >
+              <SettingsIcon size={13} strokeWidth={2.2} /> {t("nav.settings")}
+            </button>
+            {user && (
+              <button
+                type="button"
+                onClick={() => {
+                  signOut();
+                  setOpen(false);
+                }}
+                className="flex items-center gap-2.5 border-t border-white/10 px-4 py-2.5 text-start text-[13px] text-ink-muted transition-colors hover:bg-white/10 hover:text-ink"
+              >
+                <LogOut size={13} strokeWidth={2.2} /> {t("Sign out")}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/hero-carousel.tsx
+++ b/src/components/hero-carousel.tsx
@@ -12,7 +12,7 @@ const SNAP_RATIO = 0.18;
 const FLICK_VELOCITY = 0.45;
 const SLIDE_GAP_PX = 22;
 
-export function HeroCarousel({ slides }: { slides: Slide[] }) {
+export function HeroCarousel({ slides, full = false, fullQuality = false }: { slides: Slide[]; full?: boolean; fullQuality?: boolean }) {
   const [active, setActive] = useState(0);
   const [paused, setPaused] = useState(false);
   const [dragging, setDragging] = useState(false);
@@ -48,7 +48,7 @@ export function HeroCarousel({ slides }: { slides: Slide[] }) {
 
   if (slides.length === 0) {
     return (
-      <div className="min-h-[560px] animate-pulse rounded-[28px] border border-edge-soft bg-elevated/30" />
+      <div className={`animate-pulse border border-edge-soft bg-elevated/30 ${full ? "min-h-[clamp(560px,82vh,920px)] rounded-none" : "min-h-[560px] rounded-[28px]"}`} />
     );
   }
 
@@ -121,7 +121,7 @@ export function HeroCarousel({ slides }: { slides: Slide[] }) {
 
   return (
     <div
-      className="flex flex-col gap-5"
+      className={full ? "relative" : "flex flex-col gap-5"}
       onMouseEnter={() => setPaused(true)}
       onMouseLeave={() => setPaused(false)}
     >
@@ -133,7 +133,7 @@ export function HeroCarousel({ slides }: { slides: Slide[] }) {
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
         onClickCapture={onClickCapture}
-        className={`relative overflow-hidden rounded-[28px] ${
+        className={`relative overflow-hidden ${full ? "rounded-none" : "rounded-[28px]"} ${
           dragging ? "cursor-grabbing" : "cursor-grab"
         } select-none`}
         style={{ touchAction: "pan-y" }}
@@ -171,9 +171,11 @@ export function HeroCarousel({ slides }: { slides: Slide[] }) {
                     rank={s.rank}
                     active={isActive}
                     loadBackdrop={distance === 0}
+                    full={full}
+                    fullQuality={fullQuality}
                   />
                 ) : (
-                  <div className="h-[560px] w-full rounded-[28px] bg-elevated/30" />
+                  <div className={`w-full bg-elevated/30 ${full ? "h-[clamp(560px,82vh,920px)] rounded-none" : "h-[560px] rounded-[28px]"}`} />
                 )}
               </div>
             );
@@ -181,7 +183,11 @@ export function HeroCarousel({ slides }: { slides: Slide[] }) {
         </div>
       </div>
       {slides.length > 1 && (
-        <div className="flex justify-center gap-2.5 pt-1">
+        <div
+          className={`flex justify-center gap-2.5 ${
+            full ? "absolute bottom-4 inset-x-0" : "pt-1"
+          }`}
+        >
           {slides.map((_, i) => (
             <button
               key={i}

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -20,12 +20,16 @@ export const Hero = memo(function Hero({
   playTrailer = false,
   active = true,
   loadBackdrop = true,
+  full = false,      
+  fullQuality = false,
 }: {
   meta: Meta;
   rank?: { label: string; position: number };
   playTrailer?: boolean;
   active?: boolean;
   loadBackdrop?: boolean;
+  full?: boolean;
+  fullQuality?: boolean;
 }) {
   const { settings } = useSettings();
   const { openMeta } = useView();
@@ -34,7 +38,7 @@ export const Hero = memo(function Hero({
   const inWatchlist = useInWatchlist(meta.id, [resolvedImdb]);
   const [bgUrl, setBgUrl] = useState<string | undefined>(meta.background);
   const [bgResolved, setBgResolved] = useState<boolean>(!!meta.background);
-  const bg = bgUrl ? upsizeTmdb(bgUrl) : bgResolved ? meta.poster : undefined;
+  const bg = bgUrl ? upsizeTmdb(bgUrl, fullQuality) : bgResolved ? meta.poster : undefined;
   const [trailerCandidates, setTrailerCandidates] = useState<string[]>([]);
   const [trailerInfo, setTrailerInfo] = useState<TrailerInfo | null>(null);
   const [videoReady, setVideoReady] = useState(false);
@@ -171,7 +175,7 @@ export const Hero = memo(function Hero({
   return (
     <section
       onClick={() => openMeta({ ...meta, logo: logo ?? meta.logo })}
-      className="group relative h-[560px] cursor-pointer overflow-hidden rounded-[28px] bg-canvas"
+      className={`group relative cursor-pointer overflow-hidden bg-canvas ${full ? "h-[clamp(560px,82vh,920px)] rounded-none" : "h-[560px] rounded-[28px]"}`}
       style={{ isolation: "isolate" }}
     >
       {bg && loadBackdrop && (
@@ -180,13 +184,13 @@ export const Hero = memo(function Hero({
           alt=""
           decoding="async"
           fetchPriority={active ? "high" : "low"}
-          className="absolute inset-[2px] h-[calc(100%-4px)] w-[calc(100%-4px)] rounded-[26px] object-cover transition-opacity duration-500"
+          className={`absolute object-cover transition-opacity duration-500 ${full ? "inset-0 h-full w-full rounded-none" : "inset-[2px] h-[calc(100%-4px)] w-[calc(100%-4px)] rounded-[26px]"}`}
           style={{ opacity: wantsPlayback && videoReady ? 0 : 0.9 }}
         />
       )}
       {trailerInfo && (
         <div
-          className="pointer-events-none absolute inset-[2px] overflow-hidden rounded-[26px] transition-opacity duration-500"
+          className={`pointer-events-none absolute overflow-hidden transition-opacity duration-500 ${full ? "inset-0 rounded-none" : "inset-[2px] rounded-[26px]"}`}
           style={{ opacity: wantsPlayback && videoReady ? 1 : 0 }}
         >
           <video
@@ -208,7 +212,7 @@ export const Hero = memo(function Hero({
       <div className="absolute inset-x-0 bottom-0 h-2/5 bg-gradient-to-t from-canvas via-canvas/70 via-50% to-transparent" />
       <MetaAwardsCorner meta={meta} imdbId={resolvedImdb} />
 
-      <div className="relative flex h-full flex-col justify-center p-14">
+      <div className={`relative flex h-full flex-col justify-center p-14 ${full ? "pt-28 lg:pt-32" : ""}`}>
         <div className="max-w-2xl">
           {rank && (
             <div className="mb-5 inline-flex items-center gap-1.5 self-start rounded-md bg-canvas/85 px-2.5 py-1 text-[12px] font-semibold text-ink">
@@ -329,7 +333,8 @@ function Stat({ label, value }: { label: string; value: string }) {
   );
 }
 
-function upsizeTmdb(url?: string): string | undefined {
+function upsizeTmdb(url?: string, full = false): string | undefined {
   if (!url) return url;
-  return url.replace("/t/p/w780/", "/t/p/w1280/");
+  const size = full ? "original" : "w1280";
+  return url.replace("/t/p/w780/", `/t/p/${size}/`);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -679,6 +679,16 @@ html[data-theme-layout="stremio"] .harbor-bleed-stremio {
   margin-right: -2.75rem;
 }
 
+html[data-theme-layout="stremio"] .harbor-hero-full {
+  margin-left: -2.5rem;
+  margin-right: -2.75rem;
+}
+
+.harbor-hero-full {
+  width: 100vw;
+  margin-left: calc(-1 * var(--hero-bleed-x, 1.25rem));
+}
+
 .harbor-cinema-badge {
   color: oklch(0.78 0.13 60);
   border: 1px solid oklch(0.78 0.13 60 / 0.35);

--- a/src/index.css
+++ b/src/index.css
@@ -679,15 +679,27 @@ html[data-theme-layout="stremio"] .harbor-bleed-stremio {
   margin-right: -2.75rem;
 }
 
+.harbor-hero-full {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+@media (min-width: 640px) {
+  .harbor-hero-full {
+    margin-left: -2rem;
+    margin-right: -2rem;
+  }
+}
+@media (min-width: 1024px) {
+  .harbor-hero-full {
+    margin-left: -3rem;
+    margin-right: -3rem;
+  }
+}
 html[data-theme-layout="stremio"] .harbor-hero-full {
   margin-left: -2.5rem;
   margin-right: -2.75rem;
 }
 
-.harbor-hero-full {
-  width: 100vw;
-  margin-left: calc(-1 * var(--hero-bleed-x, 1.25rem));
-}
 
 .harbor-cinema-badge {
   color: oklch(0.78 0.13 60);

--- a/src/lib/i18n/locales/ar/settings.ts
+++ b/src/lib/i18n/locales/ar/settings.ts
@@ -1,4 +1,10 @@
 const settings: Record<string, string> = {
+  "Home hero": "واجهة العنوان المميّز",
+  "Make the featured banner on Home bigger and sharper.": "اجعل لافتة العنوان المميّز في الصفحة الرئيسية أكبر وأوضح.",
+  "Full hero banner": "لافتة بطل كاملة",
+  "Stretch the featured hero edge to edge and taller, across every layout.": "تمدّد لافتة البطل من الحافة إلى الحافة وبارتفاع أكبر، في جميع التخطيطات.",
+  "Full quality hero image": "صورة البطل بأعلى جودة",
+  "Load the highest-resolution artwork for the featured hero. Uses more bandwidth.": "تحميل صورة البطل المميّز بأعلى دقة. يستهلك بيانات أكثر.",
   "Display language": "لغة العرض",
   "Interface language": "لغة الواجهة",
   "Metadata language": "لغة البيانات الوصفية",

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -44,6 +44,8 @@ export const DEFAULT: Settings = {
   trailerQuality: "auto",
   detailTrailerAutoplay: false,
   heroShadow: 100,
+  heroFull: false,    
+  heroFullQuality: true,
   resumePrompt: false,
   resumePlayback: true,
   badgePlacement: "bottom",

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -70,6 +70,8 @@ export type Settings = {
   trailerQuality: "auto" | "360p" | "720p" | "1080p" | "best";
   detailTrailerAutoplay: boolean;
   heroShadow: number;
+  heroFull: boolean;         
+  heroFullQuality: boolean;
   resumePrompt: boolean;
   resumePlayback: boolean;
   badgePlacement: "top" | "bottom";

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -21,7 +21,7 @@ export type ThemePresetId =
   | "forest"
   | "noir";
 
-export type ThemeLayout = "sidebar" | "topdock" | "rail" | "stremio" | "minui" | "dracula" | "nord" | "forest" | "royal" | "custom";
+export type ThemeLayout = "sidebar" | "topdock" | "rail" | "stremio" | "minui" | "dracula" | "nord" | "forest" | "royal" | "cinematic" | "custom";
 export type ThemeCardStyle = "flat" | "glass" | "stremio" | "minui" | "crunch" | "noir" | "custom";
 export type ThemeButtonStyle = "flat" | "glossy" | "minui" | "crunch" | "noir" | "custom";
 

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -458,6 +458,27 @@ export function Home({ active = true }: { active?: boolean }) {
   }, [heroPool, heroSourceRow]);
 
   const scrollRef = useRef<HTMLElement>(null);
+  const heroWrapperRef = useRef<HTMLDivElement>(null);
+
+useEffect(() => {
+  const el = heroWrapperRef.current;
+  const main = scrollRef.current;
+  if (!el) return;
+  if (!settings.heroFull) {
+    el.style.removeProperty("--hero-bleed-x");
+    return;
+  }
+  const measure = () => {
+    if (!main) return;
+    const mainRect = main.getBoundingClientRect();
+    const mainPl = parseFloat(getComputedStyle(main).paddingLeft) || 0;
+    el.style.setProperty("--hero-bleed-x", `${mainRect.left + mainPl}px`);
+  };
+  measure();
+  const ro = new ResizeObserver(measure);
+  ro.observe(document.documentElement);
+  return () => ro.disconnect();
+}, [settings.heroFull, settings.sidebarCollapsed]);
   const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null);
   const scrollCb = useCallback((el: HTMLElement | null) => {
     (scrollRef as { current: HTMLElement | null }).current = el;
@@ -610,7 +631,7 @@ export function Home({ active = true }: { active?: boolean }) {
   return (
     <main
       ref={scrollCb}
-      className="flex-1 overflow-y-auto px-5 pt-24 pb-14 sm:px-8 lg:px-12 lg:pt-28"
+      className="flex-1 overflow-y-auto overflow-x-hidden px-5 pt-24 pb-14 sm:px-8 lg:px-12 lg:pt-28"
     >
       <ScrollRootContext.Provider value={scrollEl}>
         <div data-tauri-drag-region className="relative flex flex-col gap-12">
@@ -633,7 +654,11 @@ export function Home({ active = true }: { active?: boolean }) {
             </div>
           )}
           {settings.homeMode !== "classic" && !homeRowsCustom.hidden.includes("hero") && (
-            <div data-scroll-anchor="hero" className="relative">
+            <div
+              ref={heroWrapperRef}
+              data-scroll-anchor="hero"
+              className={`relative ${settings.heroFull ? "-mt-24 lg:-mt-28 -mb-12 harbor-hero-full" : ""}`}
+            >
               {editMode && (
                 <PinnedRowControls
                   label={t("Featured hero")}
@@ -641,7 +666,11 @@ export function Home({ active = true }: { active?: boolean }) {
                   onToggleHidden={() => handleToggleHidden("hero")}
                 />
               )}
-              <HeroCarousel slides={heroSlides} />
+              <HeroCarousel
+                slides={heroSlides}
+                full={settings.heroFull}
+                fullQuality={settings.heroFullQuality}
+              />
               {!editMode && (
                 <div className="pointer-events-none absolute -bottom-3 end-5 z-20 flex justify-end [&>*]:pointer-events-auto">
                   <CustomizeBar

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -458,27 +458,7 @@ export function Home({ active = true }: { active?: boolean }) {
   }, [heroPool, heroSourceRow]);
 
   const scrollRef = useRef<HTMLElement>(null);
-  const heroWrapperRef = useRef<HTMLDivElement>(null);
 
-useEffect(() => {
-  const el = heroWrapperRef.current;
-  const main = scrollRef.current;
-  if (!el) return;
-  if (!settings.heroFull) {
-    el.style.removeProperty("--hero-bleed-x");
-    return;
-  }
-  const measure = () => {
-    if (!main) return;
-    const mainRect = main.getBoundingClientRect();
-    const mainPl = parseFloat(getComputedStyle(main).paddingLeft) || 0;
-    el.style.setProperty("--hero-bleed-x", `${mainRect.left + mainPl}px`);
-  };
-  measure();
-  const ro = new ResizeObserver(measure);
-  ro.observe(document.documentElement);
-  return () => ro.disconnect();
-}, [settings.heroFull, settings.sidebarCollapsed]);
   const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null);
   const scrollCb = useCallback((el: HTMLElement | null) => {
     (scrollRef as { current: HTMLElement | null }).current = el;
@@ -655,7 +635,6 @@ useEffect(() => {
           )}
           {settings.homeMode !== "classic" && !homeRowsCustom.hidden.includes("hero") && (
             <div
-              ref={heroWrapperRef}
               data-scroll-anchor="hero"
               className={`relative ${settings.heroFull ? "-mt-24 lg:-mt-28 -mb-12 harbor-hero-full" : ""}`}
             >

--- a/src/views/settings/theme-panel/display-section.tsx
+++ b/src/views/settings/theme-panel/display-section.tsx
@@ -162,6 +162,24 @@ export function DisplaySection() {
       </Section>
 
       <Section
+        title={t("Home hero")}
+        subtitle={t("Make the featured banner on Home bigger and sharper.")}
+      >
+        <ToggleRow
+          label={t("Full hero banner")}
+          sub={t("Stretch the featured hero edge to edge and taller, across every layout.")}
+          value={settings.heroFull}
+          onChange={(v) => update({ heroFull: v })}
+        />
+        <ToggleRow
+          label={t("Full quality hero image")}
+          sub={t("Load the highest-resolution artwork for the featured hero. Uses more bandwidth.")}
+          value={settings.heroFullQuality}
+          onChange={(v) => update({ heroFullQuality: v })}
+        />
+      </Section>
+
+      <Section
         title={t("Home hero shadow")}
         subtitle={t("How dark the gradient behind the featured title on Home is. 100% is the classic look; lower it to let more of the artwork show through.")}
       >

--- a/src/views/settings/theme-panel/theme-studio/layout-picker.tsx
+++ b/src/views/settings/theme-panel/theme-studio/layout-picker.tsx
@@ -40,6 +40,12 @@ const LAYOUTS: LayoutDef[] = [
     diagram: (a) => <Diagram active={a} kind="minui" />,
   },
   {
+    id: "cinematic",
+    name: "Cinematic",
+    blurb: "Immersive floating overlay nav.",
+    diagram: (a) => <Diagram active={a} kind="cinematic" />,
+  },
+  {
     id: "custom",
     name: "Custom",
     blurb: "Write your own chrome with HTML + CSS.",
@@ -160,6 +166,21 @@ function Diagram({
         <circle cx="41" cy="53" r="1.8" fill={dim} />
         <circle cx="48" cy="53" r="1.8" fill={dim} />
         <circle cx="55" cy="53" r="1.8" fill={dim} />
+      </svg>
+    );
+  }
+  if (kind === "cinematic") {
+    return (
+      <svg viewBox="0 0 80 60" className="h-full w-full">
+        <rect x="3" y="3" width="74" height="54" rx="2" fill={accent} opacity="0.16" />
+        <rect x="3" y="3" width="74" height="22" rx="2" fill={accent} opacity="0.10" />
+        <rect x="22" y="7" width="36" height="7" rx="3.5" fill={accent} opacity="0.5" />
+        <circle cx="29" cy="10.5" r="1.4" fill={accent} />
+        <circle cx="36" cy="10.5" r="1.4" fill={dim} />
+        <circle cx="43" cy="10.5" r="1.4" fill={dim} />
+        <circle cx="50" cy="10.5" r="1.4" fill={dim} />
+        <rect x="10" y="40" width="30" height="4" rx="2" fill={dim} opacity="0.6" />
+        <rect x="10" y="47" width="20" height="3" rx="1.5" fill={dim} opacity="0.4" />
       </svg>
     );
   }


### PR DESCRIPTION
hello @harborstremio i add full hero banner.

- Add heroFull setting: full-bleed edge-to-edge hero across all layouts
- Add heroFullQuality setting: load original TMDB resolution for hero
- Add Cinematic layout: immersive floating gradient overlay nav
- Dynamic viewport measurement for sidebar-aware full bleed
- Arabic i18n translations for new settings

<img width="1919" height="1072" alt="image" src="https://github.com/user-attachments/assets/ffcb16c0-23ce-403e-b739-85ec5056786d" />


<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/e1299d1f-874d-4602-951c-d116e7182bdc" />

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/3a11bcce-2540-4df5-95c4-e9f6d9b70739" />

u can see how it works in the video below

https://gofile.io/d/NUWNI2

btw i did some edit on it , its better than the video now.