### PR TITLE
fix: harden seek bar interactions and prevent update loop

### DIFF
--- a/src/components/player/transport/seek-bar.tsx
+++ b/src/components/player/transport/seek-bar.tsx
@@ -12,6 +12,7 @@ import { SeekBarVisual } from "./seek-bar-visual";
 import { fmtTime } from "./transport-utils";
 
 const BUFFER_PAD_SEC = 4;
+const PENDING_MAX_MS = 2500;
 
 export function SeekBar({
   durationSec,
@@ -26,6 +27,8 @@ export function SeekBar({
   const [hover, setHover] = useState<number | null>(null);
   const [scrub, setScrub] = useState<number | null>(null);
   const [pending, setPending] = useState<number | null>(null);
+  const pendingAtRef = useRef<number | null>(null);
+  const positionRef = useRef(0);
   const { settings } = useSettings();
   const { active: trickplayActive, bufferedOnly } = useTrickplayState();
   const position = usePlaybackPositionGated(active);
@@ -43,14 +46,50 @@ export function SeekBar({
       color: s.kind === "ad" ? "rgba(239,68,68,0.9)" : undefined,
     }));
 
+  const clearInteraction = () => {
+    setScrub(null);
+    setHover(null);
+  };
+
   useEffect(() => {
     setSeekHovering(hover != null || scrub != null);
   }, [hover, scrub]);
   useEffect(() => () => setSeekHovering(false), []);
   useEffect(() => {
+    positionRef.current = position;
+  }, [position]);
+  useEffect(() => {
+    const clearInterruptedInteraction = () => {
+      setScrub(null);
+      setHover(null);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") clearInterruptedInteraction();
+    };
+    window.addEventListener("blur", clearInterruptedInteraction);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("blur", clearInterruptedInteraction);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+  useEffect(() => {
     if (pending == null) return;
-    if (Math.abs(position - pending) < 0.75) setPending(null);
-  }, [pending, position]);
+    let frameId: number;
+    const check = () => {
+      if (
+        Math.abs(positionRef.current - pending) < 0.75 ||
+        Date.now() - (pendingAtRef.current ?? 0) >= PENDING_MAX_MS
+      ) {
+        setPending(null);
+        pendingAtRef.current = null;
+      } else {
+        frameId = requestAnimationFrame(check);
+      }
+    };
+    frameId = requestAnimationFrame(check);
+    return () => cancelAnimationFrame(frameId);
+  }, [pending]);
 
   const fromEvent = (clientX: number): number => {
     const r = ref.current?.getBoundingClientRect();
@@ -64,16 +103,23 @@ export function SeekBar({
     if (scrub != null) setScrub(fromEvent(e.clientX));
   };
   const onLeave = () => setHover(null);
+  const onCancel = () => clearInteraction();
   const onDown = (e: React.PointerEvent) => {
-    e.currentTarget.setPointerCapture(e.pointerId);
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {}
     setPending(null);
+    pendingAtRef.current = null;
     setScrub(fromEvent(e.clientX));
   };
   const onUp = (e: React.PointerEvent) => {
-    e.currentTarget.releasePointerCapture(e.pointerId);
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {}
     if (scrub != null) {
       onSeek(scrub);
       setPending(scrub);
+      pendingAtRef.current = Date.now();
     }
     setScrub(null);
   };
@@ -86,6 +132,7 @@ export function SeekBar({
         onPointerLeave={onLeave}
         onPointerDown={onDown}
         onPointerUp={onUp}
+        onPointerCancel={onCancel}
         className="absolute inset-x-0 top-1/2 -translate-y-1/2 cursor-pointer"
       >
         <SeekBarVisual


### PR DESCRIPTION
## Summary

This PR fixes four distinct seek bar bugs in `src/components/player/transport/seek-bar.tsx` that affected desktop (Windows and macOS) builds.

## Bugs Fixed

### 1. Infinite pending state (stuck seek dot)
**Problem:** After seeking, the `pending` state was only cleared when `Math.abs(position - pending) < 0.75`. If the player took longer to report the target position (slow seek, buffering, or dropped precision updates), `pending` never cleared and the seek dot stayed frozen indefinitely while time/buffer continued.

**Before fix (screenshot below):** The seek dot is stuck at an old position while the elapsed time and buffer line continue moving forward. This happens intermittently — not on every seek, but frequently enough during rapid subtitle sync adjustments and slow/high-latency streams.

<img width="550" height="166" alt="IMG_0780" src="https://github.com/user-attachments/assets/3f1a2b3d-86cc-4559-8dae-170c9e51497b" />

> _The screenshot showing the stuck seek dot (before fix) will be attached by the author below._

**Fix:** Added a 2.5-second failsafe (`PENDING_MAX_MS`). When `pending` is set, a `requestAnimationFrame` loop checks on every display frame whether playback caught up or the timeout elapsed, then clears `pending`. A `pendingAtRef` timestamp ensures accurate elapsed tracking.

### 2. Ghost scrubbing after Alt+Tab / Cmd+Tab
**Problem:** When a drag was interrupted by an OS focus change (Windows `Alt+Tab`, macOS `Cmd+Tab`), the browser often fired `blur` or `visibilitychange` instead of a reliable `pointercancel`/`pointerup`. The `scrub` state was never cleared, so the seek dot kept following the cursor after the user returned to the app.

**Status:** Tested and fixed on desktop builds. No visible UI change — the dot simply stops tracking after focus loss as expected.

**Fix:** Added a `useEffect` that listens for `window.blur` and `document.visibilitychange` and clears both `scrub` and `hover` when the app loses focus or becomes hidden. Also added `onPointerCancel` to the JSX for environments that do fire it.

### 3. Unhandled pointer capture exception (app crash)
**Problem:** `setPointerCapture` and `releasePointerCapture` were called directly. In some embedded WebView or multi-touch environments these can throw a `DOMException`, which bubbled through the React event handler and crashed the component tree.

**Status:** Tested and fixed on desktop builds. No visible UI change — the seek bar continues working instead of crashing.

**Fix:** Both calls are now wrapped in `try/catch` blocks.

### 4. Maximum update depth exceeded (React infinite loop)
**Problem:** The pending cleanup `useEffect` had `position` in its dependency array. Since `position` updates on every playback frame, the effect re-ran constantly. When combined with frequent subtitle autoload state updates from `use-track-autoload.ts`, this created a tight re-render loop: effect fires → `setPending` → re-render → effect fires again → `Maximum update depth exceeded` crash.

**Status:** Discovered while testing bug 3. The crash was triggered during subtitle autoload background activity and steady-state playback without user interaction.

**Fix:** Introduced a `positionRef` that mirrors the latest `position` without triggering re-renders. The pending cleanup effect now depends only on `pending` and reads `positionRef.current` inside a `requestAnimationFrame` loop, breaking the render loop entirely.

## Changes

Only one file is modified: `src/components/player/transport/seek-bar.tsx`

| Change | Bug |
|--------|-----|
| `PENDING_MAX_MS` constant + `requestAnimationFrame`-based pending cleanup | 1, 4 |
| `positionRef` (updated in `useEffect`) to decouple effect from `position` re-renders | 4 |
| `pendingAtRef` timestamp tracking | 1 |
| `onPointerCancel` handler + `clearInteraction` | 2 |
| `window.blur` / `visibilitychange` cleanup effect | 2 |
| `try/catch` around `setPointerCapture` / `releasePointerCapture` | 3 |

## Verification

- `pnpm build` passes (TypeScript + Vite production build).
- No new dependencies or config changes.
- Bug 1: tested with real playback — seek dot recovers within ~2.5s even on slow streams. Confirmed the "stuck dot" no longer occurs.
- Bug 2: tested on desktop — `Alt+Tab`/`Cmd+Tab` during drag no longer leaves ghost scrubbing.
- Bug 3: tested by forcing `setPointerCapture` to throw — no app crash.
- Bug 4: tested during subtitle autoload activity — no `Maximum update depth exceeded` errors.

## Notes

- Bug 1 is intermittent (does not reproduce on every seek), which is consistent with the root cause: `pending` only gets stuck when the player fails to report a position within 0.75s of the seek target.
- The fix for bug 4 was discovered while testing bug 3 — the `Maximum update depth exceeded` crash appeared in logs during steady-state playback with active subtitle autoload.