### PR TITLE
Feat: Mouse side button navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -402,7 +402,7 @@ function parseDeepLinkEpisode(videoId?: string): { season: number; episode: numb
 }
 
 function Shell() {
-  const { topKind, service, meta, metaLiveContext, metaEpisodeHint, episodeDetail, personId, collectionId, filter, grid, awardType, animeAwardSource, picker, player, setView, goBack, openMeta, stackKinds, chromeHidden } = useView();
+  const { topKind, service, meta, metaLiveContext, metaEpisodeHint, episodeDetail, personId, collectionId, filter, grid, awardType, animeAwardSource, picker, player, setView, canGoBack, goBack, canGoForward, goForward, openMeta, stackKinds, chromeHidden } = useView();
   const { settings, update } = useSettings();
   const uiScaleRef = useRef(settings.uiScale);
   const { activeProfile } = useProfiles();
@@ -422,6 +422,20 @@ function Shell() {
   useViewPreloader();
 
   useEffect(() => startMaintenance(), []);
+
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.button === 3 && canGoBack) {
+        e.preventDefault();
+        goBack();
+      } else if (e.button === 4 && canGoForward) {
+        e.preventDefault();
+        goForward();
+      }
+    };
+    window.addEventListener("mousedown", onMouseDown, true);
+    return () => window.removeEventListener("mousedown", onMouseDown, true);
+  }, [canGoBack, goBack, canGoForward, goForward]);
 
   useEffect(() => {
     uiScaleRef.current = settings.uiScale;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -425,9 +425,16 @@ function Shell() {
 
   useEffect(() => {
     const onMouseDown = (e: MouseEvent) => {
-      if (e.button === 3 && canGoBack) {
-        e.preventDefault();
-        goBack();
+      if (e.button === 3) {
+        const localBack = new Event("harbor:local-back", { cancelable: true });
+        if (!window.dispatchEvent(localBack)) {
+          e.preventDefault();
+          return;
+        }
+        if (canGoBack) {
+          e.preventDefault();
+          goBack();
+        }
       } else if (e.button === 4 && canGoForward) {
         e.preventDefault();
         goForward();

--- a/src/lib/view.tsx
+++ b/src/lib/view.tsx
@@ -170,6 +170,8 @@ type ViewValue = {
   openAddonDetail: (id: string) => void;
   canGoBack: boolean;
   goBack: () => void;
+  canGoForward: boolean;
+  goForward: () => void;
   exitPlayback: () => void;
   exitPickerToDetail: (m: Meta) => void;
   exitPlayer: () => void;
@@ -284,6 +286,11 @@ function lastOfKind<K extends Frame["kind"]>(
 
 export function ViewProvider({ children }: { children: ReactNode }) {
   const [stack, setStack] = useState<Frame[]>([{ kind: "home" }]);
+  const [forwardStack, setForwardStack] = useState<Frame[]>([]);
+  const stackRef = useRef(stack);
+  const forwardStackRef = useRef(forwardStack);
+  stackRef.current = stack;
+  forwardStackRef.current = forwardStack;
   const [chromeHidden, setChromeHidden] = useState(false);
   const [homeResetTick, setHomeResetTick] = useState(0);
   const scrollMem = useRef<Map<string, ScrollSnapshot>>(new Map());
@@ -371,21 +378,52 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       : null;
   const player = top.kind === "player" ? top.src : null;
   const canGoBack = stack.length > 1;
+  const canGoForward = forwardStack.length > 0;
 
   const pop = useCallback(() => {
-    setStack((s) => (s.length > 1 ? s.slice(0, -1) : s));
+    const cur = stackRef.current;
+    if (cur.length <= 1) return;
+    const nextStack = cur.slice(0, -1);
+    const nextForwardStack = pushFrame(forwardStackRef.current, cur[cur.length - 1]);
+    stackRef.current = nextStack;
+    forwardStackRef.current = nextForwardStack;
+    setStack(nextStack);
+    setForwardStack(nextForwardStack);
   }, []);
 
+  const goForward = useCallback(() => {
+    const curForward = forwardStackRef.current;
+    const nextFrame = curForward[curForward.length - 1];
+    if (!nextFrame) return;
+    const nextForwardStack = curForward.slice(0, -1);
+    const nextStack = pushFrame(stackRef.current, nextFrame);
+    stackRef.current = nextStack;
+    forwardStackRef.current = nextForwardStack;
+    setStack(nextStack);
+    setForwardStack(nextForwardStack);
+  }, []);
+
+  const clearForwardStack = useCallback(() => {
+    if (forwardStackRef.current.length === 0) return;
+    forwardStackRef.current = [];
+    setForwardStack([]);
+  }, []);
+
+  const setNavStack = useCallback((updater: (s: Frame[]) => Frame[]) => {
+    clearForwardStack();
+    setStack(updater);
+  }, [clearForwardStack]);
+
   const exitPlayback = useCallback(() => {
-    setStack((s) => {
+    setNavStack((s) => {
       let i = s.length - 1;
       while (i > 0 && (s[i].kind === "player" || s[i].kind === "picker")) i--;
       return s.slice(0, i + 1);
     });
-  }, []);
+  }, [setNavStack]);
 
   const exitPickerToDetail = useCallback((m: Meta) => {
-    setStack((s) => {
+    setNavStack((s) => {
       let i = s.length - 1;
       while (i > 0 && (s[i].kind === "player" || s[i].kind === "picker")) i--;
       const base = s.slice(0, i + 1);
@@ -393,10 +431,10 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       if (top && top.kind === "meta") return base;
       return [...base, { kind: "meta", meta: m }];
     });
-  }, []);
+  }, [setNavStack]);
 
   const exitPlayer = useCallback(() => {
-    setStack((s) => {
+    setNavStack((s) => {
       let i = s.length - 1;
       while (i > 0 && s[i].kind === "player") i--;
       const next = s.slice(0, i + 1);
@@ -406,7 +444,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       }
       return next;
     });
-  }, []);
+  }, [setNavStack]);
 
   const [sectionReq, setSectionReq] = useState<{ section: SettingsSection | null; nonce: number }>({
     section: null,
@@ -428,7 +466,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       window.requestAnimationFrame(fireScrollTop);
       window.setTimeout(fireScrollTop, 60);
     }
-    setStack((s) => {
+    setNavStack((s) => {
       const t = s[s.length - 1];
       if (v === "home") {
         scrollMem.current.clear();
@@ -493,35 +531,35 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       if (t.kind === "settings") return s;
       return pushFrame(s, { kind: "settings" });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openSettings = useCallback((section?: SettingsSection) => {
     setSectionReq((r) => ({ section: section ?? null, nonce: r.nonce + 1 }));
-    setStack((s) => {
+    setNavStack((s) => {
       const t = s[s.length - 1];
       if (t.kind === "settings") return s;
       return pushFrame(s, { kind: "settings" });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openService = useCallback((s: StreamingService | null) => {
     if (s === null) {
-      setStack((cur) => {
+      setNavStack((cur) => {
         scrollMem.current.clear();
         rowScrollMem.current.clear();
         return cur.length === 1 && cur[0].kind === "home" ? cur : [{ kind: "home" }];
       });
       return;
     }
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (t.kind === "service" && t.service === s) return cur;
       return pushFrame(cur, { kind: "service", service: s });
     });
-  }, []);
+  }, [setNavStack]);
 
   const promoteMetaToRoot = useCallback(() => {
-    setStack((s) => {
+    setNavStack((s) => {
       if (s.length === 0) return s;
       const top = s[s.length - 1];
       if (top.kind !== "meta") return s;
@@ -532,15 +570,15 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       else root = { kind: "movies" };
       return [root, { kind: "meta", meta: m }];
     });
-  }, []);
+  }, [setNavStack]);
 
   const openMeta = useCallback(
     (m: Meta | null, opts?: { liveContext?: boolean; episodeHint?: { season: number; episode: number } }) => {
       if (m === null) {
-        setStack((s) => (s.length > 1 ? s.slice(0, -1) : s));
+        setNavStack((s) => (s.length > 1 ? s.slice(0, -1) : s));
         return;
       }
-      setStack((cur) => {
+      setNavStack((cur) => {
         const t = cur[cur.length - 1];
         if (t.kind === "meta" && t.meta.id === m.id) return cur;
         trackEvent(m.id, "open", profileFromMeta(m));
@@ -552,48 +590,48 @@ export function ViewProvider({ children }: { children: ReactNode }) {
         });
       });
     },
-    [],
+    [setNavStack],
   );
 
   const openPerson = useCallback((id: number | null) => {
     if (id === null) {
-      setStack((s) => (s.length > 1 ? s.slice(0, -1) : s));
+      setNavStack((s) => (s.length > 1 ? s.slice(0, -1) : s));
       return;
     }
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (t.kind === "person" && t.id === id) return cur;
       return pushFrame(cur, { kind: "person", id });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openQueue = useCallback(() => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (t.kind === "queue") return cur;
       return pushFrame(cur, { kind: "queue" });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openCollection = useCallback((id: number) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (t.kind === "collection" && t.id === id) return cur;
       return pushFrame(cur, { kind: "collection", id });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openMatchDetail = useCallback((game: SportsGame) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (t.kind === "match-detail" && t.game.id === game.id) return cur;
       return pushFrame(cur, { kind: "match-detail", game });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openEpisodeDetail = useCallback(
     (seriesId: string, season: number, episode: number, seriesMeta?: Meta) => {
-      setStack((cur) => {
+      setNavStack((cur) => {
         const t = cur[cur.length - 1];
         if (
           t.kind === "episode-detail" &&
@@ -606,27 +644,27 @@ export function ViewProvider({ children }: { children: ReactNode }) {
         return pushFrame(cur, { kind: "episode-detail", seriesId, season, episode, seriesMeta });
       });
     },
-    [],
+    [setNavStack],
   );
 
   const openAward = useCallback((t: import("./providers/wikidata").AwardType) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const top = cur[cur.length - 1];
       if (top.kind === "award" && top.awardType === t) return cur;
       return pushFrame(cur, { kind: "award", awardType: t });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openAnimeAward = useCallback((s: import("./anime-awards").AwardSourceId) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const top = cur[cur.length - 1];
       if (top.kind === "anime-award" && top.sourceId === s) return cur;
       return pushFrame(cur, { kind: "anime-award", sourceId: s });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openFilter = useCallback((f: MetaFilter) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (
         t.kind === "filter" &&
@@ -638,28 +676,28 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       }
       return pushFrame(cur, { kind: "filter", filter: f });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openGrid = useCallback((g: GridSpec) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (t.kind === "grid" && t.grid.title === g.title) return cur;
       return pushFrame(cur, { kind: "grid", grid: g });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openCollections = useCallback(() => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const t = cur[cur.length - 1];
       if (t.kind === "collections") return cur;
       return pushFrame(cur, { kind: "collections" });
     });
-  }, []);
+  }, [setNavStack]);
 
   const openPicker = useCallback(
     (m: Meta, ep?: PlayEpisode, opts?: { autoPlay?: boolean; attempt?: number; intent?: "play" | "download"; resume?: boolean }) => {
       if (opts?.autoPlay && getWindowFullscreen()) suppressFullscreenExitOnce();
-      setStack((cur) => {
+      setNavStack((cur) => {
         const t = cur[cur.length - 1];
         if (
           t.kind === "picker" &&
@@ -680,7 +718,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
         });
       });
     },
-    [],
+    [setNavStack],
   );
 
   const together = useTogether();
@@ -695,35 +733,35 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       setPendingLiveSrc(src);
       return;
     }
-    setStack((cur) => pushFrame(cur, { kind: "player", src }));
-  }, []);
+    setNavStack((cur) => pushFrame(cur, { kind: "player", src }));
+  }, [setNavStack]);
 
   const confirmLeavePartyForLive = useCallback(() => {
     const src = pendingLiveSrcRef.current;
     setPendingLiveSrc(null);
     if (!src) return;
     togetherRef.current.leaveSession();
-    setStack((cur) => pushFrame(cur, { kind: "player", src }));
-  }, []);
+    setNavStack((cur) => pushFrame(cur, { kind: "player", src }));
+  }, [setNavStack]);
 
   const cancelLeavePartyForLive = useCallback(() => setPendingLiveSrc(null), []);
 
   const replacePlayerSrc = useCallback((src: PlayerSrc) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const top = cur[cur.length - 1];
       if (top.kind !== "player") return cur;
       return [...cur.slice(0, -1), { kind: "player", src }];
     });
-  }, []);
+  }, [setNavStack]);
 
   const openAddonDetail = useCallback((id: string) => {
-    setStack((cur) => {
+    setNavStack((cur) => {
       const top = cur[cur.length - 1];
       if (top.kind === "addon-detail" && top.id === id) return cur;
       if (top.kind === "addon-detail") return [...cur.slice(0, -1), { kind: "addon-detail", id }];
       return pushFrame(cur, { kind: "addon-detail", id });
     });
-  }, []);
+  }, [setNavStack]);
 
   const addonDetailId = top.kind === "addon-detail" ? top.id : null;
 
@@ -778,6 +816,8 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       openAddonDetail,
       canGoBack,
       goBack: pop,
+      canGoForward,
+      goForward,
       exitPlayback,
       exitPickerToDetail,
       exitPlayer,
@@ -811,6 +851,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       picker,
       player,
       canGoBack,
+      canGoForward,
       setView,
       openSettings,
       sectionReq,
@@ -831,6 +872,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       confirmLeavePartyForLive,
       cancelLeavePartyForLive,
       pop,
+      goForward,
       exitPlayback,
       exitPickerToDetail,
       exitPlayer,

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -59,7 +59,6 @@ import { isTitleUpcoming } from "./detail/helpers";
 import { HeroAwardsCorner } from "./detail/hero-awards";
 import { CrunchyrollAwardsCorner } from "./detail/crunchyroll-corner";
 import { findAnyAwardWins, parseAwardYear } from "@/lib/anime-awards";
-import { LazyMount } from "@/components/lazy-mount";
 
 function animeAwardLookupName(
   releaseYear: number | undefined,

--- a/src/views/live.tsx
+++ b/src/views/live.tsx
@@ -121,6 +121,21 @@ export function LiveView({ active }: { active: boolean }) {
     setModeState(m);
     writeMode(m);
   }, []);
+  const goLiveHome = useCallback(() => {
+    setMode("home");
+    setQuery("");
+    setGroup(favoritesCountRef.current > 0 ? FAVORITES_GROUP_KEY : null);
+  }, [setMode]);
+  useEffect(() => {
+    if (!active) return;
+    const onLocalBack = (e: Event) => {
+      if (mode === "home" && !query && group === (favoritesCountRef.current > 0 ? FAVORITES_GROUP_KEY : null)) return;
+      e.preventDefault();
+      goLiveHome();
+    };
+    window.addEventListener("harbor:local-back", onLocalBack);
+    return () => window.removeEventListener("harbor:local-back", onLocalBack);
+  }, [active, goLiveHome, group, mode, query]);
   const [immersive, setImmersive] = useState(false);
   useEffect(() => {
     const onImm = (e: Event) => setImmersive((e as CustomEvent<boolean>).detail === true);

--- a/src/views/live.tsx
+++ b/src/views/live.tsx
@@ -66,7 +66,7 @@ function writeMode(m: ViewMode) {
 export function LiveView({ active }: { active: boolean }) {
   const t = useT();
   const { settings } = useSettings();
-  const { openMeta } = useView();
+  const { openMeta, setView } = useView();
   const sources = settings.iptvPlaylists;
 
   const [activeId, setActiveId] = useState<string | null>(() => readActiveId());
@@ -129,13 +129,18 @@ export function LiveView({ active }: { active: boolean }) {
   useEffect(() => {
     if (!active) return;
     const onLocalBack = (e: Event) => {
+      if (sources.length === 0) {
+        e.preventDefault();
+        setView("home");
+        return;
+      }
       if (mode === "home" && !query && group === (favoritesCountRef.current > 0 ? FAVORITES_GROUP_KEY : null)) return;
       e.preventDefault();
       goLiveHome();
     };
     window.addEventListener("harbor:local-back", onLocalBack);
     return () => window.removeEventListener("harbor:local-back", onLocalBack);
-  }, [active, goLiveHome, group, mode, query]);
+  }, [active, goLiveHome, group, mode, query, setView, sources.length]);
   const [immersive, setImmersive] = useState(false);
   useEffect(() => {
     const onImm = (e: Event) => setImmersive((e as CustomEvent<boolean>).detail === true);

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -355,6 +355,14 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     exitPlayback,
     openPicker,
   });
+  useEffect(() => {
+    const onLocalBack = (e: Event) => {
+      e.preventDefault();
+      void closePlayer();
+    };
+    window.addEventListener("harbor:local-back", onLocalBack);
+    return () => window.removeEventListener("harbor:local-back", onLocalBack);
+  }, [closePlayer]);
 
   const [dvrOpen, setDvrOpen] = useState(false);
   const pickAnotherOrGuide = useCallback(() => {


### PR DESCRIPTION
## Summary
Adds browser like mouse side button navigation that reuses Harbor's existing view stack.

Mouse back button goes back in app history
Mouse forward button restores the most recently backed out page
Live TV handles mouse back for grid, guide, multiview, search, category, and first run provider setup states
Playback handles mouse back through the existing player close path
Forward history is cleared when opening or replacing a page

## Notes
This uses standard WebView mouse button events: button 3 for back and button 4 for forward. No new dependency, native API, or platform specific mouse handling was added.

The forward behavior uses a small in memory stack on top of Harbor's existing view stack. When goBack pops a frame, that frame becomes available for goForward. When the user opens or replaces a page, forward history is cleared to match browser behavior.

Before falling back to app level history, the shell dispatches a cancelable local back event. This lets active views handle cleanup or internal state first.

The player consumes that local back event and calls the existing closePlayer path, so mouse back during playback still captures exit/resume state, exits PiP, stops casting, exits fullscreen, and clears/publishes party host state.

Live TV consumes local back for internal Live states that are not separate view stack pages. If Live TV is already at its home state, the event falls through to normal app history. The first run empty/provider setup flow exits Live back to Home.

Sidebar and tab navigation are intentionally not added to app history in this PR. This keeps the change focused on page level navigation and full page/internal flows that already behave like back targets.

## Discussion
This change intentionally does not include sidebar navigation.
I was not sure whether moving between sidebar destinations should be added to the app’s back/forward history, so I kept this PR focused on page level navigation and view states that already behave like back targets.
That avoids changing the sidebar UX in this PR and leaves that decision open for review.
