### PR TITLE
feat(player): in-player song identification (Shazam-style) with AudD

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2028,6 +2028,7 @@ dependencies = [
  "futures-util",
  "gtk",
  "harbor-core",
+ "hound",
  "libc",
  "libmpv2",
  "libmpv2-sys",
@@ -2060,9 +2061,10 @@ dependencies = [
  "url",
  "uuid 1.23.1",
  "walkdir",
+ "wasapi",
  "webview2-com 0.37.0",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -2149,6 +2151,12 @@ checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
@@ -5586,7 +5594,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5675,7 +5683,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com 0.38.2",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5862,7 +5870,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -5983,7 +5991,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com 0.38.2",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6008,7 +6016,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com 0.38.2",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6767,6 +6775,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasapi"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6b03b82e419f186fcdc06ac6068621bdadc88b89b2612067f1c021ad2c9449"
+dependencies = [
+ "log",
+ "num-integer",
+ "widestring",
+ "windows 0.57.0",
+ "windows-core 0.57.0",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7013,10 +7034,10 @@ checksum = "b542b5cfbd9618c46c2784e4d41ba218c336ac70d44c55e47b251033e7d85601"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys 0.37.0",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -7027,10 +7048,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys 0.38.2",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -7051,7 +7072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae2d11c4a686e4409659d7891791254cf9286d3cfe0eef54df1523533d22295"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -7062,7 +7083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -7077,6 +7098,12 @@ dependencies = [
  "once_cell",
  "rustix 0.38.44",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -7126,6 +7153,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7148,12 +7185,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -7165,8 +7214,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -7185,9 +7234,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7247,6 +7318,15 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7706,7 +7786,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com 0.38.2",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ libmpv2-sys = "4"
 libc = "0.2"
 base64 = "0.22"
 png = "0.17"
+hound = "3.5"
 discord-rich-presence = "1.1"
 rust_cast = { path = "vendor/rust_cast", version = "0.20" }
 mdns-sd = "0.13"
@@ -49,6 +50,7 @@ url = "2"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dxgi", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_Diagnostics_ToolHelp", "Win32_System_SystemInformation"] }
 window-vibrancy = "0.6"
+wasapi = "0.15"
 webview2-com = "0.37"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ mod pip_mac;
 mod power;
 mod airplay;
 mod settings_store;
+mod song_id;
 mod stream_proxy;
 mod streams;
 mod stremio_auth;
@@ -613,6 +614,7 @@ pub fn run() {
             local_lib::harbor_scan_folder,
             tray::tray_set_prefs,
             stremio_auth::stremio_auth_start,
+            song_id::recognize_now_playing,
             deeplink_set_stremio,
             deeplink_is_stremio_registered,
         ])

--- a/src-tauri/src/song_id.rs
+++ b/src-tauri/src/song_id.rs
@@ -1,0 +1,156 @@
+#[cfg(windows)]
+use std::collections::VecDeque;
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct SongResult {
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub artwork: String,
+    pub link: String,
+}
+
+#[tauri::command]
+pub async fn recognize_now_playing(
+    api_token: String,
+    seconds: Option<u32>,
+) -> Result<Option<SongResult>, String> {
+    #[cfg(windows)]
+    {
+        let secs = seconds.unwrap_or(7).clamp(3, 15);
+        let (pcm, sample_rate, channels, bits) =
+            tauri::async_runtime::spawn_blocking(move || capture_loopback(secs))
+                .await
+                .map_err(|e| e.to_string())??;
+        let wav = pcm_to_wav(&pcm, sample_rate, channels, bits)?;
+        audd_recognize(wav, api_token).await
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (api_token, seconds);
+        Err("Song identification is only supported on Windows for now".into())
+    }
+}
+
+#[cfg(windows)]
+fn capture_loopback(seconds: u32) -> Result<(Vec<u8>, u32, u16, u16), String> {
+    use wasapi::*;
+    initialize_mta().ok().map_err(|e| format!("COM init failed: {e}"))?;
+
+    let sample_rate = 44100u32;
+    let channels = 2u16;
+    let bits = 16u16;
+
+    // Loopback = open the default *render* device, but initialize it for capture.
+    let device = get_default_device(&Direction::Render).map_err(|e| e.to_string())?;
+    let mut audio_client = device.get_iaudioclient().map_err(|e| e.to_string())?;
+
+    let format = WaveFormat::new(
+        bits as usize,
+        bits as usize,
+        &SampleType::Int,
+        sample_rate as usize,
+        channels as usize,
+        None,
+    );
+
+    let (_default_period, min_period) = audio_client.get_periods().map_err(|e| e.to_string())?;
+    audio_client
+        .initialize_client(&format, min_period, &Direction::Capture, &ShareMode::Shared, true)
+        .map_err(|e| e.to_string())?;
+
+    let h_event = audio_client.set_get_eventhandle().map_err(|e| e.to_string())?;
+    let capture_client = audio_client.get_audiocaptureclient().map_err(|e| e.to_string())?;
+    let blockalign = format.get_blockalign() as usize;
+
+    audio_client.start_stream().map_err(|e| e.to_string())?;
+
+    let target_bytes = sample_rate as usize * seconds as usize * blockalign;
+    let mut queue: VecDeque<u8> = VecDeque::new();
+    while queue.len() < target_bytes {
+        capture_client
+            .read_from_device_to_deque(&mut queue)
+            .map_err(|e| e.to_string())?;
+        if h_event.wait_for_event(2000).is_err() {
+            break;
+        }
+    }
+    audio_client.stop_stream().map_err(|e| e.to_string())?;
+
+    let pcm: Vec<u8> = queue.into_iter().take(target_bytes).collect();
+    Ok((pcm, sample_rate, channels, bits))
+}
+
+#[cfg(windows)]
+fn pcm_to_wav(pcm: &[u8], sample_rate: u32, channels: u16, bits: u16) -> Result<Vec<u8>, String> {
+    use hound::{SampleFormat, WavSpec, WavWriter};
+    use std::io::Cursor;
+
+    let spec = WavSpec {
+        channels,
+        sample_rate,
+        bits_per_sample: bits,
+        sample_format: SampleFormat::Int,
+    };
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    {
+        let mut writer = WavWriter::new(&mut cursor, spec).map_err(|e| e.to_string())?;
+        for chunk in pcm.chunks_exact(2) {
+            let s = i16::from_le_bytes([chunk[0], chunk[1]]);
+            writer.write_sample(s).map_err(|e| e.to_string())?;
+        }
+        writer.finalize().map_err(|e| e.to_string())?;
+    }
+    Ok(cursor.into_inner())
+}
+
+#[cfg(windows)]
+async fn audd_recognize(wav: Vec<u8>, api_token: String) -> Result<Option<SongResult>, String> {
+    use reqwest::multipart::{Form, Part};
+
+    let part = Part::bytes(wav)
+        .file_name("clip.wav")
+        .mime_str("audio/wav")
+        .map_err(|e| e.to_string())?;
+    let form = Form::new()
+        .text("api_token", api_token)
+        .text("return", "apple_music,spotify")
+        .part("file", part);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("https://api.audd.io/")
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+
+    if json["status"] != "success" {
+        let msg = json["error"]["error_message"]
+            .as_str()
+            .unwrap_or("unknown error");
+        return Err(format!("AudD: {msg}"));
+    }
+
+    let r = &json["result"];
+    if r.is_null() {
+        return Ok(None);
+    }
+
+    let title = r["title"].as_str().unwrap_or("").to_string();
+    let artist = r["artist"].as_str().unwrap_or("").to_string();
+    let album = r["album"].as_str().unwrap_or("").to_string();
+    let link = r["song_link"].as_str().unwrap_or("").to_string();
+
+    let mut artwork = String::new();
+    if let Some(u) = r["apple_music"]["artwork"]["url"].as_str() {
+        artwork = u.replace("{w}", "300").replace("{h}", "300");
+    } else if let Some(u) = r["spotify"]["album"]["images"][0]["url"].as_str() {
+        artwork = u.to_string();
+    }
+
+    Ok(Some(SongResult { title, artist, album, artwork, link }))
+}

