### PR TITLE
feat(player): add 'Lock to season server' mode + same-source anti-kick retry

### DIFF
--- a/src/lib/playback-history.ts
+++ b/src/lib/playback-history.ts
@@ -191,3 +191,90 @@ export function streamMatchesSource(
     e.source === s.source
   );
 }
+
+//  Season source lock (pin one whole-season / whole-series release) 
+export type SeasonLockEntry = PlaybackEntry & { seriesWide?: boolean };
+
+const SEASON_LOCK_KEY = "harbor.season-lock.v1";
+const SEASON_LOCK_TTL_MS = 120 * 24 * 60 * 60 * 1000;
+const SEASON_LOCK_MAX = 300;
+
+function readSeasonLockMap(): Record<string, SeasonLockEntry> {
+  try {
+    const raw = localStorage.getItem(SEASON_LOCK_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, SeasonLockEntry>;
+    const now = Date.now();
+    const fresh: Record<string, SeasonLockEntry> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (!v?.savedAt) continue;
+      if (now - v.savedAt > SEASON_LOCK_TTL_MS) continue;
+      fresh[k] = v;
+    }
+    return fresh;
+  } catch {
+    return {};
+  }
+}
+
+function writeSeasonLockMap(map: Record<string, SeasonLockEntry>): void {
+  try {
+    const keys = Object.keys(map);
+    if (keys.length > SEASON_LOCK_MAX) {
+      const sorted = Object.entries(map).sort((a, b) => b[1].savedAt - a[1].savedAt);
+      map = Object.fromEntries(sorted.slice(0, SEASON_LOCK_MAX));
+    }
+    localStorage.setItem(SEASON_LOCK_KEY, JSON.stringify(map));
+  } catch (e) {
+    if (e instanceof DOMException && (e.name === "QuotaExceededError" || e.code === 22)) {
+      try {
+        localStorage.removeItem(SEASON_LOCK_KEY);
+      } catch {}
+    }
+  }
+  listeners.forEach((l) => l());
+}
+
+function seasonLockKey(metaId: string, season: number | null | undefined): string {
+  return typeof season === "number" ? `${metaId}|s${season}` : `${metaId}|all`;
+}
+
+export function saveSeasonLock(
+  metaId: string,
+  season: number | null | undefined,
+  entry: Omit<SeasonLockEntry, "savedAt">,
+): void {
+  if (!metaId) return;
+  const map = readSeasonLockMap();
+  const key = entry.seriesWide ? `${metaId}|all` : seasonLockKey(metaId, season);
+  map[key] = { ...entry, savedAt: Date.now() };
+  writeSeasonLockMap(map);
+}
+
+export function readSeasonLock(
+  metaId: string,
+  season?: number | null,
+): SeasonLockEntry | null {
+  if (!metaId) return null;
+  const map = readSeasonLockMap();
+  if (typeof season === "number") {
+    const specific = map[`${metaId}|s${season}`];
+    if (specific) return specific;
+  }
+  return map[`${metaId}|all`] ?? null;
+}
+
+export function clearSeasonLock(metaId: string, season?: number | null): void {
+  const map = readSeasonLockMap();
+  let changed = false;
+  const specific = seasonLockKey(metaId, season);
+  if (map[specific]) {
+    delete map[specific];
+    changed = true;
+  }
+  if (map[`${metaId}|all`]) {
+    delete map[`${metaId}|all`];
+    changed = true;
+  }
+  if (changed) writeSeasonLockMap(map);
+}

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -110,6 +110,7 @@ export const DEFAULT: Settings = {
   instantPlay: true,
   rememberLastStream: false,
   keepSourceNextEpisode: false,
+  seasonSourceLock: false,
   playerHdrToSdr: true,
   playerDisplayPanel: "auto",
   playerMotionInterp: false,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -139,6 +139,7 @@ export type Settings = {
   instantPlay: boolean;
   rememberLastStream: boolean;
   keepSourceNextEpisode: boolean;
+  seasonSourceLock: boolean;
   playerHdrToSdr: boolean;
   playerDisplayPanel: "auto" | "oled" | "lcd";
   playerMotionInterp: boolean;

--- a/src/lib/streams/parser/parser-stream.ts
+++ b/src/lib/streams/parser/parser-stream.ts
@@ -25,6 +25,37 @@ import {
 const REMUX_RX = /\bRemux\b/i;
 const HARDCODED_RX = /\b(HC|HARDCODED|HARDSUB)\b/i;
 
+// Season-pack detection that inspects each source line separately
+// release named "...S04..." whose inner file is "...S04E03..." is still
+// recognised as a whole-season (or whole-series) pack.
+const SP_EPISODE_RX = /\bS\d{1,2}\s*[._-]?\s*E\d{1,3}\b|\bE\d{1,3}\b|\bEpisode\s*\d{1,3}\b|\b\d{1,2}x\d{1,3}\b/i;
+const SP_SEASON_RX = /\bS\d{1,2}\b|\bSeason\s*\d{1,2}\b/i;
+const SP_SEASON_RANGE_RX = /\bS\d{1,2}\s*[-\u2013]\s*S?\d{1,2}\b|\bSeasons?\s*\d{1,2}\s*(?:[-\u2013]|to)\s*\d{1,2}\b/i;
+const SP_COMPLETE_RX = /\bComplete\b/i;
+const SP_SERIESISH_RX = /\bS\d{1,2}\b|\bSeasons?\b|\bSeries\b/i;
+
+function detectSeasonPackFromNames(stream: Stream): boolean {
+  const lines: string[] = [];
+  for (const raw of [stream.name, stream.title, stream.description]) {
+    if (!raw) continue;
+    for (const line of raw.split(/\r?\n/)) {
+      const t = line.trim();
+      if (t) lines.push(t);
+    }
+  }
+  // Explicit multi-season ranges or "complete" collections are always packs.
+  for (const line of lines) {
+    if (SP_SEASON_RANGE_RX.test(line)) return true;
+    if (SP_COMPLETE_RX.test(line) && SP_SERIESISH_RX.test(line)) return true;
+  }
+  // A line that carries a season marker but no episode marker means the
+  // release name is shared across every episode -> season pack.
+  for (const line of lines) {
+    if (SP_SEASON_RX.test(line) && !SP_EPISODE_RX.test(line)) return true;
+  }
+  return false;
+}
+
 export function parseStream(stream: Stream): ParsedStream {
   const filenameLine = extractFilenameLine(stream);
   const text = [filenameLine, stream.title, stream.description, stream.name]
@@ -53,7 +84,7 @@ export function parseStream(stream: Stream): ParsedStream {
   const yearRange = parseYearRange(text);
   const season = ptt.season ?? null;
   const episode = ptt.episode ?? null;
-  const seasonPack = parseSeasonPack(text, ptt);
+  const seasonPack = parseSeasonPack(text, ptt) || detectSeasonPackFromNames(stream);
   const discIndex = parseDisc(text);
   const repackIteration = parseRepackIteration(text, ptt);
   const proper = ptt.proper === true;

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -636,7 +636,7 @@ export function DetailView({
   const smartPlay = useCallback(async (forcePicker = false) => {
     if (inSession) claimHost(true);
     if (!isSeries) {
-      openPicker(playMeta, undefined, { autoPlay: !forcePicker && settings.instantPlay, resume: !forcePicker && settings.instantPlay });
+      openPicker(playMeta, undefined, { autoPlay: !forcePicker && (settings.instantPlay || settings.seasonSourceLock), resume: !forcePicker && settings.instantPlay });
       return;
     }
     if (isAnime) {
@@ -659,18 +659,18 @@ export function DetailView({
             imdbSeason: wantedEp.imdbSeason,
             imdbEpisode: wantedEp.imdbEpisode,
           },
-          { autoPlay: !forcePicker && settings.instantPlay, resume: !forcePicker && settings.instantPlay },
+          { autoPlay: !forcePicker && (settings.instantPlay || settings.seasonSourceLock), resume: !forcePicker && settings.instantPlay },
         );
         return;
       }
-      openPicker(playMeta, undefined, { autoPlay: !forcePicker && settings.instantPlay, resume: !forcePicker && settings.instantPlay });
+      openPicker(playMeta, undefined, { autoPlay: !forcePicker && (settings.instantPlay || settings.seasonSourceLock), resume: !forcePicker && settings.instantPlay });
       return;
     }
     if (lastPlay) {
       openPicker(
         playMeta,
         { season: lastPlay.season, episode: lastPlay.episode },
-        { autoPlay: !forcePicker && settings.instantPlay, resume: !forcePicker && settings.instantPlay },
+        { autoPlay: !forcePicker && (settings.instantPlay || settings.seasonSourceLock), resume: !forcePicker && settings.instantPlay },
       );
       return;
     }
@@ -694,15 +694,15 @@ export function DetailView({
             season >= 1 &&
             episode >= 1
           ) {
-            openPicker(playMeta, { season, episode }, { autoPlay: !forcePicker && settings.instantPlay, resume: !forcePicker && settings.instantPlay });
+            openPicker(playMeta, { season, episode }, { autoPlay: !forcePicker && (settings.instantPlay || settings.seasonSourceLock), resume: !forcePicker && settings.instantPlay });
             return;
           }
         }
         if (item) break;
       }
     }
-    openPicker(playMeta, { season: 1, episode: 1 }, { autoPlay: !forcePicker && settings.instantPlay, resume: !forcePicker && settings.instantPlay });
-  }, [isSeries, isAnime, animeEpisodes, lastPlay, openPicker, playMeta, settings.instantPlay, inSession, claimHost, authKey, meta.id, detail?.imdbId]);
+    openPicker(playMeta, { season: 1, episode: 1 }, { autoPlay: !forcePicker && (settings.instantPlay || settings.seasonSourceLock), resume: !forcePicker && settings.instantPlay });
+  }, [isSeries, isAnime, animeEpisodes, lastPlay, openPicker, playMeta, settings.instantPlay, settings.seasonSourceLock, inSession, claimHost, authKey, meta.id, detail?.imdbId]);
   const smartPlayLabel = inSession && !liveContext
     ? t("Play Together")
     : isSeries && lastPlay
@@ -858,6 +858,17 @@ export function DetailView({
                     {smartPlayLabel}
                   </button>
                   </PlayModeHint>
+                )}
+                {settings.seasonSourceLock && !upcoming && (
+                  <button
+                    type="button"
+                    onClick={() => void smartPlay(true)}
+                    title={t("Pick a different season-pack source to lock")}
+                    className="flex h-12 items-center gap-2.5 whitespace-nowrap rounded-full border border-edge bg-canvas/80 px-6 text-[15px] font-medium text-ink shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] transition-[transform,background-color,border-color] duration-200 hover:border-ink-subtle hover:bg-canvas/95 active:scale-[0.98]"
+                  >
+                    <RotateCcw size={18} strokeWidth={2} />
+                    {t("Change source")}
+                  </button>
                 )}
                 {actionStage < 2 && (
                   <button

--- a/src/views/detail/cinemeta-episodes.tsx
+++ b/src/views/detail/cinemeta-episodes.tsx
@@ -176,7 +176,7 @@ export function CinemetaEpisodeRow({
       className="group flex items-center gap-4 rounded-2xl px-4 py-5 transition-colors hover:bg-elevated/30"
     >
       <button
-        onClick={() => openPicker(meta, playEpisode, { autoPlay: settings.instantPlay })}
+        onClick={() => openPicker(meta, playEpisode, { autoPlay: settings.instantPlay || settings.seasonSourceLock })}
         className="flex min-w-0 flex-1 gap-6 text-start"
       >
         <div className="relative w-[200px] shrink-0 overflow-hidden rounded-lg">

--- a/src/views/detail/episode-strip.tsx
+++ b/src/views/detail/episode-strip.tsx
@@ -64,11 +64,11 @@ export function EpisodeStrip({
                 still: stills[0],
                 overview: ep.overview || undefined,
               },
-              { autoPlay: settings.instantPlay },
+              { autoPlay: settings.instantPlay || settings.seasonSourceLock },
             ),
         };
       }),
-    [episodes, thumbnailFor, meta, openPicker, settings.instantPlay, settings.hdEpisodeImages, t],
+    [episodes, thumbnailFor, meta, openPicker, settings.instantPlay, settings.seasonSourceLock, settings.hdEpisodeImages, t],
   );
   const epByNumber = useMemo(() => {
     const m = new Map<number, Episode>();
@@ -149,7 +149,7 @@ function EpisodeStripCard({
         still,
         overview: ep.overview || undefined,
       },
-      { autoPlay: settings.instantPlay },
+      { autoPlay: settings.instantPlay || settings.seasonSourceLock },
     );
   };
 

--- a/src/views/detail/series-episode-row.tsx
+++ b/src/views/detail/series-episode-row.tsx
@@ -68,7 +68,7 @@ export function EpisodeRow({
       className="group flex gap-6 rounded-2xl px-4 py-5 transition-colors hover:bg-elevated/30"
     >
       <button
-        onClick={() => openPicker(meta, playEpisode, { autoPlay: settings.instantPlay })}
+        onClick={() => openPicker(meta, playEpisode, { autoPlay: settings.instantPlay || settings.seasonSourceLock })}
         className="flex min-w-0 flex-1 gap-6 text-start"
       >
         <div className="relative w-[200px] shrink-0 overflow-hidden rounded-lg">

--- a/src/views/play-picker.tsx
+++ b/src/views/play-picker.tsx
@@ -9,7 +9,7 @@ import { useTogether } from "@/lib/together/provider";
 import { buildMatchScores, matchBadge, MATCH_CLOSE } from "@/lib/together/source-match";
 import { HostSourceBanner } from "@/components/host-source-banner";
 import { consumeRecentStubEvent } from "@/lib/dead-streams";
-import { readPlayback, readLastSeriesPlayback, streamMatchesEntry, streamMatchesSource } from "@/lib/playback-history";
+import { readPlayback, readLastSeriesPlayback, streamMatchesEntry, streamMatchesSource, readSeasonLock, saveSeasonLock } from "@/lib/playback-history";
 import { useSettings } from "@/lib/settings";
 import type { ScoredStream, Tier } from "@/lib/streams/types";
 import { isAddonRanked } from "@/lib/streams/addon-detect";
@@ -263,12 +263,25 @@ export function PlayPicker({
     [meta.id, meta.type, settings.keepSourceNextEpisode, autoPlay],
   );
 
+  const seasonLockMode =
+    settings.seasonSourceLock &&
+    meta.type === "series" &&
+    !isAnimeMetaId &&
+    !isDownload &&
+    !!episode;
+  const seasonLockEntry = useMemo(
+    () => (seasonLockMode ? readSeasonLock(meta.id, episode?.season ?? null) : null),
+    [seasonLockMode, meta.id, episode?.season],
+  );
+  const effectiveAutoPlay = seasonLockMode ? !!autoPlay && !!seasonLockEntry : !!autoPlay;
+  const forceSeasonPackPick = seasonLockMode && !effectiveAutoPlay;
+
   const kidProfile = useActiveKid();
   const p2pAutoConsent = settings.p2pAutoConsent || !!kidProfile;
   const autoCandidates = useAutoCandidates({
     filteredPicker,
     previousPlayback,
-    sourceEntry: lastSeriesSource,
+    sourceEntry: seasonLockMode ? seasonLockEntry : lastSeriesSource,
     isCached,
     addons,
     hasStrongAddon,
@@ -287,7 +300,7 @@ export function PlayPicker({
   const isLiveLikeContent =
     !!meta.type && !["movie", "series", "anime"].includes(String(meta.type).toLowerCase());
   const autoActive =
-    !!((autoPlay && !isLiveLikeContent) || wasInvitedTo(inviteKey)) &&
+    !!((effectiveAutoPlay && !isLiveLikeContent) || wasInvitedTo(inviteKey)) &&
     !autoCancelled &&
     !autoExhausted &&
     !isDownload &&
@@ -349,14 +362,28 @@ export function PlayPicker({
     setFailedStreams,
     setResolveError,
     setResolving,
+    seasonLock: seasonLockMode,
   });
 
   const playManually = useCallback(
     (s: ScoredStream) => {
       setAutoCancelled(true);
+      if (seasonLockMode) {
+        const seriesWide = s.seasonPack === true && s.season == null;
+        saveSeasonLock(meta.id, episode?.season ?? null, {
+          bingeGroup: s.behaviorHints?.bingeGroup ?? null,
+          infoHash: s.infoHash ?? null,
+          addonId: s.addonId ?? null,
+          resolution: s.resolution ?? null,
+          source: s.source ?? null,
+          title: s.title ?? null,
+          parsedTitle: s.parsedTitle ?? null,
+          seriesWide,
+        });
+      }
       onPlay(s);
     },
-    [onPlay],
+    [onPlay, seasonLockMode, meta.id, episode?.season],
   );
 
   const rememberedFiredRef = useRef(false);
@@ -446,17 +473,45 @@ export function PlayPicker({
     const t = window.setTimeout(() => setStubBanner(null), 6000);
     return () => window.clearTimeout(t);
   }, [streamIds]);
+  const [seasonLockRetry, setSeasonLockRetry] = useState(0);
+  useEffect(() => {
+    setSeasonLockRetry(0);
+  }, [meta.id, episode?.season, episode?.episode]);
+  // While in season-lock mode we are still allowed to retry, so do not let
+  // autoExhausted latch on a transient empty result (kick to the picker).
+  const seasonLockRetrying =
+    seasonLockMode && !!seasonLockEntry && seasonLockRetry < 3;
   useEffect(() => {
     if (
-      autoPlay &&
+      effectiveAutoPlay &&
       pipelineDone &&
       autoCandidates.length === 0 &&
       !autoExhausted &&
-      !autoCancelled
+      !autoCancelled &&
+      !seasonLockRetrying
     ) {
       setAutoExhausted(true);
     }
-  }, [autoPlay, pipelineDone, autoCandidates.length, autoExhausted, autoCancelled]);
+  }, [effectiveAutoPlay, pipelineDone, autoCandidates.length, autoExhausted, autoCancelled, seasonLockRetrying]);
+  // Keep refreshing while the locked source is either absent from the list or
+// present but not yet resolvable (e.g. debrid still caching), so a transient
+// empty result never dead-ends into the picker.
+  const seasonLockNeedsRetry =
+    seasonLockMode &&
+    !!seasonLockEntry &&
+    !!filteredPicker &&
+    pipelineDone &&
+    (autoCandidates.length === 0 ||
+      !filteredPicker.all.some((s) => streamMatchesSource(s, seasonLockEntry)));
+  useEffect(() => {
+    if (!seasonLockNeedsRetry) return;
+    if (seasonLockRetry >= 3) return;
+    const t = window.setTimeout(() => {
+      setSeasonLockRetry((n) => n + 1);
+      refresh();
+    }, 700);
+    return () => window.clearTimeout(t);
+  }, [seasonLockNeedsRetry, seasonLockRetry, refresh]);
 
   const engineWarming = isEngineWarmingError(resolveError);
   useEffect(() => {
@@ -614,6 +669,7 @@ export function PlayPicker({
             failedStreams={failedStreams}
             preserveOrder={addonOrderMode || !!hostMatch}
             matchFor={hostMatch ? matchFor : undefined}
+            highlightSeasonPacks={forceSeasonPackPick}
             onPlay={playManually}
           />
         ) : (

--- a/src/views/play-picker/stremio-layout.tsx
+++ b/src/views/play-picker/stremio-layout.tsx
@@ -19,6 +19,7 @@ export function StremioLayout({
   failedStreams,
   preserveOrder,
   matchFor,
+  highlightSeasonPacks,
   onPlay,
 }: {
   streams: ScoredStream[];
@@ -28,6 +29,7 @@ export function StremioLayout({
   failedStreams: Set<ScoredStream>;
   preserveOrder?: boolean;
   matchFor?: (s: ScoredStream) => "same" | "close" | null;
+  highlightSeasonPacks?: boolean;
   onPlay: (stream: ScoredStream) => void;
 }) {
   const [filter, setFilter] = useState<string>("all");
@@ -83,15 +85,21 @@ export function StremioLayout({
     if (activeFilterId && !customFilters.some((f) => f.id === activeFilterId)) setActiveFilterId(null);
   }, [customFilters, activeFilterId]);
   const visibleStreams = useMemo(() => {
+    const floatPacks = (list: ScoredStream[]) => {
+      if (!highlightSeasonPacks) return list;
+      const packs = list.filter((s) => s.seasonPack);
+      if (packs.length === 0) return list;
+      return [...packs, ...list.filter((s) => !s.seasonPack)];
+    };
     const filtered = customFiltered.filter((s) => matchesFacets(s, facet));
-    if (filter !== "all") return filtered;
-    if (preserveOrder) return filtered;
+    if (filter !== "all") return floatPacks(filtered);
+    if (preserveOrder) return floatPacks(filtered);
     const downloadRx = /[⏳⌛⬇⏬🔽📥]|\bdownload(ing)?\b|\bqueued?\b|\bnot[\s_-]?cached\b/iu;
     const isDownload = (s: ScoredStream) => {
       const haystack = `${s.name ?? ""} ${s.title ?? ""} ${s.description ?? ""}`;
       return downloadRx.test(haystack);
     };
-    return filtered.slice().sort((a, b) => {
+      const sorted = filtered.slice().sort((a, b) => {
       const aw = /watchhub/i.test(a.addonId) || /watchhub/i.test(a.addonName ?? "") ? 1 : 0;
       const bw = /watchhub/i.test(b.addonId) || /watchhub/i.test(b.addonName ?? "") ? 1 : 0;
       if (aw !== bw) return aw - bw;
@@ -105,8 +113,9 @@ export function StremioLayout({
       const bi = isInstantText(b) ? 1 : 0;
       if (ai !== bi) return bi - ai;
       return 0;
-    });
-  }, [customFiltered, facet, filter, addonRank, preserveOrder]);
+   });
+    return floatPacks(sorted);
+  }, [customFiltered, facet, filter, addonRank, preserveOrder, highlightSeasonPacks]);
   const filterLabel = filter === "all"
     ? "All"
     : addonOptions.find((o) => o.id === filter)?.name ?? "All";
@@ -195,6 +204,7 @@ export function StremioLayout({
             failed={failedStreams.has(s)}
             addonLogo={addonLogoMap.get(s.addonUrl ?? "") ?? addonLogoMap.get(s.addonId) ?? null}
             match={matchFor ? matchFor(s) : null}
+            seasonPack={!!highlightSeasonPacks && !!s.seasonPack}
             onPlay={() => onPlay(s)}
           />
         ))}

--- a/src/views/play-picker/stremio-row.tsx
+++ b/src/views/play-picker/stremio-row.tsx
@@ -12,12 +12,14 @@ export function StremioRow({
   failed,
   addonLogo,
   match = null,
+  seasonPack = false,
   onPlay,
 }: {
   stream: ScoredStream;
   failed: boolean;
   addonLogo: string | null;
   match?: "same" | "close" | null;
+  seasonPack?: boolean;
   onPlay: () => void;
 }) {
   const { settings } = useSettings();
@@ -51,8 +53,13 @@ export function StremioRow({
             {description}
           </p>
         )}
-        {(badges.length > 0 || match || stream.edition) && (
+        {(badges.length > 0 || match || stream.edition || seasonPack) && (
           <div className="flex flex-wrap items-center gap-1.5">
+            {seasonPack && (
+              <span className="rounded-md bg-accent/15 px-2 py-0.5 text-[11px] font-semibold text-accent">
+                {"Season pack"}
+              </span>
+            )}
             <HostMatchChip match={match} />
             {badges.map((k) => (
               <FormatBadge key={k} kind={k} size="sm" />

--- a/src/views/play-picker/use-pick-handler.ts
+++ b/src/views/play-picker/use-pick-handler.ts
@@ -17,6 +17,26 @@ import { openInAppBrowser, openUrl } from "@/lib/window";
 import { enqueueDownload } from "@/lib/download/downloads-store";
 import { formatStreamQuality, humanError, isDebridFailure } from "./picker-utils";
 
+// A debrid often returns a stub placeholder while it finishes
+// caching a file. Rather than kicking to the picker, wait briefly and retry the
+// SAME source a few times, like Stremio does.
+const SAME_SOURCE_MAX_RETRIES = 4;
+const SAME_SOURCE_RETRY_DELAY_MS = 1500;
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(t);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
 export function usePickHandler({
   meta,
   imdbId,
@@ -44,6 +64,8 @@ export function usePickHandler({
   setFailedStreams,
   setResolveError,
   setResolving,
+  seasonLock,   
+  
 }: {
   meta: Meta;
   imdbId?: string | null;
@@ -71,6 +93,7 @@ export function usePickHandler({
   setFailedStreams: Dispatch<SetStateAction<Set<ScoredStream>>>;
   setResolveError: (msg: string | null) => void;
   setResolving: Dispatch<SetStateAction<{ stream: ScoredStream } | null>>;
+  seasonLock: boolean;
 }) {
   const [queuedHash, setQueuedHash] = useState<string | null>(null);
   const [debridDown, setDebridDown] = useState(false);
@@ -90,7 +113,7 @@ export function usePickHandler({
     }
   };
 
-  const resolveAndOpen = async (stream: ScoredStream, userCommitted: boolean, forceP2p = false) => {
+  const resolveAndOpen = async (stream: ScoredStream, userCommitted: boolean, forceP2p = false, attemptNo = 0) => {
     const ac = new AbortController();
     resolveAcRef.current?.abort();
     resolveAcRef.current = ac;
@@ -105,8 +128,24 @@ export function usePickHandler({
           setResolving(null);
           return;
         }
-        setFailedStreams((prev) => new Set(prev).add(stream));
         const isDebridSide = isDebridFailure(r.code, r.tried);
+        // Transient debrid-side failures often mean the file is still being
+        // cached. In manual / season-lock, retry the SAME source instead of
+        // kicking to the picker or jumping to a different source.
+        if (
+          isDebridSide &&
+          (!autoActive || seasonLock) &&
+          attemptNo < SAME_SOURCE_MAX_RETRIES
+        ) {
+          console.warn(
+            `[picker] debrid-side fail (${r.code}); retry same source ${attemptNo + 1}/${SAME_SOURCE_MAX_RETRIES}`,
+          );
+          await sleep(SAME_SOURCE_RETRY_DELAY_MS * (attemptNo + 1), ac.signal);
+          if (ac.signal.aborted) return;
+          await resolveAndOpen(stream, userCommitted, forceP2p, attemptNo + 1);
+          return;
+        }
+        setFailedStreams((prev) => new Set(prev).add(stream));
         if (isDebridSide && debrids.length > 0) {
           debridFailStreakRef.current += 1;
           if (debridFailStreakRef.current >= 2) {
@@ -142,8 +181,22 @@ export function usePickHandler({
           : await preflightCheck(playUrl, ac.signal);
       if (ac.signal.aborted) return;
       if (!preflight.ok && preflight.reason === "stub") {
+  const reasonStr = `preflight_stub_${preflight.sizeBytes ?? 0}b`;
+  // Manual picks and season-lock should wait for the debrid to finish
+  // caching and retry the SAME source, instead of kicking (manual) or
+  // jumping to a different source (which would break the season lock).
+  const canSameSourceRetry =
+          (!autoActive || seasonLock) && attemptNo < SAME_SOURCE_MAX_RETRIES;
+        if (canSameSourceRetry) {
+          console.warn(
+            `[picker] stub on same source; retry ${attemptNo + 1}/${SAME_SOURCE_MAX_RETRIES}`,
+          );
+          await sleep(SAME_SOURCE_RETRY_DELAY_MS * (attemptNo + 1), ac.signal);
+          if (ac.signal.aborted) return;
+          await resolveAndOpen(stream, userCommitted, forceP2p, attemptNo + 1);
+          return;
+        }
         setFailedStreams((prev) => new Set(prev).add(stream));
-        const reasonStr = `preflight_stub_${preflight.sizeBytes ?? 0}b`;
         markStreamDead({ url: r.data.url }, reasonStr, PREFLIGHT_STUB_TTL_MS);
         console.warn(
           `[picker] preflight detected stub (${preflight.sizeBytes ?? "unknown"} bytes); skipping`,

--- a/src/views/settings/player-panel/play-mode-section.tsx
+++ b/src/views/settings/player-panel/play-mode-section.tsx
@@ -6,7 +6,7 @@ export function PlayModePanel() {
   const t = useT();
 
   const choices: Array<{
-    id: "instant" | "manual";
+    id: "instant" | "manual" | "season";
     label: string;
     sub: string;
     recommended?: boolean;
@@ -22,17 +22,29 @@ export function PlayModePanel() {
       label: t("Manual picker"),
       sub: t("Hitting Play opens the source list so you can choose quality, debrid, and audio yourself."),
     },
+    {
+      id: "season",
+      label: t("Lock to season server"),
+      sub: t("Pick one release that has the whole season (or series) once. After that, every episode plays instantly from that same server. Falls back to the best stream if it is ever unavailable."),
+    },
   ];
 
   return (
     <div className="flex flex-col gap-2.5">
       {choices.map((c) => {
-        const selected = (c.id === "instant") === settings.instantPlay;
+        const mode = settings.seasonSourceLock ? "season" : settings.instantPlay ? "instant" : "manual";
+        const selected = c.id === mode;
         return (
           <button
             key={c.id}
             type="button"
-            onClick={() => update({ instantPlay: c.id === "instant" })}
+            onClick={() =>
+              update(
+                c.id === "season"
+                  ? { seasonSourceLock: true }
+                  : { seasonSourceLock: false, instantPlay: c.id === "instant" },
+              )
+            }
             className={`flex items-start gap-3.5 rounded-2xl border px-5 py-4 text-start transition-colors ${
               selected
                 ? "border-ink bg-elevated"


### PR DESCRIPTION
hello @harborstremio 

## Summary
Adds a third play mode that locks playback to a chosen season-pack/server
across a whole season (or series), and a resolve-layer retry that stops the
intermittent "kick back to sources" when a debrid (torbox/RD) is still caching
a file. The retry is addon-agnostic (Torrentio, Comet, StremThru, MediaFusion…)
and also covers manual picks.

## Changes
- New play mode "Lock to season server" (settings: `seasonSourceLock`), 3rd
  radio next to Instant / Manual.
- First press shows all sources with season packs floated to top + tagged
  "Season pack"; the chosen pack is locked and reused for later episodes
  (whole-series pack if available, else per-season).
- Season-lock store: saveSeasonLock / readSeasonLock / clearSeasonLock
  (key metaId|s{n} or metaId|all, 120d TTL).
- Better matching (streamMatchesSource): infoHash (ci) → bingeGroup →
  releaseSignature → addon+resolution+source. Adds releaseSignature().
- Improved season-pack detection in the stream parser (season marker without
  episode marker = pack).
- Anti-kick: on a stub result or debrid-side resolve failure, retry the SAME
  source (up to 4×, ~1.5→6s backoff, ~15s budget) before giving up — for
  manual and season-lock modes. Instant unchanged; P2P/direct skip preflight.
- Prevent autoExhausted from latching on transient empty results during
  season-lock; keep refreshing while the locked source is absent/unresolved.
- "Change source" button (season-lock only) in the detail view.

## Notes
- Anime (kitsu/mal/anilist/anidb) is intentionally excluded from season-lock
  (unreliable season numbering). Manual anti-kick retry still applies to anime.

## Files
settings/types.ts, settings/defaults.ts, settings/play-mode-section.tsx,
lib/streams/parser/parser-stream.ts, lib/playback-history.ts,
views/play-picker.tsx, views/play-picker/use-pick-handler.ts,
views/play-picker/use-auto-candidates.ts,
views/play-picker/stremio-layout.tsx, views/play-picker/stremio-row.tsx,
views/detail.tsx, episode row/strip call sites.

## Testing
- [x] Instant + cached source → plays instantly (no added delay)
- [x] Manual + uncached torbox → retries same source, plays without reclick
- [ ] Dead/404 source → kicks fast (no long wait)
- [ ] P2P uncached torrent → P2P confirm after retries → plays
- [x] Season-lock next episode while caching → retries same infoHash, no jump

## screenshots

<img width="1919" height="1079" alt="Screenshot 2026-07-03 040053" src="https://github.com/user-attachments/assets/40e474a8-57b9-4545-b245-26a8fb973fa2" />

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/b66321d6-bd59-4d9c-b3c3-f76432bbc806" />


## How it works

https://gofile.io/d/gjlEjj