### PR TITLE
Feat: Add player volume feedback indicator

### DIFF
--- a/src/components/player/volume-indicator.tsx
+++ b/src/components/player/volume-indicator.tsx
@@ -1,0 +1,69 @@
+import { Volume1, Volume2, VolumeX } from "lucide-react";
+import { useT } from "@/lib/i18n";
+import { NORMAL_FRACTION, VOL_MAX, boostColor, fractionFromValue } from "./transport/transport-utils";
+
+export type VolumeIndicatorState = {
+  visible: boolean;
+  volume: number;
+  muted: boolean;
+  seq: number;
+};
+
+export function VolumeIndicator({
+  state,
+  allowBoost,
+}: {
+  state: VolumeIndicatorState;
+  allowBoost: boolean;
+}) {
+  const t = useT();
+  const max = allowBoost ? VOL_MAX : 1;
+  const volume = Math.max(0, Math.min(max, state.volume));
+  const muted = state.muted || volume <= 0;
+  const fillPct = muted ? 0 : (allowBoost ? fractionFromValue(volume) : volume) * 100;
+  const pct = Math.round((muted ? 0 : volume) * 100);
+  const boosting = allowBoost && !muted && volume > 1.001;
+  const color = boostColor(volume);
+  const Icon = muted ? VolumeX : volume < 0.5 ? Volume1 : Volume2;
+
+  return (
+    <div
+      key={state.seq}
+      className={`pointer-events-none absolute left-1/2 top-9 z-30 flex min-w-[16rem] -translate-x-1/2 items-center gap-3.5 rounded-[20px] border border-white/14 bg-black/82 py-3 ps-3 pe-4 text-white shadow-[0_22px_58px_-22px_rgba(0,0,0,0.95),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl transition-[opacity,transform] duration-200 ease-out ${
+        state.visible ? "translate-y-0 scale-100 opacity-100" : "-translate-y-2 scale-95 opacity-0"
+      }`}
+    >
+      <span
+        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[15px] bg-white/12 ring-1 ring-white/10"
+        style={{ color: boosting ? color : "rgba(255,255,255,0.95)" }}
+      >
+        <Icon size={24} strokeWidth={2.1} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-2.5">
+        <span className="flex items-center justify-between gap-4">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/58">
+            {t("Volume")}
+          </span>
+          <span
+            className="font-mono text-[22px] font-bold tabular-nums leading-none"
+            style={{ color: boosting ? color : "rgba(255,255,255,0.92)" }}
+          >
+            {muted ? t("Muted") : `${pct}%`}
+          </span>
+        </span>
+        <span className="relative h-2.5 overflow-hidden rounded-full bg-white/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.55)]">
+          <span
+            className="absolute inset-y-0 left-0 rounded-full transition-[width] duration-150 ease-out"
+            style={{ width: `${fillPct}%`, background: boosting ? color : "rgba(255,255,255,0.92)" }}
+          />
+          {allowBoost && (
+            <span
+              className="absolute inset-y-[-2px] w-px bg-white/35"
+              style={{ left: `${NORMAL_FRACTION * 100}%` }}
+            />
+          )}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -65,6 +65,7 @@ import { useSdrBoostGate } from "./player/hooks/use-sdr-boost-gate";
 import { PlayerOverlayLayers, type PlayerOverlayLayersProps } from "./player/player-overlay-layers";
 import { HdrStageBridge } from "./player/hdr-stage-bridge";
 import { setSkipSegmentsView } from "@/lib/skip-intro/segment-store";
+import type { VolumeIndicatorState } from "@/components/player/volume-indicator";
 import type { ToastInfo } from "@/views/addons/addons-types";
 
 export function PlayerView({ src }: { src: PlayerSrc }) {
@@ -471,6 +472,36 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     }
   }, [textSync.enterSync, showSyncToast, t]);
 
+  const volumeIndicatorTimerRef = useRef<number | null>(null);
+  const [volumeIndicator, setVolumeIndicator] = useState<VolumeIndicatorState>({
+    visible: false,
+    volume: snap.volume,
+    muted: snap.muted,
+    seq: 0,
+  });
+  const showVolumeFeedback = useCallback((volume: number, muted: boolean) => {
+    if (volumeIndicatorTimerRef.current != null) {
+      window.clearTimeout(volumeIndicatorTimerRef.current);
+    }
+    setVolumeIndicator((current) => ({
+      visible: true,
+      volume,
+      muted,
+      seq: current.seq + 1,
+    }));
+    volumeIndicatorTimerRef.current = window.setTimeout(() => {
+      setVolumeIndicator((current) => ({ ...current, visible: false }));
+      volumeIndicatorTimerRef.current = null;
+    }, 1200);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (volumeIndicatorTimerRef.current != null) {
+        window.clearTimeout(volumeIndicatorTimerRef.current);
+      }
+    };
+  }, []);
+
   const videoFill = useVideoFill(bridgeRef, src.url, playing);
   useLivePictureEq(bridgeRef, src.url);
   const anime4k = useAnime4k(bridgeRef, src.url, src);