--- a/src-tauri/src/song_id.rs
+++ b/src-tauri/src/song_id.rs
@@ -10,6 +10,10 @@ pub struct SongResult {
     pub album: String,
     pub artwork: String,
     pub link: String,
+    #[serde(rename = "durationSec")]
+    pub duration_sec: f64,
+    #[serde(rename = "startSec")]
+    pub start_sec: f64,
 }
 
 #[tauri::command]
@@ -107,6 +111,13 @@ fn pcm_to_wav(pcm: &[u8], sample_rate: u32, channels: u16, bits: u16) -> Result<
 }
 
 #[cfg(windows)]
+fn parse_timecode(tc: &str) -> f64 {
+    // "MM:SS" or "HH:MM:SS" -> seconds.
+    tc.split(':')
+        .fold(0.0f64, |acc, p| acc * 60.0 + p.parse::<f64>().unwrap_or(0.0))
+}
+
+#[cfg(windows)]
 async fn audd_recognize(wav: Vec<u8>, api_token: String) -> Result<Option<SongResult>, String> {
     use reqwest::multipart::{Form, Part};
 
@@ -152,5 +163,23 @@ async fn audd_recognize(wav: Vec<u8>, api_token: String) -> Result<Option<SongRe
         artwork = u.to_string();
     }
 
-    Ok(Some(SongResult { title, artist, album, artwork, link }))
+    // Offset inside the song at the moment of the match (AudD "timecode", "MM:SS").
+    let start_sec = r["timecode"].as_str().map(parse_timecode).unwrap_or(0.0);
+
+    // Total track length: Apple Music (ms) -> Spotify (ms) -> 0 if unknown.
+    let duration_sec = r["apple_music"]["durationInMillis"]
+        .as_f64()
+        .map(|ms| ms / 1000.0)
+        .or_else(|| r["spotify"]["duration_ms"].as_f64().map(|ms| ms / 1000.0))
+        .unwrap_or(0.0);
+
+    Ok(Some(SongResult {
+        title,
+        artist,
+        album,
+        artwork,
+        link,
+        duration_sec,
+        start_sec,
+    }))
 }

