### PR TITLE
Fix addon catalog pagination for variable page sizes

### DIFF
--- a/src/components/source-folder-card.tsx
+++ b/src/components/source-folder-card.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useView } from "@/lib/view";
 import type { SourceFolder } from "@/lib/custom-sources";
 import { useAuth } from "@/lib/auth";
-import { gatherCatalogAddons, fetchAddonCatalogPage } from "@/lib/addons";
+import { createAddonCatalogFetcher, gatherCatalogAddons } from "@/lib/addons";
 import { Pencil, X } from "lucide-react";
 import { createPortal } from "react-dom";
 import { EditFolderImagesModal } from "./edit-folder-images-modal";
@@ -122,12 +122,11 @@ export function SourceFolderCard({
 
       openGrid({
         title: folder.title,
-        fetcher: async (page: number) => {
-          const base = addon.transportUrl.replace(/\/manifest\.json$/, "");
-          const skip = (page - 1) * 20;
-          const metas = await fetchAddonCatalogPage(base, source.type, source.catalogId, skip);
-          return metas;
-        },
+        fetcher: createAddonCatalogFetcher({
+          base: addon.transportUrl.replace(/\/manifest\.json$/, ""),
+          type: source.type,
+          id: source.catalogId,
+        }),
       });
     } finally {
       setLoading(false);

--- a/src/lib/addons.ts
+++ b/src/lib/addons.ts
@@ -44,8 +44,10 @@ export type AddonRow = {
   type: string;
   name: string;
   metas: Meta[];
-  more?: { base: string; type: string; id: string };
+  more?: { base: string; type: string; id: string; extras?: CatalogExtra[] };
 };
+
+export type CatalogExtra = { name: string; value: string };
 
 export function addonAccepts(addon: Addon, resource: string, type: string, id: string): boolean {
   const m = addon.manifest;
@@ -258,17 +260,33 @@ export async function gatherCatalogAddons(authKey: string | null): Promise<Addon
 
 const NON_CONTENT_TYPES = new Set(["addon_catalog"]);
 
-function catalogRequestUrl(base: string, cat: CatalogDef): string | null {
+function normalizeCatalogExtras(extra?: CatalogExtra | CatalogExtra[]): CatalogExtra[] {
+  if (!extra) return [];
+  return Array.isArray(extra) ? extra : [extra];
+}
+
+function catalogExtraPath(extras: CatalogExtra[], skip = 0): string {
+  const parts = extras.map((e) => `${encodeURIComponent(e.name)}=${encodeURIComponent(e.value)}`);
+  if (skip > 0) parts.push(`skip=${skip}`);
+  return parts.length ? `/${parts.join("&")}` : "";
+}
+
+function catalogRequest(base: string, cat: CatalogDef): { url: string; extras: CatalogExtra[] } | null {
   const required = (cat.extra ?? []).filter((e) => e.isRequired);
-  if (required.length === 0) return `${base}/catalog/${cat.type}/${cat.id}.json`;
-  const parts: string[] = [];
+  if (required.length === 0) {
+    return { url: `${base}/catalog/${cat.type}/${cat.id}.json`, extras: [] };
+  }
+  const extras: CatalogExtra[] = [];
   for (const e of required) {
     if (e.name === "search") return null;
     const opt = e.options?.[0];
     if (!opt) return null;
-    parts.push(`${encodeURIComponent(e.name)}=${encodeURIComponent(opt)}`);
+    extras.push({ name: e.name, value: opt });
   }
-  return `${base}/catalog/${cat.type}/${cat.id}/${parts.join("&")}.json`;
+  return {
+    url: `${base}/catalog/${cat.type}/${cat.id}${catalogExtraPath(extras)}.json`,
+    extras,
+  };
 }
 
 export async function loadAddonRows(
@@ -283,9 +301,9 @@ export async function loadAddonRows(
       .filter((c) => c && c.name && c.type && c.id && !NON_CONTENT_TYPES.has(c.type.toLowerCase()))
       .map(async (cat): Promise<AddonRow | null> => {
         const base = addon.transportUrl.replace(/\/manifest\.json$/, "");
-        const url = catalogRequestUrl(base, cat);
-        if (!url) return null;
-        const res = await fetchWithTimeout(url);
+        const request = catalogRequest(base, cat);
+        if (!request) return null;
+        const res = await fetchWithTimeout(request.url);
         if (!res || !res.ok) return null;
         try {
           const json = await res.json();
@@ -303,7 +321,12 @@ export async function loadAddonRows(
             type: cat.type,
             name: cat.name,
             metas,
-            more: { base, type: cat.type, id: cat.id },
+            more: {
+              base,
+              type: cat.type,
+              id: cat.id,
+              extras: request.extras.length > 0 ? request.extras : undefined,
+            },
           };
         } catch {
           return null;
@@ -346,12 +369,9 @@ export async function fetchAddonCatalogPage(
   type: string,
   id: string,
   skip: number,
-  extra?: { name: string; value: string },
+  extra?: CatalogExtra | CatalogExtra[],
 ): Promise<Meta[]> {
-  const parts: string[] = [];
-  if (extra) parts.push(`${encodeURIComponent(extra.name)}=${encodeURIComponent(extra.value)}`);
-  if (skip > 0) parts.push(`skip=${skip}`);
-  const seg = parts.length ? `/${parts.join("&")}` : "";
+  const seg = catalogExtraPath(normalizeCatalogExtras(extra), skip);
   const res = await fetchWithTimeout(`${base}/catalog/${type}/${id}${seg}.json`);
   if (!res || !res.ok) return [];
   try {

--- a/src/lib/addons.ts
+++ b/src/lib/addons.ts
@@ -44,10 +44,17 @@ export type AddonRow = {
   type: string;
   name: string;
   metas: Meta[];
-  more?: { base: string; type: string; id: string; extras?: CatalogExtra[] };
+  more?: AddonCatalogCursor;
 };
 
 export type CatalogExtra = { name: string; value: string };
+
+export type AddonCatalogCursor = {
+  base: string;
+  type: string;
+  id: string;
+  extras?: CatalogExtra[];
+};
 
 export function addonAccepts(addon: Addon, resource: string, type: string, id: string): boolean {
   const m = addon.manifest;
@@ -259,6 +266,7 @@ export async function gatherCatalogAddons(authKey: string | null): Promise<Addon
 }
 
 const NON_CONTENT_TYPES = new Set(["addon_catalog"]);
+const DEFAULT_CATALOG_PAGE_SIZE = 20;
 
 function normalizeCatalogExtras(extra?: CatalogExtra | CatalogExtra[]): CatalogExtra[] {
   if (!extra) return [];
@@ -380,6 +388,23 @@ export async function fetchAddonCatalogPage(
   } catch {
     return [];
   }
+}
+
+export function createAddonCatalogFetcher(
+  cursor: AddonCatalogCursor,
+  opts: {
+    initialPageSize?: number;
+    mapMeta?: (meta: Meta) => Meta;
+  } = {},
+): (page: number) => Promise<Meta[]> {
+  let pageSize = opts.initialPageSize && opts.initialPageSize > 0 ? opts.initialPageSize : null;
+  return async (page: number): Promise<Meta[]> => {
+    const step = pageSize ?? DEFAULT_CATALOG_PAGE_SIZE;
+    const skip = page <= 1 ? 0 : (page - 1) * step;
+    const metas = await fetchAddonCatalogPage(cursor.base, cursor.type, cursor.id, skip, cursor.extras);
+    if (metas.length > 0 && pageSize == null) pageSize = metas.length;
+    return opts.mapMeta ? metas.map(opts.mapMeta) : metas;
+  };
 }
 
 const TMDB_PROVIDER_ID_PATTERNS: RegExp[] = [

--- a/src/lib/catalog-browse.ts
+++ b/src/lib/catalog-browse.ts
@@ -1,7 +1,5 @@
-import { fetchAddonCatalogPage, gatherCatalogAddons } from "./addons";
-import type { Meta } from "./cinemeta";
+import { createAddonCatalogFetcher, gatherCatalogAddons, type CatalogExtra } from "./addons";
 
-const FALLBACK_PAGE = 20;
 const NON_CONTENT = new Set(["addon_catalog"]);
 
 export type BrowseCatalog = {
@@ -44,13 +42,7 @@ export async function listBrowseCatalogs(authKey: string | null): Promise<Browse
 }
 
 export function browseFetcher(cat: BrowseCatalog, genre: string | null) {
-  let pageSize: number | null = null;
-  return async (page: number): Promise<Meta[]> => {
-    const step = pageSize ?? FALLBACK_PAGE;
-    const skip = page <= 1 ? 0 : (page - 1) * step;
-    const extra = genre && cat.genreExtra ? { name: cat.genreExtra, value: genre } : undefined;
-    const metas = await fetchAddonCatalogPage(cat.base, cat.type, cat.id, skip, extra);
-    if (page === 1 && metas.length > 0) pageSize = metas.length;
-    return metas;
-  };
+  const extras: CatalogExtra[] | undefined =
+    genre && cat.genreExtra ? [{ name: cat.genreExtra, value: genre }] : undefined;
+  return createAddonCatalogFetcher({ base: cat.base, type: cat.type, id: cat.id, extras });
 }

--- a/src/lib/catalog-browse.ts
+++ b/src/lib/catalog-browse.ts
@@ -1,7 +1,7 @@
 import { fetchAddonCatalogPage, gatherCatalogAddons } from "./addons";
 import type { Meta } from "./cinemeta";
 
-const PAGE = 100;
+const FALLBACK_PAGE = 20;
 const NON_CONTENT = new Set(["addon_catalog"]);
 
 export type BrowseCatalog = {
@@ -44,9 +44,13 @@ export async function listBrowseCatalogs(authKey: string | null): Promise<Browse
 }
 
 export function browseFetcher(cat: BrowseCatalog, genre: string | null) {
-  return (page: number): Promise<Meta[]> => {
-    const skip = (page - 1) * PAGE;
+  let pageSize: number | null = null;
+  return async (page: number): Promise<Meta[]> => {
+    const step = pageSize ?? FALLBACK_PAGE;
+    const skip = page <= 1 ? 0 : (page - 1) * step;
     const extra = genre && cat.genreExtra ? { name: cat.genreExtra, value: genre } : undefined;
-    return fetchAddonCatalogPage(cat.base, cat.type, cat.id, skip, extra);
+    const metas = await fetchAddonCatalogPage(cat.base, cat.type, cat.id, skip, extra);
+    if (page === 1 && metas.length > 0) pageSize = metas.length;
+    return metas;
   };
 }

--- a/src/views/anime.tsx
+++ b/src/views/anime.tsx
@@ -526,6 +526,7 @@ export function AnimeView({ active = true }: { active?: boolean }) {
                                 row.more!.type,
                                 row.more!.id,
                                 (p - 1) * row.metas.length,
+                                row.more!.extras,
                               )
                             ).map(cleanMeta),
                           initial: row.metas.map(cleanMeta),

--- a/src/views/anime.tsx
+++ b/src/views/anime.tsx
@@ -9,7 +9,7 @@ import { PickCard } from "@/components/pick-card";
 import { Row, ScrollRootContext } from "@/components/row";
 import { AnimeRankCard } from "@/components/top-rank-card";
 import { useAuth } from "@/lib/auth";
-import { fetchAddonCatalogPage, loadAddonRows, normalizeName, type AddonRow } from "@/lib/addons";
+import { createAddonCatalogFetcher, loadAddonRows, normalizeName, type AddonRow } from "@/lib/addons";
 import type { Meta } from "@/lib/cinemeta";
 import { findTopAward, parseAwardYear, uniqueWinnerFranchisesAcrossSources } from "@/lib/anime-awards";
 import { publishResumeStates } from "@/lib/hover-preview/store";
@@ -519,16 +519,10 @@ export function AnimeView({ active = true }: { active?: boolean }) {
                     ? () =>
                         openGrid({
                           title: row.name,
-                          fetcher: async (p) =>
-                            (
-                              await fetchAddonCatalogPage(
-                                row.more!.base,
-                                row.more!.type,
-                                row.more!.id,
-                                (p - 1) * row.metas.length,
-                                row.more!.extras,
-                              )
-                            ).map(cleanMeta),
+                          fetcher: createAddonCatalogFetcher(row.more!, {
+                            initialPageSize: row.metas.length,
+                            mapMeta: cleanMeta,
+                          }),
                           initial: row.metas.map(cleanMeta),
                         })
                     : undefined

--- a/src/views/home/home-rows.ts
+++ b/src/views/home/home-rows.ts
@@ -262,7 +262,13 @@ export function mergeRows(
       fetcher:
         canPage && more
           ? async (page) => {
-              const ms = await fetchAddonCatalogPage(more.base, more.type, more.id, (page - 1) * step);
+              const ms = await fetchAddonCatalogPage(
+                more.base,
+                more.type,
+                more.id,
+                (page - 1) * step,
+                more.extras,
+              );
               return origin ? ms.map((m) => ({ ...m, addonOrigin: origin })) : ms;
             }
           : undefined,

--- a/src/views/home/home-rows.ts
+++ b/src/views/home/home-rows.ts
@@ -1,4 +1,4 @@
-import { fetchAddonCatalogPage, normalizeName, type AddonRow } from "@/lib/addons";
+import { createAddonCatalogFetcher, normalizeName, type AddonRow } from "@/lib/addons";
 import { topMovies, topSeries, type Meta } from "@/lib/cinemeta";
 import {
   jikanNewReleases,
@@ -252,6 +252,13 @@ export function mergeRows(
     const more = a.more;
     const origin = a.metas[0]?.addonOrigin;
     const canPage = !!more && step > 0;
+    const fetcher =
+      canPage && more
+        ? createAddonCatalogFetcher(more, {
+            initialPageSize: step,
+            mapMeta: origin ? (m) => ({ ...m, addonOrigin: origin }) : undefined,
+          })
+        : undefined;
     out.push({
       key: a.key,
       type: a.type as "movie" | "series",
@@ -259,19 +266,7 @@ export function mergeRows(
       metas: a.metas,
       page: 1,
       hasMore: canPage,
-      fetcher:
-        canPage && more
-          ? async (page) => {
-              const ms = await fetchAddonCatalogPage(
-                more.base,
-                more.type,
-                more.id,
-                (page - 1) * step,
-                more.extras,
-              );
-              return origin ? ms.map((m) => ({ ...m, addonOrigin: origin })) : ms;
-            }
-          : undefined,
+      fetcher,
     });
   }
   return out;


### PR DESCRIPTION
## Summary
Fixes #531
- Preserve required addon catalog extras on rows so follow-up catalog page requests keep the same addon filters.
- Add a shared addon catalog fetcher that learns each catalog's page size from the first response instead of assuming a fixed skip interval.
- Route catalog browse, home rows, anime rows, and custom catalog sources through that shared fetcher so Bingecat-style 20-item catalogs page correctly.

## Context
Bingecat returns 20 items per catalog page and expects the next request to use `skip=20`. Harbor's generic catalog browser was requesting the first page and then jumping to `skip=100`, so it stopped after the first 20 items even though Stremio continued to 50. Other addon rows had separate pagination code paths, so this follow-up centralizes the addon catalog skip calculation to avoid repeating the same mistake.

<img width="2042" height="1329" alt="image" src="https://github.com/user-attachments/assets/d46bca6b-9e57-4c73-99d5-ccf8e401c205" />
