### PR TITLE
Feat/tmdb image language priority

### DIFF
--- a/src/components/cinema-hero.tsx
+++ b/src/components/cinema-hero.tsx
@@ -6,6 +6,7 @@ import { meta as fetchMeta, narrowMediaType, type Meta } from "@/lib/cinemeta";
 import { tmdbLogo, tmdbTrailerList, useTmdbImdbId } from "@/lib/providers/tmdb";
 import { useImdbRating } from "@/lib/imdb-rating";
 import { useSettings } from "@/lib/settings";
+import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { smartPlayEpisode } from "@/lib/smart-play";
 import { fetchTrailer, prefetchTrailer, trailerSrc, type TrailerInfo } from "@/lib/trailer";
 import { useT } from "@/lib/i18n";
@@ -205,6 +206,7 @@ function CinemaSlide({
   const t = useT();
   const { settings } = useSettings();
   const { openMeta, openPicker } = useView();
+  const description = useLocalizedOverview(meta);
   const resolvedImdb = useTmdbImdbId(meta.id);
   const imdbRating = useImdbRating(meta, resolvedImdb);
   const [logo, setLogo] = useState<string | undefined>(meta.logo);
@@ -224,7 +226,7 @@ function CinemaSlide({
     if (!logoResolved) {
       const isTmdb = meta.id.startsWith("tmdb:");
       const lookup = isTmdb
-        ? tmdbLogo(settings.tmdbKey, meta.id)
+        ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
         : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
       lookup
         .then((url) => {
@@ -375,9 +377,9 @@ function CinemaSlide({
               <span>{meta.genres.slice(0, 3).join(" · ")}</span>
             )}
           </div>
-          {meta.description && (
+          {description && (
             <p className="line-clamp-2 max-w-[560px] text-[15.5px] leading-relaxed text-ink-muted">
-              {meta.description}
+              {description}
             </p>
           )}
           <div className="mt-2 flex items-center gap-3">

--- a/src/components/featured-banner/side-panel.tsx
+++ b/src/components/featured-banner/side-panel.tsx
@@ -4,6 +4,7 @@ import type { Meta } from "@/lib/cinemeta";
 import { pickRandom } from "@/lib/feed/tags";
 import { tmdbMovieImages } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
+import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { useLiveImdbRating } from "@/lib/live-imdb";
 import { ImdbIcon } from "../icons/imdb-icon";
 import type { LightboxState } from "./types";
@@ -21,6 +22,7 @@ export function SidePanel({
 }) {
   const { settings } = useSettings();
   const [stills, setStills] = useState<string[]>([]);
+  const description = useLocalizedOverview(meta);
   const live = useLiveImdbRating(meta);
 
   useEffect(() => {
@@ -82,9 +84,9 @@ export function SidePanel({
           />
         ))}
       </div>
-      {meta.description && (
+      {description && (
         <p className="text-[12.5px] leading-snug text-ink-muted line-clamp-3">
-          {meta.description}
+          {description}
         </p>
       )}
       {live.value && (

--- a/src/components/feed-hero.tsx
+++ b/src/components/feed-hero.tsx
@@ -3,6 +3,7 @@ import type { FeedItem } from "@/lib/feed";
 import { useT } from "@/lib/i18n";
 import { useTmdbImdbId } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
+import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { smartPlayEpisode } from "@/lib/smart-play";
 import { useView } from "@/lib/view";
 import { toggleWatchlist, useInWatchlist } from "@/lib/watchlist";
@@ -28,6 +29,7 @@ export function FeedHero({
   const { openMeta, openPicker } = useView();
   const t = useT();
   const meta = item.meta;
+  const description = useLocalizedOverview(meta);
   const resolvedImdb = useTmdbImdbId(meta.id);
   const live = useLiveImdbRating(meta);
   const saved = useInWatchlist(meta.id, [resolvedImdb]);
@@ -119,9 +121,9 @@ export function FeedHero({
               </>
             )}
           </div>
-          {meta.description && (
+          {description && (
             <p className="max-w-[68ch] text-[15.5px] leading-[1.55] text-ink/80 line-clamp-2">
-              {meta.description}
+              {description}
             </p>
           )}
           <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2">

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -9,6 +9,7 @@ import { omdbPrefetch, useOmdbScores } from "@/lib/providers/omdb";
 import { useImdbRating } from "@/lib/imdb-rating";
 import { tmdbImdbId, tmdbLogo, tmdbMovieImages, tmdbTrailerList, useTmdbImdbId } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
+import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { fetchTrailer, prefetchTrailer, trailerSrc, type TrailerInfo } from "@/lib/trailer";
 import { useView } from "@/lib/view";
 import { usePageVisible } from "@/lib/visibility";
@@ -34,6 +35,7 @@ export const Hero = memo(function Hero({
   const { settings } = useSettings();
   const { openMeta } = useView();
   const t = useT();
+  const description = useLocalizedOverview(meta);
   const resolvedImdb = useTmdbImdbId(meta.id);
   const inWatchlist = useInWatchlist(meta.id, [resolvedImdb]);
   const [bgUrl, setBgUrl] = useState<string | undefined>(meta.background);
@@ -95,7 +97,7 @@ export const Hero = memo(function Hero({
     const isTmdb = meta.id.startsWith("tmdb:");
     const resolve: Promise<{ logo?: string; background?: string }> = isTmdb
       ? Promise.all([
-          tmdbLogo(settings.tmdbKey, meta.id),
+          tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage),
           tmdbMovieImages(settings.tmdbKey, meta.id).then((urls) => urls[0]),
         ]).then(([logo, background]) => ({ logo, background }))
       : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => ({
@@ -223,9 +225,9 @@ export const Hero = memo(function Hero({
             </div>
           )}
           <HeroTitlePlate name={meta.name} logo={logo} loaded={logoLoaded} resolved={logoResolved} onLoad={() => setLogoLoaded(true)} onError={() => { setLogo(undefined); setLogoResolved(true); }} />
-          {meta.description && (
+          {description && (
             <p className="mt-6 line-clamp-3 max-w-xl text-[16px] leading-relaxed text-ink-muted">
-              {meta.description}
+              {description}
             </p>
           )}
           <div className="mt-6 flex flex-wrap items-center gap-x-8 gap-y-2 text-[14px]">

--- a/src/components/peek-hero.tsx
+++ b/src/components/peek-hero.tsx
@@ -205,7 +205,7 @@ function PeekSlide({
     let cancelled = false;
     const isTmdb = meta.id.startsWith("tmdb:");
     const lookup = isTmdb
-      ? tmdbLogo(settings.tmdbKey, meta.id)
+      ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
       : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
     lookup
       .then((url) => {

--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -143,7 +143,7 @@ export const PickCard = memo(function PickCard({
 
   const [imgIdx, setImgIdx] = useState(0);
   const [hydratedPoster, setHydratedPoster] = useState<string | undefined>();
-  const localizedPoster = useLocalizedPoster(meta.id);
+  const localizedPoster = useLocalizedPoster(meta.id, meta.originalLanguage);
   const wantTmdbPoster = needsTmdbForPoster(settings.rpdbKey, meta.id);
   const resolvedTmdb = useTmdbIdFromImdb(wantTmdbPoster ? meta.id : undefined);
   const animeTmdb = useTmdbIdFromImdb(animeImdb) ?? undefined;

--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -30,7 +30,7 @@ import { useInWatchlist } from "@/lib/watchlist";
 import { ClapperMini } from "./icons/clapper-mini";
 import { ImdbIcon } from "./icons/imdb-icon";
 import { MalLogo } from "./icons/mal-logo";
-import { Poster } from "./poster";
+import { Poster, useLocalizedPoster } from "./poster";
 import { ElegantHoverActions } from "./pick-card/elegant-hover";
 import { RtBadge } from "./rt-badge";
 import mdblistLogo from "@/assets/addon-logos/mdblist.png";
@@ -143,6 +143,7 @@ export const PickCard = memo(function PickCard({
 
   const [imgIdx, setImgIdx] = useState(0);
   const [hydratedPoster, setHydratedPoster] = useState<string | undefined>();
+  const localizedPoster = useLocalizedPoster(meta.id);
   const wantTmdbPoster = needsTmdbForPoster(settings.rpdbKey, meta.id);
   const resolvedTmdb = useTmdbIdFromImdb(wantTmdbPoster ? meta.id : undefined);
   const animeTmdb = useTmdbIdFromImdb(animeImdb) ?? undefined;
@@ -152,12 +153,16 @@ export const PickCard = memo(function PickCard({
       ? resolvedTmdb ?? undefined
       : undefined;
   const posterCandidates = useMemo(() => {
+    // Prefer the language-localized poster; RPDB (when configured) still wins, and
+    // the catalog poster stays the fallback.
+    const base = localizedPoster ?? meta.poster;
     const seen = new Set<string>();
     const out: string[] = [];
     for (const u of [
-      animeImdb ? rpdbPoster(settings.rpdbKey, animeImdb, meta.poster, animeTmdb) : undefined,
-      animeTvdb ? rpdbPoster(settings.rpdbKey, `tvdb:${animeTvdb}`, meta.poster) : undefined,
-      rpdbPoster(settings.rpdbKey, meta.id, meta.poster, posterAltId),
+      animeImdb ? rpdbPoster(settings.rpdbKey, animeImdb, base, animeTmdb) : undefined,
+      animeTvdb ? rpdbPoster(settings.rpdbKey, `tvdb:${animeTvdb}`, base) : undefined,
+      rpdbPoster(settings.rpdbKey, meta.id, base, posterAltId),
+      localizedPoster,
       meta.poster,
       hydratedPoster,
     ]) {
@@ -166,7 +171,7 @@ export const PickCard = memo(function PickCard({
       out.push(u);
     }
     return out;
-  }, [settings.rpdbKey, meta.id, posterAltId, meta.poster, hydratedPoster, animeImdb, animeTvdb, animeTmdb]);
+  }, [settings.rpdbKey, meta.id, posterAltId, meta.poster, hydratedPoster, animeImdb, animeTvdb, animeTmdb, localizedPoster]);
   const posterSrc = posterCandidates[imgIdx];
 
   useEffect(() => {

--- a/src/components/player/cast-modal.tsx
+++ b/src/components/player/cast-modal.tsx
@@ -77,7 +77,8 @@ export function CastModal({
       : `${IMG}/w342${detail.poster}`
     : null;
   const poster = detailPoster ?? meta.poster;
-  const overview = detail?.overview?.trim() || meta.description?.trim() || "";
+  const overview =
+    detail?.overview?.trim() || (meta.id.startsWith("tmdb:") ? "" : meta.description?.trim()) || "";
   const year = detail?.year ?? meta.releaseInfo ?? meta.releaseDate?.slice(0, 4) ?? "";
   const rating = detail?.rating ?? meta.imdbRating ?? "";
   const runtime = detail?.runtime ?? meta.runtime ?? "";

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -11,23 +11,24 @@ import { externalToKitsu, kitsuToImdb, kitsuToTvdb } from "@/lib/providers/anime
 import { tmdbLocalizedPoster } from "@/lib/providers/tmdb/tmdb-images";
 import { shouldLocalizePosters } from "@/lib/providers/tmdb/tmdb-image-lang";
 
-// Resolves a card's poster in the user's picked image languages (e.g. Arabic then
-// English) via a per-title /images lookup, lazily and cached. Only runs when the top
-// image language is non-English; falls back to the catalog poster otherwise.
-export function useLocalizedPoster(metaId: string): string | undefined {
+// Resolves a card's poster in the user's image-language order (e.g. Arabic then
+// English, then the title's original language) via a per-title /images lookup, lazily
+// and cached. Independent of the metadata (text) language. Only runs when the top
+// image language differs from the catalog poster language; falls back otherwise.
+export function useLocalizedPoster(metaId: string, originalLang?: string | null): string | undefined {
   const { settings } = useSettings();
   const [url, setUrl] = useState<string | undefined>(undefined);
   useEffect(() => {
     setUrl(undefined);
     if (!settings.tmdbKey || !metaId.startsWith("tmdb:") || !shouldLocalizePosters()) return;
     let alive = true;
-    void tmdbLocalizedPoster(settings.tmdbKey, metaId).then((u) => {
+    void tmdbLocalizedPoster(settings.tmdbKey, metaId, originalLang).then((u) => {
       if (alive && u) setUrl(u);
     });
     return () => {
       alive = false;
     };
-  }, [metaId, settings.tmdbKey]);
+  }, [metaId, originalLang, settings.tmdbKey]);
   return url;
 }
 
@@ -100,10 +101,11 @@ export function usePosterChain(
   metaId: string,
   metaPoster?: string,
   type?: "movie" | "series",
+  originalLang?: string | null,
 ) {
   const altId = useRpdbAltId(rpdbKey, metaId, type);
   const { animeImdb, animeTvdb, animeTmdb } = useAnimeRpdbIds(rpdbKey, metaId);
-  const localized = useLocalizedPoster(metaId);
+  const localized = useLocalizedPoster(metaId, originalLang);
   const candidates = useMemo(() => {
     // Prefer the language-localized poster; RPDB (when configured) still wins, and
     // the catalog poster remains the final fallback.

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -8,6 +8,28 @@ import {
 } from "@/lib/providers/tmdb/tmdb-imdb-resolve";
 import { useSettings } from "@/lib/settings";
 import { externalToKitsu, kitsuToImdb, kitsuToTvdb } from "@/lib/providers/anime-mapping";
+import { tmdbLocalizedPoster } from "@/lib/providers/tmdb/tmdb-images";
+import { shouldLocalizePosters } from "@/lib/providers/tmdb/tmdb-image-lang";
+
+// Resolves a card's poster in the user's picked image languages (e.g. Arabic then
+// English) via a per-title /images lookup, lazily and cached. Only runs when the top
+// image language is non-English; falls back to the catalog poster otherwise.
+export function useLocalizedPoster(metaId: string): string | undefined {
+  const { settings } = useSettings();
+  const [url, setUrl] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    setUrl(undefined);
+    if (!settings.tmdbKey || !metaId.startsWith("tmdb:") || !shouldLocalizePosters()) return;
+    let alive = true;
+    void tmdbLocalizedPoster(settings.tmdbKey, metaId).then((u) => {
+      if (alive && u) setUrl(u);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [metaId, settings.tmdbKey]);
+  return url;
+}
 
 type Ratio = "portrait" | "landscape" | "wide";
 
@@ -81,13 +103,18 @@ export function usePosterChain(
 ) {
   const altId = useRpdbAltId(rpdbKey, metaId, type);
   const { animeImdb, animeTvdb, animeTmdb } = useAnimeRpdbIds(rpdbKey, metaId);
+  const localized = useLocalizedPoster(metaId);
   const candidates = useMemo(() => {
+    // Prefer the language-localized poster; RPDB (when configured) still wins, and
+    // the catalog poster remains the final fallback.
+    const base = localized ?? metaPoster;
     const out: string[] = [];
     const seen = new Set<string>();
     for (const u of [
-      animeImdb ? rpdbPoster(rpdbKey, animeImdb, metaPoster, animeTmdb) : undefined,
-      animeTvdb ? rpdbPoster(rpdbKey, `tvdb:${animeTvdb}`, metaPoster) : undefined,
-      rpdbPoster(rpdbKey, metaId, metaPoster, altId),
+      animeImdb ? rpdbPoster(rpdbKey, animeImdb, base, animeTmdb) : undefined,
+      animeTvdb ? rpdbPoster(rpdbKey, `tvdb:${animeTvdb}`, base) : undefined,
+      rpdbPoster(rpdbKey, metaId, base, altId),
+      localized,
       metaPoster,
     ]) {
       if (u && !seen.has(u)) {
@@ -96,7 +123,7 @@ export function usePosterChain(
       }
     }
     return out;
-  }, [rpdbKey, metaId, altId, metaPoster, animeImdb, animeTvdb, animeTmdb]);
+  }, [rpdbKey, metaId, altId, metaPoster, animeImdb, animeTvdb, animeTmdb, localized]);
   const sig = candidates.join("|");
   const failedRef = useRef<Set<string>>(new Set());
   const sigRef = useRef(sig);

--- a/src/components/search/meta-list.tsx
+++ b/src/components/search/meta-list.tsx
@@ -1,7 +1,46 @@
 import { Star } from "lucide-react";
 import type { Meta } from "@/lib/cinemeta";
+import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { ResultPoster } from "./result-poster";
 import { useView } from "@/lib/view";
+
+function MetaRow({ m, onClose }: { m: Meta; onClose: () => void }) {
+  const { openMeta } = useView();
+  const description = useLocalizedOverview(m);
+  return (
+    <button
+      onClick={() => {
+        openMeta(m);
+        onClose();
+      }}
+      className="group flex items-center gap-4 rounded-2xl border border-transparent px-3 py-2.5 text-start transition-colors hover:border-edge-soft hover:bg-elevated/50 active:scale-[0.997]"
+    >
+      <div className="h-[96px] w-[64px] shrink-0 overflow-hidden rounded-xl shadow-[0_6px_16px_-8px_rgba(0,0,0,0.55)] ring-1 ring-edge-soft">
+        <ResultPoster id={m.id} poster={m.poster} className="block h-full w-full" />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="truncate text-[16px] font-semibold text-ink">{m.name}</span>
+        <div className="flex items-center gap-2 text-[12.5px] text-ink-muted">
+          {m.releaseInfo && <span>{m.releaseInfo}</span>}
+          {m.releaseInfo && m.imdbRating && (
+            <span aria-hidden className="h-1 w-1 rounded-full bg-ink-subtle" />
+          )}
+          {m.imdbRating && (
+            <span className="flex items-center gap-1 text-ink">
+              <Star size={11} className="fill-accent text-accent" />
+              {m.imdbRating}
+            </span>
+          )}
+        </div>
+        {description && (
+          <span className="line-clamp-2 text-[12.5px] leading-snug text-ink-subtle">
+            {description}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
 
 export function MetaList({
   title,
@@ -12,7 +51,6 @@ export function MetaList({
   items: Meta[];
   onClose: () => void;
 }) {
-  const { openMeta } = useView();
   if (items.length === 0) return null;
   return (
     <section>
@@ -21,38 +59,7 @@ export function MetaList({
       </h3>
       <div className="grid gap-1">
         {items.map((m) => (
-          <button
-            key={m.id}
-            onClick={() => {
-              openMeta(m);
-              onClose();
-            }}
-            className="group flex items-center gap-4 rounded-2xl border border-transparent px-3 py-2.5 text-start transition-colors hover:border-edge-soft hover:bg-elevated/50 active:scale-[0.997]"
-          >
-            <div className="h-[96px] w-[64px] shrink-0 overflow-hidden rounded-xl shadow-[0_6px_16px_-8px_rgba(0,0,0,0.55)] ring-1 ring-edge-soft">
-              <ResultPoster id={m.id} poster={m.poster} className="block h-full w-full" />
-            </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <span className="truncate text-[16px] font-semibold text-ink">{m.name}</span>
-              <div className="flex items-center gap-2 text-[12.5px] text-ink-muted">
-                {m.releaseInfo && <span>{m.releaseInfo}</span>}
-                {m.releaseInfo && m.imdbRating && (
-                  <span aria-hidden className="h-1 w-1 rounded-full bg-ink-subtle" />
-                )}
-                {m.imdbRating && (
-                  <span className="flex items-center gap-1 text-ink">
-                    <Star size={11} className="fill-accent text-accent" />
-                    {m.imdbRating}
-                  </span>
-                )}
-              </div>
-              {m.description && (
-                <span className="line-clamp-2 text-[12.5px] leading-snug text-ink-subtle">
-                  {m.description}
-                </span>
-              )}
-            </div>
-          </button>
+          <MetaRow key={m.id} m={m} onClose={onClose} />
         ))}
       </div>
     </section>

--- a/src/components/search/meta-list.tsx
+++ b/src/components/search/meta-list.tsx
@@ -13,7 +13,7 @@ function MetaRow({ m, onClose }: { m: Meta; onClose: () => void }) {
         openMeta(m);
         onClose();
       }}
-      className="group flex items-center gap-4 rounded-2xl border border-transparent px-3 py-2.5 text-start transition-colors hover:border-edge-soft hover:bg-elevated/50 active:scale-[0.997]"
+      className="group flex min-w-0 items-center gap-4 rounded-2xl border border-transparent px-3 py-2.5 text-start transition-colors hover:border-edge-soft hover:bg-elevated/50 active:scale-[0.997]"
     >
       <div className="h-[96px] w-[64px] shrink-0 overflow-hidden rounded-xl shadow-[0_6px_16px_-8px_rgba(0,0,0,0.55)] ring-1 ring-edge-soft">
         <ResultPoster id={m.id} poster={m.poster} className="block h-full w-full" />
@@ -53,11 +53,11 @@ export function MetaList({
 }) {
   if (items.length === 0) return null;
   return (
-    <section>
+    <section className="min-w-0">
       <h3 className="mb-3 text-[12px] font-semibold uppercase tracking-[0.2em] text-ink-subtle">
         {title}
       </h3>
-      <div className="grid gap-1">
+      <div className="grid min-w-0 gap-1">
         {items.map((m) => (
           <MetaRow key={m.id} m={m} onClose={onClose} />
         ))}

--- a/src/components/search/top-match.tsx
+++ b/src/components/search/top-match.tsx
@@ -1,6 +1,7 @@
 import { Play, Star } from "lucide-react";
 import type { SearchResults } from "@/lib/search";
 import { ResultPoster } from "./result-poster";
+import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { useView } from "@/lib/view";
 
 export function TopMatch({
@@ -13,7 +14,9 @@ export function TopMatch({
   const { openMeta } = useView();
   const yearTxt = match.meta.releaseInfo ?? "";
   const rating = match.voteAverage && match.voteAverage > 0 ? match.voteAverage.toFixed(1) : null;
-  const synopsis = (match.overview ?? "").trim();
+  // Same metadata-language handling as the heroes: show the plot in the reading
+  // language, not the (image-language) search response language.
+  const synopsis = (useLocalizedOverview(match.meta) ?? "").trim();
 
   const handleOpen = () => {
     openMeta(match.meta);

--- a/src/lib/logo.ts
+++ b/src/lib/logo.ts
@@ -46,7 +46,7 @@ async function doResolve(tmdbKey: string, m: Meta): Promise<string | undefined> 
   }
   if (m.id.startsWith("tmdb:")) {
     if (tmdbKey) {
-      const fromTmdb = await tmdbLogo(tmdbKey, m.id);
+      const fromTmdb = await tmdbLogo(tmdbKey, m.id, m.originalLanguage);
       if (fromTmdb) return fromTmdb;
       const tt = await tmdbImdbId(tmdbKey, m.id);
       if (tt) {

--- a/src/lib/providers/tmdb/tmdb-anime.ts
+++ b/src/lib/providers/tmdb/tmdb-anime.ts
@@ -1,6 +1,6 @@
-import { get, tmdbLanguageIso } from "./tmdb-client";
+import { get } from "./tmdb-client";
 import { pickLogo } from "./tmdb-images";
-import { loadStoredSettings } from "@/lib/settings/load";
+import { imageLangParam } from "./tmdb-image-lang";
 
 type SearchTvHit = {
   id: number;
@@ -49,7 +49,7 @@ export async function tmdbAnimeMatch(
   name: string,
   year: string | undefined,
   kind: "movie" | "tv",
-): Promise<number | null> {
+): Promise<{ id: number; originalLang?: string } | null> {
   if (!key || !name) return null;
   const params: Record<string, string> = { query: name, include_adult: "false" };
   if (year) params[kind === "tv" ? "first_air_date_year" : "year"] = year;
@@ -60,6 +60,7 @@ export async function tmdbAnimeMatch(
     const ranked = hits
       .map((h) => ({
         id: h.id,
+        originalLang: h.original_language,
         score: scoreHit(
           name,
           {
@@ -73,7 +74,7 @@ export async function tmdbAnimeMatch(
         ),
       }))
       .sort((a, b) => b.score - a.score);
-    return ranked[0]?.id ?? null;
+    return ranked[0] ? { id: ranked[0].id, originalLang: ranked[0].originalLang } : null;
   }
   const data = await get<{ results?: SearchMovieHit[] }>(key, "search/movie", params);
   const hits = data?.results ?? [];
@@ -81,6 +82,7 @@ export async function tmdbAnimeMatch(
   const ranked = hits
     .map((h) => ({
       id: h.id,
+      originalLang: h.original_language,
       score: scoreHit(
         name,
         {
@@ -94,7 +96,7 @@ export async function tmdbAnimeMatch(
       ),
     }))
     .sort((a, b) => b.score - a.score);
-  return ranked[0]?.id ?? null;
+  return ranked[0] ? { id: ranked[0].id, originalLang: ranked[0].originalLang } : null;
 }
 
 export async function tmdbAnimeLogo(
@@ -103,17 +105,15 @@ export async function tmdbAnimeLogo(
   year: string | undefined,
   kind: "movie" | "tv",
 ): Promise<{ logo?: string; backdrop?: string; tmdbId?: number } | null> {
-  const id = await tmdbAnimeMatch(key, name, year, kind);
-  if (!id) return null;
-  const iso = tmdbLanguageIso();
-  const settings = loadStoredSettings();
-  const translatePosters = settings.translatePosters && !settings.posterBaseUrl;
+  const match = await tmdbAnimeMatch(key, name, year, kind);
+  if (!match) return null;
+  const { id, originalLang } = match;
   const imgs = await get<{ logos?: any[]; backdrops?: any[] }>(
     key,
     `${kind}/${id}/images`,
-    { include_image_language: translatePosters && iso && iso !== "en" ? `${iso},en,null` : "en,null" },
+    { include_image_language: imageLangParam(originalLang) },
   );
-  const logo = pickLogo(imgs?.logos ?? []);
+  const logo = pickLogo(imgs?.logos ?? [], originalLang);
   const backdropPath = (imgs?.backdrops ?? [])[0]?.file_path;
   return {
     logo,

--- a/src/lib/providers/tmdb/tmdb-client.ts
+++ b/src/lib/providers/tmdb/tmdb-client.ts
@@ -1,5 +1,4 @@
 import { fetch as tauriHttpFetch } from "@tauri-apps/plugin-http";
-import { imageRequestLang } from "./tmdb-image-lang";
 
 const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
@@ -99,8 +98,10 @@ export async function get<T>(
   if (!key) return null;
   const url = new URL(`${TMDB}/${path}`);
   url.searchParams.set("api_key", key);
-  // Metadata language wins; otherwise localize posters/art to the top image language.
-  const lang = effectiveTmdbLanguage() || imageRequestLang();
+  // Only the metadata (text) language drives the bulk `language` param. Posters/art
+  // are localized separately per-title via include_image_language + /images, so the
+  // image language never leaks into the catalog text and vice-versa.
+  const lang = effectiveTmdbLanguage();
   if (lang && !params.language) url.searchParams.set("language", lang);
   for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   const target = url.toString();

--- a/src/lib/providers/tmdb/tmdb-client.ts
+++ b/src/lib/providers/tmdb/tmdb-client.ts
@@ -1,4 +1,5 @@
 import { fetch as tauriHttpFetch } from "@tauri-apps/plugin-http";
+import { imageRequestLang } from "./tmdb-image-lang";
 
 const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
@@ -98,7 +99,8 @@ export async function get<T>(
   if (!key) return null;
   const url = new URL(`${TMDB}/${path}`);
   url.searchParams.set("api_key", key);
-  const lang = effectiveTmdbLanguage();
+  // Metadata language wins; otherwise localize posters/art to the top image language.
+  const lang = effectiveTmdbLanguage() || imageRequestLang();
   if (lang && !params.language) url.searchParams.set("language", lang);
   for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   const target = url.toString();

--- a/src/lib/providers/tmdb/tmdb-details.ts
+++ b/src/lib/providers/tmdb/tmdb-details.ts
@@ -1,7 +1,8 @@
 import type { Meta } from "../../cinemeta";
-import { get, IMG, tmdbLanguageIso } from "./tmdb-client";
+import { get, IMG, effectiveTmdbLanguage } from "./tmdb-client";
 import { loadStoredSettings } from "@/lib/settings/load";
-import { pickLogo } from "./tmdb-images";
+import { pickLogo, fetchMovieAssets } from "./tmdb-images";
+import { imageLangParam, imageLangRank } from "./tmdb-image-lang";
 import { pickTrailers, type Video } from "./tmdb-trailers";
 import type { PersonRef } from "./tmdb-people";
 
@@ -188,16 +189,29 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
     return null;
   }
 
-  const iso = tmdbLanguageIso();
   const settings = loadStoredSettings();
-  const translatePosters = settings.translatePosters && !settings.posterBaseUrl;
+  // Text (title, overview, cast/crew, genres) uses the metadata language — the
+  // image language only drives which artwork is returned (include_image_language).
+  const metaLang = effectiveTmdbLanguage() || "en";
   const raw = await get<any>(key, `${kind}/${id}`, {
     append_to_response: "credits,aggregate_credits,recommendations,similar,videos,external_ids,images,keywords,translations",
-    include_image_language: translatePosters && iso && iso !== "en" ? `${iso},en,null` : "en,null",
+    language: metaLang,
+    include_image_language: imageLangParam(),
   });
   if (!raw) return null;
 
-  const logo = pickLogo(raw.images?.logos ?? []);
+  const origLang = typeof raw.original_language === "string" ? raw.original_language : "";
+  let logo = pickLogo(raw.images?.logos ?? [], origLang);
+  let posterSource = raw.images?.posters;
+  // If nothing matched the preferred languages, re-fetch including the title's own
+  // (original) language so we show real art instead of falling back to plain text.
+  if (!logo && origLang && !imageLangParam().split(",").includes(origLang)) {
+    const assets = await fetchMovieAssets(key, `tmdb:${kind}:${id}`, origLang);
+    if (assets) {
+      logo = pickLogo(assets.logos ?? [], origLang);
+      posterSource = assets.posters ?? posterSource;
+    }
+  }
   const rawKeywords = raw.keywords?.keywords ?? raw.keywords?.results ?? [];
   const keywords: number[] = rawKeywords
     .map((k: any) => k?.id)
@@ -292,22 +306,28 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   let overview = raw.overview ?? "";
   let tagline = raw.tagline ?? "";
   if (!settings.translateDescriptions) {
-    const enTrans = raw.translations?.translations?.find((t: any) => t.iso_639_1 === "en");
-    if (enTrans?.data?.overview) overview = enTrans.data.overview;
-    if (enTrans?.data?.tagline) tagline = enTrans.data.tagline;
+    const enTrans = raw.translations?.translations?.find((t: any) => t.iso_639_1 === "en")?.data;
+    if (enTrans?.overview) overview = enTrans.overview;
+    if (enTrans?.tagline) tagline = enTrans.tagline;
   }
 
   let finalPosterPath = raw.poster_path;
-  if (!translatePosters && raw.images?.posters?.length) {
-    const enPoster = raw.images.posters.find((p: any) => p.iso_639_1 === "en") || raw.images.posters[0];
-    if (enPoster) finalPosterPath = enPoster.file_path;
+  if (!settings.posterBaseUrl && posterSource?.length) {
+    const best = [...posterSource].sort(
+      (a: any, b: any) =>
+        imageLangRank(b.iso_639_1, origLang) - imageLangRank(a.iso_639_1, origLang) ||
+        (b.vote_average ?? 0) - (a.vote_average ?? 0),
+    )[0];
+    if (best) finalPosterPath = best.file_path;
   }
 
   return {
     kind,
     id: raw.id,
     imdbId: raw.external_ids?.imdb_id ?? null,
-    title: raw.title ?? raw.name,
+    title: settings.translateTitles
+      ? (raw.title || raw.name)
+      : (raw.original_title || raw.original_name || raw.title || raw.name),
     originalTitle: raw.original_title ?? raw.original_name ?? "",
     tagline,
     overview,
@@ -380,7 +400,9 @@ export async function tmdbSeasonEpisodes(
   seasonNumber: number,
 ): Promise<Episode[]> {
   if (!key) return [];
-  const data = await get<any>(key, `tv/${tvId}/season/${seasonNumber}`);
+  const data = await get<any>(key, `tv/${tvId}/season/${seasonNumber}`, {
+    language: effectiveTmdbLanguage() || "en",
+  });
   if (!data?.episodes) return [];
   return data.episodes.map((e: any) => ({
     id: e.id,

--- a/src/lib/providers/tmdb/tmdb-episode-details.ts
+++ b/src/lib/providers/tmdb/tmdb-episode-details.ts
@@ -5,7 +5,8 @@ import type {
   CrewMember,
   StillImage,
 } from "./tmdb-episode-types";
-import { get } from "./tmdb-client";
+import { effectiveTmdbLanguage, get } from "./tmdb-client";
+import { imageLangParam } from "./tmdb-image-lang";
 
 /**
  * Fetch comprehensive episode details from TMDB API
@@ -26,7 +27,8 @@ export async function tmdbEpisodeDetail(
     const path = `tv/${tvId}/season/${seasonNumber}/episode/${episodeNumber}`;
     const params = {
       append_to_response: "credits,images,external_ids",
-      include_image_language: "en,null",
+      language: effectiveTmdbLanguage() || "en",
+      include_image_language: imageLangParam(),
     };
 
     const data = await get<TmdbEpisodeResponse>(apiKey, path, params);

--- a/src/lib/providers/tmdb/tmdb-image-lang.ts
+++ b/src/lib/providers/tmdb/tmdb-image-lang.ts
@@ -1,5 +1,6 @@
 import { loadStoredSettings } from "@/lib/settings/load";
 import { normalizeLang } from "@/lib/subtitles/language";
+import { tmdbLanguageIso } from "./tmdb-client";
 
 // User-ordered image-language priority. null = "Original" (TMDB no-language art).
 // Reads settings.tmdbImageLangs (display names) and maps to TMDB ISO codes.
@@ -23,7 +24,9 @@ export function imageLangPriority(): (string | null)[] {
 // ("Original" in the user's list just pins those fallbacks earlier.) This is why a
 // logo/poster always appears when one exists in any form, instead of bare text.
 function effectiveOrder(originalLang?: string | null): (string | null)[] {
-  const orig = originalLang ? normalizeLang(originalLang) || originalLang : null;
+  const orig = originalLang
+    ? (normalizeLang(originalLang) || originalLang).toLowerCase()
+    : null;
   const order: (string | null)[] = [];
   const add = (c: string | null) => {
     if (!order.includes(c)) order.push(c);
@@ -54,21 +57,15 @@ export function imageLangRank(iso: string | null | undefined, originalLang?: str
   return idx === -1 ? -1 : order.length - idx;
 }
 
-// Top concrete (non-"Original") language for localizing bulk catalog/list posters
-// via TMDB's `language` param. Returns "" when the list is Original-only/empty.
-export function imageRequestLang(): string {
-  for (const c of imageLangPriority()) if (c) return c;
-  return "";
-}
-
-// Concrete picked languages in order (drops the "Original" placeholder).
-export function pickedImageLangs(): string[] {
-  return imageLangPriority().filter((c): c is string => c !== null);
-}
-
-// Whether per-card poster enrichment is worthwhile: only when the top preference is
-// a non-English language, since English is already TMDB's default catalog fallback.
+// Whether per-card poster enrichment is worthwhile. TMDB's list endpoints return
+// poster_path in the bulk request `language` (the metadata language, or English when
+// unset), so the catalog poster follows the TEXT language. We enrich per-card only
+// when the user's top image preference differs from that bulk poster language — this
+// is what keeps posters independent of the metadata language (e.g. Arabic text but
+// English posters). "Original" first always needs a per-title fetch.
 export function shouldLocalizePosters(): boolean {
-  const top = imageRequestLang();
-  return !!top && top !== "en";
+  const [first] = imageLangPriority();
+  const bulk = tmdbLanguageIso() || "en";
+  if (first == null) return true;
+  return first !== bulk;
 }

--- a/src/lib/providers/tmdb/tmdb-image-lang.ts
+++ b/src/lib/providers/tmdb/tmdb-image-lang.ts
@@ -1,0 +1,74 @@
+import { loadStoredSettings } from "@/lib/settings/load";
+import { normalizeLang } from "@/lib/subtitles/language";
+
+// User-ordered image-language priority. null = "Original" (TMDB no-language art).
+// Reads settings.tmdbImageLangs (display names) and maps to TMDB ISO codes.
+// Falls back to English then Original when the list is empty.
+export function imageLangPriority(): (string | null)[] {
+  const names = loadStoredSettings().tmdbImageLangs ?? [];
+  const out: (string | null)[] = [];
+  for (const name of names) {
+    if (/^original$/i.test(name.trim())) {
+      if (!out.includes(null)) out.push(null);
+      continue;
+    }
+    const code = normalizeLang(name);
+    if (code && !out.includes(code)) out.push(code);
+  }
+  return out.length ? out : ["en", null];
+}
+
+// The effective per-title fallback order: the user's picked languages first, then
+// the title's own original language, then textless art as the final fallback.
+// ("Original" in the user's list just pins those fallbacks earlier.) This is why a
+// logo/poster always appears when one exists in any form, instead of bare text.
+function effectiveOrder(originalLang?: string | null): (string | null)[] {
+  const orig = originalLang ? normalizeLang(originalLang) || originalLang : null;
+  const order: (string | null)[] = [];
+  const add = (c: string | null) => {
+    if (!order.includes(c)) order.push(c);
+  };
+  for (const c of imageLangPriority()) {
+    if (c === null) {
+      if (orig) add(orig);
+      add(null);
+    } else add(c);
+  }
+  if (orig) add(orig);
+  add(null);
+  return order;
+}
+
+// Comma-separated value for TMDB's include_image_language param, e.g. "ar,en,ja,null".
+export function imageLangParam(originalLang?: string | null): string {
+  return effectiveOrder(originalLang)
+    .map((c) => c ?? "null")
+    .join(",");
+}
+
+// Rank an image's language against the effective order. Higher is better.
+// -1 means the language is outside the order (still selectable as an absolute last resort).
+export function imageLangRank(iso: string | null | undefined, originalLang?: string | null): number {
+  const order = effectiveOrder(originalLang);
+  const idx = order.indexOf(iso ?? null);
+  return idx === -1 ? -1 : order.length - idx;
+}
+
+// Top concrete (non-"Original") language for localizing bulk catalog/list posters
+// via TMDB's `language` param. Returns "" when the list is Original-only/empty.
+export function imageRequestLang(): string {
+  for (const c of imageLangPriority()) if (c) return c;
+  return "";
+}
+
+// Concrete picked languages in order (drops the "Original" placeholder).
+export function pickedImageLangs(): string[] {
+  return imageLangPriority().filter((c): c is string => c !== null);
+}
+
+// Whether per-card poster enrichment is worthwhile: only when the top preference is
+// a non-English language, since English is already TMDB's default catalog fallback.
+export function shouldLocalizePosters(): boolean {
+  const top = imageRequestLang();
+  return !!top && top !== "en";
+}

--- a/src/lib/providers/tmdb/tmdb-images.ts
+++ b/src/lib/providers/tmdb/tmdb-images.ts
@@ -1,7 +1,7 @@
 import { lruSet } from "@/lib/cache";
 import { registerCache } from "@/lib/memory-profiler";
 import { get, IMG } from "./tmdb-client";
-import { imageLangParam, imageLangRank, pickedImageLangs } from "./tmdb-image-lang";
+import { imageLangParam, imageLangRank } from "./tmdb-image-lang";
 
 export type LogoEntry = { file_path: string; iso_639_1: string | null; vote_average?: number };
 
@@ -54,24 +54,24 @@ export const pickLogo = (logos: LogoEntry[], originalLang?: string | null): stri
   return best?.file_path ? `${IMG}/w342${best.file_path}` : undefined;
 };
 
-// Best poster for a title in one of the user's picked languages (e.g. Arabic then
-// English). Returns undefined when the title has no poster in a preferred language,
-// so callers fall back to the catalog poster (the title's original-language art).
-export async function tmdbLocalizedPoster(key: string, metaId: string): Promise<string | undefined> {
-  const picks = pickedImageLangs();
-  if (!picks.length) return undefined;
-  const assets = await fetchMovieAssets(key, metaId);
-  const posters = (assets?.posters ?? []).filter(
-    (p) => typeof p.iso_639_1 === "string" && picks.includes(p.iso_639_1),
-  );
+// Best poster for a title in the user's image-language order — picked languages
+// first, then the title's own original language, then textless art. Fetched via a
+// per-title /images lookup restricted to those languages, so it is fully independent
+// of the metadata (text) language: the catalog poster's language never leaks in.
+// Returns undefined only when the title has no usable poster in any of those
+// languages, so callers fall back to the catalog poster.
+export async function tmdbLocalizedPoster(
+  key: string,
+  metaId: string,
+  originalLang?: string | null,
+): Promise<string | undefined> {
+  const assets = await fetchMovieAssets(key, metaId, originalLang);
+  const posters = assets?.posters ?? [];
   if (!posters.length) return undefined;
-  const rank = (iso?: string | null) => {
-    const i = picks.indexOf(iso ?? "");
-    return i === -1 ? -1 : picks.length - i;
-  };
-  const best = [...posters].sort(
-    (a, b) => rank(b.iso_639_1) - rank(a.iso_639_1) || (b.vote_average ?? 0) - (a.vote_average ?? 0),
-  )[0];
+  const best = posters
+    .map((p) => ({ p, r: imageLangRank(p.iso_639_1 ?? null, originalLang) }))
+    .filter((x) => x.r >= 0)
+    .sort((a, b) => b.r - a.r || (b.p.vote_average ?? 0) - (a.p.vote_average ?? 0))[0]?.p;
   return best?.file_path ? `${IMG}/w342${best.file_path}` : undefined;
 }
 

--- a/src/lib/providers/tmdb/tmdb-images.ts
+++ b/src/lib/providers/tmdb/tmdb-images.ts
@@ -1,7 +1,7 @@
 import { lruSet } from "@/lib/cache";
 import { registerCache } from "@/lib/memory-profiler";
-import { loadStoredSettings } from "@/lib/settings/load";
-import { get, IMG, tmdbLanguageIso } from "./tmdb-client";
+import { get, IMG } from "./tmdb-client";
+import { imageLangParam, imageLangRank, pickedImageLangs } from "./tmdb-image-lang";
 
 export type LogoEntry = { file_path: string; iso_639_1: string | null; vote_average?: number };
 
@@ -17,47 +17,63 @@ const movieAssetsInflight = new Map<string, Promise<RawImages | null>>();
 
 registerCache("tmdb:movieAssets", () => movieAssetsCache.size);
 
-export async function fetchMovieAssets(key: string, metaId: string): Promise<RawImages | null> {
+export async function fetchMovieAssets(
+  key: string,
+  metaId: string,
+  originalLang?: string | null,
+): Promise<RawImages | null> {
   if (!key) return null;
   const match = metaId.match(/^tmdb:(movie|tv):(\d+)$/);
   if (!match) return null;
-  const cached = movieAssetsCache.get(metaId);
+  const cacheKey = originalLang ? `${metaId}|${originalLang}` : metaId;
+  const cached = movieAssetsCache.get(cacheKey);
   if (cached) return cached;
-  const inflight = movieAssetsInflight.get(metaId);
+  const inflight = movieAssetsInflight.get(cacheKey);
   if (inflight) return inflight;
   const [, kind, id] = match;
-  const iso = tmdbLanguageIso();
-  const settings = loadStoredSettings();
-  const translatePosters = settings.translatePosters && !settings.posterBaseUrl;
   const p = get<RawImages>(key, `${kind}/${id}/images`, {
-    include_image_language: translatePosters && iso && iso !== "en" ? `${iso},en,null` : "en,null",
+    include_image_language: imageLangParam(originalLang),
   }).then((data) => {
-    movieAssetsInflight.delete(metaId);
-    if (data) lruSet(movieAssetsCache, metaId, data, MOVIE_ASSETS_MAX);
+    movieAssetsInflight.delete(cacheKey);
+    if (data) lruSet(movieAssetsCache, cacheKey, data, MOVIE_ASSETS_MAX);
     return data;
   });
-  movieAssetsInflight.set(metaId, p);
+  movieAssetsInflight.set(cacheKey, p);
   return p;
 }
 
-export const pickLogo = (logos: LogoEntry[]): string | undefined => {
+export const pickLogo = (logos: LogoEntry[], originalLang?: string | null): string | undefined => {
   if (!logos?.length) return undefined;
-  const iso = tmdbLanguageIso();
   const score = (l: LogoEntry) => {
-    const lang =
-      iso && iso !== "en" && l.iso_639_1 === iso
-        ? 150
-        : l.iso_639_1 === "en"
-          ? 100
-          : l.iso_639_1 == null
-            ? 50
-            : 0;
+    const r = imageLangRank(l.iso_639_1, originalLang);
+    const base = r >= 0 ? r * 100 : 0;
     const isPng = l.file_path?.toLowerCase().endsWith(".png") ? 5 : 0;
-    return lang + isPng + (l.vote_average ?? 0);
+    return base + isPng + (l.vote_average ?? 0);
   };
   const best = [...logos].sort((a, b) => score(b) - score(a))[0];
   return best?.file_path ? `${IMG}/w342${best.file_path}` : undefined;
 };
+
+// Best poster for a title in one of the user's picked languages (e.g. Arabic then
+// English). Returns undefined when the title has no poster in a preferred language,
+// so callers fall back to the catalog poster (the title's original-language art).
+export async function tmdbLocalizedPoster(key: string, metaId: string): Promise<string | undefined> {
+  const picks = pickedImageLangs();
+  if (!picks.length) return undefined;
+  const assets = await fetchMovieAssets(key, metaId);
+  const posters = (assets?.posters ?? []).filter(
+    (p) => typeof p.iso_639_1 === "string" && picks.includes(p.iso_639_1),
+  );
+  if (!posters.length) return undefined;
+  const rank = (iso?: string | null) => {
+    const i = picks.indexOf(iso ?? "");
+    return i === -1 ? -1 : picks.length - i;
+  };
+  const best = [...posters].sort(
+    (a, b) => rank(b.iso_639_1) - rank(a.iso_639_1) || (b.vote_average ?? 0) - (a.vote_average ?? 0),
+  )[0];
+  return best?.file_path ? `${IMG}/w342${best.file_path}` : undefined;
+}
 
 export async function tmdbMovieImages(key: string, metaId: string): Promise<string[]> {
   const data = await fetchMovieAssets(key, metaId);
@@ -77,7 +93,8 @@ export async function tmdbMovieImages(key: string, metaId: string): Promise<stri
 export async function tmdbLogo(
   key: string,
   metaId: string,
+  originalLang?: string | null,
 ): Promise<string | undefined> {
-  const data = await fetchMovieAssets(key, metaId);
-  return pickLogo(data?.logos ?? []);
+  const data = await fetchMovieAssets(key, metaId, originalLang);
+  return pickLogo(data?.logos ?? [], originalLang);
 }

--- a/src/lib/providers/tmdb/tmdb-lite.ts
+++ b/src/lib/providers/tmdb/tmdb-lite.ts
@@ -1,4 +1,4 @@
-import { get, IMG } from "./tmdb-client";
+import { effectiveTmdbLanguage, get, IMG } from "./tmdb-client";
 
 export type TmdbLiteMeta = {
   name: string | null;
@@ -15,6 +15,28 @@ type RawLite = {
   poster_path?: string | null;
   backdrop_path?: string | null;
 };
+
+// Overview in the metadata language (titles/overviews), independent of the image
+// language that may be driving list requests. Defaults to English. Used to keep
+// hero/detail plot text in the user's reading language even when posters are localized.
+const overviewCache = new Map<string, string>();
+export async function tmdbMetadataOverview(key: string, metaId: string): Promise<string | undefined> {
+  if (!key) return undefined;
+  const m = metaId.match(/^tmdb:(movie|tv):(\d+)$/);
+  if (!m) return undefined;
+  const metaLang = effectiveTmdbLanguage() || "en";
+  const cacheKey = `${metaId}|${metaLang}`;
+  const hit = overviewCache.get(cacheKey);
+  if (hit !== undefined) return hit || undefined;
+  try {
+    const raw = await get<{ overview?: string }>(key, `${m[1]}/${m[2]}`, { language: metaLang });
+    const ov = raw?.overview?.trim() || "";
+    overviewCache.set(cacheKey, ov);
+    return ov || undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export async function tmdbLiteMeta(key: string, metaId: string): Promise<TmdbLiteMeta | null> {
   if (!key) return null;

--- a/src/lib/providers/tmdb/tmdb-meta-mappers.ts
+++ b/src/lib/providers/tmdb/tmdb-meta-mappers.ts
@@ -55,11 +55,14 @@ function genresFromIds(ids: number[] | undefined, kind: "movie" | "tv"): string[
 }
 
 export const movieMeta = (m: RawMovie): Meta => {
-  const translate = loadStoredSettings().translateTitles;
+  const s = loadStoredSettings();
+  // The request language can be driven by the image language, so only show the
+  // translated title when the user actually picked a metadata language.
+  const useTranslated = !!s.tmdbLanguage && s.translateTitles;
   return {
     id: `tmdb:movie:${m.id}`,
     type: "movie",
-    name: translate ? m.title : m.original_title || m.title,
+    name: useTranslated ? m.title : m.original_title || m.title,
     poster: poster(m.poster_path),
     background: back(m.backdrop_path),
     description: m.overview,
@@ -71,12 +74,14 @@ export const movieMeta = (m: RawMovie): Meta => {
   };
 };
 
-export const seriesMeta = (s: RawSeries): Meta => {
-  const translate = loadStoredSettings().translateTitles;
+export const seriesMeta = (item: RawSeries): Meta => {
+  const settings = loadStoredSettings();
+  const useTranslated = !!settings.tmdbLanguage && settings.translateTitles;
+  const s = item;
   return {
     id: `tmdb:tv:${s.id}`,
     type: "series",
-    name: translate ? s.name : s.original_name || s.name,
+    name: useTranslated ? s.name : s.original_name || s.name,
     poster: poster(s.poster_path),
     background: back(s.backdrop_path),
     description: s.overview,

--- a/src/lib/providers/tmdb/tmdb-people.ts
+++ b/src/lib/providers/tmdb/tmdb-people.ts
@@ -1,6 +1,6 @@
 import type { Meta } from "../../cinemeta";
 import { lruSet } from "../../cache";
-import { get, IMG } from "./tmdb-client";
+import { effectiveTmdbLanguage, get, IMG } from "./tmdb-client";
 
 const PERSON_NAME_CACHE_MAX = 3000;
 const PERSON_CACHE_MAX = 10;
@@ -147,6 +147,7 @@ export async function tmdbPerson(key: string, personId: number): Promise<PersonD
 async function fetchPerson(key: string, personId: number): Promise<PersonDetail | null> {
   const raw = await get<any>(key, `person/${personId}`, {
     append_to_response: "combined_credits,external_ids",
+    language: effectiveTmdbLanguage() || "en",
   });
   if (!raw) return null;
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -170,7 +170,6 @@ export async function searchAll(
   const data = await get<Page<MultiItem>>(key, "search/multi", {
     query: trimmed,
     include_adult: "false",
-    language: "en-US",
   });
   const exclude = new Set(opts.excludeGenres ?? []);
   const hasExcludedGenre = (gs?: number[]) => (gs ?? []).some((id) => exclude.has(id));

--- a/src/lib/settings.tsx
+++ b/src/lib/settings.tsx
@@ -102,6 +102,21 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     window.location.reload();
   }, [settings.tmdbLanguage, settings.uiLanguage]);
 
+  // Image-language changes come from an add/remove picker, so debounce the
+  // reload and let the user finish editing before refreshing catalog art.
+  const imgLangRef = useRef<string | null>(null);
+  useEffect(() => {
+    const sig = settings.tmdbImageLangs.join(",");
+    if (imgLangRef.current === null) {
+      imgLangRef.current = sig;
+      return;
+    }
+    if (imgLangRef.current === sig) return;
+    imgLangRef.current = sig;
+    const t = window.setTimeout(() => window.location.reload(), 1200);
+    return () => window.clearTimeout(t);
+  }, [settings.tmdbImageLangs]);
+
   useEffect(() => {
     applyTheme(settings.theme);
   }, [settings.theme]);

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -4,7 +4,6 @@ import type { Settings } from "./types";
 export const STORAGE_KEY = "harbor.settings";
 
 export const DEFAULT: Settings = {
-  translatePosters: false,
   blurComments: false,
   blurEpisodes: false,
   tmdbKey: "",
@@ -164,6 +163,7 @@ export const DEFAULT: Settings = {
   trackBlockWords: ["commentary"],
   forcedSubsWhenNativeAudio: false,
   tmdbLanguage: "",
+  tmdbImageLangs: ["English", "Original"],
   posterBaseUrl: "",
   hidePosterTitles: false,
   hoverPreview: false,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -43,7 +43,6 @@ export type LetterboxdSettings = {
 };
 
 export type Settings = {
-  translatePosters: boolean;
   blurComments: boolean;
   blurEpisodes: boolean;
   tmdbKey: string;
@@ -193,6 +192,7 @@ export type Settings = {
   trackBlockWords: string[];
   forcedSubsWhenNativeAudio: boolean;
   tmdbLanguage: string;
+  tmdbImageLangs: string[];
   posterBaseUrl: string;
   hidePosterTitles: boolean;
   hoverPreview: boolean;

--- a/src/lib/surprise-me.ts
+++ b/src/lib/surprise-me.ts
@@ -63,7 +63,7 @@ async function fetchTmdb(
   params: Record<string, string> = {},
 ): Promise<TrendingItem[]> {
   try {
-    const data = await get<Page<TrendingItem>>(key, path, { language: "en-US", ...params });
+    const data = await get<Page<TrendingItem>>(key, path, { ...params });
     return data?.results ?? [];
   } catch {
     return [];

--- a/src/lib/use-localized-overview.ts
+++ b/src/lib/use-localized-overview.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import type { Meta } from "@/lib/cinemeta";
+import { tmdbMetadataOverview } from "@/lib/providers/tmdb/tmdb-lite";
+import { useSettings } from "@/lib/settings";
+
+/**
+ * Returns a title's plot in the metadata language (English by default), fetched
+ * per-title so it stays readable even when the Image languages setting localizes
+ * list requests. Falls back to the catalog description until the fetch resolves.
+ */
+export function useLocalizedOverview(meta: Meta): string | undefined {
+  const { settings } = useSettings();
+  const isTmdb = meta.id.startsWith("tmdb:");
+  // For TMDB items the catalog description is in the (image) request language, so
+  // hold it back until the metadata-language text loads — avoids an Arabic→English
+  // flash. Non-TMDB descriptions are already in the right language, so show them.
+  const [overview, setOverview] = useState<string | undefined>(
+    isTmdb ? undefined : meta.description,
+  );
+  useEffect(() => {
+    if (!isTmdb || !settings.tmdbKey) {
+      setOverview(meta.description);
+      return;
+    }
+    setOverview(undefined);
+    let alive = true;
+    void tmdbMetadataOverview(settings.tmdbKey, meta.id).then((o) => {
+      if (alive) setOverview(o ?? meta.description);
+    });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [meta.id, settings.tmdbKey]);
+  return overview;
+}

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -539,7 +539,10 @@ export function DetailView({
 
   const rawTitle = detail?.title ?? meta.name;
   const title = isAnime ? stripFranchiseSuffix(rawTitle) : rawTitle;
-  const overview = detail?.overview ?? meta.description ?? "";
+  // For TMDB titles the catalog description is in the (image) request language, so
+  // wait for the localized detail rather than flashing it. Non-TMDB metas are already
+  // in the reading language, so show them immediately.
+  const overview = detail?.overview ?? (meta.id.startsWith("tmdb:") ? "" : meta.description) ?? "";
   const tagline = detail?.tagline ?? "";
   const backdrop =
     pinnedBackdropHi || backdrops[backdropIdx] || meta.background || detail?.backdrop || (loading ? undefined : meta.poster) || undefined;

--- a/src/views/kids-detail.tsx
+++ b/src/views/kids-detail.tsx
@@ -45,7 +45,8 @@ export function KidsDetailView({
 
   const backdrop = detail?.backdrop || base?.background || meta.background || meta.poster;
   const logo = detail?.logo || base?.logo || meta.logo;
-  const overview = detail?.overview || base?.description || meta.description || "";
+  const overview =
+    detail?.overview || base?.description || (meta.id.startsWith("tmdb:") ? "" : meta.description) || "";
   const genres = (detail?.genres?.length ? detail.genres : base?.genres) ?? [];
   const runtime = detail?.runtime;
   const year = meta.releaseInfo || base?.releaseInfo;

--- a/src/views/kids/kids-hero.tsx
+++ b/src/views/kids/kids-hero.tsx
@@ -73,7 +73,7 @@ function KidsHeroCard({
     let cancelled = false;
     const isTmdb = meta.id.startsWith("tmdb:");
     const lookup = isTmdb
-      ? tmdbLogo(settings.tmdbKey, meta.id)
+      ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
       : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
     lookup
       .then((url) => {

--- a/src/views/library/local-tab.tsx
+++ b/src/views/library/local-tab.tsx
@@ -2,7 +2,6 @@ import { FolderPlus, HardDrive, Loader2, Play, RefreshCw, Trash2 } from "lucide-
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Poster, usePosterChain } from "@/components/poster";
 import { effectiveTmdbLanguage } from "@/lib/providers/tmdb/tmdb-client";
-import { imageRequestLang } from "@/lib/providers/tmdb/tmdb-image-lang";
 import { tmdbLiteMeta } from "@/lib/providers/tmdb/tmdb-lite";
 import {
   addLocalEntries,
@@ -325,7 +324,7 @@ async function tmdbLookup(
 ): Promise<{ tmdbId?: number; imdbId?: string; poster?: string }> {
   const path = type === "movie" ? "movie" : "tv";
   const params = new URLSearchParams({ api_key: key, query: title });
-  const lang = effectiveTmdbLanguage() || imageRequestLang();
+  const lang = effectiveTmdbLanguage();
   if (lang) params.set("language", lang);
   if (year && type === "movie") params.set("year", String(year));
   if (year && type === "show") params.set("first_air_date_year", String(year));

--- a/src/views/library/local-tab.tsx
+++ b/src/views/library/local-tab.tsx
@@ -1,6 +1,9 @@
 import { FolderPlus, HardDrive, Loader2, Play, RefreshCw, Trash2 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Poster, usePosterChain } from "@/components/poster";
+import { effectiveTmdbLanguage } from "@/lib/providers/tmdb/tmdb-client";
+import { imageRequestLang } from "@/lib/providers/tmdb/tmdb-image-lang";
+import { tmdbLiteMeta } from "@/lib/providers/tmdb/tmdb-lite";
 import {
   addLocalEntries,
   parseFilename,
@@ -212,10 +215,24 @@ function OwnedCard({ entry }: { entry: LocalEntry }) {
   const [confirm, setConfirm] = useState(false);
   const { openPlayer } = useView();
   const { settings } = useSettings();
+  // Resolve the poster live in the current image language, so it follows the
+  // Image languages setting instead of the (English) poster cached at scan time.
+  const [livePoster, setLivePoster] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    if (!entry.tmdbId || !settings.tmdbKey) return;
+    let alive = true;
+    const kind = entry.type === "show" ? "tv" : "movie";
+    void tmdbLiteMeta(settings.tmdbKey, `tmdb:${kind}:${entry.tmdbId}`).then((m) => {
+      if (alive && m?.poster) setLivePoster(m.poster);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [entry.tmdbId, entry.type, settings.tmdbKey]);
   const poster = usePosterChain(
     settings.rpdbKey,
     entry.imdbId ?? `local:${entry.id}`,
-    entry.poster ?? undefined,
+    livePoster ?? entry.poster ?? undefined,
     entry.type === "show" ? "series" : "movie",
   );
 
@@ -308,6 +325,8 @@ async function tmdbLookup(
 ): Promise<{ tmdbId?: number; imdbId?: string; poster?: string }> {
   const path = type === "movie" ? "movie" : "tv";
   const params = new URLSearchParams({ api_key: key, query: title });
+  const lang = effectiveTmdbLanguage() || imageRequestLang();
+  if (lang) params.set("language", lang);
   if (year && type === "movie") params.set("year", String(year));
   if (year && type === "show") params.set("first_air_date_year", String(year));
   const r = await fetch(`https://api.themoviedb.org/3/search/${path}?${params}`);

--- a/src/views/settings/language-panel.tsx
+++ b/src/views/settings/language-panel.tsx
@@ -8,6 +8,9 @@ import { Section, ToggleRow } from "./shared";
 import { SubtitleStylePanel } from "./player-panel";
 import { LanguagesPicker } from "./streaming-panel";
 import { DisplayLanguageSection } from "./language-panel/display-language-section";
+import { ALL_LANGUAGE_NAMES } from "@/lib/subtitles/language";
+
+const IMAGE_LANG_OPTIONS = ["Original", ...ALL_LANGUAGE_NAMES];
 
 const TMDB_LANGUAGES: DropdownOption[] = [
   { value: "es-ES", label: "Español (España)" },
@@ -124,6 +127,17 @@ export function LanguagePanel() {
           />
         </>
       )}
+    </Section>
+
+    <Section
+      title={t("Image languages")}
+      subtitle={t("Posters, logos, and title art load in the first available language from this list, falling back down the order. \"Original\" uses the title's own language. Put your main language first. Needs a TMDB key.")}
+    >
+      <LanguagesPicker
+        value={settings.tmdbImageLangs}
+        onChange={(langs) => update({ tmdbImageLangs: langs })}
+        options={IMAGE_LANG_OPTIONS}
+      />
     </Section>
 
     <Section

--- a/src/views/settings/streaming-panel.tsx
+++ b/src/views/settings/streaming-panel.tsx
@@ -242,9 +242,13 @@ const LANGUAGE_OPTIONS = ALL_LANGUAGE_NAMES;
 export function LanguagesPicker({
   value,
   onChange,
+  options = LANGUAGE_OPTIONS,
+  placeholder = "Search languages (Tamil, Telugu, ...)",
 }: {
   value: string[];
   onChange: (next: string[]) => void;
+  options?: string[];
+  placeholder?: string;
 }) {
   const [query, setQuery] = useState("");
   const selected = new Set(value);
@@ -255,7 +259,7 @@ export function LanguagesPicker({
     onChange([...next]);
   };
   const q = query.trim().toLowerCase();
-  const available = LANGUAGE_OPTIONS.filter((l) => !selected.has(l));
+  const available = options.filter((l) => !selected.has(l));
   const matches = q ? available.filter((l) => l.toLowerCase().includes(q)) : available;
   const COMMON = 24;
   const shown = q ? matches : matches.slice(0, COMMON);
@@ -287,7 +291,7 @@ export function LanguagesPicker({
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search languages (Tamil, Telugu, ...)"
+          placeholder={placeholder}
           spellCheck={false}
           className="h-10 w-full rounded-xl border border-edge bg-canvas ps-9 pe-3 text-[13.5px] text-ink outline-none transition-colors focus:border-ink placeholder:text-ink-subtle/60"
         />


### PR DESCRIPTION
Adds an "Image languages" panel in Settings → Languages. You build an ordered list (e.g. Arabic → English → Original) and all TMDB artwork — posters, logos, and title art — loads in the first available language from the list, falling back down the order. "Original" uses the title's own language.

Mirrors the existing Subtitle/Audio language pickers: add/remove pills, insertion order = priority (first = highest). Default ["English", "Original"] preserves current behavior exactly.

Behavior

- Only images follow the image-language priority. Text metadata (titles, overviews, cast/crew, genres, episodes) stays in the metadata language and is fetched separately, so descriptions never switch to the image language.
- Applies across catalog cards, posters, hero logos/art, detail pages, and search results.
- Per-title fallback: if a picked language has no logo/poster for a specific title, it falls back down the list rather than showing plain text.
- Purpose of this PR: add more customization by separating the image language from the metadata language — so text (titles, overviews, taglines) can stay in one language while posters, logos, and backdrops are fetched in another.


<img width="1896" height="1022" alt="Screenshot 2026-07-03 at 10-45-32 Harbor" src="https://github.com/user-attachments/assets/3a350184-25c6-463c-b205-d809a27488bf" />
<img width="1896" height="1022" alt="Screenshot 2026-07-03 at 10-45-11 Harbor" src="https://github.com/user-attachments/assets/b16ed269-55c2-4ced-8147-fbb2d8a4c165" />
Notes / known limitation

- Anime posters are unaffected by this setting. Anime artwork comes from a different provider (AniList/Kitsu — original Japanese art), not TMDB, so it can't be localized through TMDB's image-language param. Only anime logos (which do route through TMDB) respect the priority. This is a provider limitation, not a bug.
- Replaces the previously dormant, UI-less translatePosters flag with the new tmdbImageLangs ordered list.

Testing

- Set Arabic, English, Original; confirmed /images and detail requests carry include_image_language=ar,en,null and Arabic art shows when present, falling back to English then Original.
- Regression: default ["English","Original"] matches prior behavior.

Also includes a small fix: long result titles in search previously expanded their column and collided with the neighbor — now they truncate (min-w-0 chain).

<img width="1915" height="1040" alt="Screenshot_20260703_104837" src="https://github.com/user-attachments/assets/01030bb7-501b-4ed4-880b-4eed3d861961" />

<img width="1920" height="1045" alt="Screenshot_20260703_105002" src="https://github.com/user-attachments/assets/7caed5b7-b809-4537-a562-4375728e36c8" />
