### PR TITLE
Feat: Add UI scale keyboard shortcuts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,7 @@ const PRESSURE_EVICT_MS = 1500;
 const UI_SCALE_MIN = 0.8;
 const UI_SCALE_MAX = 1.6;
 const UI_SCALE_STEP = 0.05;
+const UI_SCALE_ACTIVITY_EVENT = "harbor:ui-scale-activity";
 
 function clampUiScale(scale: number): number {
   return Math.max(UI_SCALE_MIN, Math.min(UI_SCALE_MAX, Math.round(scale * 100) / 100));
@@ -425,25 +426,33 @@ function Shell() {
       if (!usesZoomModifier(e)) return;
       if (e.key === "0") {
         e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
         setUiScale(1);
       } else if (e.key === "+" || e.key === "=") {
         e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
         stepUiScale(1);
       } else if (e.key === "-" || e.key === "_") {
         e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
         stepUiScale(-1);
       }
     };
     const onWheel = (e: WheelEvent) => {
       if (!usesZoomModifier(e)) return;
       e.preventDefault();
+      e.stopPropagation();
+      window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
       stepUiScale(e.deltaY < 0 ? 1 : -1);
     };
-    window.addEventListener("keydown", onKey);
-    window.addEventListener("wheel", onWheel, { passive: false });
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("wheel", onWheel, { capture: true, passive: false });
     return () => {
-      window.removeEventListener("keydown", onKey);
-      window.removeEventListener("wheel", onWheel);
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("wheel", onWheel, true);
     };
   }, [update]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import { FavoritesProvider } from "@/lib/iptv/favorites";
 import { MediaFavoritesProvider } from "@/lib/media-favorites";
 import { LocalWatchlistProvider } from "@/lib/local-watchlist";
 import { useSettings } from "@/lib/settings";
+import { effectiveBinding, eventToBinding } from "@/lib/hotkeys";
 import { ViewProvider, useView, type Frame, type MetaFilter, type View } from "@/lib/view";
 import type { MetaType } from "@/lib/cinemeta";
 import { useDiscordPresence } from "@/lib/discord/use-discord-presence";
@@ -422,19 +423,34 @@ function Shell() {
       setUiScale(uiScaleRef.current + direction * UI_SCALE_STEP);
     };
     const usesZoomModifier = (e: KeyboardEvent | WheelEvent) => e.ctrlKey || e.metaKey;
-    const isUiScaleKey = (key: string) => key === "0" || key === "+" || key === "=" || key === "-" || key === "_";
+    const isDefaultUiScaleUp = (e: KeyboardEvent) =>
+      usesZoomModifier(e) && (e.key === "+" || e.key === "=");
+    const isDefaultUiScaleDown = (e: KeyboardEvent) =>
+      usesZoomModifier(e) && (e.key === "-" || e.key === "_");
+    const isDefaultUiScaleReset = (e: KeyboardEvent) =>
+      usesZoomModifier(e) && e.key === "0";
     const onKey = (e: KeyboardEvent) => {
-      if (!usesZoomModifier(e)) return;
-      if (!isUiScaleKey(e.key)) return;
+      const binding = eventToBinding(e);
+      const overrides = settings.hotkeys ?? {};
+      const uiScaleUpCustom = "globalUiScaleUp" in overrides;
+      const uiScaleDownCustom = "globalUiScaleDown" in overrides;
+      const uiScaleResetCustom = "globalUiScaleReset" in overrides;
+      const matchesUp =
+        effectiveBinding("globalUiScaleUp", overrides) === binding || (!uiScaleUpCustom && isDefaultUiScaleUp(e));
+      const matchesDown =
+        effectiveBinding("globalUiScaleDown", overrides) === binding || (!uiScaleDownCustom && isDefaultUiScaleDown(e));
+      const matchesReset =
+        effectiveBinding("globalUiScaleReset", overrides) === binding || (!uiScaleResetCustom && isDefaultUiScaleReset(e));
+      if (!matchesUp && !matchesDown && !matchesReset) return;
       e.preventDefault();
       e.stopPropagation();
       if (e.repeat) return;
       window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
-      if (e.key === "0") {
+      if (matchesReset) {
         setUiScale(1);
-      } else if (e.key === "+" || e.key === "=") {
+      } else if (matchesUp) {
         stepUiScale(1);
-      } else if (e.key === "-" || e.key === "_") {
+      } else if (matchesDown) {
         stepUiScale(-1);
       }
     };
@@ -451,7 +467,7 @@ function Shell() {
       window.removeEventListener("keydown", onKey, true);
       window.removeEventListener("wheel", onWheel, true);
     };
-  }, [update]);
+  }, [settings.hotkeys, update]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -442,6 +442,7 @@ function Shell() {
       const matchesReset =
         effectiveBinding("globalUiScaleReset", overrides) === binding || (!uiScaleResetCustom && isDefaultUiScaleReset(e));
       if (!matchesUp && !matchesDown && !matchesReset) return;
+      if (player && matchesReset) return;
       e.preventDefault();
       e.stopPropagation();
       if (e.repeat) return;
@@ -467,7 +468,7 @@ function Shell() {
       window.removeEventListener("keydown", onKey, true);
       window.removeEventListener("wheel", onWheel, true);
     };
-  }, [settings.hotkeys, update]);
+  }, [player, settings.hotkeys, update]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
 import { FloatingBack } from "@/chrome/floating-back";
 import { WindowControls } from "@/chrome/window-controls";
 import { WindowResizeEdges } from "@/chrome/window-resize-edges";
