### PR TITLE
fix(player): keep fullscreen when exiting the player

### DIFF
--- a/src/views/player/hooks/use-fullscreen.ts
+++ b/src/views/player/hooks/use-fullscreen.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import {
-  exitWindowFullscreen,
   getWindowFullscreen,
   setWindowFullscreen,
   subscribeFullscreen,
@@ -11,13 +10,6 @@ export function useFullscreen() {
   const [fullscreen, setFullscreen] = useState(getWindowFullscreen);
 
   useEffect(() => subscribeFullscreen(() => setFullscreen(getWindowFullscreen())), []);
-
-  useEffect(
-    () => () => {
-      void exitWindowFullscreen();
-    },
-    [],
-  );
 
   useEffect(() => {
     const onChange = () => {

--- a/src/views/player/hooks/use-player-exit.ts
+++ b/src/views/player/hooks/use-player-exit.ts
@@ -4,7 +4,6 @@ import { clearPlayback, readPlayback, savePlayback, streamMatchesEntry } from "@
 import type { PlayerBridge } from "@/lib/player/bridge";
 import { getPlaybackPosition } from "@/lib/player/playback-clock";
 import { saveResumeMs } from "@/lib/resume";
-import { exitWindowFullscreen } from "@/lib/fullscreen-state";
 import type { PartialSyncState } from "@/lib/together/provider";
 import { useView, type PlayerSrc, type PlayerStreamRef } from "@/lib/view";
 import { MAX_AUTORETRY_ATTEMPTS } from "../player-utils";
@@ -68,7 +67,6 @@ export function usePlayerExit(params: {
     }
     await exitPip();
     if (castActiveRef.current) await stopCast().catch(() => {});
-    await exitWindowFullscreen();
     if (inRoom && isHost) {
       publishState({
         mediaId: null,


### PR DESCRIPTION
## Problem

When the app is in fullscreen and you start playing something, pressing **Back** or letting the video **finish** returns you to the browse UI — but also drops the window **out of fullscreen**. On macOS this is especially jarring because fullscreen is native (a separate Space with an animated transition).

## Root cause

Leaving the player force-exits window fullscreen in two places, and every exit path (back button, video-end auto-return, Esc-to-close) funnels through them:

- `closePlayer()` in `src/views/player/hooks/use-player-exit.ts` called `exitWindowFullscreen()`.
- The player's `useFullscreen` hook (`src/views/player/hooks/use-fullscreen.ts`) repeated the exit in an unmount cleanup effect.

The player does **not** auto-enter fullscreen when it opens — it only *reasserts* fullscreen if you were already fullscreen. So force-exiting on close is an asymmetry with no matching enter, and the result is that returning to browse always loses fullscreen.

## Fix

Remove both fullscreen-exit calls so fullscreen persists when returning to the browse UI. `exitWindowFullscreen()` itself is left intact — only the two automatic call sites on player exit are removed.

## Behavior unchanged

- Manual fullscreen toggle (F key) still works.
- The `playerEscExitsFullscreen` setting still works: when enabled, Esc exits fullscreen and stays in the player.
- The `fullscreenchange` listener still syncs state if the OS/user exits fullscreen by other means.

## Test plan

While in fullscreen:

- [ ] Play a movie → press **Back** → stays fullscreen
- [ ] Play a movie → let it **finish** → auto-returns, stays fullscreen
- [ ] Press **F** in the player → exits fullscreen (manual)
- [ ] With `playerEscExitsFullscreen` ON → **Esc** exits fullscreen, stays in player; OFF → **Esc** closes player, stays fullscreen
- [ ] Episode auto-advance / next-episode still works
- [ ] `pnpm exec tsc -b` passes (verified locally)
