### PR TITLE
Fix poster cards rendering blank on older WebView2/Chromium (#403)

### DIFF
--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -248,7 +248,7 @@ export const PickCard = memo(function PickCard({
         data-preview-anchor
         onPointerEnter={(e) => hoverPreviewEnter(meta, e.currentTarget, e.buttons)}
         onPointerLeave={(e) => hoverPreviewLeave(e.currentTarget)}
-        className="relative transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0.24,1)] will-change-transform group-hover:[-webkit-transform:translate3d(0,-0.5rem,0)] group-hover:[transform:translate3d(0,-0.5rem,0)]"
+        className="relative w-full transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0.24,1)] will-change-transform group-hover:[-webkit-transform:translate3d(0,-0.5rem,0)] group-hover:[transform:translate3d(0,-0.5rem,0)]"
       >
         <Poster
           src={posterSrc}

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -105,10 +105,16 @@ export function usePosterChain(
   };
 }
 
-const ASPECT: Record<Ratio, string> = {
-  portrait: "aspect-[2/3]",
-  landscape: "aspect-[16/9]",
-  wide: "aspect-[16/7]",
+// Height is reserved with an in-flow padding spacer (see render below) instead of
+// relying solely on CSS `aspect-ratio`. Older WebView2/Chromium engines (≲124, e.g.
+// the 123.x runtime shipped on debloated Windows builds) fail to size `aspect-ratio`
+// grid items, collapsing every poster card to 0px height so artwork never shows.
+// The padding-top hack works identically on every engine.
+// https://github.com/harborstremio/harbor/issues/403
+const ASPECT_PAD: Record<Ratio, string> = {
+  portrait: "150%", // 3 / 2
+  landscape: "56.25%", // 9 / 16
+  wide: "43.75%", // 7 / 16
 };
 
 export function Poster({
@@ -198,9 +204,10 @@ export function Poster({
 
   return (
     <div
-      className={`harbor-poster your-card relative overflow-hidden rounded-[var(--poster-radius,12px)] ${ASPECT[ratio]} ${className}`}
+      className={`harbor-poster your-card relative w-full overflow-hidden rounded-[var(--poster-radius,12px)] ${className}`}
       style={showPlate ? { background: gradient(hue) } : undefined}
     >
+      <div aria-hidden style={{ paddingTop: ASPECT_PAD[ratio] }} />
       {current && (
         <img
           key={current}


### PR DESCRIPTION
## Summary

Fixes #403 — on some Windows machines **all poster artwork in the rails is blank** (only the hero/background and text render). It reproduces on **Chromium < ~124**, most commonly the **WebView2 `123.x` runtime that stays frozen on debloated Windows installs** (e.g. Windows builds with Edge/WebView2 auto-update stripped). Maintainers on a current engine can't reproduce it, which is why #403 was closed without a fix.

## Root cause

The poster `<img>` is `position: absolute`, so the card box has **zero intrinsic width**. The card's width was inherited from a parent flex item (`pick-card`'s wrapper) that relied on `align-items: stretch` to size itself.

Older Chromium **fails to stretch that flex item**, so it collapses to `width: 0` → `height: 0` (both `aspect-ratio` and any padding are width-relative), and every poster disappears. The hero and detail background are explicitly sized, so they were unaffected.

Verified by on-screen instrumentation on a real WebView2 `123.0.2420.97` runtime: the rail track measured `169px` columns and the image decoded fine (`naturalWidth=300`), but the card wrapper measured `width: 0`. After the fix the same wrapper measures `169px` and posters render.

## Fix

- `pick-card.tsx` — give the poster wrapper an explicit `w-full` so its width comes from the (definite) grid column instead of flex stretch.
- `poster.tsx` — `w-full` on `.harbor-poster` for the same robustness in other rails, and reserve card height with an in-flow padding spacer instead of `aspect-ratio` alone (works identically on modern engines, but degrades gracefully on very old ones).

No visual change on current engines; collapsed posters now render on old WebView2.

## Test plan

- Built a Windows x64 binary from this branch and ran it on the reporting machine's frozen **WebView2 123** runtime (no engine override): poster rails that were previously blank now render correctly.
- No behavior change observed on current Chromium.