### PR TITLE
Add Docker setup for serving the web UI on port 1420

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules/
+.pnpm-store/
+dist/
+build/
+src-tauri/target/
+src-tauri/binaries/
+harbor-core/target/
+.git/
+.github/
+.vscode/
+.kiro/
+*.log
+Dockerfile
+docker-compose.yaml
+.dockerignore
+history.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# Serve Harbor's Vite/React web UI (no Rust/Tauri toolchain needed for the browser build).
+FROM node:22-bookworm-slim
+
+# The corepack bundled with node can fail to verify the pnpm 11 signature
+# ("Cannot find matching keyid"). Upgrade corepack first, then activate the
+# exact pnpm version pinned in package.json.
+RUN npm install -g corepack@latest && corepack enable
+
+WORKDIR /app
+
+# Copy manifests first for layer caching. pnpm-workspace.yaml carries the
+# build-script allow-list (esbuild) that pnpm 10+/11 requires.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN corepack prepare pnpm@11.9.0 --activate
+
+# Deterministic install from the committed lockfile (no `pnpm add`, no drift).
+RUN pnpm install --frozen-lockfile
+
+# pnpm 11 blocks postinstall build scripts by default; force esbuild's so the
+# Vite bundler's native binary is linked even if the allow-list is not honored.
+RUN pnpm rebuild esbuild
+
+# App source.
+COPY . .
+
+EXPOSE 1420
+
+# Bind to all interfaces so the port is reachable from the host.
+CMD ["pnpm", "dev", "--host", "0.0.0.0"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  harbor-web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: harbor-web
+    restart: unless-stopped
+    ports:
+      - "1420:1420"
+    environment:
+      - NODE_ENV=development
+      # Vite file-watching over a bind mount is unreliable without polling.
+      - CHOKIDAR_USEPOLLING=true
+    volumes:
+      - .:/app                 # live-edit source
+      - /app/node_modules      # keep the image's install (don't let the bind mount hide it)
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
- Adds Dockerfile, docker-compose.yaml, .dockerignore to run the web UI on port 1420 in a container.
- Deliberately skips the Rust/Tauri toolchain (browser-only build) for a small, fast image.
- Fixes pnpm 11 corepack signature error + blocked build-script issue; installs with --frozen-lockfile.
- Caveat: SPA only — Tauri-native features don't work in a plain browser.