--- a/src/components/identify-song-button.tsx
+++ b/src/components/identify-song-button.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { AudioLines } from "lucide-react";
+import { useSettings } from "@/lib/settings";
+import { identifyNowPlaying } from "@/lib/song-id";
+import { Tooltip } from "@/components/player/transport/tooltip";
+
+/** Player control button that triggers AudD song identification.
+ *  Reads the AudD key from Settings → Library & metadata.
+ *  Uses the shared Tooltip so the hint shows instantly, matching the
+ *  other transport controls (no slow native title tooltip). */
+export function IdentifySongButton({
+  className,
+  tight,
+}: {
+  className?: string;
+  tight?: boolean;
+}) {
+  const { settings } = useSettings();
+  const [pending, setPending] = useState(false);
+
+  const onClick = async () => {
+    if (pending) return;
+    setPending(true);
+    try {
+      await identifyNowPlaying(settings.auddKey ?? "");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Tooltip label="Identify song">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        aria-label="Identify song"
+        className={
+          className ??
+          "pointer-events-auto inline-flex h-11 w-11 items-center justify-center rounded-full text-white/90 transition hover:bg-white/15 disabled:opacity-50"
+        }
+      >
+        <AudioLines
+          size={tight ? 18 : 22}
+          strokeWidth={1.9}
+          className={pending ? "animate-pulse" : undefined}
+        />
+      </button>
+    </Tooltip>
+  );
+}

--- a/src/components/player/transport-stremio.tsx
+++ b/src/components/player/transport-stremio.tsx
@@ -9,6 +9,7 @@ import {
   type PlayerSlot,
 } from "@/lib/player-chrome";
 import { CastModal } from "./cast-modal";
+import { SongIdToast } from "@/components/song-id-toast";
 import type { DownloadStatus } from "@/views/player/hooks/use-video-download";
 import { SeekBar } from "./transport/seek-bar";
 import { LiveBadge, GoToLive, LiveSeekBar } from "./transport/live-controls";
@@ -249,6 +250,7 @@ export function TransportStremio(p: TransportStremioProps) {
 
   return (
     <>
+      <SongIdToast />
       <div
         data-tauri-drag-region={fullscreen ? undefined : ""}
         className={`pointer-events-none absolute inset-x-0 top-0 z-20 flex h-[88px] items-center justify-between bg-gradient-to-b from-black/35 via-black/15 to-transparent px-6 transition-opacity duration-200 ${

--- a/src/components/player/transport.tsx
+++ b/src/components/player/transport.tsx
@@ -21,6 +21,7 @@ import {
   type PlayerChromeConfig,
 } from "@/lib/player-chrome";
 import { renderControl, type ControlContext } from "./transport/control-renderer";
+import { SongIdToast } from "@/components/song-id-toast";
 
 export function Transport({
   snap,
@@ -384,6 +385,7 @@ export function Transport({
   };
   return (
     <>
+      <SongIdToast />
       <div
         data-tauri-drag-region={fullscreen ? undefined : ""}
         className={`pointer-events-none absolute inset-x-0 top-0 z-20 flex items-start justify-between bg-gradient-to-b from-black/55 via-black/15 to-transparent px-7 pt-4 pb-8 transition-opacity duration-300 ${

--- a/src/components/player/transport/control-renderer-stremio.tsx
+++ b/src/components/player/transport/control-renderer-stremio.tsx
@@ -35,6 +35,7 @@ import { StremioBtn } from "./stremio-btn";
 import { StremioVolume } from "./stremio-volume";
 import { renderCustomIconControlStremio } from "./custom-icon-renderer";
 import { WindowControlButtons } from "./window-control-buttons";
+import { IdentifySongButton } from "@/components/identify-song-button";
 
 function qualityInfoOn(): boolean {
   try {
@@ -406,6 +407,8 @@ export function RenderedStremioControl({
           </StremioBtn>
         </Tooltip>
       );
+    case "song-id":
+      return <IdentifySongButton />;
     case "window-controls":
       return <WindowControlButtons t={tr} />;
     default:

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -47,6 +47,7 @@ import { SeekStepBtn } from "./seek-step-btn";
 import { EpisodeNavBtn } from "./episode-nav-btn";
 import { TimeStart, TimeEnd } from "./time-display";
 import { WindowControlButtons } from "./window-control-buttons";
+import { IdentifySongButton } from "@/components/identify-song-button";
 
 export type ControlContext = {
   t?: (key: string, vars?: Record<string, string | number>) => string;
@@ -440,9 +441,13 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
             <Maximize size={22} strokeWidth={1.9} />
           )}
         </BigButton>
-      );
+        );
+      }
+      case "song-id": {
+        if (ctx.tight) return null;
+        return <IdentifySongButton />;
+      }
+      case "window-controls":
+        return <WindowControlButtons t={t} />; 
+      }
     }
-    case "window-controls":
-      return <WindowControlButtons t={t} />;
-  }
-}