@@ -167,6 +167,13 @@ function useViewPreloader() {
 const KEEP_ALIVE_MS = 1500;
 const IDLE_EVICT_MS = 60 * 1000;
 const PRESSURE_EVICT_MS = 1500;
+const UI_SCALE_MIN = 0.8;
+const UI_SCALE_MAX = 1.6;
+const UI_SCALE_STEP = 0.05;
+
+function clampUiScale(scale: number): number {
+  return Math.max(UI_SCALE_MIN, Math.min(UI_SCALE_MAX, Math.round(scale * 100) / 100));
+}
 
 function useKeepAlive(active: boolean, requested: boolean, pin = false): boolean {
   const [mounted, setMounted] = useState(active && requested);
@@ -381,7 +388,8 @@ function parseDeepLinkEpisode(videoId?: string): { season: number; episode: numb
 
 function Shell() {
   const { topKind, service, meta, metaLiveContext, metaEpisodeHint, episodeDetail, personId, collectionId, filter, grid, awardType, animeAwardSource, picker, player, setView, goBack, openMeta, stackKinds, chromeHidden } = useView();
-  const { settings } = useSettings();
+  const { settings, update } = useSettings();
+  const uiScaleRef = useRef(settings.uiScale);
   const preview = useThemePreview();
   const layout = useMemo(
     () => (preview ? preview.layout : activeLayout(settings.theme)),
@@ -396,6 +404,48 @@ function Shell() {
   useViewPreloader();
 
   useEffect(() => startMaintenance(), []);
+
+  useEffect(() => {
+    uiScaleRef.current = settings.uiScale;
+  }, [settings.uiScale]);
+
+  useEffect(() => {
+    const setUiScale = (next: number) => {
+      const uiScale = clampUiScale(next);
+      if (uiScale !== uiScaleRef.current) {
+        uiScaleRef.current = uiScale;
+        update({ uiScale });
+      }
+    };
+    const stepUiScale = (direction: 1 | -1) => {
+      setUiScale(uiScaleRef.current + direction * UI_SCALE_STEP);
+    };
+    const usesZoomModifier = (e: KeyboardEvent | WheelEvent) => e.ctrlKey || e.metaKey;
+    const onKey = (e: KeyboardEvent) => {
+      if (!usesZoomModifier(e)) return;
+      if (e.key === "0") {
+        e.preventDefault();
+        setUiScale(1);
+      } else if (e.key === "+" || e.key === "=") {
+        e.preventDefault();
+        stepUiScale(1);
+      } else if (e.key === "-" || e.key === "_") {
+        e.preventDefault();
+        stepUiScale(-1);
+      }
+    };
+    const onWheel = (e: WheelEvent) => {
+      if (!usesZoomModifier(e)) return;
+      e.preventDefault();
+      stepUiScale(e.deltaY < 0 ? 1 : -1);
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("wheel", onWheel, { passive: false });
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("wheel", onWheel);
+    };
+  }, [update]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -422,22 +422,19 @@ function Shell() {
       setUiScale(uiScaleRef.current + direction * UI_SCALE_STEP);
     };
     const usesZoomModifier = (e: KeyboardEvent | WheelEvent) => e.ctrlKey || e.metaKey;
+    const isUiScaleKey = (key: string) => key === "0" || key === "+" || key === "=" || key === "-" || key === "_";
     const onKey = (e: KeyboardEvent) => {
       if (!usesZoomModifier(e)) return;
+      if (!isUiScaleKey(e.key)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.repeat) return;
+      window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
       if (e.key === "0") {
-        e.preventDefault();
-        e.stopPropagation();
-        window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
         setUiScale(1);
       } else if (e.key === "+" || e.key === "=") {
-        e.preventDefault();
-        e.stopPropagation();
-        window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
         stepUiScale(1);
       } else if (e.key === "-" || e.key === "_") {
-        e.preventDefault();
-        e.stopPropagation();
-        window.dispatchEvent(new Event(UI_SCALE_ACTIVITY_EVENT));
         stepUiScale(-1);
       }
     };

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -40,6 +40,9 @@ export type HotkeyId =
   | "playerTvGuide"
   | "playerDvr"
   | "playerSleep"
+  | "globalUiScaleUp"
+  | "globalUiScaleDown"
+  | "globalUiScaleReset"
   | "globalSearchFocus";
 
 export type HotkeyDef = {
@@ -53,6 +56,9 @@ export type HotkeyDef = {
 
 export const HOTKEYS: HotkeyDef[] = [
   { id: "globalSearchFocus", scope: "Global", group: "Navigation", label: "Focus search", description: "Jump to the top-bar search from anywhere.", defaultBinding: "/" },
+  { id: "globalUiScaleUp", scope: "Global", group: "Interface", label: "Increase interface scale", description: "Make Harbor's interface larger.", defaultBinding: "ctrl+=" },
+  { id: "globalUiScaleDown", scope: "Global", group: "Interface", label: "Decrease interface scale", description: "Make Harbor's interface smaller.", defaultBinding: "ctrl+-" },
+  { id: "globalUiScaleReset", scope: "Global", group: "Interface", label: "Reset interface scale", description: "Restore Harbor's interface scale to 100%.", defaultBinding: "ctrl+0" },
 
   { id: "playerClose", scope: "Player", group: "Playback", label: "Close player", description: "Exit playback and return to the previous view.", defaultBinding: "Escape" },
   { id: "playerPlayPause", scope: "Player", group: "Playback", label: "Play / pause", description: "Toggle playback.", defaultBinding: "Space" },

--- a/src/views/player/drag-click-stage.tsx
+++ b/src/views/player/drag-click-stage.tsx
@@ -11,6 +11,7 @@ export function DragClickStage(props: {
       className="pointer-events-auto absolute inset-0 z-[3]"
       onWheel={(e) => {
         if (drawMode || pipMode) return;
+        if (e.ctrlKey || e.metaKey) return;
         onWheelVolume?.(e.deltaY);
       }}
       onMouseDown={(e) => {

--- a/src/views/player/hooks/use-chrome-visibility.ts
+++ b/src/views/player/hooks/use-chrome-visibility.ts
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties } from "re
 import { getSeekHovering, subscribeSeekHovering } from "@/lib/player/playback-clock";
 import { CHROME_HIDE_MS_PAUSED, CHROME_HIDE_MS_PLAYING, CHROME_HIDE_MS_RESUME } from "../player-utils";
 
+const UI_SCALE_ACTIVITY_EVENT = "harbor:ui-scale-activity";
+const UI_SCALE_RESIZE_HOLD_MS = 700;
+
 export function useChromeVisibility(params: {
   playing: boolean;
   drawMode: boolean;
@@ -16,6 +19,8 @@ export function useChromeVisibility(params: {
   }, [chromeVisible]);
 
   const hideTimer = useRef<number | null>(null);
+  const resizeTimer = useRef<number | null>(null);
+  const resizingUiRef = useRef(false);
   const anyMenuOpenRef = useRef(false);
   const resumeHideRef = useRef(false);
 
@@ -23,7 +28,7 @@ export function useChromeVisibility(params: {
     setChromeVisible(true);
     setChromeHidden(pipMode);
     if (hideTimer.current) window.clearTimeout(hideTimer.current);
-    if (anyMenuOpenRef.current || getSeekHovering()) return;
+    if (resizingUiRef.current || anyMenuOpenRef.current || getSeekHovering()) return;
     let wait = playing && !drawMode ? CHROME_HIDE_MS_PLAYING : CHROME_HIDE_MS_PAUSED;
     if (resumeHideRef.current) {
       resumeHideRef.current = false;
@@ -48,9 +53,29 @@ export function useChromeVisibility(params: {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("touchstart", onMove);
       if (hideTimer.current) window.clearTimeout(hideTimer.current);
+      if (resizeTimer.current) window.clearTimeout(resizeTimer.current);
       setChromeHidden(false);
     };
   }, [wakeChrome, setChromeHidden]);
+
+  useEffect(() => {
+    const onScaleActivity = () => {
+      resizingUiRef.current = true;
+      setChromeVisible(true);
+      setChromeHidden(pipMode);
+      if (hideTimer.current) window.clearTimeout(hideTimer.current);
+      if (resizeTimer.current) window.clearTimeout(resizeTimer.current);
+      resizeTimer.current = window.setTimeout(() => {
+        resizingUiRef.current = false;
+        wakeChrome();
+      }, UI_SCALE_RESIZE_HOLD_MS);
+    };
+    window.addEventListener(UI_SCALE_ACTIVITY_EVENT, onScaleActivity);
+    return () => {
+      window.removeEventListener(UI_SCALE_ACTIVITY_EVENT, onScaleActivity);
+      if (resizeTimer.current) window.clearTimeout(resizeTimer.current);
+    };
+  }, [pipMode, setChromeHidden, wakeChrome]);
 
   useEffect(() => {
     const onLeave = (e: MouseEvent) => {

--- a/src/views/settings/hotkeys-panel.tsx
+++ b/src/views/settings/hotkeys-panel.tsx
@@ -127,6 +127,13 @@ export function HotkeysPanel() {
                       />
                     );
                   })}
+                  {scope === "Global" && groupName === "Interface" && (
+                    <ReadOnlyHotkeyRow
+                      label={t("Adjust interface scale with wheel")}
+                      description={t("Hold Ctrl or Cmd and scroll to resize Harbor's interface smoothly.")}
+                      binding="Ctrl / ⌘ + Scroll"
+                    />
+                  )}
                 </div>
               ))}
             </div>
@@ -134,6 +141,30 @@ export function HotkeysPanel() {
         );
       })}
     </>
+  );
+}
+
+function ReadOnlyHotkeyRow({
+  label,
+  description,
+  binding,
+}: {
+  label: string;
+  description: string;
+  binding: string;
+}) {
+  const t = useT();
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-edge-soft bg-canvas/40 px-4 py-3">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-[14px] font-medium text-ink">{label}</span>
+        <span className="text-[12.5px] text-ink-subtle">{description}</span>
+      </div>
+      <div className="flex h-8 min-w-[128px] items-center justify-center rounded-lg border border-edge bg-elevated px-3 text-[12.5px] font-semibold text-ink">
+        {binding}
+      </div>
+      <span className="sr-only">{t("Fixed shortcut")}</span>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds browser-like interface scaling shortcuts that reuse Harbor’s existing `uiScale` setting.

- `Ctrl/Cmd + +` increases interface scale
- `Ctrl/Cmd + -` decreases interface scale
- `Ctrl/Cmd + scroll wheel` adjusts interface scale a
- `Ctrl/Cmd + 0` resets interface scale outside playback
- Adds the keyboard shortcuts to Settings → Shortcuts under Global → Interface
- Keeps player controls visible while resizing in playback
- Prevents `Ctrl/Cmd + scroll wheel` from also changing player volume

## Notes

This uses the existing `uiScale` setting and clamps to the current Settings slider range of 80% to 160%. No new persistence or scaling system was added.

During playback, interface-scale reset is intentionally disabled so the existing player shortcut `Ctrl + 0` can continue to turn Anime4K off. Scale up/down and scroll-wheel scaling still work in playback.

The keyboard shortcuts are shown in Settings → Shortcuts and can be rebound. The wheel gesture is shown as a fixed shortcut because the current hotkey recorder only captures keyboard input.

## Test Plan

- Ran `pnpm build`
- Verified TypeScript and Vite production build complete successfully
- Manually checked expected behavior for scale increase, decrease, reset, and scroll-wheel scaling
- Confirmed `Ctrl/Cmd + scroll wheel` does not also change player volume
- Confirmed interface-scale reset does not intercept `Ctrl + 0` during playback



https://github.com/user-attachments/assets/d575f45e-ab72-41f7-8793-31522f2f69f0


https://github.com/user-attachments/assets/e0c19d21-6cbe-4db0-889a-5011b651e02c

