### PR TITLE
build.rs: branch on target OS (not host) so Harbor can cross-compile

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -3,8 +3,13 @@ use std::path::PathBuf;
 fn main() {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    #[cfg(target_os = "windows")]
-    {
+    // Branch on the *target* OS, not the host. In a build script `cfg!(target_os)`
+    // reflects the machine running the build, which breaks cross-compilation
+    // (e.g. Linux -> Windows would take the Linux branch and fail to find libmpv).
+    // `CARGO_CFG_TARGET_OS` is the platform we're actually building for.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    if target_os == "windows" {
         let libmpv = manifest.join("libmpv");
         if libmpv.join("mpv.lib").exists() {
             println!("cargo:rustc-link-search=native={}", libmpv.display());
@@ -15,8 +20,7 @@ fn main() {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    {
+    if target_os == "macos" {
         let mut prefixes: Vec<String> = Vec::new();
         if let Ok(p) = std::env::var("HOMEBREW_PREFIX") {
             if !p.is_empty() {
@@ -48,8 +52,7 @@ fn main() {
         }
     }
 
-    #[cfg(target_os = "linux")]
-    {
+    if target_os == "linux" {
         let mut found = false;
         if let Ok(out) = std::process::Command::new("pkg-config")
             .args(["--variable=libdir", "mpv"])


### PR DESCRIPTION
## Summary

`src-tauri/build.rs` selects the libmpv linking strategy with `#[cfg(target_os = ...)]`. In a **build script**, those `cfg` checks evaluate for the **host** running the script, not the **target** being built. So cross-compiling (e.g. Linux → Windows with `cargo-xwin`) takes the *Linux* branch and panics with `libmpv not found` instead of using the bundled Windows import library — even though `src-tauri/libmpv/mpv.lib` is present.

This switches the OS selection to read `CARGO_CFG_TARGET_OS` (the actual compile target), so the correct branch runs when cross-compiling while native builds are unchanged.

## Why

Enables building Windows binaries from a Linux host / CI (cargo-xwin) without a Windows machine. I used this to produce a Windows x64 build for verifying #403 on an old WebView2 runtime.

## Test plan

- Linux → `x86_64-pc-windows-msvc` via `cargo-xwin`: previously failed in `build.rs`; now links against the bundled `mpv.lib` and produces `harbor.exe`.
- Native builds unaffected (the same branch runs because host == target).