@@ -518,6 +549,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     gif,
     clip,
     videoFill,
+    onVolumeFeedback: showVolumeFeedback,
   });
 
   const { pendingResumeSec, acknowledgeResume, pendingSeekSec, clearPendingSeek } = useBridgeLoad({
@@ -653,11 +685,14 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   }, [snap.volume]);
   const onVolumeWheel = useCallback((deltaY: number) => {
     const dir = deltaY < 0 ? 1 : -1;
-    const next = Math.min(6, Math.max(0, volumeRef.current + dir * 0.05));
+    const max = bridgeRef.current?.capabilities().engine === "mpv" ? 6 : 1;
+    const next = Math.min(max, Math.max(0, volumeRef.current + dir * 0.05));
     volumeRef.current = next;
     bridgeRef.current?.setVolume(next);
-    writePlayerVolume({ volume: next });
-  }, []);
+    bridgeRef.current?.setMuted(false);
+    writePlayerVolume({ volume: next, muted: false });
+    showVolumeFeedback(next, false);
+  }, [showVolumeFeedback]);
 
   const overlayProps: PlayerOverlayLayersProps = {
     snap,
@@ -669,6 +704,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     subAssNative,
     showStats,
     holdSpeedActive,
+    volumeIndicator,
     videoFillPill: videoFill.pill,
     cropMode: videoFill.mode,
     onCropMode: videoFill.setMode,
@@ -684,6 +720,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     playPauseToggle,
     toggleFullscreen,
     onVolumeWheel,
+    onVolumeFeedback: showVolumeFeedback,
     isLocalSrc,
     swappingEp,
     swapResolvingKey,

--- a/src/views/player/hooks/use-keyboard-shortcuts.ts
+++ b/src/views/player/hooks/use-keyboard-shortcuts.ts
@@ -41,6 +41,7 @@ export function useKeyboardShortcuts(params: {
   onToggleAnime4k?: () => void;
   onAnime4kOn?: () => void;
   onAnime4kOff?: () => void;
+  onVolumeFeedback?: (volume: number, muted: boolean) => void;
 }) {
   const {
     bridgeRef,
@@ -77,6 +78,7 @@ export function useKeyboardShortcuts(params: {
     onToggleAnime4k,
     onAnime4kOn,
     onAnime4kOff,
+    onVolumeFeedback,
   } = params;
   const { settings } = useSettings();
   const overrides = settings.hotkeys ?? {};
@@ -171,22 +173,31 @@ export function useKeyboardShortcuts(params: {
       if (match("playerVolumeUp")) {
         e.preventDefault();
         const step = e.shiftKey ? 0.5 : 0.05;
-        const next = Math.min(6, Math.max(0, snap.volume + step));
+        const max = bridgeRef.current?.capabilities().engine === "mpv" ? 6 : 1;
+        const next = Math.min(max, Math.max(0, snap.volume + step));
         bridgeRef.current?.setVolume(next);
-        writePlayerVolume({ volume: next });
+        bridgeRef.current?.setMuted(false);
+        writePlayerVolume({ volume: next, muted: false });
+        onVolumeFeedback?.(next, false);
         return;
       }
       if (match("playerVolumeDown")) {
         e.preventDefault();
         const step = e.shiftKey ? 0.5 : 0.05;
-        const next = Math.max(0, snap.volume - step);
+        const max = bridgeRef.current?.capabilities().engine === "mpv" ? 6 : 1;
+        const next = Math.min(max, Math.max(0, snap.volume - step));
         bridgeRef.current?.setVolume(next);
-        writePlayerVolume({ volume: next });
+        bridgeRef.current?.setMuted(false);
+        writePlayerVolume({ volume: next, muted: false });
+        onVolumeFeedback?.(next, false);
         return;
       }
       if (match("playerMute")) {
         e.preventDefault();
-        bridgeRef.current?.setMuted(!snap.muted);
+        const next = !snap.muted;
+        bridgeRef.current?.setMuted(next);
+        writePlayerVolume({ muted: next });
+        onVolumeFeedback?.(snap.volume, next);
         return;
       }
       if (match("playerFullscreen")) {
@@ -380,7 +391,7 @@ export function useKeyboardShortcuts(params: {
       window.removeEventListener("blur", onBlur);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [closePlayer, togglePip, drawMode, snap.muted, snap.volume, snap.rate, snap.durationSec, snap.subDelaySec, overrides, seekBackStepSec, seekForwardStepSec, seekTo, toggleSwitcher, toggleEpisodePanel, toggleGuide, toggleDvr, toggleSleep, onScreenshot, onGifRecord, onClipRecord, onToggleCrop, onPanscanUp, onPanscanDown, onPrevChannel, onToggleAnime4k, onAnime4kOn, onAnime4kOff, onFrameStep]);
+  }, [closePlayer, togglePip, drawMode, snap.muted, snap.volume, snap.rate, snap.durationSec, snap.subDelaySec, overrides, seekBackStepSec, seekForwardStepSec, seekTo, toggleSwitcher, toggleEpisodePanel, toggleGuide, toggleDvr, toggleSleep, onScreenshot, onGifRecord, onClipRecord, onToggleCrop, onPanscanUp, onPanscanDown, onPrevChannel, onToggleAnime4k, onAnime4kOn, onAnime4kOff, onFrameStep, onVolumeFeedback]);
 
   return { holdSpeedActive };
 }

--- a/src/views/player/hooks/use-player-hotkeys.ts
+++ b/src/views/player/hooks/use-player-hotkeys.ts
@@ -39,6 +39,7 @@ export function usePlayerHotkeys(params: {
   onToggleAnime4k?: () => void;
   onAnime4kOn?: () => void;
   onAnime4kOff?: () => void;
+  onVolumeFeedback?: (volume: number, muted: boolean) => void;
 }) {
   const {
     bridgeRef,
@@ -70,6 +71,7 @@ export function usePlayerHotkeys(params: {
     onToggleAnime4k,
     onAnime4kOn,
     onAnime4kOff,
+    onVolumeFeedback,
   } = params;
 
   const [showStats, setShowStats] = useState(false);
@@ -113,6 +115,7 @@ export function usePlayerHotkeys(params: {
     onAnime4kOn,
     onAnime4kOff,
     onFrameStep: (dir) => bridgeRef.current?.frameStep?.(dir),
+    onVolumeFeedback,
   });
 
   return { holdSpeedActive, showStats };

--- a/src/views/player/player-overlay-layers.tsx
+++ b/src/views/player/player-overlay-layers.tsx
@@ -40,6 +40,7 @@ export type PlayerOverlayLayersProps = {
   subAssNative: boolean;
   showStats: boolean;
   holdSpeedActive: boolean;
+  volumeIndicator: ComponentProps<typeof StageOverlays>["volumeIndicator"];
   videoFillPill: string | null;
   subDropToast: string | null;
   pipMode: boolean;
@@ -50,6 +51,7 @@ export type PlayerOverlayLayersProps = {
   playPauseToggle: () => void;
   toggleFullscreen: () => void;
   onVolumeWheel: (deltaY: number) => void;
+  onVolumeFeedback: (volume: number, muted: boolean) => void;
   isLocalSrc: boolean;
   swappingEp: boolean;
   swapResolvingKey: string | null;
@@ -181,6 +183,7 @@ export function PlayerOverlayLayers(p: PlayerOverlayLayersProps) {
         subAssNative={p.subAssNative}
         showStats={p.showStats}
         holdSpeedActive={p.holdSpeedActive}
+        volumeIndicator={p.volumeIndicator}
         videoFillPill={p.videoFillPill}
         subDropToast={p.subDropToast}
         onSubDelay={(s) => { p.bridgeRef.current?.setSubDelay(s); }}
@@ -326,6 +329,7 @@ export function PlayerOverlayLayers(p: PlayerOverlayLayersProps) {
           download={p.download}
           onOpenDvr={p.openDvr}
           sleep={p.sleep}
+          onVolumeFeedback={p.onVolumeFeedback}
         />
       )}
 

--- a/src/views/player/shell-layer.tsx
+++ b/src/views/player/shell-layer.tsx
@@ -59,6 +59,7 @@ export function ShellLayer({
   download,
   onOpenDvr,
   sleep,
+  onVolumeFeedback,
 }: {
   shellId: string;
   shellSnap: PlayerSnapshot;
@@ -112,6 +113,7 @@ export function ShellLayer({
   download: ReturnType<typeof useVideoDownload>;
   onOpenDvr?: () => void;
   sleep: PlayerShellProps["sleep"];
+  onVolumeFeedback?: (volume: number, muted: boolean) => void;
 }) {
   const ActiveShell = getPlayerShell(shellId).Component;
   return (
@@ -135,10 +137,13 @@ export function ShellLayer({
         const next = !snapRef.current.muted;
         bridgeRef.current?.setMuted(next);
         writePlayerVolume({ muted: next });
+        onVolumeFeedback?.(snapRef.current.volume, next);
       }}
       onVolume={(v) => {
         bridgeRef.current?.setVolume(v);
-        writePlayerVolume({ volume: v });
+        bridgeRef.current?.setMuted(false);
+        writePlayerVolume({ volume: v, muted: false });
+        onVolumeFeedback?.(v, false);
       }}
       onAudio={(id) => {
         bridgeRef.current?.setAudioTrack(id);

--- a/src/views/player/stage-overlays.tsx
+++ b/src/views/player/stage-overlays.tsx
@@ -4,6 +4,7 @@ import { StatsOverlay } from "@/components/player/stats-overlay";
 import { SubStyleBar } from "@/components/player/sub-style-bar";
 import { SubSyncBar } from "@/components/player/sub-sync-bar";
 import { SubtitleOverlay } from "@/components/player/subtitle-overlay";
+import { VolumeIndicator, type VolumeIndicatorState } from "@/components/player/volume-indicator";
 import type { PlayerSnapshot } from "@/lib/player/bridge";
 import { useT } from "@/lib/i18n";
 
@@ -15,6 +16,7 @@ export function StageOverlays({
   subAssNative,
   showStats,
   holdSpeedActive,
+  volumeIndicator,
   videoFillPill,
   subDropToast,
   onSubDelay,
@@ -28,6 +30,7 @@ export function StageOverlays({
   subAssNative: boolean;
   showStats: boolean;
   holdSpeedActive: boolean;
+  volumeIndicator: VolumeIndicatorState;
   videoFillPill: string | null;
   subDropToast: string | null;
   onSubDelay: (sec: number) => void;
@@ -35,6 +38,7 @@ export function StageOverlays({
   chromeVisible: boolean;
 }) {
   const t = useT();
+  const showVolumeIndicator = volumeIndicator.visible && !chromeVisible;
   return (
     <>
       {(!pipMode || subShowInPip) && !subAssNative && (
@@ -49,7 +53,13 @@ export function StageOverlays({
           <span className="font-normal text-ink-muted">{t("speed")}</span>
         </div>
       )}
-      {videoFillPill && !holdSpeedActive && !pipMode && (
+      {!holdSpeedActive && !pipMode && (
+        <VolumeIndicator
+          state={{ ...volumeIndicator, visible: showVolumeIndicator }}
+          allowBoost={engine === "mpv"}
+        />
+      )}
+      {videoFillPill && !holdSpeedActive && !showVolumeIndicator && !pipMode && (
         <div className="pointer-events-none absolute left-1/2 top-8 z-30 -translate-x-1/2 rounded-full bg-canvas/85 px-3.5 py-1.5 text-[13px] font-semibold text-ink backdrop-blur-md">
           {videoFillPill}
         </div>


### PR DESCRIPTION
## Summary

Adds a transient volume indicator while watching, so hidden player controls still give feedback when volume changes.

## Changes

- Shows a compact volume HUD only when player chrome is hidden.
- Handles keyboard volume up/down, mouse wheel volume, mute, and player volume controls.
- **Volume up/down now unmute automatically.**
- Uses linear volume fill for HTML5 playback.
- Uses Harbor’s booste volume scale/colors for mpv playback above 100%.
- Keeps HTML5 hidden volume changes capped to 100%, matching visible controls.

<img width="3791" height="2045" alt="image" src="https://github.com/user-attachments/assets/c3d3189b-7643-4fd2-ac07-565be380286d" />

<img width="3791" height="2036" alt="image" src="https://github.com/user-attachments/assets/cd8e8792-ce4d-4cca-ba16-9c10f014b07c" />

<img width="3777" height="2030" alt="image" src="https://github.com/user-attachments/assets/9ea4c2d5-f95c-48e0-930e-dce03f5cf476" />


