### PR TITLE
fix: harden seek bar interactions and prevent update loop

### DIFF
--- a/src/components/player/transport/seek-bar.tsx
+++ b/src/components/player/transport/seek-bar.tsx
@@ -12,6 +12,7 @@ import { SeekBarVisual } from "./seek-bar-visual";
 import { fmtTime } from "./transport-utils";
 
 const BUFFER_PAD_SEC = 4;
+const PENDING_MAX_MS = 2500;
 
 export function SeekBar({
   durationSec,
@@ -26,9 +27,12 @@ export function SeekBar({
   const [hover, setHover] = useState<number | null>(null);
   const [scrub, setScrub] = useState<number | null>(null);
   const [pending, setPending] = useState<number | null>(null);
+  const pendingAtRef = useRef<number | null>(null);
+  const positionRef = useRef(0);
   const { settings } = useSettings();
   const { active: trickplayActive, bufferedOnly } = useTrickplayState();
   const position = usePlaybackPositionGated(active);
+  positionRef.current = position;
   const buffered = usePlaybackBufferedGated(active);
   const dur = durationSec || 1;
   const value = scrub ?? pending ?? position;
@@ -43,14 +47,50 @@ export function SeekBar({
       color: s.kind === "ad" ? "rgba(239,68,68,0.9)" : undefined,
     }));
 
+  const clearInteraction = () => {
+    setScrub(null);
+    setHover(null);
+  };
+
   useEffect(() => {
     setSeekHovering(hover != null || scrub != null);
   }, [hover, scrub]);
   useEffect(() => () => setSeekHovering(false), []);
   useEffect(() => {
+    const clearInterruptedInteraction = () => {
+      setScrub(null);
+      setHover(null);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") clearInterruptedInteraction();
+    };
+    window.addEventListener("blur", clearInterruptedInteraction);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("blur", clearInterruptedInteraction);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+  useEffect(() => {
     if (pending == null) return;
-    if (Math.abs(position - pending) < 0.75) setPending(null);
-  }, [pending, position]);
+    const startedAt = pendingAtRef.current ?? Date.now();
+    pendingAtRef.current = startedAt;
+    const clear = () => {
+      setPending(null);
+      pendingAtRef.current = null;
+    };
+    if (Math.abs(positionRef.current - pending) < 0.75 || Date.now() - startedAt >= PENDING_MAX_MS) {
+      clear();
+      return;
+    }
+    const interval = window.setInterval(() => {
+      if (Math.abs(positionRef.current - pending) < 0.75 || Date.now() - startedAt >= PENDING_MAX_MS) {
+        clearInterval(interval);
+        clear();
+      }
+    }, 100);
+    return () => clearInterval(interval);
+  }, [pending]);
 
   const fromEvent = (clientX: number): number => {
     const r = ref.current?.getBoundingClientRect();
@@ -64,16 +104,23 @@ export function SeekBar({
     if (scrub != null) setScrub(fromEvent(e.clientX));
   };
   const onLeave = () => setHover(null);
+  const onCancel = () => clearInteraction();
   const onDown = (e: React.PointerEvent) => {
-    e.currentTarget.setPointerCapture(e.pointerId);
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {}
     setPending(null);
+    pendingAtRef.current = null;
     setScrub(fromEvent(e.clientX));
   };
   const onUp = (e: React.PointerEvent) => {
-    e.currentTarget.releasePointerCapture(e.pointerId);
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {}
     if (scrub != null) {
       onSeek(scrub);
       setPending(scrub);
+      pendingAtRef.current = Date.now();
     }
     setScrub(null);
   };
@@ -86,6 +133,7 @@ export function SeekBar({
         onPointerLeave={onLeave}
         onPointerDown={onDown}
         onPointerUp={onUp}
+        onPointerCancel={onCancel}
         className="absolute inset-x-0 top-1/2 -translate-y-1/2 cursor-pointer"
       >
         <SeekBarVisual


### PR DESCRIPTION
## Summary

This PR fixes four distinct seek bar bugs in `src/components/player/transport/seek-bar.tsx` that affected desktop (Windows and macOS) builds.

## Bugs Fixed

### 1. Infinite pending state (stuck seek dot)
**Problem:** After seeking, the `pending` state was only cleared when `Math.abs(position - pending) < 0.75`. If the player took longer to report the target position (slow seek, buffering, or dropped precision updates), `pending` never cleared and the seek dot stayed frozen indefinitely while time/buffer continued.

**Fix:** Added a 2.5-second failsafe (`PENDING_MAX_MS`). When `pending` is set, an interval checks every 100ms whether playback caught up or the timeout elapsed, then clears `pending`. A `pendingAtRef` timestamp ensures accurate elapsed tracking.

### 2. Ghost scrubbing after Alt+Tab / Cmd+Tab
**Problem:** When a drag was interrupted by an OS focus change (Windows `Alt+Tab`, macOS `Cmd+Tab`), the browser often fired `blur` or `visibilitychange` instead of a reliable `pointercancel`/`pointerup`. The `scrub` state was never cleared, so the seek dot kept following the cursor after the user returned to the app.

**Fix:** Added a `useEffect` that listens for `window.blur` and `document.visibilitychange` and clears both `scrub` and `hover` when the app loses focus or becomes hidden. Also added `onPointerCancel` to the JSX for environments that do fire it.

### 3. Unhandled pointer capture exception (app crash)
**Problem:** `setPointerCapture` and `releasePointerCapture` were called directly. In some embedded WebView or multi-touch environments these can throw a `DOMException`, which bubbled through the React event handler and crashed the component tree.

**Fix:** Both calls are now wrapped in `try/catch` blocks.

### 4. Maximum update depth exceeded (React infinite loop)
**Problem:** The pending cleanup `useEffect` had `position` in its dependency array. Since `position` updates on every playback frame, the effect re-ran constantly. When combined with frequent subtitle autoload state updates from `use-track-autoload.ts`, this created a tight re-render loop: effect fires → `setPending` → re-render → effect fires again → `Maximum update depth exceeded` crash.

**Fix:** Introduced a `positionRef` that mirrors the latest `position` without triggering re-renders. The pending cleanup effect now depends only on `pending` and reads `positionRef.current` inside an interval, breaking the render loop entirely.

## Changes

Only one file is modified: `src/components/player/transport/seek-bar.tsx`

```
+const PENDING_MAX_MS = 2500;
+const pendingAtRef = useRef<number | null>(null);
+const positionRef = useRef(0);
+positionRef.current = position;
+const clearInteraction = () => { setScrub(null); setHover(null); };
+useEffect(... blur/visibilitychange cleanup ...)
+useEffect(... pending interval with positionRef ...)
+const onCancel = () => clearInteraction();
+try { setPointerCapture } catch {}
+try { releasePointerCapture } catch {}
+onPointerCancel={onCancel}
```

## Verification

- `pnpm build` passes (TypeScript + Vite production build).
- No new dependencies or config changes.
- Tested with real playback and subtitle sync spam.

## Testing (Windows / macOS)

1. **Pending state:** Click far on the seek bar with a slow stream. Dot recovers within ~2.5s even if player doesn't report the exact target.
2. **Ghost scrubbing:** Hold-drag the seek bar, `Alt+Tab`/`Cmd+Tab` away, release, return. Dot does not follow cursor.
3. **Pointer crash:** Override `setPointerCapture` to throw in DevTools. Clicking seek bar does not crash the app.
4. **Update loop:** Play a movie with subtitle autoload active. No `Maximum update depth exceeded` errors.