### PR TITLE
feat: add IMDb API fallback for cast-modal when no TMDB key

### DIFF
--- a/src/components/player/cast-modal.tsx
+++ b/src/components/player/cast-modal.tsx
@@ -2,6 +2,7 @@ import { Loader2, Star, Users, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import { animeDetails } from "@/lib/providers/anime-detail";
+import { imdbapiDetails } from "@/lib/providers/imdbapi/imdbapi-details";
 import { useSettings } from "@/lib/settings";
 import { useT } from "@/lib/i18n";
 import { activeLayout } from "@/lib/theme";
@@ -31,7 +32,7 @@ export function CastModal({
 
   useEffect(() => {
     if (!open) return;
-    if (!anime && !tmdbKey) {
+    if (!anime && !tmdbKey && !(settings.imdbApiFallback && meta.id.startsWith("tt"))) {
       setDetail(null);
       return;
     }
@@ -39,7 +40,9 @@ export function CastModal({
     setLoading(true);
     const fetch: Promise<TmdbDetail | null> = anime
       ? animeDetails(settings, meta).then((r) => r?.detail ?? null)
-      : tmdbDetails(tmdbKey as string, meta);
+      : tmdbKey
+        ? tmdbDetails(tmdbKey, meta)
+        : imdbapiDetails(meta.id);
     fetch
       .then((d) => {
         if (!cancelled) setDetail(d);
@@ -273,7 +276,7 @@ function CastStrip({ cast }: { cast: CastEntry[] }) {
         <div key={c.id} className="flex flex-col items-center gap-1.5 text-center">
           {c.profilePath ? (
             <img
-              src={`${IMG}/w185${c.profilePath}`}
+              src={c.profilePath.startsWith("http") ? c.profilePath : `${IMG}/w185${c.profilePath}`}
               alt=""
               loading="lazy"
               className="h-20 w-20 rounded-full object-cover ring-1 ring-edge-soft"

--- a/src/lib/providers/imdbapi/imdbapi-details.ts
+++ b/src/lib/providers/imdbapi/imdbapi-details.ts
@@ -1,0 +1,185 @@
+import type { TmdbDetail } from "../tmdb/tmdb-details";
+
+const BASE = "https://api.imdbapi.dev/titles";
+
+interface ImdbTitleResponse {
+  id: string;
+  type: string;
+  primaryTitle: string;
+  primaryImage?: { url: string };
+  startYear?: number;
+  runtimeSeconds?: number;
+  genres?: string[];
+  rating?: { aggregateRating: number; voteCount: number };
+  plot?: string;
+  directors?: Array<{
+    id: string;
+    displayName: string;
+    primaryImage?: { url: string };
+  }>;
+  writers?: Array<{
+    id: string;
+    displayName: string;
+    primaryImage?: { url: string };
+  }>;
+  stars?: Array<{
+    id: string;
+    displayName: string;
+    primaryImage?: { url: string };
+  }>;
+}
+
+interface ImdbEpisodeEntry {
+  id: string;
+  title: string;
+  primaryImage?: { url: string };
+  season: string;
+  episodeNumber: number;
+  runtimeSeconds?: number;
+  plot?: string;
+  rating?: { aggregateRating: number; voteCount: number };
+}
+
+interface ImdbCreditsEntry {
+  name: {
+    id: string;
+    displayName: string;
+    primaryImage?: { url: string };
+  };
+  category: string;
+  characters?: string[];
+}
+
+const cache = new Map<string, TmdbDetail>();
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+function formatRuntime(seconds: number | undefined): string | undefined {
+  if (!seconds) return undefined;
+  const min = Math.round(seconds / 60);
+  return `${min} min`;
+}
+
+function toTmdbDetail(title: ImdbTitleResponse, cast: TmdbDetail["cast"]): TmdbDetail {
+  return {
+    kind: title.type === "movie" ? "movie" : "tv",
+    id: 0,
+    imdbId: title.id,
+    title: title.primaryTitle ?? "",
+    originalTitle: title.primaryTitle ?? "",
+    tagline: "",
+    overview: title.plot ?? "",
+    poster: title.primaryImage?.url ?? undefined,
+    backdrop: undefined,
+    logo: undefined,
+    year: title.startYear ? String(title.startYear) : undefined,
+    rating: title.rating?.aggregateRating
+      ? Number(title.rating.aggregateRating).toFixed(1)
+      : undefined,
+    voteCount: title.rating?.voteCount ?? 0,
+    runtime: formatRuntime(title.runtimeSeconds),
+    status: "Released",
+    genres: title.genres ?? [],
+    originalLanguage: "",
+    spokenLanguages: [],
+    productionCountries: [],
+    productionCompanies: [],
+    networks: [],
+    productionCompaniesRich: [],
+    productionCountriesRich: [],
+    spokenLanguagesRich: [],
+    networksRich: [],
+    trailerYtId: null,
+    trailerCandidates: [],
+    extraVideos: [],
+    gallery: { backdrops: [], posters: [], logos: [] },
+    cast,
+    crew: [],
+    directors: (title.directors ?? []).map((d) => ({ id: 0, name: d.displayName })),
+    writers: (title.writers ?? []).map((w) => ({ id: 0, name: w.displayName })),
+    creators: [],
+    producers: [],
+    composer: [],
+    cinematography: [],
+    editor: [],
+    recommendations: [],
+    similar: [],
+    collection: null,
+    seasons: [],
+    numberOfSeasons: 0,
+    numberOfEpisodes: 0,
+    keywords: [],
+  };
+}
+
+function creditsToCast(credits: ImdbCreditsEntry[]): TmdbDetail["cast"] {
+  return credits
+    .filter((c) => c.category === "actor" || c.category === "actress")
+    .map((c, i) => ({
+      id: 0,
+      name: c.name.displayName,
+      character: c.characters?.[0] ?? "",
+      profilePath: c.name.primaryImage?.url ?? null,
+      order: i,
+    }));
+}
+
+export async function imdbapiDetails(
+  metaId: string,
+  season?: number,
+  episode?: number,
+): Promise<TmdbDetail | null> {
+  if (!metaId.startsWith("tt")) return null;
+
+  const cacheKey = season !== undefined && episode !== undefined
+    ? `${metaId}:s${season}e${episode}`
+    : metaId;
+
+  const cached = cache.get(cacheKey);
+  if (cached) return cached;
+
+  // Fetch series/movie title
+  const title = await fetchJson<ImdbTitleResponse>(`${BASE}/${metaId}`);
+  if (!title) return null;
+
+  let targetId = metaId;
+
+  // If season/episode requested, find the episode tt ID
+  if (season !== undefined && episode !== undefined && title.type !== "movie") {
+    const eps = await fetchJson<{ episodes: ImdbEpisodeEntry[] }>(
+      `${BASE}/${metaId}/episodes`,
+    );
+    const match = eps?.episodes?.find(
+      (e) => Number(e.season) === season && e.episodeNumber === episode,
+    );
+    if (match) targetId = match.id;
+  }
+
+  // Fetch credits for the target (series or specific episode)
+  const creditsResp = await fetchJson<{ credits: ImdbCreditsEntry[] }>(
+    `${BASE}/${targetId}/credits`,
+  );
+
+  const cast = creditsResp ? creditsToCast(creditsResp.credits) : [];
+
+  // If we fetched episode-level, also get that episode's metadata
+  let detail = title;
+  if (targetId !== metaId) {
+    const epTitle = await fetchJson<ImdbTitleResponse>(`${BASE}/${targetId}`);
+    if (epTitle) detail = epTitle;
+  }
+
+  const result = toTmdbDetail(detail, cast);
+  cache.set(cacheKey, result);
+  return result;
+}

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -306,4 +306,5 @@ export const DEFAULT: Settings = {
   adSkipEnabled: false,
   adReportAlwaysShow: false,
   adReportFirstSeen: false,
+  imdbApiFallback: true,
 };

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -356,4 +356,5 @@ export type Settings = {
   adSkipEnabled: boolean;
   adReportAlwaysShow: boolean;
   adReportFirstSeen: boolean;
+  imdbApiFallback: boolean;
 };

--- a/src/views/settings/library-panel.tsx
+++ b/src/views/settings/library-panel.tsx
@@ -321,6 +321,12 @@ export function LibraryPanel({
             </>
           }
         />
+        <ToggleRow
+          label={t("Use free IMDb API as fallback")}
+          sub={t("When no TMDB key is set, show cast, crew, and title details from the free IMDb API (imdbapi.dev). Requires an internet connection.")}
+          value={settings.imdbApiFallback}
+          onChange={(v) => update({ imdbApiFallback: v })}
+        />
         <KeyField
           label={t("OMDb · Rotten Tomatoes scores")}
           placeholder={t("8-character key")}


### PR DESCRIPTION
Add free imdbapi.dev API as a fallback metadata source for the 'About this title' modal when users have not configured a TMDB API key.

Changes:
- New provider: src/lib/providers/imdbapi/imdbapi-details.ts Fetches title details, cast, crew, and images from api.imdbapi.dev. Returns a TmdbDetail-compatible shape so it slots into the existing modal with zero UI changes. Caches results to avoid duplicate fetches.

- Settings: added 'imdbApiFallback' boolean toggle (default: true) in types.ts and defaults.ts.

- Settings UI: added ToggleRow in Library & metadata panel, right
  below the TMDB key field. Label: 'Use free IMDb API as fallback'.

- CastModal: added third branch in useEffect — when no TMDB key is set but toggle is ON and meta.id starts with 'tt', fetches from imdbapi.dev instead of showing the 'Add a TMDB key' prompt.

- CastStrip: fixed image src to handle full URLs from imdbapi.dev (checks startsWith('http') before prepending IMG/w185 prefix). Poster fallback already handled this — no change needed.

Behavior:
- TMDB key set → TMDB (unchanged)
- No TMDB key + toggle ON → imdbapi.dev (new)
- No TMDB key + toggle OFF → 'Add a TMDB key' message (unchanged)
- Anime titles → Kitsu/AniZip (unchanged)

<img width="752" height="410" alt="Screenshot 2026-07-05 222320" src="https://github.com/user-attachments/assets/c78123d5-3e7a-43cb-a959-1d633a330e1e" />