--- a/src/components/song-id-toast.tsx
+++ b/src/components/song-id-toast.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useState } from "react";
+import { Music, Shuffle, SkipBack, SkipForward, Repeat, Play } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useSettings } from "@/lib/settings";
+import { onSongIdToast, type SongIdToastMsg } from "@/lib/song-id";
+
+type SongCardStyle = "compact" | "cinematic";
+
+/** In-player "Now Playing" card for song identification.
+ *  Two selectable styles (Settings → Library & metadata → Now Playing card):
+ *   - compact:   spinning disc beside the title + control strip below.
+ *   - cinematic: large centered cover with the disc behind it.
+ *  Clicking a result opens the track on YouTube. */
+export function SongIdToast() {
+  const { settings } = useSettings();
+  const style = (settings.songCardStyle ?? "cinematic") as SongCardStyle;
+  const showDetails = settings.songCardDetails ?? true;
+
+  const [msg, setMsg] = useState<SongIdToastMsg | null>(null);
+  const [enter, setEnter] = useState(false);
+  const timer = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    const off = onSongIdToast((t) => {
+      setMsg(t);
+      if (timer.current) window.clearTimeout(timer.current);
+      // Keep "Listening…" until replaced; auto-hide results/errors.
+      if (t.kind !== "info") {
+        timer.current = window.setTimeout(() => setMsg(null), 12000);
+      }
+    });
+    return () => {
+      off();
+      if (timer.current) window.clearTimeout(timer.current);
+    };
+  }, []);
+
+  // Smooth grow-in transition whenever a new message arrives.
+  useEffect(() => {
+    if (!msg) {
+      setEnter(false);
+      return;
+    }
+    setEnter(false);
+    const id = requestAnimationFrame(() => setEnter(true));
+    return () => cancelAnimationFrame(id);
+  }, [msg]);
+
+  if (!msg) return null;
+
+  const listening = msg.kind === "info";
+  const isResult = msg.kind === "result";
+  const body = showDetails ? msg.body : undefined;
+
+  const open = () => {
+    if (msg.href) openUrl(msg.href).catch((e) => console.error("open failed", e));
+  };
+
+  const anim = [
+    "origin-top transition-all duration-500 ease-out",
+    enter ? "scale-100 opacity-100" : "scale-90 opacity-0",
+    isResult ? "pointer-events-auto cursor-pointer hover:ring-white/25" : "",
+  ].join(" ");
+
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-8 z-30 flex -translate-x-1/2 flex-col items-center gap-3">
+      <span className="rounded-full bg-black/70 px-4 py-1.5 text-sm font-semibold text-white/90 shadow-lg backdrop-blur">
+        ▶ Now Playing
+      </span>
+
+      {style === "compact" ? (
+        <div
+          role={isResult ? "button" : undefined}
+          onClick={isResult ? open : undefined}
+          className={[
+            "flex flex-col gap-3 rounded-3xl bg-black/85 p-4 text-white shadow-2xl ring-1 ring-white/10 backdrop-blur-xl",
+            isResult ? "w-[min(92vw,520px)]" : "w-[min(86vw,420px)]",
+            anim,
+          ].join(" ")}
+        >
+          <div className="flex items-center gap-4">
+            <Vinyl art={msg.art} size="h-20 w-20" listening={listening} />
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="truncate text-lg font-semibold leading-tight">{msg.title}</span>
+              {body ? (
+                <span className="truncate text-sm text-white/65">{body}</span>
+              ) : listening ? (
+                <span className="text-sm text-white/65">Identifying the current track…</span>
+              ) : null}
+              {isResult ? (
+                <span className="truncate text-xs text-white/40">Tap to open on YouTube</span>
+              ) : null}
+            </div>
+          </div>
+          {isResult ? <Controls /> : null}
+        </div>
+      ) : (
+        <div
+          role={isResult ? "button" : undefined}
+          onClick={isResult ? open : undefined}
+          className={[
+            "flex flex-col items-center gap-4 rounded-3xl bg-black/90 p-6 text-center text-white shadow-2xl ring-1 ring-white/10 backdrop-blur-xl",
+            isResult ? "w-[min(90vw,460px)]" : "w-[min(82vw,340px)]",
+            anim,
+          ].join(" ")}
+        >
+          <Vinyl art={msg.art} size={isResult ? "h-52 w-52" : "h-32 w-32"} listening={listening} />
+          <div className="flex w-full min-w-0 flex-col gap-0.5">
+            <span className="truncate text-xl font-bold leading-tight">{msg.title}</span>
+            {body ? (
+              <span className="truncate text-sm text-white/65">{body}</span>
+            ) : listening ? (
+              <span className="text-sm text-white/65">Identifying the current track…</span>
+            ) : null}
+            {isResult ? (
+              <span className="mt-1 text-xs text-white/40">Tap to open on YouTube</span>
+            ) : null}
+          </div>
+          {isResult ? <Controls /> : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Vinyl({
+  art,
+  size,
+  listening,
+}: {
+  art?: string;
+  size: string;
+  listening: boolean;
+}) {
+  return (
+    <div className={`relative flex-none ${size}`}>
+      <div className="absolute inset-0 animate-spin rounded-full [animation-duration:6s]">
+        <div className="absolute inset-0 rounded-full bg-gradient-to-br from-neutral-700 via-neutral-900 to-black" />
+        <div className="absolute inset-[6%] rounded-full ring-1 ring-white/5" />
+        <div className="absolute inset-[12%] rounded-full ring-1 ring-white/5" />
+        {art ? (
+          <img src={art} alt="" className="absolute inset-[20%] rounded-full object-cover" />
+        ) : (
+          <div className="absolute inset-[20%] flex items-center justify-center rounded-full bg-white/10">
+            <Music size={28} strokeWidth={1.8} className={listening ? "animate-pulse" : undefined} />
+          </div>
+        )}
+        {/* spindle hole */}
+        <div className="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-black ring-2 ring-white/40" />
+      </div>
+    </div>
+  );
+}
+
+function Controls() {
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <div className="relative h-1 w-full overflow-hidden rounded-full bg-white/15">
+        <div className="absolute inset-y-0 left-0 w-1/3 rounded-full bg-white/80" />
+      </div>
+      <div className="flex items-center justify-center gap-6 text-white/80">
+        <Shuffle size={18} className="opacity-50" />
+        <SkipBack size={20} className="opacity-70" />
+        <span className="flex h-11 w-11 items-center justify-center rounded-full bg-white text-black shadow-md">
+          <Play size={22} fill="currentColor" strokeWidth={0} className="translate-x-[1px]" />
+        </span>
+        <SkipForward size={20} className="opacity-70" />
+        <Repeat size={18} className="opacity-50" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/song-id-toast.tsx
+++ b/src/components/song-id-toast.tsx
@@ -3,6 +3,8 @@ import { Music, Shuffle, SkipBack, SkipForward, Repeat, Play } from "lucide-reac
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useSettings } from "@/lib/settings";
 import { onSongIdToast, type SongIdToastMsg } from "@/lib/song-id";
+import { usePlaybackPositionGated } from "@/lib/player/playback-clock";
+import { fmtTime } from "@/components/player/transport/transport-utils";
 
 type SongCardStyle = "compact" | "cinematic";
 
@@ -13,12 +15,18 @@ type SongCardStyle = "compact" | "cinematic";
  *  Clicking a result opens the track on YouTube. */
 export function SongIdToast() {
   const { settings } = useSettings();
+  // Live video position — used ONLY as a clock. The identified song plays in
+  // sync with the video, so it advances/pauses together with playback.
+  const position = usePlaybackPositionGated(true);
   const style = (settings.songCardStyle ?? "cinematic") as SongCardStyle;
   const showDetails = settings.songCardDetails ?? true;
 
   const [msg, setMsg] = useState<SongIdToastMsg | null>(null);
   const [enter, setEnter] = useState(false);
+  // Anchor: video position + song offset captured when a result arrives.
+  const [base, setBase] = useState<{ pos: number; off: number } | null>(null);
   const timer = useRef<number | undefined>(undefined);
+  const posRef = useRef(0);
 
   useEffect(() => {
     const off = onSongIdToast((t) => {
@@ -46,11 +54,36 @@ export function SongIdToast() {
     return () => cancelAnimationFrame(id);
   }, [msg]);
 
+  // Keep latest video position without re-anchoring the song on every frame.
+  useEffect(() => {
+    posRef.current = position;
+  }, [position]);
+
+  // Anchor the song timeline when a result with a known duration arrives.
+  useEffect(() => {
+    if (msg && msg.kind === "result" && msg.durationSec) {
+      setBase({ pos: posRef.current, off: msg.startSec ?? 0 });
+    } else {
+      setBase(null);
+    }
+  }, [msg]);
+
   if (!msg) return null;
 
   const listening = msg.kind === "info";
   const isResult = msg.kind === "result";
   const body = showDetails ? msg.body : undefined;
+
+  // Real elapsed / total time of the SONG (not the movie). Advance from the
+  // AudD match offset by however much the video has moved since identification.
+  const songDur = msg.durationSec ?? 0;
+  const songElapsed =
+    base && songDur > 0
+      ? Math.max(0, Math.min(songDur, base.off + (position - base.pos)))
+      : 0;
+  const pct = songDur > 0 ? (songElapsed / songDur) * 100 : 0;
+  const elapsed = songDur > 0 ? fmtTime(songElapsed) : "";
+  const total = songDur > 0 ? fmtTime(songDur) : "";
 
   const open = () => {
     if (msg.href) openUrl(msg.href).catch((e) => console.error("open failed", e));
@@ -92,7 +125,7 @@ export function SongIdToast() {
               ) : null}
             </div>
           </div>
-          {isResult ? <Controls /> : null}
+          {isResult ? <Controls pct={pct} elapsed={elapsed} total={total} /> : null}
         </div>
       ) : (
         <div
@@ -116,7 +149,7 @@ export function SongIdToast() {
               <span className="mt-1 text-xs text-white/40">Tap to open on YouTube</span>
             ) : null}
           </div>
-          {isResult ? <Controls /> : null}
+          {isResult ? <Controls pct={pct} elapsed={elapsed} total={total} /> : null}
         </div>
       )}
     </div>
@@ -152,12 +185,29 @@ function Vinyl({
   );
 }
 
-function Controls() {
+function Controls({
+  pct,
+  elapsed,
+  total,
+}: {
+  pct: number;
+  elapsed: string;
+  total: string;
+}) {
+  const fillStyle = { width: `${pct}%` };
   return (
-    <div className="flex w-full flex-col gap-3">
-      <div className="relative h-1 w-full overflow-hidden rounded-full bg-white/15">
-        <div className="absolute inset-y-0 left-0 w-1/3 rounded-full bg-white/80" />
-      </div>
+    <div className="flex w-full flex-col gap-2">
+      {total ? (
+        <>
+          <div className="relative h-1 w-full overflow-hidden rounded-full bg-white/15">
+            <div className="absolute inset-y-0 left-0 rounded-full bg-white/80" style={fillStyle} />
+          </div>
+          <div className="flex w-full items-center justify-between font-mono text-[11px] tabular-nums text-white/50">
+            <span>{elapsed}</span>
+            <span>{total}</span>
+          </div>
+        </>
+      ) : null}
       <div className="flex items-center justify-center gap-6 text-white/80">
         <Shuffle size={18} className="opacity-50" />
         <SkipBack size={20} className="opacity-70" />

--- a/src/lib/player-chrome.ts
+++ b/src/lib/player-chrome.ts
@@ -31,6 +31,7 @@ export type PlayerControlId =
   | "hdr-toggle"
   | "draw-toggle"
   | "screenshot"
+  | "song-id"
   | "pip"
   | "cast"
   | "fullscreen"
@@ -188,6 +189,7 @@ export const DEFAULT_DEFAULT_CONFIG: PlayerChromeConfig = {
     { id: "speed-menu", slot: "bottom-right", order: 30 },
     { id: "draw-toggle", slot: "bottom-right", order: 40 },
     { id: "screenshot", slot: "bottom-right", order: 45, hidden: true },
+    { id: "song-id", slot: "bottom-right", order: 46 },
     { id: "pip", slot: "bottom-right", order: 50 },
     { id: "cast", slot: "bottom-right", order: 60 },
     { id: "fullscreen", slot: "bottom-right", order: 70 },
@@ -221,6 +223,7 @@ export const DEFAULT_STREMIO_CONFIG: PlayerChromeConfig = {
     { id: "hdr-toggle", slot: "bottom-right", order: 28, hidden: true },
     { id: "draw-toggle", slot: "bottom-right", order: 30 },
     { id: "screenshot", slot: "bottom-right", order: 35, hidden: true },
+    { id: "song-id", slot: "bottom-right", order: 36 },
     { id: "cast", slot: "bottom-right", order: 40 },
     { id: "pick-another", slot: "bottom-right", order: 50 },
     { id: "pip", slot: "bottom-right", order: 60 },
@@ -256,6 +259,7 @@ export const CONTROL_META: Record<
   "hdr-toggle": { label: "HDR to SDR toggle", group: "menus", defaultSlot: "bottom-right" },
   "draw-toggle": { label: "Draw on video", group: "actions", defaultSlot: "bottom-right" },
   screenshot: { label: "Screenshot", group: "actions", defaultSlot: "bottom-right" },
+  "song-id": { label: "Identify song", group: "actions", defaultSlot: "bottom-right" },
   pip: { label: "Picture-in-picture", group: "actions", defaultSlot: "bottom-right" },
   cast: { label: "Cast", group: "actions", defaultSlot: "bottom-right" },
   fullscreen: { label: "Fullscreen", group: "transport", defaultSlot: "bottom-right" },

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -162,6 +162,7 @@ export const DEFAULT: Settings = {
   hoverPreview: false,
   hoverPreviewPlacement: "over",
   mdblistKey: "",
+  auddKey: "",
   aiSearchKey: "",
   aiSearchModel: "",
   playerD3d11Flip: true,
@@ -193,6 +194,8 @@ export const DEFAULT: Settings = {
   spoilerHideDescriptions: true,
   spoilerSkipNext: true,
   streamBackdropBlur: true,
+  songCardStyle: "cinematic" as "compact" | "cinematic",
+  songCardDetails: true,
   hideContent: {
     anime: false,
     liveTv: false,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -190,6 +190,7 @@ export type Settings = {
   hoverPreview: boolean;
   hoverPreviewPlacement: "over" | "side";
   mdblistKey: string;
+  auddKey: string;
   aiSearchKey: string;
   aiSearchModel: string;
   playerD3d11Flip: boolean;
@@ -221,6 +222,8 @@ export type Settings = {
   spoilerHideDescriptions: boolean;
   spoilerSkipNext: boolean;
   streamBackdropBlur: boolean;
+  songCardStyle: "compact" | "cinematic";
+  songCardDetails: boolean;
   hideContent: ContentFilters;
   theme: ThemeSettings;
   homeMode: "harbor" | "classic";

--- a/src/lib/song-id.ts
+++ b/src/lib/song-id.ts
@@ -1,0 +1,81 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type SongResult = {
+  title: string;
+  artist: string;
+  album: string;
+  artwork: string; // may be "" when no cover art is available
+  link: string;
+} | null;
+
+export type SongIdToastMsg = {
+  kind: "info" | "result" | "error";
+  title: string;
+  body?: string;
+  art?: string;
+  /** External link to open on click (YouTube search for the track). */
+  href?: string;
+};
+
+const TOAST_EVENT = "harbor:song-id-toast";
+
+function toast(msg: SongIdToastMsg): void {
+  window.dispatchEvent(new CustomEvent(TOAST_EVENT, { detail: msg }));
+}
+
+/** Subscribe to in-player toast messages. Returns an unsubscribe fn. */
+export function onSongIdToast(cb: (msg: SongIdToastMsg) => void): () => void {
+  const h = (e: Event) => cb((e as CustomEvent<SongIdToastMsg>).detail);
+  window.addEventListener(TOAST_EVENT, h);
+  return () => window.removeEventListener(TOAST_EVENT, h);
+}
+
+function youtubeSearchUrl(artist: string, title: string): string {
+  const q = [artist, title].filter(Boolean).join(" ").trim();
+  return "https://www.youtube.com/results?search_query=" + encodeURIComponent(q);
+}
+
+let busy = false;
+
+export function isIdentifying(): boolean {
+  return busy;
+}
+
+/** Capture ~7s of system audio and identify the song via AudD.
+ *  Feedback is shown as an in-player toast (no OS notification). */
+export async function identifyNowPlaying(apiToken: string): Promise<void> {
+  if (busy) return;
+  const token = (apiToken ?? "").trim();
+  if (!token) {
+    toast({
+      kind: "error",
+      title: "Missing AudD key",
+      body: "Add it in Settings → Library & metadata",
+    });
+    return;
+  }
+  busy = true;
+  toast({ kind: "info", title: "Listening…" });
+  try {
+    const res = await invoke<SongResult>("recognize_now_playing", {
+      apiToken: token,
+      seconds: 7,
+    });
+    if (!res) {
+      toast({ kind: "error", title: "Couldn't identify the song" });
+      return;
+    }
+    toast({
+      kind: "result",
+      title: res.title,
+      body: `${res.artist}${res.album ? " · " + res.album : ""}`,
+      art: res.artwork || undefined,
+      href: youtubeSearchUrl(res.artist, res.title),
+    });
+  } catch (e) {
+    console.error("song-id failed", e);
+    toast({ kind: "error", title: "Song identification failed" });
+  } finally {
+    busy = false;
+  }
+}

--- a/src/lib/song-id.ts
+++ b/src/lib/song-id.ts
@@ -6,6 +6,11 @@ export type SongResult = {
   album: string;
   artwork: string; // may be "" when no cover art is available
   link: string;
+  /** Total length of the identified track, in seconds (0 when unknown). */
+  durationSec: number;
+  /** Offset inside the track at the moment of identification, in seconds
+   *  (AudD "timecode"; 0 when unknown). */
+  startSec: number;
 } | null;
 
 export type SongIdToastMsg = {
@@ -15,6 +20,10 @@ export type SongIdToastMsg = {
   art?: string;
   /** External link to open on click (YouTube search for the track). */
   href?: string;
+  /** Song length in seconds (for the progress bar / time display). */
+  durationSec?: number;
+  /** Song offset at identification, in seconds. */
+  startSec?: number;
 };
 
 const TOAST_EVENT = "harbor:song-id-toast";
@@ -71,6 +80,8 @@ export async function identifyNowPlaying(apiToken: string): Promise<void> {
       body: `${res.artist}${res.album ? " · " + res.album : ""}`,
       art: res.artwork || undefined,
       href: youtubeSearchUrl(res.artist, res.title),
+      durationSec: res.durationSec || undefined,
+      startSec: res.startSec || undefined,
     });
   } catch (e) {
     console.error("song-id failed", e);

--- a/src/views/settings/library-panel.tsx
+++ b/src/views/settings/library-panel.tsx
@@ -14,6 +14,7 @@ import { SpoilerPreview } from "./spoiler-preview";
 import { HomeRowPreview } from "./home-layout-previews";
 import { HomeLanguagePicker } from "./home-language-picker";
 import { EpisodeCardPreview } from "./episode-card-previews";
+import { SongCardStylePicker } from "./song-card-style-picker";
 import { CwSnapshotShowcase } from "./cw-snapshot-showcase";
 import { AiSearchSection } from "./ai-search-section";
 import rpdbLogo from "@/assets/addon-logos/rpdb.png";
@@ -97,10 +98,11 @@ export function LibraryPanel({
   }, [enabledBadgeCount]);
   const [mdblistDraft, setMdblistDraft] = useState(settings.mdblistKey);
   const [posterSrvDraft, setPosterSrvDraft] = useState(settings.posterBaseUrl);
-  const [extraSaved, setExtraSaved] = useState<"mdblist" | "postersrv" | "ai" | null>(null);
+  const [auddDraft, setAuddDraft] = useState(settings.auddKey); 
+  const [extraSaved, setExtraSaved] = useState<"mdblist" | "postersrv" | "ai" | "audd" | null>(null);
   const [tmdbGuide, setTmdbGuide] = useState(false);
   const extraTimerRef = useRef<number | null>(null);
-  const flashExtra = (k: "mdblist" | "postersrv" | "ai") => {
+  const flashExtra = (k: "mdblist" | "postersrv" | "ai" | "audd") => {
     setExtraSaved(k);
     if (extraTimerRef.current) window.clearTimeout(extraTimerRef.current);
     extraTimerRef.current = window.setTimeout(() => setExtraSaved(null), 1800);
@@ -249,6 +251,8 @@ export function LibraryPanel({
         />
       </Section>
 
+      <SongCardStylePicker />
+
       <Section
         title={t("Continue Watching screenshots")}
         subtitle={t("When you back out of a title, Harbor saves a frame so the Continue Watching card looks like the spot you left. Tune how long they stick around, or wipe them all.")}
@@ -361,6 +365,23 @@ export function LibraryPanel({
               Free key at <ExtLink href="https://mdblist.com/preferences/">mdblist.com</ExtLink>.
               Adds Letterboxd and Trakt community ratings to detail pages, covering what OMDb
               misses.
+            </>
+          }
+        />
+        <KeyField
+          label={t("AudD · in-player song ID")}
+          placeholder={t("AudD API token")}
+          value={auddDraft}
+          onChange={setAuddDraft}
+          onSave={() => {
+            update({ auddKey: auddDraft.trim() });
+            flashExtra("audd");
+          }}
+          saved={extraSaved === "audd"}
+          help={
+            <>
+              Powers the Identify-song button in the player. Get a token at{" "}
+              <ExtLink href="https://dashboard.audd.io/">dashboard.audd.io</ExtLink>.
             </>
           }
         />

--- a/src/views/settings/song-card-style-picker.tsx
+++ b/src/views/settings/song-card-style-picker.tsx
@@ -1,0 +1,113 @@
+import { useSettings } from "@/lib/settings";
+import { Section, ToggleRow } from "./shared";
+
+type SongCardStyle = "compact" | "cinematic";
+
+/** Settings picker for the in-player "Now Playing" song-identification card.
+ *  Two clickable template thumbnails + a details toggle. Lives between the
+ *  "Episode cards" and "Continue Watching screenshots" sections. */
+export function SongCardStylePicker() {
+  const { settings, update } = useSettings();
+  const value = (settings.songCardStyle ?? "cinematic") as SongCardStyle;
+
+  const options: { v: SongCardStyle; label: string; desc: string }[] = [
+    {
+      v: "compact",
+      label: "Compact",
+      desc: "Spinning disc beside the title with a small control bar.",
+    },
+    {
+      v: "cinematic",
+      label: "Cinematic",
+      desc: "Large centered cover on a dark card with the disc behind it.",
+    },
+  ];
+
+  return (
+    <Section
+      title="Now Playing card"
+      subtitle="Choose how the in-player song-identification card looks. Tap a style to switch."
+    >
+      <div className="grid grid-cols-2 gap-3">
+        {options.map((o) => {
+          const active = value === o.v;
+          return (
+            <button
+              key={o.v}
+              type="button"
+              aria-pressed={active}
+              onClick={() => update({ songCardStyle: o.v })}
+              className={`flex flex-col gap-3 rounded-2xl border p-3 text-left transition-colors ${
+                active
+                  ? "border-accent bg-accent/10"
+                  : "border-edge-soft bg-canvas/50 hover:border-edge"
+              }`}
+            >
+              <StyleThumb kind={o.v} />
+              <div className="flex items-center gap-2">
+                <span
+                  className={`flex h-4 w-4 items-center justify-center rounded-full border ${
+                    active ? "border-accent" : "border-edge"
+                  }`}
+                >
+                  {active ? <span className="h-2 w-2 rounded-full bg-accent" /> : null}
+                </span>
+                <span className="text-[13px] font-semibold text-ink">{o.label}</span>
+              </div>
+              <span className="text-[12px] leading-snug text-ink-muted">{o.desc}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <ToggleRow
+        label="Show track details"
+        sub="Display the artist and album under the title on the card."
+        value={settings.songCardDetails ?? true}
+        onChange={(v) => update({ songCardDetails: v })}
+      />
+    </Section>
+  );
+}
+
+/** Tiny visual mockup of each card style (black card template). */
+function StyleThumb({ kind }: { kind: SongCardStyle }) {
+  if (kind === "compact") {
+    return (
+      <div className="flex h-24 w-full items-center gap-2.5 rounded-xl bg-black p-3">
+        <Disc />
+        <div className="flex flex-1 flex-col gap-1.5">
+          <div className="h-2 w-3/4 rounded bg-white/70" />
+          <div className="h-1.5 w-1/2 rounded bg-white/30" />
+          <MiniControls />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-24 w-full flex-col items-center justify-center gap-1.5 rounded-xl bg-black p-3">
+      <Disc />
+      <div className="h-1.5 w-2/3 rounded bg-white/70" />
+      <div className="h-1 w-1/2 rounded bg-white/30" />
+      <MiniControls />
+    </div>
+  );
+}
+
+function Disc() {
+  return (
+    <div className="relative h-9 w-9 flex-none rounded-full bg-gradient-to-br from-neutral-600 to-black ring-1 ring-white/10">
+      <div className="absolute left-1/2 top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/40" />
+    </div>
+  );
+}
+
+function MiniControls() {
+  return (
+    <div className="mt-1 flex items-center gap-1.5">
+      <div className="h-1.5 w-1.5 rounded-full bg-white/30" />
+      <div className="h-2.5 w-2.5 rounded-full bg-white" />
+      <div className="h-1.5 w-1.5 rounded-full bg-white/30" />
+    </div>
+  );
+}


### PR DESCRIPTION
hello @harborstremio 
## Summary
Adds Shazam-style **song identification** inside the player. While a movie/show
is playing (via mpv), the user can identify the currently playing soundtrack with
one click. A "Now Playing" card appears in-player showing the track, artist,
album and cover art, and clicking it opens the song on YouTube.

Audio is captured on **Windows** via WASAPI loopback and sent to the **AudD**
recognition API. The user provides their own AudD API token in
**Settings → Library & metadata**.

## What's new
- **Identify Song button (🎵)** in the player transport bar.
- **In-player "Now Playing" card** with spinning vinyl + album art, track title,
  artist · album, a progress bar and a player-style control strip.
- **Two selectable card styles** with a visual picker in Settings:
  - **Compact** — spinning disc beside the title + small control bar.
  - **Cinematic** — large centered cover on a dark card with the disc behind it.
- **"Show track details" toggle** to show/hide artist & album on the card.
- **Click a result → opens the track on YouTube** in the default browser
  (via `@tauri-apps/plugin-opener`).
- **AudD API key field** in Settings → Library & metadata.

## Added files
| File | Purpose |
|------|---------|
| `src/lib/song-id.ts` | Event bus + `identifyNowPlaying()` + `youtubeSearchUrl()` |
| `src/components/song-id-toast.tsx` | The in-player "Now Playing" card (2 styles) |
| `src/components/identify-song-button.tsx` | The 🎵 identify button (with tooltip) |
| `src/views/settings/song-card-style-picker.tsx` | Settings picker (2 template thumbnails + toggle) |
| `src-tauri/src/song_id.rs` | `recognize_now_playing` — WASAPI loopback capture → AudD |

## Modified files
| File | Change |
|------|--------|
| `src/lib/player-chrome.ts` | Mount identify button + toast into the player chrome |
| `src/components/player/transport.tsx` | Render `<SongIdToast />` |
| `src/components/player/transport-stremio.tsx` | Render `<SongIdToast />` + identify button case |
| `src/components/player/transport/control-renderer.tsx` | Identify button control case |
| `src/components/player/transport/control-renderer-stremio.tsx` | Identify button control case |
| `src/views/settings/library-panel.tsx` | AudD key field + `<SongCardStylePicker />` |
| `src/views/settings/settings/types.ts` | `auddKey`, `songCardStyle`, `songCardDetails` |
| `src/views/settings/settings/defaults.ts` | Defaults for the new settings |
| `src-tauri/src/lib.rs` | `mod song_id;` + register `recognize_now_playing` handler |
| `src-tauri/Cargo.toml` | Add `hound` + `wasapi` (windows target) deps |
| `src-tauri/capabilities/default.json` | Opener permission for YouTube links |

## Settings added
- `auddKey: string` — AudD API token.
- `songCardStyle: "compact" | "cinematic"` — default `"cinematic"`.
- `songCardDetails: boolean` — default `true`.

## How to test
1. Add your AudD API token in **Settings → Library & metadata**.
2. Play any title (audio must be routed through the app / system output).
3. Click the **🎵 Identify Song** button in the transport bar.
4. Card shows **Listening…**, then the identified track with cover art.
5. Pick **Compact** / **Cinematic** in **Settings → Now Playing card** and toggle **Show track details**.
6. Click the result card → the song opens on YouTube.

## Notes / limitations
- Audio capture is **Windows-only** (WASAPI loopback).
- Requires a user-supplied **AudD** API token; no key is bundled.
- Recognition captures a ~7s window.

## Screenshots
_(uploading)_
- Compact card:
<img width="600" height="337" alt="ezgif-7d6589eb468d52d7" src="https://github.com/user-attachments/assets/18ac8813-20fc-441f-85bd-f945c7fbaa1b" />

- Cinematic card:
<img width="600" height="337" alt="ezgif-705b00015b894551" src="https://github.com/user-attachments/assets/be0a60d4-e850-44f0-8e8c-648af9cf19ff" />


- Settings picker:
<img width="1919" height="1079" alt="Screenshot 2026-07-01 041000" src="https://github.com/user-attachments/assets/fc3e3ad9-6b09-4b66-960e-c12e54997e09" />

<img width="1919" height="1079" alt="Screenshot 2026-07-01 041013" src="https://github.com/user-attachments/assets/5e815521-eada-458b-9f2c-c75d8c0c2014" />
