### PR TITLE
feat: Full SIMKL API Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "tauri:build:linux-system": "tauri build --config src-tauri/tauri.linux-system.conf.json",
     "setup:libmpv": "node scripts/fetch-libmpv.mjs",
     "setup:ffmpeg": "node scripts/fetch-ffmpeg.mjs",
-    "setup:fonts": "node scripts/fetch-fonts.mjs"
+    "setup:fonts": "node scripts/fetch-fonts.mjs",
+    "copy-installer": "node -e \"const fs = require('fs'); fs.mkdirSync('C:/Users/abd20/.gemini/antigravity/brain/81456ec3-555b-4df2-800a-a36f861508d5', { recursive: true }); fs.copyFileSync('src-tauri/target/release/bundle/nsis/Harbor_0.9.20_x64-setup.exe', 'C:/Users/abd20/.gemini/antigravity/brain/81456ec3-555b-4df2-800a-a36f861508d5/Harbor_0.9.20_x64-setup.exe')\""
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/src/components/episode-watched-menu.tsx
+++ b/src/components/episode-watched-menu.tsx
@@ -53,7 +53,10 @@ export function EpisodeWatchedMenu({
   const showIds = (() => {
     if (!simklConnected) return null;
     const r = stremioIdToSimklTarget(metaId, { season: target.season, episode: target.episode });
-    return r.ok && r.target.kind === "episode" ? r.target.show.ids : null;
+    if (!r.ok) return null;
+    if (r.target.kind === "episode") return r.target.show.ids;
+    if (r.target.kind === "anime-episode") return r.target.anime.ids;
+    return null;
   })();
 
   const left = Math.min(target.x, window.innerWidth - 232);

--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -26,6 +26,8 @@ import {
 import { useSettings } from "@/lib/settings";
 import { useSimklCardScores, useSimklCardScoresByAnimeId } from "@/lib/simkl/ratings";
 import { simklRequest } from "@/lib/simkl/client";
+import { getLocalCache } from "@/lib/simkl/activities";
+import { aniZipByKitsu, aniZipByMal } from "@/lib/providers/anizip";
 import simklLogo from "@/assets/simkl.png";
 import { useView } from "@/lib/view";
 import { observe } from "@/lib/visibility";
@@ -49,6 +51,20 @@ const WATCHLIST_POS: Record<string, string> = {
   bottomStart: "bottom-1.5 start-1.5",
   bottomEnd: "bottom-1.5 end-1.5",
 };
+
+function getTitleFromAniZip(titles: Record<string, string>, lang: "english" | "romaji" | "native"): string | null {
+  if (lang === "english") return titles.en || titles.en_jp || titles.ja || null;
+  if (lang === "romaji") return titles["x-jat"] || titles.en_jp || titles.en || null;
+  if (lang === "native") return titles.ja || titles["x-jat"] || titles.en || null;
+  return null;
+}
+
+function getTitleFromKitsu(titles: { en?: string; en_jp?: string; ja_jp?: string }, lang: "english" | "romaji" | "native"): string | null {
+  if (lang === "english") return titles.en || titles.en_jp || titles.ja_jp || null;
+  if (lang === "romaji") return titles.en_jp || titles.en || titles.ja_jp || null;
+  if (lang === "native") return titles.ja_jp || titles.en_jp || titles.en || null;
+  return null;
+}
 
 export const PickCard = memo(function PickCard({
   meta,
@@ -266,6 +282,109 @@ export const PickCard = memo(function PickCard({
     };
   }, [posterSrc, hydratedPoster, meta.type, meta.id]);
 
+  const [translatedTitle, setTranslatedTitle] = useState<string | null>(null);
+
+  useEffect(() => {
+    setTranslatedTitle(null);
+    if (!isAnimeCardId) return;
+
+    let cancelled = false;
+    const cache = getLocalCache();
+    let kitsuId: number | null = null;
+    let malId: number | null = null;
+
+    if (cache) {
+      const parts = meta.id.split(":");
+      const type = parts[0];
+      const idVal = parts[1];
+
+      if (type === "kitsu") {
+        kitsuId = Number(idVal);
+      } else if (type === "mal") {
+        malId = Number(idVal);
+      }
+
+      let simklId: number | null = null;
+      if (type === "simkl") {
+        simklId = Number(idVal);
+      } else if (type === "kitsu" && kitsuId) {
+        simklId = cache.kitsuToSimkl[String(kitsuId)] ?? null;
+      } else if (type === "mal" && malId) {
+        simklId = cache.malToSimkl[String(malId)] ?? null;
+      }
+
+      if (simklId) {
+        if (!kitsuId) {
+          const kStr = Object.keys(cache.kitsuToSimkl).find((k) => cache.kitsuToSimkl[k] === simklId);
+          if (kStr) kitsuId = Number(kStr);
+        }
+        if (!malId) {
+          const mStr = Object.keys(cache.malToSimkl).find((k) => cache.malToSimkl[k] === simklId);
+          if (mStr) malId = Number(mStr);
+        }
+      }
+    }
+
+    const preferred = settings.simklAnimeTitleLanguage;
+
+    const fetchTitles = async () => {
+      // 1. Try AniZip by MAL ID
+      if (malId) {
+        const map = await aniZipByMal(malId).catch(() => null);
+        if (cancelled) return;
+        if (map?.titles) {
+          const title = getTitleFromAniZip(map.titles, preferred);
+          if (title) {
+            setTranslatedTitle(title);
+            return;
+          }
+        }
+      }
+
+      // 2. Try AniZip by Kitsu ID
+      if (kitsuId) {
+        const map = await aniZipByKitsu(kitsuId).catch(() => null);
+        if (cancelled) return;
+        if (map?.titles) {
+          const title = getTitleFromAniZip(map.titles, preferred);
+          if (title) {
+            setTranslatedTitle(title);
+            return;
+          }
+        }
+      }
+
+      // 3. Try Kitsu Details API directly
+      if (kitsuId) {
+        try {
+          const res = await fetch(`https://kitsu.io/api/edge/anime/${kitsuId}`, {
+            headers: { Accept: "application/vnd.api+json" }
+          });
+          if (res.ok) {
+            const j = await res.json();
+            const attr = j?.data?.attributes;
+            if (attr?.titles) {
+              const title = getTitleFromKitsu(attr.titles, preferred) || attr.canonicalTitle;
+              if (cancelled) return;
+              if (title) {
+                setTranslatedTitle(title);
+                return;
+              }
+            }
+          }
+        } catch {
+          // ignore
+        }
+      }
+    };
+
+    fetchTitles().catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [meta.id, isAnimeCardId, settings.simklAnimeTitleLanguage]);
+
   useEffect(() => {
     if (
       !settings.omdbKey &&
@@ -397,7 +516,7 @@ export const PickCard = memo(function PickCard({
               : "line-clamp-2 min-h-9 text-[13px] font-medium leading-snug text-ink"
           }
         >
-          {meta.name}
+          {translatedTitle || meta.name}
         </p>
       )}
     </button>

--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -24,6 +24,9 @@ import {
   useTmdbImdbId,
 } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
+import { useSimklCardScores, useSimklCardScoresByAnimeId } from "@/lib/simkl/ratings";
+import { simklRequest } from "@/lib/simkl/client";
+import simklLogo from "@/assets/simkl.png";
 import { useView } from "@/lib/view";
 import { observe } from "@/lib/visibility";
 import { useInWatchlist } from "@/lib/watchlist";
@@ -67,7 +70,7 @@ export const PickCard = memo(function PickCard({
   const customProps = activeCustom ? customHoverPosterProps(activeCustom) : null;
   const badgeFade = inCardHover !== "none" || activeCustom ? "transition-opacity duration-150 group-hover:opacity-0 group-focus-within:opacity-0" : "";
   const t = useT();
-  const isAnimeCardId = /^(kitsu|mal|anilist|anidb):/.test(meta.id);
+  const isAnimeCardId = /^(kitsu|mal|anilist|anidb|simkl):/.test(meta.id);
   const inCinema = isInCinema(meta);
   const rerun = (inCinema || flagRerun) && isRerun(meta);
   const showCinema = inCinema && !rerun;
@@ -130,8 +133,17 @@ export const PickCard = memo(function PickCard({
     : cardImdbValue
       ? "imdb"
       : "tmdb";
+  const simklCardScoreImdb = useSimklCardScores(
+    settings.showSimklBadge && !isAnimeCardId ? imdbId : undefined,
+  );
+  const simklCardScoreAnime = useSimklCardScoresByAnimeId(
+    settings.showSimklBadge && isAnimeCardId ? meta.id : undefined,
+  );
+  const simklCardScore = isAnimeCardId ? simklCardScoreAnime : simklCardScoreImdb;
   const cardBadges: CardBadge[] = [];
   if (cardRating) cardBadges.push({ kind: "rating", source: cardRatingSource, value: cardRating });
+  if (settings.showSimklBadge && simklCardScore.score != null)
+    cardBadges.push({ kind: "simkl", value: simklCardScore.score });
   if (settings.showRtBadge && cached?.rtCritics != null)
     cardBadges.push({ kind: "rt", value: cached.rtCritics });
   if (settings.showPopcornBadge && cardScores?.rtAudience != null)
@@ -226,11 +238,23 @@ export const PickCard = memo(function PickCard({
       meta.id.startsWith("mal:") ||
       meta.id.startsWith("anilist:") ||
       meta.id.startsWith("anidb:");
-    const hydrator = isAnimeId
-      ? animeKitsuMeta(meta.id).then((m) => (m ? { poster: m.poster } : null))
-      : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) =>
-          full ? { poster: full.poster } : null,
-        );
+    const isSimklId = meta.id.startsWith("simkl:");
+    const hydrator = isSimklId
+      ? (async () => {
+          const simklId = meta.id.slice(5);
+          const detail = await simklRequest<{ poster?: string }>(
+            `/anime/${simklId}`,
+            { method: "GET", authed: false },
+          ).catch(() => null);
+          return detail?.poster
+            ? { poster: `https://simkl.in/posters/${detail.poster}_m.jpg` }
+            : null;
+        })()
+      : isAnimeId
+        ? animeKitsuMeta(meta.id).then((m) => (m ? { poster: m.poster } : null))
+        : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) =>
+            full ? { poster: full.poster } : null,
+          );
     hydrator
       .then((res) => {
         if (cancelled || !res?.poster) return;
@@ -387,7 +411,8 @@ type CardBadge =
   | { kind: "metacritic"; value: number }
   | { kind: "letterboxd"; value: number }
   | { kind: "mdblist"; value: number }
-  | { kind: "trakt"; value: number };
+  | { kind: "trakt"; value: number }
+  | { kind: "simkl"; value: number };
 
 function metacriticTone(v: number): string {
   if (v >= 61) return "bg-emerald-500";
@@ -451,6 +476,13 @@ function BadgeContent({ badge }: { badge: CardBadge }) {
         <span className="flex items-center gap-0.5">
           <img src={traktLogo} alt="" className="h-[11px] w-[11px] object-contain" />
           <span>{Math.round(badge.value)}%</span>
+        </span>
+      );
+    case "simkl":
+      return (
+        <span className="flex items-center gap-0.5">
+          <img src={simklLogo} alt="" className="h-[11px] w-[11px] rounded-[2px] object-contain" />
+          <span>{Math.round(badge.value)}</span>
         </span>
       );
   }

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -13,11 +13,81 @@ import { isAuthenticated as simklConnected } from "./simkl/session";
 
 export { fetchLibraryCalendar } from "./calendar-library";
 
+/* ─── In-memory cache with stale-while-revalidate for calendar sources ─────── */
+
+interface CacheEntry {
+  items: CalendarItem[];
+  timestamp: number;
+}
+
+const calendarCache = new Map<string, CacheEntry>();
+const calendarInFlight = new Map<string, Promise<CalendarItem[]>>();
+const CACHE_STALE_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Wrap a calendar fetch function with in-memory caching.
+ * Returns cached data instantly if available (stale-while-revalidate).
+ * Deduplicates in-flight requests for the same cache key.
+ */
+function withCalendarCache(
+  cacheKey: string,
+  fetcher: () => Promise<CalendarItem[]>,
+): Promise<CalendarItem[]> {
+  const cached = calendarCache.get(cacheKey);
+  const now = Date.now();
+
+  // Return cached data immediately if available
+  if (cached) {
+    // If stale, trigger background refresh but return cached data
+    if (now - cached.timestamp >= CACHE_STALE_MS) {
+      if (!calendarInFlight.has(cacheKey)) {
+        const promise = fetcher()
+          .then((items) => {
+            calendarCache.set(cacheKey, { items, timestamp: Date.now() });
+            return items;
+          })
+          .catch(() => cached.items) // On error, keep cached data
+          .finally(() => {
+            calendarInFlight.delete(cacheKey);
+          });
+        calendarInFlight.set(cacheKey, promise);
+      }
+    }
+    return Promise.resolve(cached.items);
+  }
+
+  // No cache — check if there's an in-flight request
+  if (calendarInFlight.has(cacheKey)) {
+    return calendarInFlight.get(cacheKey)!;
+  }
+
+  // Fresh fetch
+  const promise = fetcher()
+    .then((items) => {
+      calendarCache.set(cacheKey, { items, timestamp: Date.now() });
+      return items;
+    })
+    .finally(() => {
+      calendarInFlight.delete(cacheKey);
+    });
+  calendarInFlight.set(cacheKey, promise);
+  return promise;
+}
+
+/** Clear all cached calendar data (e.g. on SIMKL disconnect). */
+export function clearCalendarSourceCache() {
+  calendarCache.clear();
+  calendarInFlight.clear();
+}
+
 export async function fetchSimklPremieresCalendar(
   year: number,
   month: number,
 ): Promise<CalendarItem[]> {
-  return fetchSimklCdnCalendar(year, month).catch(() => []);
+  const cacheKey = `simkl-premieres:${year}-${month}`;
+  return withCalendarCache(cacheKey, () =>
+    fetchSimklCdnCalendar(year, month).catch(() => []),
+  );
 }
 
 export async function fetchSimklCalendar(
@@ -26,36 +96,39 @@ export async function fetchSimklCalendar(
   opts: { tmdbKey: string },
 ): Promise<CalendarItem[]> {
   if (!simklConnected()) return [];
-  const [watchlist, watching] = await Promise.all([
-    fetchSimklWatchlist().catch(() => []),
-    fetchWatchingItems().catch(() => []),
-  ]);
-  const items = [...watchlist, ...watching];
-  const candidates: SavedCandidate[] = [];
-  const seenIds = new Set<string>();
-  for (const it of items) {
-    const id =
-      it.ids.imdb ??
-      (it.ids.tmdb
-        ? it.type === "movie"
-          ? `tmdb:movie:${it.ids.tmdb}`
-          : `tmdb:tv:${it.ids.tmdb}`
-        : it.ids.mal
-          ? `mal:${it.ids.mal}`
-          : null);
-    if (!id) continue;
-    if (seenIds.has(id)) continue;
-    seenIds.add(id);
-    candidates.push({
-      id,
-      type: it.type === "show" ? "series" : "movie",
-      name: it.title,
-      mtime: 0,
-      temp: false,
-    });
-  }
-  if (candidates.length === 0) return [];
-  return resolveSavedCalendar(candidates, year, month, opts);
+  const cacheKey = `simkl-calendar:${year}-${month}`;
+  return withCalendarCache(cacheKey, async () => {
+    const [watchlist, watching] = await Promise.all([
+      fetchSimklWatchlist().catch(() => []),
+      fetchWatchingItems().catch(() => []),
+    ]);
+    const items = [...watchlist, ...watching];
+    const candidates: SavedCandidate[] = [];
+    const seenIds = new Set<string>();
+    for (const it of items) {
+      const id =
+        it.ids.imdb ??
+        (it.ids.tmdb
+          ? it.type === "movie"
+            ? `tmdb:movie:${it.ids.tmdb}`
+            : `tmdb:tv:${it.ids.tmdb}`
+          : it.ids.mal
+            ? `mal:${it.ids.mal}`
+            : null);
+      if (!id) continue;
+      if (seenIds.has(id)) continue;
+      seenIds.add(id);
+      candidates.push({
+        id,
+        type: it.type === "show" ? "series" : "movie",
+        name: it.title,
+        mtime: 0,
+        temp: false,
+      });
+    }
+    if (candidates.length === 0) return [];
+    return resolveSavedCalendar(candidates, year, month, opts);
+  });
 }
 
 const TRAKT_MAX_FORWARD_MONTHS = 6;

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -7,7 +7,7 @@ import {
 } from "./trakt/calendar";
 import type { CalendarItem } from "./calendar";
 import { resolveSavedCalendar, type SavedCandidate } from "./calendar-library";
-import { fetchWatchlist as fetchSimklWatchlist } from "./simkl/watchlist";
+import { fetchWatchlist as fetchSimklWatchlist, fetchWatchingItems } from "./simkl/watchlist";
 import { fetchSimklCdnCalendar } from "./simkl/calendar";
 import { isAuthenticated as simklConnected } from "./simkl/session";
 
@@ -26,8 +26,13 @@ export async function fetchSimklCalendar(
   opts: { tmdbKey: string },
 ): Promise<CalendarItem[]> {
   if (!simklConnected()) return [];
-  const items = await fetchSimklWatchlist().catch(() => []);
+  const [watchlist, watching] = await Promise.all([
+    fetchSimklWatchlist().catch(() => []),
+    fetchWatchingItems().catch(() => []),
+  ]);
+  const items = [...watchlist, ...watching];
   const candidates: SavedCandidate[] = [];
+  const seenIds = new Set<string>();
   for (const it of items) {
     const id =
       it.ids.imdb ??
@@ -39,6 +44,8 @@ export async function fetchSimklCalendar(
           ? `mal:${it.ids.mal}`
           : null);
     if (!id) continue;
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
     candidates.push({
       id,
       type: it.type === "show" ? "series" : "movie",

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -8,7 +8,7 @@ import {
 import type { CalendarItem } from "./calendar";
 import { resolveSavedCalendar, type SavedCandidate } from "./calendar-library";
 import { fetchWatchlist as fetchSimklWatchlist } from "./simkl/watchlist";
-import { fetchSimklPremieres, resolveSimklIds } from "./simkl/premieres";
+import { fetchSimklCdnCalendar } from "./simkl/calendar";
 import { isAuthenticated as simklConnected } from "./simkl/session";
 
 export { fetchLibraryCalendar } from "./calendar-library";
@@ -17,34 +17,7 @@ export async function fetchSimklPremieresCalendar(
   year: number,
   month: number,
 ): Promise<CalendarItem[]> {
-  const premieres = await fetchSimklPremieres(year).catch(() => []);
-  const thisMonth = premieres.filter((p) => inMonth(p.date, year, month));
-  const resolved = await Promise.all(
-    thisMonth.map(async (p) => ({ p, ids: await resolveSimklIds(p.simklId, p.isAnime).catch(() => null) })),
-  );
-  const out: CalendarItem[] = [];
-  for (const { p, ids } of resolved) {
-    const id =
-      ids?.imdb ??
-      (ids?.tmdb ? `tmdb:tv:${ids.tmdb}` : null) ??
-      (ids?.kitsu ? `kitsu:${ids.kitsu}` : null) ??
-      (ids?.mal ? `mal:${ids.mal}` : null) ??
-      `simkl:${p.simklId}`;
-    out.push({
-      id,
-      imdbId: ids?.imdb ?? null,
-      type: "tv",
-      name: `${p.title} (premiere)`,
-      poster: p.poster,
-      background: null,
-      releaseDate: p.date,
-      isAnime: p.isAnime,
-      overview: "",
-      voteAverage: 0,
-    });
-  }
-  out.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
-  return out;
+  return fetchSimklCdnCalendar(year, month).catch(() => []);
 }
 
 export async function fetchSimklCalendar(

--- a/src/lib/providers/mdblist.ts
+++ b/src/lib/providers/mdblist.ts
@@ -7,6 +7,7 @@ export type MdblistScores = {
   trakt: number | null;
   metacritic: number | null;
   rtAudience: number | null;
+  simkl: number | null;
 };
 
 type RatingRow = { source?: string; value?: number | null };
@@ -34,12 +35,14 @@ function parse(json: ApiShape): MdblistScores {
     return typeof r?.value === "number" && r.value > 0 ? r.value : null;
   };
   const agg = positive(json.score_average, json.scoreaverage, json.score);
+  const simklVal = val("simkl");
   return {
     score: agg,
     letterboxd: val("letterboxd"),
     trakt: val("trakt"),
     metacritic: val("metacritic"),
     rtAudience: val("tomatoesaudience") ?? val("audience") ?? val("popcorn"),
+    simkl: simklVal !== null ? (simklVal > 10 ? simklVal / 10 : simklVal) : null,
   };
 }
 

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -7,22 +7,14 @@ export const DEFAULT: Settings = {
   simklGranularFilters: {
     movies: {
       plantowatch: true,
-      completed: true,
-      dropped: true,
     },
     shows: {
       watching: true,
       plantowatch: true,
-      completed: true,
-      hold: true,
-      dropped: true,
     },
     anime: {
       watching: true,
       plantowatch: true,
-      completed: true,
-      hold: true,
-      dropped: true,
     },
   },
   blurComments: false,
@@ -306,8 +298,9 @@ export const DEFAULT: Settings = {
     },
   },
   calendarSource: "library",
-  simklCalendarPremieresEnabled: true,
   simklHomeRailsEnabled: true,
+  simklUpNextRailEnabled: true,
+  simklTrendingRailEnabled: true,
   simklScrobbleEnabled: true,
   weekStartsMonday: false,
   customCalendar: {

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -302,6 +302,7 @@ export const DEFAULT: Settings = {
   simklUpNextRailEnabled: true,
   simklTrendingRailEnabled: true,
   simklScrobbleEnabled: true,
+  simklAnimeTitleLanguage: "english",
   weekStartsMonday: false,
   customCalendar: {
     trackedPeople: [],

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -4,6 +4,27 @@ import type { Settings } from "./types";
 export const STORAGE_KEY = "harbor.settings";
 
 export const DEFAULT: Settings = {
+  simklGranularFilters: {
+    movies: {
+      plantowatch: true,
+      completed: true,
+      dropped: true,
+    },
+    shows: {
+      watching: true,
+      plantowatch: true,
+      completed: true,
+      hold: true,
+      dropped: true,
+    },
+    anime: {
+      watching: true,
+      plantowatch: true,
+      completed: true,
+      hold: true,
+      dropped: true,
+    },
+  },
   blurComments: false,
   blurEpisodes: false,
   tmdbKey: "",
@@ -31,6 +52,9 @@ export const DEFAULT: Settings = {
   showTraktBadge: false,
   showDetailRatings: true,
   showTraktComments: false,
+  showSimklBadge: true,
+  simklShowCommunityRatings: true,
+  simklEnableUserRatings: true,
   cardBadgeLimit: 3,
   showQualityBadge: true,
   showCardBadges: true,
@@ -282,6 +306,9 @@ export const DEFAULT: Settings = {
     },
   },
   calendarSource: "library",
+  simklCalendarPremieresEnabled: true,
+  simklHomeRailsEnabled: true,
+  simklScrobbleEnabled: true,
   weekStartsMonday: false,
   customCalendar: {
     trackedPeople: [],

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -45,22 +45,14 @@ export type LetterboxdSettings = {
 export interface SimklGranularFilters {
   movies: {
     plantowatch: boolean;
-    completed: boolean;
-    dropped: boolean;
   };
   shows: {
     watching: boolean;
     plantowatch: boolean;
-    completed: boolean;
-    hold: boolean;
-    dropped: boolean;
   };
   anime: {
     watching: boolean;
     plantowatch: boolean;
-    completed: boolean;
-    hold: boolean;
-    dropped: boolean;
   };
 }
 
@@ -346,8 +338,9 @@ export type Settings = {
     | "custom"
     | "simkl"
     | "simkl-anticipated";
-  simklCalendarPremieresEnabled: boolean;
   simklHomeRailsEnabled: boolean;
+  simklUpNextRailEnabled: boolean;
+  simklTrendingRailEnabled: boolean;
   simklScrobbleEnabled: boolean;
   weekStartsMonday: boolean;
   customCalendar: {

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -342,6 +342,7 @@ export type Settings = {
   simklUpNextRailEnabled: boolean;
   simklTrendingRailEnabled: boolean;
   simklScrobbleEnabled: boolean;
+  simklAnimeTitleLanguage: "english" | "romaji" | "native";
   weekStartsMonday: boolean;
   customCalendar: {
     trackedPeople: Array<{

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -42,7 +42,30 @@ export type LetterboxdSettings = {
   listRefs: Array<{ id: string; name: string; owner?: string; filmCount?: number }>;
 };
 
+export interface SimklGranularFilters {
+  movies: {
+    plantowatch: boolean;
+    completed: boolean;
+    dropped: boolean;
+  };
+  shows: {
+    watching: boolean;
+    plantowatch: boolean;
+    completed: boolean;
+    hold: boolean;
+    dropped: boolean;
+  };
+  anime: {
+    watching: boolean;
+    plantowatch: boolean;
+    completed: boolean;
+    hold: boolean;
+    dropped: boolean;
+  };
+}
+
 export type Settings = {
+  simklGranularFilters: SimklGranularFilters;
   blurComments: boolean;
   blurEpisodes: boolean;
   tmdbKey: string;
@@ -70,6 +93,9 @@ export type Settings = {
   showTraktBadge: boolean;
   showDetailRatings: boolean;
   showTraktComments: boolean;
+  showSimklBadge: boolean;
+  simklShowCommunityRatings: boolean;
+  simklEnableUserRatings: boolean;
   cardBadgeLimit: number;
   showQualityBadge: boolean;
   showCardBadges: boolean;
@@ -320,6 +346,9 @@ export type Settings = {
     | "custom"
     | "simkl"
     | "simkl-anticipated";
+  simklCalendarPremieresEnabled: boolean;
+  simklHomeRailsEnabled: boolean;
+  simklScrobbleEnabled: boolean;
   weekStartsMonday: boolean;
   customCalendar: {
     trackedPeople: Array<{

--- a/src/lib/simkl/activities.ts
+++ b/src/lib/simkl/activities.ts
@@ -13,6 +13,7 @@ export type SimklCacheItem = {
   userRating: number | null;          // 1-10 value or null
   watchedAt: string | null;           // Date when added or watched
   watchedEpisodes?: string[];         // For shows & anime: array of "season:episode" watched
+  poster?: string | null;             // Caches paths like "19/198249"
 };
 
 export type SimklCache = {
@@ -81,6 +82,7 @@ interface RawNode {
   title?: string;
   year?: number | null;
   ids?: RawIds;
+  poster?: string | null;
 }
 
 interface RawEntry {
@@ -206,6 +208,7 @@ function parseAndMergeEntry(cache: SimklCache, entry: RawEntry, type: "movie" | 
     userRating: userRating ?? existing?.userRating ?? null,
     watchedAt: entry.added_to_watchlist_at ?? existing?.watchedAt ?? null,
     watchedEpisodes: watchedEpisodes ?? existing?.watchedEpisodes,
+    poster: (entry.anime?.poster || entry.show?.poster || entry.movie?.poster) ?? existing?.poster ?? null,
   };
 
   cache.items[simklIdStr] = item;
@@ -502,6 +505,7 @@ export function updateCachedStatus(
       userRating: existing?.userRating ?? null,
       watchedAt: existing?.watchedAt ?? new Date().toISOString(),
       watchedEpisodes: existing?.watchedEpisodes,
+      poster: existing?.poster ?? null,
     };
     cache.items[simklIdStr] = item;
     if (externalIds) {

--- a/src/lib/simkl/activities.ts
+++ b/src/lib/simkl/activities.ts
@@ -1,0 +1,585 @@
+import { simklRequest } from "./client";
+import { getSession } from "./session";
+import type { WatchlistStatus } from "./list-status";
+import { invalidateListStatusCache } from "./list-status";
+import type { SimklTarget } from "./types";
+
+export type SimklCacheItem = {
+  simklId: number;
+  type: "movie" | "show" | "anime";
+  title: string;
+  year: number | null;
+  status: WatchlistStatus;
+  userRating: number | null;          // 1-10 value or null
+  watchedAt: string | null;           // Date when added or watched
+  watchedEpisodes?: string[];         // For shows & anime: array of "season:episode" watched
+};
+
+export type SimklCache = {
+  lastSync: string | null;            // activities.all ISO-8601 timestamp
+  activities: {
+    movies: string | null;            // activities.movies.all timestamp
+    shows: string | null;             // activities.tv_shows.all timestamp
+    anime: string | null;             // activities.anime.all timestamp
+    ratings: string | null;           // activities.tv_shows.rated_at / movies.rated_at etc
+  } | null;
+  items: Record<string, SimklCacheItem>; // Keyed by SIMKL ID (e.g. "12345")
+  imdbToSimkl: Record<string, number>;
+  tmdbToSimkl: Record<string, number>; // Format: "movie:123" or "tv:123"
+  malToSimkl: Record<string, number>;
+  kitsuToSimkl: Record<string, number>;
+};
+
+const CACHE_KEY = "harbor.simkl.cache.v2";
+
+export function getLocalCache(): SimklCache | null {
+  if (typeof window === "undefined" || typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as SimklCache;
+  } catch {
+    return null;
+  }
+}
+
+export function saveLocalCache(cache: SimklCache) {
+  if (typeof window === "undefined" || typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+  } catch (e) {
+    console.error("Failed to save SIMKL cache", e);
+  }
+}
+
+export function clearLocalCache() {
+  if (typeof window === "undefined" || typeof localStorage === "undefined") return;
+  localStorage.removeItem(CACHE_KEY);
+}
+
+interface RawIds {
+  simkl?: number;
+  imdb?: string;
+  tmdb?: number | string;
+  tvdb?: number;
+  mal?: number;
+  anidb?: number;
+  kitsu?: number | string;
+}
+
+interface RawEpisode {
+  number?: number;
+  watched_at?: string | null;
+}
+
+interface RawSeason {
+  number?: number;
+  episodes?: RawEpisode[];
+}
+
+interface RawNode {
+  title?: string;
+  year?: number | null;
+  ids?: RawIds;
+}
+
+interface RawEntry {
+  status?: string;
+  added_to_watchlist_at?: string;
+  user_rating?: number | null;
+  rating?: number | null;
+  movie?: RawNode;
+  show?: RawNode;
+  anime?: RawNode;
+  seasons?: RawSeason[];
+}
+
+interface RawAllItems {
+  movies?: RawEntry[];
+  shows?: RawEntry[];
+  anime?: RawEntry[];
+}
+
+interface RawRatingEntry {
+  rating?: number;
+  movie?: { ids?: RawIds };
+  show?: { ids?: RawIds };
+  anime?: { ids?: RawIds };
+}
+
+interface RawRatingsResponse {
+  movies?: RawRatingEntry[];
+  shows?: RawRatingEntry[];
+  anime?: RawRatingEntry[];
+}
+
+function isStatus(s: string | undefined): s is WatchlistStatus {
+  return (
+    s === "watching" || s === "plantowatch" || s === "hold" || s === "completed" || s === "dropped"
+  );
+}
+
+function getLatestTimestamp(...dates: Array<string | null | undefined>): string | null {
+  const validDates = dates.filter(Boolean) as string[];
+  if (validDates.length === 0) return null;
+  return validDates.reduce((latest, current) => (current > latest ? current : latest));
+}
+
+function indexItem(cache: SimklCache, item: SimklCacheItem, ids: RawIds | undefined) {
+  if (!ids) return;
+  const simklId = item.simklId;
+  
+  if (ids.imdb) {
+    cache.imdbToSimkl[ids.imdb] = simklId;
+  }
+  if (ids.tmdb != null) {
+    const tmdbKey = item.type === "movie" ? `movie:${ids.tmdb}` : `tv:${ids.tmdb}`;
+    cache.tmdbToSimkl[tmdbKey] = simklId;
+  }
+  if (ids.mal != null) {
+    cache.malToSimkl[String(ids.mal)] = simklId;
+  }
+  if (ids.kitsu != null) {
+    cache.kitsuToSimkl[String(ids.kitsu)] = simklId;
+  }
+}
+
+function pruneItem(cache: SimklCache, simklId: number) {
+  const simklIdStr = String(simklId);
+  delete cache.items[simklIdStr];
+
+  for (const key of Object.keys(cache.imdbToSimkl)) {
+    if (cache.imdbToSimkl[key] === simklId) delete cache.imdbToSimkl[key];
+  }
+  for (const key of Object.keys(cache.tmdbToSimkl)) {
+    if (cache.tmdbToSimkl[key] === simklId) delete cache.tmdbToSimkl[key];
+  }
+  for (const key of Object.keys(cache.malToSimkl)) {
+    if (cache.malToSimkl[key] === simklId) delete cache.malToSimkl[key];
+  }
+  for (const key of Object.keys(cache.kitsuToSimkl)) {
+    if (cache.kitsuToSimkl[key] === simklId) delete cache.kitsuToSimkl[key];
+  }
+}
+
+function parseAndMergeEntry(cache: SimklCache, entry: RawEntry, type: "movie" | "show" | "anime") {
+  const node = type === "movie" ? entry.movie : type === "anime" ? (entry.anime || entry.show || entry.movie) : entry.show;
+  if (!node || !node.ids || !node.ids.simkl) return;
+
+  const simklId = node.ids.simkl;
+  const simklIdStr = String(simklId);
+
+  let status: WatchlistStatus = "plantowatch";
+  if (entry.status && isStatus(entry.status)) {
+    status = entry.status;
+  }
+
+  let userRating: number | null = null;
+  if (entry.user_rating != null) {
+    userRating = entry.user_rating;
+  } else if (entry.rating != null) {
+    userRating = entry.rating;
+  }
+
+  let watchedEpisodes: string[] | undefined;
+  if (type !== "movie" && entry.seasons) {
+    const eps: string[] = [];
+    for (const s of entry.seasons) {
+      for (const ep of s.episodes ?? []) {
+        if (ep.watched_at && s.number != null && ep.number != null) {
+          eps.push(`${s.number}:${ep.number}`);
+        }
+      }
+    }
+    if (eps.length > 0) {
+      watchedEpisodes = eps;
+    }
+  }
+
+  const existing = cache.items[simklIdStr];
+  const item: SimklCacheItem = {
+    simklId,
+    type,
+    title: node.title ?? existing?.title ?? "",
+    year: node.year ?? existing?.year ?? null,
+    status,
+    userRating: userRating ?? existing?.userRating ?? null,
+    watchedAt: entry.added_to_watchlist_at ?? existing?.watchedAt ?? null,
+    watchedEpisodes: watchedEpisodes ?? existing?.watchedEpisodes,
+  };
+
+  cache.items[simklIdStr] = item;
+  indexItem(cache, item, node.ids);
+}
+
+function mergeRatings(cache: SimklCache, ratings: RawRatingsResponse) {
+  const mergeList = (list: RawRatingEntry[] | undefined, type: "movie" | "show" | "anime") => {
+    for (const entry of list ?? []) {
+      const node = type === "movie" ? entry.movie : type === "anime" ? (entry.anime || entry.show || entry.movie) : entry.show;
+      if (!node?.ids?.simkl) continue;
+      const simklId = node.ids.simkl;
+      const simklIdStr = String(simklId);
+      
+      const existing = cache.items[simklIdStr];
+      if (existing) {
+        existing.userRating = entry.rating ?? null;
+      } else {
+        const item: SimklCacheItem = {
+          simklId,
+          type,
+          title: "",
+          year: null,
+          status: "completed",
+          userRating: entry.rating ?? null,
+          watchedAt: null,
+        };
+        cache.items[simklIdStr] = item;
+        indexItem(cache, item, node.ids);
+      }
+    }
+  };
+  mergeList(ratings.movies, "movie");
+  mergeList(ratings.shows, "show");
+  mergeList(ratings.anime, "anime");
+}
+
+async function bootstrapCache(): Promise<SimklCache> {
+  const cache: SimklCache = {
+    lastSync: null,
+    activities: null,
+    items: {},
+    imdbToSimkl: {},
+    tmdbToSimkl: {},
+    malToSimkl: {},
+    kitsuToSimkl: {},
+  };
+
+  // 1. Pull Shows sequentially
+  const showsData = await simklRequest<RawAllItems>(
+    "/sync/all-items/shows/all?extended=full&episode_watched_at=yes"
+  ).catch(() => ({}) as RawAllItems);
+  for (const entry of showsData.shows ?? []) {
+    parseAndMergeEntry(cache, entry, "show");
+  }
+
+  // 2. Pull Movies sequentially
+  const moviesData = await simklRequest<RawAllItems>(
+    "/sync/all-items/movies/all?extended=full&episode_watched_at=yes"
+  ).catch(() => ({}) as RawAllItems);
+  for (const entry of moviesData.movies ?? []) {
+    parseAndMergeEntry(cache, entry, "movie");
+  }
+
+  // 3. Pull Anime sequentially
+  const animeData = await simklRequest<RawAllItems>(
+    "/sync/all-items/anime/all?extended=full&episode_watched_at=yes"
+  ).catch(() => ({}) as RawAllItems);
+  for (const entry of animeData.anime ?? []) {
+    parseAndMergeEntry(cache, entry, "anime");
+  }
+
+  // 4. Pull User Ratings
+  const ratingsData = await simklRequest<RawRatingsResponse>(
+    "/sync/ratings"
+  ).catch(() => ({}) as RawRatingsResponse);
+  mergeRatings(cache, ratingsData);
+
+  // 5. Fetch /sync/activities
+  const activities = await simklRequest<any>("/sync/activities").catch(() => null);
+  
+  if (activities) {
+    const tvShowsRatedAt = activities.shows?.rated_at || activities.tv_shows?.rated_at;
+    const ratingsTimestamp = getLatestTimestamp(
+      activities.movies?.rated_at,
+      tvShowsRatedAt,
+      activities.anime?.rated_at
+    );
+    
+    cache.lastSync = activities.all || new Date().toISOString();
+    cache.activities = {
+      movies: activities.movies?.all ?? null,
+      shows: activities.shows?.all ?? activities.tv_shows?.all ?? null,
+      anime: activities.anime?.all ?? null,
+      ratings: ratingsTimestamp,
+    };
+  }
+
+  saveLocalCache(cache);
+  return cache;
+}
+
+async function performDeltaSync(cache: SimklCache, activities: any): Promise<SimklCache> {
+  const currentLastSync = cache.lastSync;
+  
+  if (activities.all && activities.all === currentLastSync) {
+    return cache;
+  }
+
+  const dateFrom = currentLastSync ? encodeURIComponent(currentLastSync) : "";
+  const deltaData = await simklRequest<RawAllItems>(
+    `/sync/all-items?date_from=${dateFrom}`
+  ).catch(() => ({}) as RawAllItems);
+
+  for (const entry of deltaData.shows ?? []) {
+    parseAndMergeEntry(cache, entry, "show");
+  }
+  for (const entry of deltaData.movies ?? []) {
+    parseAndMergeEntry(cache, entry, "movie");
+  }
+  for (const entry of deltaData.anime ?? []) {
+    parseAndMergeEntry(cache, entry, "anime");
+  }
+
+  const moviesRemoved = activities.movies?.removed_from_list;
+  const tvShowsRemoved = activities.shows?.removed_from_list || activities.tv_shows?.removed_from_list;
+  const animeRemoved = activities.anime?.removed_from_list;
+
+  const isRemovedSinceLastSync = (removedDate: string | null | undefined) => {
+    if (!removedDate || !currentLastSync) return false;
+    return new Date(removedDate) > new Date(currentLastSync);
+  };
+
+  const hasRemovals = isRemovedSinceLastSync(moviesRemoved) ||
+                      isRemovedSinceLastSync(tvShowsRemoved) ||
+                      isRemovedSinceLastSync(animeRemoved);
+
+  if (hasRemovals) {
+    const idsOnlyData = await simklRequest<RawAllItems>(
+      "/sync/all-items?extended=simkl_ids_only"
+    ).catch(() => ({}) as RawAllItems);
+
+    const validIds = new Set<number>();
+    const addIds = (entries: RawEntry[] | undefined, type: "movie" | "show" | "anime") => {
+      for (const e of entries ?? []) {
+        const node = type === "movie" ? e.movie : type === "anime" ? (e.anime || e.show || e.movie) : e.show;
+        if (node?.ids?.simkl) {
+          validIds.add(node.ids.simkl);
+        }
+      }
+    };
+    addIds(idsOnlyData.movies, "movie");
+    addIds(idsOnlyData.shows, "show");
+    addIds(idsOnlyData.anime, "anime");
+
+    for (const simklIdStr of Object.keys(cache.items)) {
+      const item = cache.items[simklIdStr];
+      if (!validIds.has(item.simklId)) {
+        pruneItem(cache, item.simklId);
+      }
+    }
+  }
+
+  const tvShowsRatedAt = activities.shows?.rated_at || activities.tv_shows?.rated_at;
+  const ratingsTimestamp = getLatestTimestamp(
+    activities.movies?.rated_at,
+    tvShowsRatedAt,
+    activities.anime?.rated_at
+  );
+
+  cache.lastSync = activities.all || new Date().toISOString();
+  cache.activities = {
+    movies: activities.movies?.all ?? null,
+    shows: activities.shows?.all ?? activities.tv_shows?.all ?? null,
+    anime: activities.anime?.all ?? null,
+    ratings: ratingsTimestamp,
+  };
+
+  saveLocalCache(cache);
+  return cache;
+}
+
+let activeSyncPromise: Promise<SimklCache> | null = null;
+
+export function syncWatchlistCache(): Promise<SimklCache> {
+  if (activeSyncPromise) return activeSyncPromise;
+
+  activeSyncPromise = (async () => {
+    try {
+      const session = getSession();
+      if (!session) {
+        throw new Error("User not authenticated");
+      }
+
+      let cache = getLocalCache();
+      if (!cache || !cache.lastSync) {
+        cache = await bootstrapCache();
+        invalidateListStatusCache();
+      } else {
+        const activities = await simklRequest<any>("/sync/activities").catch(() => null);
+        if (activities) {
+          const previousLastSync = cache.lastSync;
+          cache = await performDeltaSync(cache, activities);
+          if (cache.lastSync !== previousLastSync) {
+            invalidateListStatusCache();
+          }
+        }
+      }
+      return cache;
+    } finally {
+      activeSyncPromise = null;
+    }
+  })();
+
+  return activeSyncPromise;
+}
+
+export async function getCachedSimklData(): Promise<{
+  statuses: Map<string, WatchlistStatus>;
+  watched: Map<string, Set<string>>;
+}> {
+  let cache = getLocalCache();
+  if (!cache || !cache.lastSync) {
+    cache = await syncWatchlistCache().catch(() => null);
+  }
+  
+  const statuses = new Map<string, WatchlistStatus>();
+  const watched = new Map<string, Set<string>>();
+
+  if (!cache) {
+    return { statuses, watched };
+  }
+
+  const registerKeys = (item: SimklCacheItem, simklId: number) => {
+    const keys: string[] = [];
+    
+    for (const [imdbId, sId] of Object.entries(cache.imdbToSimkl)) {
+      if (sId === simklId) keys.push(imdbId);
+    }
+    for (const [tmdbKey, sId] of Object.entries(cache.tmdbToSimkl)) {
+      if (sId === simklId) {
+        const parts = tmdbKey.split(":");
+        if (parts.length === 2) {
+          keys.push(`tmdb:${parts[0]}:${parts[1]}`);
+        }
+      }
+    }
+    for (const [malId, sId] of Object.entries(cache.malToSimkl)) {
+      if (sId === simklId) keys.push(`mal:${malId}`);
+    }
+    for (const [kitsuId, sId] of Object.entries(cache.kitsuToSimkl)) {
+      if (sId === simklId) keys.push(`kitsu:${kitsuId}`);
+    }
+    
+    for (const k of keys) {
+      statuses.set(k, item.status);
+      if (item.watchedEpisodes && item.watchedEpisodes.length > 0) {
+        watched.set(k, new Set(item.watchedEpisodes));
+      }
+    }
+  };
+
+  for (const simklIdStr of Object.keys(cache.items)) {
+    const item = cache.items[simklIdStr];
+    registerKeys(item, item.simklId);
+  }
+
+  return { statuses, watched };
+}
+
+export function updateCachedStatus(
+  simklId: number,
+  type: "movie" | "show" | "anime",
+  title: string,
+  year: number | null,
+  status: WatchlistStatus | null,
+  externalIds?: RawIds
+) {
+  const cache = getLocalCache();
+  if (!cache) return;
+
+  const simklIdStr = String(simklId);
+
+  if (status === null) {
+    pruneItem(cache, simklId);
+  } else {
+    const existing = cache.items[simklIdStr];
+    const item: SimklCacheItem = {
+      simklId,
+      type,
+      title: title || existing?.title || "",
+      year: year ?? existing?.year ?? null,
+      status,
+      userRating: existing?.userRating ?? null,
+      watchedAt: existing?.watchedAt ?? new Date().toISOString(),
+      watchedEpisodes: existing?.watchedEpisodes,
+    };
+    cache.items[simklIdStr] = item;
+    if (externalIds) {
+      indexItem(cache, item, externalIds);
+    }
+  }
+
+  saveLocalCache(cache);
+}
+
+export function updateCachedStatusByTarget(
+  target: SimklTarget,
+  status: WatchlistStatus | null
+) {
+  const isMovie = target.kind === "movie";
+  const isAnime = target.kind === "anime" || target.kind === "anime-episode";
+  const ids =
+    target.kind === "episode"
+      ? target.show.ids
+      : target.kind === "anime-episode"
+        ? target.anime.ids
+        : target.ids;
+  if (!ids?.simkl) return;
+
+  const type = isMovie ? "movie" : isAnime ? "anime" : "show";
+
+  updateCachedStatus(ids.simkl, type, "", null, status, ids as RawIds);
+}
+
+export function updateCachedRatingByTarget(target: SimklTarget, rating: number | null) {
+  const cache = getLocalCache();
+  if (!cache) return;
+
+  const ids =
+    target.kind === "episode"
+      ? target.show.ids
+      : target.kind === "anime-episode"
+        ? target.anime.ids
+        : target.ids;
+  if (!ids?.simkl) return;
+
+  const simklIdStr = String(ids.simkl);
+  const existing = cache.items[simklIdStr];
+  if (existing) {
+    existing.userRating = rating;
+  } else {
+    const isMovie = target.kind === "movie";
+    const isAnime = target.kind === "anime" || target.kind === "anime-episode";
+    const type = isMovie ? "movie" : isAnime ? "anime" : "show";
+    const item: SimklCacheItem = {
+      simklId: ids.simkl,
+      type,
+      title: "",
+      year: null,
+      status: "completed",
+      userRating: rating,
+      watchedAt: new Date().toISOString(),
+    };
+    cache.items[simklIdStr] = item;
+    indexItem(cache, item, ids as RawIds);
+  }
+
+  saveLocalCache(cache);
+  invalidateListStatusCache();
+}
+
+export function getCachedRatingByTarget(target: SimklTarget): number | null {
+  const cache = getLocalCache();
+  if (!cache) return null;
+
+  const ids =
+    target.kind === "episode"
+      ? target.show.ids
+      : target.kind === "anime-episode"
+        ? target.anime.ids
+        : target.ids;
+  if (!ids?.simkl) return null;
+
+  return cache.items[String(ids.simkl)]?.userRating ?? null;
+}
+

--- a/src/lib/simkl/anime-grouping.ts
+++ b/src/lib/simkl/anime-grouping.ts
@@ -40,8 +40,8 @@ export interface AnimeFranchise {
  * Conservative — only strips clear season suffixes to avoid false positives.
  */
 const SEASON_PATTERNS: RegExp[] = [
-  // Trailing punctuation: ".", "°", "'", ":", "!", "?", "..."
-  /[.\u00b0'`:!?]+$/,
+  // Trailing punctuation: ".", "°", "'", ":", "!", "?", "...", and bracket characters
+  /[.\u00b0'`:!?,_\-\(\)\[\]{}#]+$/,
   // "Season N" or "S N" at the end
   /\s+season\s*\d+$/i,
   /\s+s\d+$/i,
@@ -72,6 +72,17 @@ const SEASON_PATTERNS: RegExp[] = [
   /\s+r\d?$/i,
   // "TV" at the end (e.g., "Gintama TV")
   /\s+tv$/i,
+  // Custom enhanced suffixes (e.g. Gintama Porori Hen / Enchousen)
+  /\s+porori\s+hen$/i,
+  /\s+enchousen$/i,
+  /\s+hen$/i,
+  /\s+season$/i,
+  /\s*\(tv\)$/i,
+  /\s*\(movie\)$/i,
+  /\s*\(ova\)$/i,
+  /\s*\[tv\]$/i,
+  /\s*\[movie\]$/i,
+  /\s*\[ova\]$/i,
 ];
 
 /**
@@ -135,10 +146,10 @@ const relationsCache = new Map<number, Set<number>>();
 const relationsInFlight = new Map<number, Promise<Set<number>>>();
 
 /**
- * Fetch related anime SIMKL IDs from the /anime/{id} endpoint.
+ * Fetch related anime SIMKL IDs from the appropriate endpoint.
  * Results are cached in-memory.
  */
-async function fetchRelations(simklId: number): Promise<Set<number>> {
+async function fetchRelations(simklId: number, type: "movie" | "show" | "anime"): Promise<Set<number>> {
   if (relationsCache.has(simklId)) {
     return relationsCache.get(simklId)!;
   }
@@ -148,8 +159,9 @@ async function fetchRelations(simklId: number): Promise<Set<number>> {
 
   const promise = (async () => {
     try {
+      const endpoint = type === "movie" ? `/movies/${simklId}` : `/anime/${simklId}`;
       const detail = await simklRequest<SimklAnimeDetail>(
-        `/anime/${simklId}`,
+        endpoint,
         { method: "GET", authed: false },
       );
       const related = new Set<number>();
@@ -267,26 +279,28 @@ export async function enhanceGroupsWithRelations(
     }
   }
 
-  // Identify singletons (franchises with only 1 item) — these are candidates for merging
-  const singletons = franchises.filter((f) => f.items.length === 1);
-  const singletonsToCheck = singletons.slice(0, maxApiCalls);
+  // Identify all groups - check all groups to bridge Romaji/English variations
+  const groupsToCheck = franchises.slice(0, maxApiCalls);
 
-  // Fetch relations for each singleton in parallel (limited concurrency)
+  // Fetch relations for each group in parallel (limited concurrency)
   const BATCH_SIZE = 10;
   const mergePairs: Array<[number, number]> = []; // [franchiseIndexA, franchiseIndexB]
 
-  for (let i = 0; i < singletonsToCheck.length; i += BATCH_SIZE) {
-    const batch = singletonsToCheck.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < groupsToCheck.length; i += BATCH_SIZE) {
+    const batch = groupsToCheck.slice(i, i + BATCH_SIZE);
     const results = await Promise.all(
       batch.map(async (franchise) => {
-        const simklId = franchise.simklIds[0];
-        const relations = await fetchRelations(simklId);
+        const representative = franchise.items[0];
+        if (!representative) return { franchise, relations: new Set<number>() };
+        const relations = await fetchRelations(representative.simklId, representative.type);
         return { franchise, relations };
       }),
     );
 
     for (const { franchise, relations } of results) {
-      const currentIdx = simklIdToFranchise.get(franchise.simklIds[0])!;
+      const representative = franchise.items[0];
+      if (!representative) continue;
+      const currentIdx = simklIdToFranchise.get(representative.simklId)!;
       for (const relatedId of relations) {
         const targetIdx = simklIdToFranchise.get(relatedId);
         if (targetIdx != null && targetIdx !== currentIdx) {

--- a/src/lib/simkl/anime-grouping.ts
+++ b/src/lib/simkl/anime-grouping.ts
@@ -1,0 +1,406 @@
+/**
+ * Anime Franchise Grouping — Hybrid Approach
+ *
+ * Groups anime items by franchise so that multiple seasons of the same series
+ * (e.g., "Gintama", "Gintama.", "Gintama°") appear as a single card in the UI.
+ *
+ * Methods (in priority order):
+ * 1. Title normalization — strip season indicators and compare base titles
+ * 2. SIMKL relations API — fetch related anime from /anime/{id} endpoint
+ * 3. Safety threshold — if confidence is low, don't group
+ */
+
+import type { SimklCacheItem } from "./activities";
+import { simklRequest } from "./client";
+
+/* ─── Types ───────────────────────────────────────────────────────────────── */
+
+export interface AnimeFranchise {
+  /** Normalized franchise key (e.g., "gintama") */
+  key: string;
+  /** Display name for the franchise (uses the first/oldest season's title) */
+  name: string;
+  /** All SIMKL IDs that belong to this franchise */
+  simklIds: number[];
+  /** All items in the franchise */
+  items: SimklCacheItem[];
+  /** Best available poster (from any item in the group) */
+  bestTitle: string;
+  /** Year range: earliest start → latest end */
+  yearStart: number | null;
+  yearEnd: number | null;
+  /** Average community rating across seasons (computed by caller) */
+  averageRating: number | null;
+}
+
+/* ─── Title Normalization ─────────────────────────────────────────────────── */
+
+/**
+ * Season indicator patterns to strip from titles for grouping.
+ * Conservative — only strips clear season suffixes to avoid false positives.
+ */
+const SEASON_PATTERNS: RegExp[] = [
+  // Trailing punctuation: ".", "°", "'", ":", "!", "?", "..."
+  /[.\u00b0'`:!?]+$/,
+  // "Season N" or "S N" at the end
+  /\s+season\s*\d+$/i,
+  /\s+s\d+$/i,
+  // "Nth Season" at the end
+  /\s+\d+(st|nd|rd|th)\s+season$/i,
+  // "Part N" or "Cour N" at the end
+  /\s+part\s*\d+$/i,
+  /\s+cour\s*\d+$/i,
+  // "II", "III", "IV" Roman numerals at the end
+  /\s+(ii|iii|iv|v|vi|vii|viii|ix|x)$/i,
+  // "2nd", "3rd" etc. at the end
+  /\s+\d+(st|nd|rd|th)$/i,
+  // Year suffix at the end (e.g., "Fairy Tail 2014" → "Fairy Tail")
+  /\s+\d{4}$/,
+  // "Final Season" at the end
+  /\s+final\s+season$/i,
+  // "The Final" at the end
+  /\s+the\s+final$/i,
+  // "Final" at the end (e.g., "Gintama Final" → "Gintama")
+  // Note: This could group movies with series, but the title normalization
+  // is only used for anime grouping in the library, not for movie grouping
+  /\s+final$/i,
+  // Common sequel terms
+  /\s+shippuden$/i,
+  /\s+gaiden$/i,
+  /\s+side\s+story$/i,
+  // "R" / "R2" at the end (e.g., "Code Geass R2")
+  /\s+r\d?$/i,
+  // "TV" at the end (e.g., "Gintama TV")
+  /\s+tv$/i,
+];
+
+/**
+ * Normalize a title for franchise grouping.
+ * Strips season indicators and normalizes whitespace/punctuation.
+ */
+export function normalizeAnimeTitle(title: string): string {
+  let normalized = title.trim().toLowerCase();
+
+  // Remove common prefixes/suffixes that don't affect franchise identity
+  normalized = normalized
+    .replace(/\s+/g, " ") // collapse whitespace
+    .trim();
+
+  // Apply season pattern stripping iteratively (e.g., "Gintama. Season 2" → "Gintama")
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const pattern of SEASON_PATTERNS) {
+      if (pattern.test(normalized)) {
+        normalized = normalized.replace(pattern, "").trim();
+        changed = true;
+      }
+    }
+  }
+
+  // Strip everything after a colon (e.g., "Attack on Titan: Final Season" → "Attack on Titan")
+  // This is done AFTER other patterns to handle cases like "Gintama.: Shinyaku Benkyou Arc"
+  // where the trailing "." is stripped first, then the colon content is stripped
+  if (normalized.includes(":")) {
+    normalized = normalized.split(":")[0].trim();
+  }
+
+  // Remove all non-alphanumeric characters for comparison
+  normalized = normalized.replace(/[^a-z0-9]/g, "");
+
+  return normalized;
+}
+
+/* ─── SIMKL Relations API ─────────────────────────────────────────────────── */
+
+interface SimklRelation {
+  title?: string;
+  en_title?: string | null;
+  year?: number;
+  anime_type?: string;
+  relation_type?: string;
+  is_direct?: boolean;
+  ids?: {
+    simkl_id?: number;
+  };
+}
+
+interface SimklAnimeDetail {
+  relations?: SimklRelation[];
+}
+
+/** In-memory cache: SIMKL ID → Set of related SIMKL IDs */
+const relationsCache = new Map<number, Set<number>>();
+/** In-flight requests */
+const relationsInFlight = new Map<number, Promise<Set<number>>>();
+
+/**
+ * Fetch related anime SIMKL IDs from the /anime/{id} endpoint.
+ * Results are cached in-memory.
+ */
+async function fetchRelations(simklId: number): Promise<Set<number>> {
+  if (relationsCache.has(simklId)) {
+    return relationsCache.get(simklId)!;
+  }
+  if (relationsInFlight.has(simklId)) {
+    return relationsInFlight.get(simklId)!;
+  }
+
+  const promise = (async () => {
+    try {
+      const detail = await simklRequest<SimklAnimeDetail>(
+        `/anime/${simklId}`,
+        { method: "GET", authed: false },
+      );
+      const related = new Set<number>();
+      if (detail.relations && Array.isArray(detail.relations)) {
+        for (const rel of detail.relations) {
+          if (rel.ids?.simkl_id && rel.is_direct !== false) {
+            related.add(rel.ids.simkl_id);
+          }
+        }
+      }
+      relationsCache.set(simklId, related);
+      return related;
+    } catch {
+      relationsCache.set(simklId, new Set());
+      return new Set<number>();
+    } finally {
+      relationsInFlight.delete(simklId);
+    }
+  })();
+
+  relationsInFlight.set(simklId, promise);
+  return promise;
+}
+
+/* ─── Franchise Grouping ─────────────────────────────────────────────────── */
+
+/**
+ * Group anime cache items by franchise using title normalization.
+ * This is the fast, synchronous first pass — no API calls.
+ *
+ * @param items All anime items from the cache
+ * @param useRelationsApi Kept for API compatibility but ignored (use enhanceGroupsWithRelations)
+ */
+export function groupAnimeByFranchise(
+  items: SimklCacheItem[],
+  useRelationsApi = false,
+): AnimeFranchise[] {
+  void useRelationsApi; // Relations enhancement is now async — use enhanceGroupsWithRelations()
+
+  // Step 1: Group by normalized title
+  const titleGroups = new Map<string, SimklCacheItem[]>();
+
+  for (const item of items) {
+    const normalizedTitle = normalizeAnimeTitle(item.title);
+    if (!normalizedTitle) continue;
+
+    const group = titleGroups.get(normalizedTitle) ?? [];
+    group.push(item);
+    titleGroups.set(normalizedTitle, group);
+  }
+
+  // Build franchise objects from title groups
+  const franchises: AnimeFranchise[] = [];
+
+  for (const [normalizedTitle, groupItems] of titleGroups) {
+    // Sort items by year (ascending) so the first item is the earliest
+    groupItems.sort((a, b) => (a.year ?? 9999) - (b.year ?? 9999));
+
+    const years = groupItems.map((i) => i.year).filter((y): y is number => y != null);
+    const yearStart = years.length > 0 ? Math.min(...years) : null;
+    const yearEnd = years.length > 0 ? Math.max(...years) : null;
+
+    // Use the first (oldest) item's title as the franchise display name
+    // But prefer the shortest title (likely the base franchise name)
+    const titles = groupItems.map((i) => i.title);
+    const bestTitle = titles.reduce((best, current) =>
+      current.length < best.length ? current : best,
+    );
+
+    franchises.push({
+      key: normalizedTitle,
+      name: bestTitle,
+      simklIds: groupItems.map((i) => i.simklId),
+      items: groupItems,
+      bestTitle,
+      yearStart,
+      yearEnd,
+      averageRating: null, // Computed by caller if needed
+    });
+  }
+
+  // Sort franchises by name
+  franchises.sort((a, b) => a.name.localeCompare(b.name));
+
+  return franchises;
+}
+
+/**
+ * Enhance franchise grouping by using the SIMKL relations API.
+ *
+ * After title-based grouping, this function:
+ * 1. Identifies singleton groups (franchises with only 1 item)
+ * 2. Fetches relations for each singleton via /anime/{id}
+ * 3. If a relation links to an item in another group, merges the two groups
+ *
+ * This catches cases like:
+ * - "Gintama" → "Gintama.: Shinyaku Benkyou Arc" (different normalized titles but related)
+ * - "Attack on Titan" → "Shingeki no Kyojin" (same series, different title)
+ *
+ * @param franchises The title-based franchise groups
+ * @param maxApiCalls Limit to avoid excessive API requests (default: 50)
+ * @returns Merged franchise groups
+ */
+export async function enhanceGroupsWithRelations(
+  franchises: AnimeFranchise[],
+  maxApiCalls = 50,
+): Promise<AnimeFranchise[]> {
+  if (franchises.length <= 1) return franchises;
+
+  // Build a map: simklId → franchise index
+  const simklIdToFranchise = new Map<number, number>();
+  for (let i = 0; i < franchises.length; i++) {
+    for (const simklId of franchises[i].simklIds) {
+      simklIdToFranchise.set(simklId, i);
+    }
+  }
+
+  // Identify singletons (franchises with only 1 item) — these are candidates for merging
+  const singletons = franchises.filter((f) => f.items.length === 1);
+  const singletonsToCheck = singletons.slice(0, maxApiCalls);
+
+  // Fetch relations for each singleton in parallel (limited concurrency)
+  const BATCH_SIZE = 10;
+  const mergePairs: Array<[number, number]> = []; // [franchiseIndexA, franchiseIndexB]
+
+  for (let i = 0; i < singletonsToCheck.length; i += BATCH_SIZE) {
+    const batch = singletonsToCheck.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (franchise) => {
+        const simklId = franchise.simklIds[0];
+        const relations = await fetchRelations(simklId);
+        return { franchise, relations };
+      }),
+    );
+
+    for (const { franchise, relations } of results) {
+      const currentIdx = simklIdToFranchise.get(franchise.simklIds[0])!;
+      for (const relatedId of relations) {
+        const targetIdx = simklIdToFranchise.get(relatedId);
+        if (targetIdx != null && targetIdx !== currentIdx) {
+          mergePairs.push([currentIdx, targetIdx]);
+        }
+      }
+    }
+  }
+
+  if (mergePairs.length === 0) return franchises;
+
+  // Union-Find to merge groups
+  const parent = franchises.map((_, i) => i);
+  function find(x: number): number {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  }
+  function union(a: number, b: number) {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  }
+
+  for (const [a, b] of mergePairs) {
+    union(a, b);
+  }
+
+  // Build merged franchises
+  const mergedGroups = new Map<number, number[]>();
+  for (let i = 0; i < franchises.length; i++) {
+    const root = find(i);
+    const group = mergedGroups.get(root) ?? [];
+    group.push(i);
+    mergedGroups.set(root, group);
+  }
+
+  const result: AnimeFranchise[] = [];
+  for (const indices of mergedGroups.values()) {
+    if (indices.length === 1) {
+      result.push(franchises[indices[0]]);
+      continue;
+    }
+
+    // Merge all items from all franchises in this group
+    const allItems: SimklCacheItem[] = [];
+    for (const idx of indices) {
+      allItems.push(...franchises[idx].items);
+    }
+    allItems.sort((a, b) => (a.year ?? 9999) - (b.year ?? 9999));
+
+    const years = allItems.map((i) => i.year).filter((y): y is number => y != null);
+    const yearStart = years.length > 0 ? Math.min(...years) : null;
+    const yearEnd = years.length > 0 ? Math.max(...years) : null;
+
+    const titles = allItems.map((i) => i.title);
+    const bestTitle = titles.reduce((best, current) =>
+      current.length < best.length ? current : best,
+    );
+
+    // Use the first franchise's key as the merged key
+    const firstKey = franchises[indices[0]].key;
+
+    result.push({
+      key: firstKey,
+      name: bestTitle,
+      simklIds: allItems.map((i) => i.simklId),
+      items: allItems,
+      bestTitle,
+      yearStart,
+      yearEnd,
+      averageRating: null,
+    });
+  }
+
+  result.sort((a, b) => a.name.localeCompare(b.name));
+  return result;
+}
+
+/**
+ * Compute the average rating across all seasons in a franchise.
+ * @param franchise The franchise to compute the average for
+ * @param getRating Function to get the community rating for a SIMKL ID
+ * @returns Average rating or null if no ratings available
+ */
+export function computeFranchiseAverageRating(
+  franchise: AnimeFranchise,
+  getRating: (simklId: number) => number | null,
+): number | null {
+  const ratings = franchise.simklIds
+    .map((id) => getRating(id))
+    .filter((r): r is number => r != null && r > 0);
+
+  if (ratings.length === 0) return null;
+  return ratings.reduce((sum, r) => sum + r, 0) / ratings.length;
+}
+
+/**
+ * Format a year range for display.
+ * e.g., "2005-2021" or "2019" if start === end
+ */
+export function formatYearRange(start: number | null, end: number | null): string {
+  if (start == null && end == null) return "";
+  if (start === end) return start != null ? String(start) : "";
+  if (start != null && end != null) return `${start}-${end}`;
+  return start != null ? String(start) : String(end);
+}
+
+/**
+ * Clear all cached relations data (e.g., on SIMKL disconnect).
+ */
+export function clearAnimeGroupingCache() {
+  relationsCache.clear();
+  relationsInFlight.clear();
+}

--- a/src/lib/simkl/calendar.ts
+++ b/src/lib/simkl/calendar.ts
@@ -1,0 +1,118 @@
+import { safeFetch as fetch } from "@/lib/safe-fetch";
+import type { CalendarItem } from "@/lib/calendar";
+import { SIMKL_CLIENT_ID } from "./config";
+
+export type SimklCdnItem = {
+  title: string;
+  poster?: string;
+  date: string; // ISO date string e.g., "2026-06-30T00:00:00-05:00"
+  release_date?: string;
+  ratings?: {
+    simkl?: {
+      rating?: number | null;
+      votes?: number | null;
+    };
+  };
+  ids?: {
+    simkl_id?: number;
+    slug?: string;
+    tmdb?: string | number;
+    imdb?: string;
+  };
+  episode?: {
+    season?: number;
+    episode?: number;
+  };
+};
+
+function mapCdnItem(item: SimklCdnItem, type: "tv" | "movie", isAnime: boolean): CalendarItem {
+  const tmdbId = item.ids?.tmdb ? String(item.ids.tmdb) : null;
+  const id =
+    item.ids?.imdb ??
+    (tmdbId
+      ? type === "movie"
+        ? `tmdb:movie:${tmdbId}`
+        : `tmdb:tv:${tmdbId}`
+      : `simkl:${item.ids?.simkl_id}`);
+
+  let name = item.title;
+  if (type === "tv" && item.episode?.season !== undefined && item.episode?.episode !== undefined) {
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const epLabel = `S${pad(item.episode.season)}E${pad(item.episode.episode)}`;
+    name = `${item.title} ${epLabel}`;
+  }
+
+  const poster = item.poster ? `https://simkl.in/posters/${item.poster}_m.jpg` : null;
+
+  return {
+    id,
+    imdbId: item.ids?.imdb ?? null,
+    type,
+    name,
+    poster,
+    background: null,
+    releaseDate: (item.date ?? "").slice(0, 10),
+    isAnime,
+    overview: "",
+    voteAverage: item.ratings?.simkl?.rating ?? 0,
+  };
+}
+
+export async function fetchSimklCdnRolling(catalog: "tv" | "anime" | "movie"): Promise<CalendarItem[]> {
+  const filename = catalog === "movie" ? "movie_release.json" : `${catalog}.json`;
+  const url = `https://data.simkl.in/calendar/${filename}?client_id=${SIMKL_CLIENT_ID}&app-name=harbor&app-version=0.9.19`;
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": "harbor/0.9.19" } });
+    if (!res.ok) return [];
+    const data = (await res.json()) as SimklCdnItem[];
+    const type = catalog === "movie" ? "movie" : "tv";
+    const isAnime = catalog === "anime";
+    return data.map((item) => mapCdnItem(item, type, isAnime));
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchSimklCdnArchive(
+  year: number,
+  month: number, // 0-indexed (0 = Jan)
+  catalog: "tv" | "anime" | "movie",
+): Promise<CalendarItem[]> {
+  const filename = catalog === "movie" ? "movie_release.json" : `${catalog}.json`;
+  const simklMonth = month + 1; // 1-indexed for Simkl CDN
+  const url = `https://data.simkl.in/calendar/${year}/${simklMonth}/${filename}?client_id=${SIMKL_CLIENT_ID}&app-name=harbor&app-version=0.9.19`;
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": "harbor/0.9.19" } });
+    if (!res.ok) return [];
+    const data = (await res.json()) as SimklCdnItem[];
+    const type = catalog === "movie" ? "movie" : "tv";
+    const isAnime = catalog === "anime";
+    return data.map((item) => mapCdnItem(item, type, isAnime));
+  } catch {
+    return [];
+  }
+}
+
+const calendarCache = new Map<string, Promise<CalendarItem[]>>();
+
+export function fetchSimklCdnCalendar(year: number, month: number): Promise<CalendarItem[]> {
+  const cacheKey = `${year}-${month}`;
+  let p = calendarCache.get(cacheKey);
+  if (!p) {
+    p = Promise.all([
+      fetchSimklCdnArchive(year, month, "tv"),
+      fetchSimklCdnArchive(year, month, "anime"),
+      fetchSimklCdnArchive(year, month, "movie"),
+    ]).then(([tv, anime, movies]) => {
+      const combined = [...tv, ...anime, ...movies];
+      combined.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
+      return combined;
+    });
+    calendarCache.set(cacheKey, p);
+  }
+  return p;
+}
+
+export function clearCalendarCache() {
+  calendarCache.clear();
+}

--- a/src/lib/simkl/client.ts
+++ b/src/lib/simkl/client.ts
@@ -5,6 +5,7 @@ export type SimklRequestOptions = {
   method?: "GET" | "POST" | "PUT" | "DELETE";
   body?: unknown;
   authed?: boolean;
+  token?: string;
 };
 
 export class SimklApiError extends Error {
@@ -16,21 +17,34 @@ export class SimklApiError extends Error {
   }
 }
 
-function baseHeaders(): Record<string, string> {
-  return {
-    "Content-Type": "application/json",
+function baseHeaders(method: string): Record<string, string> {
+  const headers: Record<string, string> = {
     "simkl-api-key": SIMKL_CLIENT_ID,
+    "User-Agent": "harbor/0.9.19",
   };
+  if (method === "POST" || method === "PUT") {
+    headers["Content-Type"] = "application/json";
+  }
+  return headers;
 }
 
 async function doFetch(path: string, opts: SimklRequestOptions): Promise<Response> {
-  const headers = baseHeaders();
-  if (opts.authed !== false) {
+  const method = opts.method ?? "GET";
+  const headers = baseHeaders(method);
+  if (opts.token) {
+    headers["Authorization"] = `Bearer ${opts.token}`;
+  } else if (opts.authed !== false) {
     const session = getSession();
     if (session) headers["Authorization"] = `Bearer ${session.accessToken}`;
   }
-  return fetch(`${SIMKL_API_BASE}${path}`, {
-    method: opts.method ?? "GET",
+
+  const url = new URL(`${SIMKL_API_BASE}${path}`);
+  url.searchParams.set("client_id", SIMKL_CLIENT_ID);
+  url.searchParams.set("app-name", "harbor");
+  url.searchParams.set("app-version", "0.9.19");
+
+  return fetch(url.toString(), {
+    method,
     headers,
     body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
   });

--- a/src/lib/simkl/config.ts
+++ b/src/lib/simkl/config.ts
@@ -4,3 +4,4 @@ export const SIMKL_CLIENT_ID =
   "9609ef0a6051b6fdcf3290fd962fd65e0f8e969c942555410cffd37afca91997";
 export const SIMKL_VERIFY_URL = "https://simkl.com/pin";
 export const WATCHED_RATIO = 0.85;
+export const SIMKL_WATCHED_RATIO = 0.80;

--- a/src/lib/simkl/device-auth.ts
+++ b/src/lib/simkl/device-auth.ts
@@ -1,18 +1,15 @@
-import { SIMKL_API_BASE, SIMKL_CLIENT_ID } from "./config";
+import { simklRequest } from "./client";
 import { setSession } from "./session";
 import type { SimklPin, SimklSession } from "./types";
 
 export async function requestPin(): Promise<SimklPin> {
-  const res = await fetch(
-    `${SIMKL_API_BASE}/oauth/pin?client_id=${encodeURIComponent(SIMKL_CLIENT_ID)}`,
-  );
-  if (!res.ok) throw new Error(`Simkl pin request failed: HTTP ${res.status}`);
-  const data = (await res.json()) as {
+  interface PinResponse {
     user_code: string;
     verification_url: string;
     expires_in: number;
     interval: number;
-  };
+  }
+  const data = await simklRequest<PinResponse>("/oauth/pin", { authed: false });
   return {
     userCode: data.user_code,
     verificationUrl: data.verification_url,
@@ -30,11 +27,11 @@ export type PollHandle = { cancel: () => void };
 
 async function pollOnce(userCode: string): Promise<SimklSession | null> {
   try {
-    const res = await fetch(
-      `${SIMKL_API_BASE}/oauth/pin/${userCode}?client_id=${encodeURIComponent(SIMKL_CLIENT_ID)}`,
-    );
-    if (!res.ok) return null;
-    const data = (await res.json()) as { result?: string; access_token?: string };
+    interface PollResponse {
+      result?: string;
+      access_token?: string;
+    }
+    const data = await simklRequest<PollResponse>(`/oauth/pin/${userCode}`, { authed: false });
     if (data.result === "OK" && data.access_token) {
       return { accessToken: data.access_token, username: null };
     }
@@ -71,16 +68,15 @@ export function pollForToken(pin: SimklPin, onUpdate: (result: PollResult) => vo
 
 export async function fetchUsername(session: SimklSession): Promise<string | null> {
   try {
-    const res = await fetch(`${SIMKL_API_BASE}/users/settings`, {
+    interface SettingsResponse {
+      user?: {
+        name?: string;
+      };
+    }
+    const data = await simklRequest<SettingsResponse>("/users/settings", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "simkl-api-key": SIMKL_CLIENT_ID,
-        Authorization: `Bearer ${session.accessToken}`,
-      },
+      token: session.accessToken,
     });
-    if (!res.ok) return null;
-    const data = (await res.json()) as { user?: { name?: string } };
     return data.user?.name ?? null;
   } catch {
     return null;

--- a/src/lib/simkl/history.ts
+++ b/src/lib/simkl/history.ts
@@ -74,6 +74,35 @@ export async function addToHistory(target: SimklTarget): Promise<boolean> {
       });
       return (r?.added?.movies ?? 0) > 0;
     }
+    if (target.kind === "anime-episode") {
+      const r = await simklRequest<{ added?: { episodes?: number; anime?: number } }>(
+        "/sync/history",
+        {
+          method: "POST",
+          body: {
+            anime: [
+              {
+                ids: target.anime.ids,
+                seasons: [
+                  {
+                    number: target.season,
+                    episodes: [{ number: target.number, watched_at: watchedAt }],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      );
+      return (r?.added?.episodes ?? r?.added?.anime ?? 0) > 0;
+    }
+    if (target.kind === "anime") {
+      const r = await simklRequest<{ added?: { anime?: number } }>("/sync/history", {
+        method: "POST",
+        body: { anime: [{ ids: target.ids, watched_at: watchedAt }] },
+      });
+      return (r?.added?.anime ?? 0) > 0;
+    }
     if (target.kind === "episode") {
       const r = await simklRequest<{ added?: { episodes?: number; shows?: number } }>(
         "/sync/history",
@@ -113,11 +142,13 @@ export async function markEpisodesWatched(
 ): Promise<boolean> {
   if (episodes.length === 0) return false;
   const watchedAt = new Date().toISOString();
+  const isAnime = show.mal != null || show.kitsu != null || show.anidb != null;
+  const key = isAnime ? "anime" : "shows";
   try {
     await simklRequest("/sync/history", {
       method: "POST",
       body: {
-        shows: [
+        [key]: [
           {
             ids: show,
             seasons: [
@@ -141,11 +172,13 @@ export async function unmarkEpisodeWatched(
   season: number,
   episode: number,
 ): Promise<boolean> {
+  const isAnime = show.mal != null || show.kitsu != null || show.anidb != null;
+  const key = isAnime ? "anime" : "shows";
   try {
     await simklRequest("/sync/history/remove", {
       method: "POST",
       body: {
-        shows: [{ ids: show, seasons: [{ number: season, episodes: [{ number: episode }] }] }],
+        [key]: [{ ids: show, seasons: [{ number: season, episodes: [{ number: episode }] }] }],
       },
     });
     return true;

--- a/src/lib/simkl/home-rails.ts
+++ b/src/lib/simkl/home-rails.ts
@@ -10,6 +10,8 @@ import { safeFetch } from "@/lib/safe-fetch";
 import { SIMKL_CLIENT_ID } from "./config";
 import { getLocalCache } from "./activities";
 import type { Settings } from "@/lib/settings";
+import { groupAnimeByFranchise, type AnimeFranchise } from "./anime-grouping";
+import { simklRequest } from "./client";
 
 const PER_RAIL = 24;
 
@@ -191,6 +193,56 @@ export async function hydrateSimklItems(items: SimklItem[], tmdbKey: string): Pr
   return metas.filter((m): m is Meta => !!m && !!m.poster);
 }
 
+/**
+ * Convert SimklItem[] to SimklCacheItem-like objects for franchise grouping.
+ * The grouping function works with SimklCacheItem, so we adapt SimklItem to that shape.
+ */
+function groupSimklItemsByFranchise(items: SimklItem[]): AnimeFranchise[] {
+  const cacheLikeItems = items.map((it) => ({
+    simklId: it.ids.simkl ?? 0,
+    type: "anime" as const,
+    title: it.title,
+    year: it.year,
+    status: "watching" as const,
+    userRating: null,
+    watchedAt: null,
+  }));
+  return groupAnimeByFranchise(cacheLikeItems);
+}
+
+/**
+ * Hydrate franchise groups — uses the first item in each franchise as representative.
+ * Fetches poster from SIMKL /anime/{id} endpoint.
+ */
+async function hydrateSimklItemsFranchise(
+  franchises: AnimeFranchise[],
+  _tmdbKey: string,
+): Promise<Meta[]> {
+  const metas = await Promise.all(
+    franchises.map(async (f) => {
+      const first = f.items[0];
+      if (!first || !first.simklId) return null;
+      try {
+        const detail = await simklRequest<{ title?: string; poster?: string; year?: number }>(
+          `/anime/${first.simklId}`,
+          { method: "GET", authed: false },
+        );
+        if (!detail?.poster) return null;
+        return {
+          id: `simkl:${first.simklId}`,
+          type: "series" as const,
+          name: f.name,
+          poster: `https://simkl.in/posters/${detail.poster}_m.jpg`,
+          releaseInfo: f.yearStart ? String(f.yearStart) : undefined,
+        } as Meta;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return metas.filter((m): m is Meta => !!m && !!m.poster);
+}
+
 export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]> {
   // If settings.simklHomeRailsEnabled is false, do not return/display any SIMKL rows
   // (but you can still keep background cache updates active).
@@ -293,10 +345,34 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
     fetchSimklTrending().catch(() => []),
   ]);
 
-  // Hydrate metas
-  const [planMetas, watchMetas, upcomingMetas, trendingMetas] = await Promise.all([
-    hydrateSimklItems(plan.slice(0, PER_RAIL), tmdbKey),
-    hydrateSimklItems(watching.slice(0, PER_RAIL), tmdbKey),
+  // Split items by type for individual rails
+  // Anime items have type "show" but possess mal/anidb IDs
+  const isAnimeType = (it: SimklItem) => it.ids.mal != null || it.ids.anidb != null;
+  const watchingShows = watching.filter((it) => it.type === "show" && !isAnimeType(it));
+  const watchingAnimeRaw = watching.filter((it) => it.type === "show" && isAnimeType(it));
+  const planMovies = plan.filter((it) => it.type === "movie");
+  const planShows = plan.filter((it) => it.type === "show" && !isAnimeType(it));
+  const planAnimeRaw = plan.filter((it) => it.type === "show" && isAnimeType(it));
+
+  // Group anime by franchise so seasons appear as a single card
+  const watchingAnime = groupSimklItemsByFranchise(watchingAnimeRaw);
+  const planAnime = groupSimklItemsByFranchise(planAnimeRaw);
+
+  // Hydrate metas for all individual rails
+  const [
+    watchingShowsMetas,
+    watchingAnimeMetas,
+    planMoviesMetas,
+    planShowsMetas,
+    planAnimeMetas,
+    upcomingMetas,
+    trendingMetas,
+  ] = await Promise.all([
+    hydrateSimklItems(watchingShows.slice(0, PER_RAIL), tmdbKey),
+    hydrateSimklItemsFranchise(watchingAnime.slice(0, PER_RAIL), tmdbKey),
+    hydrateSimklItems(planMovies.slice(0, PER_RAIL), tmdbKey),
+    hydrateSimklItems(planShows.slice(0, PER_RAIL), tmdbKey),
+    hydrateSimklItemsFranchise(planAnime.slice(0, PER_RAIL), tmdbKey),
     hydrateSimklItems(upcomingShows.slice(0, PER_RAIL), tmdbKey),
     hydrateSimklItems(trendingItems.slice(0, PER_RAIL), tmdbKey),
   ]);
@@ -309,20 +385,84 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
     return hydrateSimklItems(slice, tmdbKey);
   };
 
-  if (watchMetas.length >= 4 && (settings.simklGranularFilters.shows.watching || settings.simklGranularFilters.anime.watching)) {
+  const pagerFranchise = (items: AnimeFranchise[]) => async (page: number) => {
+    const slice = items.slice((page - 1) * PER_RAIL, page * PER_RAIL);
+    if (slice.length === 0) return [];
+    return hydrateSimklItemsFranchise(slice, tmdbKey);
+  };
+
+  // Rail 1: Watching TV Shows
+  if (watchingShowsMetas.length >= 4 && settings.simklGranularFilters.shows.watching) {
     rows.push({
-      key: "simkl-watching",
-      type: watching[0]?.type === "show" ? "series" : "movie",
-      name: "Watching on Simkl",
-      metas: watchMetas,
+      key: "simkl-watching-shows",
+      type: "series",
+      name: "Watching TV Shows on Simkl",
+      metas: watchingShowsMetas,
       page: 1,
-      hasMore: watching.length > PER_RAIL,
+      hasMore: watchingShows.length > PER_RAIL,
       noDedup: true,
-      fetcher: pager(watching),
+      fetcher: pager(watchingShows),
     });
   }
 
-  if (upcomingMetas.length >= 4 && (settings.simklGranularFilters.shows.watching || settings.simklGranularFilters.shows.plantowatch || settings.simklGranularFilters.anime.watching || settings.simklGranularFilters.anime.plantowatch)) {
+  // Rail 2: Watching Anime
+  if (watchingAnimeMetas.length >= 4 && settings.simklGranularFilters.anime.watching) {
+    rows.push({
+      key: "simkl-watching-anime",
+      type: "series",
+      name: "Watching Anime on Simkl",
+      metas: watchingAnimeMetas,
+      page: 1,
+      hasMore: watchingAnime.length > PER_RAIL,
+      noDedup: true,
+      fetcher: pagerFranchise(watchingAnime),
+    });
+  }
+
+  // Rail 3: Plan to Watch Movies
+  if (planMoviesMetas.length >= 4 && settings.simklGranularFilters.movies.plantowatch) {
+    rows.push({
+      key: "simkl-plantowatch-movies",
+      type: "movie",
+      name: "Plan to Watch Movies on Simkl",
+      metas: planMoviesMetas,
+      page: 1,
+      hasMore: planMovies.length > PER_RAIL,
+      noDedup: true,
+      fetcher: pager(planMovies),
+    });
+  }
+
+  // Rail 4: Plan to Watch TV Shows
+  if (planShowsMetas.length >= 4 && settings.simklGranularFilters.shows.plantowatch) {
+    rows.push({
+      key: "simkl-plantowatch-shows",
+      type: "series",
+      name: "Plan to Watch TV Shows on Simkl",
+      metas: planShowsMetas,
+      page: 1,
+      hasMore: planShows.length > PER_RAIL,
+      noDedup: true,
+      fetcher: pager(planShows),
+    });
+  }
+
+  // Rail 5: Plan to Watch Anime
+  if (planAnimeMetas.length >= 4 && settings.simklGranularFilters.anime.plantowatch) {
+    rows.push({
+      key: "simkl-plantowatch-anime",
+      type: "series",
+      name: "Plan to Watch Anime on Simkl",
+      metas: planAnimeMetas,
+      page: 1,
+      hasMore: planAnime.length > PER_RAIL,
+      noDedup: true,
+      fetcher: pagerFranchise(planAnime),
+    });
+  }
+
+  // Rail 6: Up Next on Simkl (combined, with its own toggle)
+  if (upcomingMetas.length >= 4 && settings.simklUpNextRailEnabled) {
     rows.push({
       key: "simkl-upcoming",
       type: "series",
@@ -335,20 +475,8 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
     });
   }
 
-  if (planMetas.length >= 4 && (settings.simklGranularFilters.movies.plantowatch || settings.simklGranularFilters.shows.plantowatch || settings.simklGranularFilters.anime.plantowatch)) {
-    rows.push({
-      key: "simkl-plantowatch",
-      type: plan[0]?.type === "show" ? "series" : "movie",
-      name: "Your Simkl Plan to Watch",
-      metas: planMetas,
-      page: 1,
-      hasMore: plan.length > PER_RAIL,
-      noDedup: true,
-      fetcher: pager(plan),
-    });
-  }
-
-  if (trendingMetas.length >= 4) {
+  // Rail 7: Simkl Trending Today (with its own toggle)
+  if (trendingMetas.length >= 4 && settings.simklTrendingRailEnabled) {
     rows.push({
       key: "simkl-trending",
       type: trendingItems[0]?.type === "show" ? "series" : "movie",

--- a/src/lib/simkl/home-rails.ts
+++ b/src/lib/simkl/home-rails.ts
@@ -10,7 +10,7 @@ import { safeFetch } from "@/lib/safe-fetch";
 import { SIMKL_CLIENT_ID } from "./config";
 import { getLocalCache } from "./activities";
 import type { Settings } from "@/lib/settings";
-import { groupAnimeByFranchise, type AnimeFranchise } from "./anime-grouping";
+import { groupAnimeByFranchise, enhanceGroupsWithRelations, type AnimeFranchise } from "./anime-grouping";
 import { simklRequest } from "./client";
 
 const PER_RAIL = 24;
@@ -25,6 +25,8 @@ interface SimklCdnItem {
     slug?: string;
     tmdb?: string | number;
     imdb?: string;
+    mal?: string | number;
+    kitsu?: string | number;
   };
   episode?: {
     season?: number;
@@ -198,21 +200,28 @@ export async function hydrateSimklItems(items: SimklItem[], tmdbKey: string): Pr
  * The grouping function works with SimklCacheItem, so we adapt SimklItem to that shape.
  */
 function groupSimklItemsByFranchise(items: SimklItem[]): AnimeFranchise[] {
-  const cacheLikeItems = items.map((it) => ({
-    simklId: it.ids.simkl ?? 0,
-    type: "anime" as const,
-    title: it.title,
-    year: it.year,
-    status: "watching" as const,
-    userRating: null,
-    watchedAt: null,
-  }));
+  const cache = getLocalCache();
+  const cacheLikeItems = items.map((it) => {
+    const simklId = it.ids.simkl;
+    const cached = cache && simklId ? cache.items[String(simklId)] : null;
+    return {
+      simklId: simklId ?? 0,
+      type: (cached?.type ?? (it.type === "movie" ? "movie" : "anime")) as any,
+      title: it.title,
+      year: it.year,
+      status: cached?.status ?? "watching" as const,
+      userRating: cached?.userRating ?? null,
+      watchedAt: cached?.watchedAt ?? null,
+      watchedEpisodes: cached?.watchedEpisodes ?? [],
+      poster: cached?.poster ?? null,
+    };
+  });
   return groupAnimeByFranchise(cacheLikeItems);
 }
 
 /**
- * Hydrate franchise groups — uses the first item in each franchise as representative.
- * Fetches poster from SIMKL /anime/{id} endpoint.
+ * Hydrate franchise groups — uses the representative item (prioritizing active progress)
+ * and resolves its poster with cached poster fallback.
  */
 async function hydrateSimklItemsFranchise(
   franchises: AnimeFranchise[],
@@ -220,24 +229,79 @@ async function hydrateSimklItemsFranchise(
 ): Promise<Meta[]> {
   const metas = await Promise.all(
     franchises.map(async (f) => {
-      const first = f.items[0];
-      if (!first || !first.simklId) return null;
-      try {
-        const detail = await simklRequest<{ title?: string; poster?: string; year?: number }>(
-          `/anime/${first.simklId}`,
-          { method: "GET", authed: false },
-        );
-        if (!detail?.poster) return null;
-        return {
-          id: `simkl:${first.simklId}`,
-          type: "series" as const,
-          name: f.name,
-          poster: `https://simkl.in/posters/${detail.poster}_m.jpg`,
-          releaseInfo: f.yearStart ? String(f.yearStart) : undefined,
-        } as Meta;
-      } catch {
-        return null;
+      // Prioritize active progress representative
+      const representative = (() => {
+        const watching = f.items.filter((it) => it.status === "watching");
+        if (watching.length > 0) {
+          watching.sort((a, b) => {
+            const tA = a.watchedAt ? new Date(a.watchedAt).getTime() : 0;
+            const tB = b.watchedAt ? new Date(b.watchedAt).getTime() : 0;
+            return tB - tA;
+          });
+          return watching[0];
+        }
+        return f.items[0];
+      })();
+
+      if (!representative || !representative.simklId) return null;
+
+      let posterUrl: string | undefined = undefined;
+
+      // 1. Try to use representative's cached poster
+      if (representative.poster) {
+        posterUrl = `https://simkl.in/posters/${representative.poster}_m.jpg`;
       }
+
+      // 2. Fall back to other items in the franchise if they have a cached poster
+      if (!posterUrl) {
+        const fallbackItem = f.items.find((it) => it.poster);
+        if (fallbackItem?.poster) {
+          posterUrl = `https://simkl.in/posters/${fallbackItem.poster}_m.jpg`;
+        }
+      }
+
+      // 3. Fall back to calling the SIMKL details API for the representative
+      if (!posterUrl) {
+        try {
+          const detail = await simklRequest<{ title?: string; poster?: string; year?: number }>(
+            `/anime/${representative.simklId}`,
+            { method: "GET", authed: false },
+          );
+          if (detail?.poster) {
+            posterUrl = `https://simkl.in/posters/${detail.poster}_m.jpg`;
+          }
+        } catch {
+          // Ignore
+        }
+      }
+
+      // 4. If we still don't have a poster, fall back to first item's details
+      if (!posterUrl && representative !== f.items[0] && f.items[0]?.simklId) {
+        try {
+          const detail = await simklRequest<{ title?: string; poster?: string; year?: number }>(
+            `/anime/${f.items[0].simklId}`,
+            { method: "GET", authed: false },
+          );
+          if (detail?.poster) {
+            posterUrl = `https://simkl.in/posters/${detail.poster}_m.jpg`;
+          }
+        } catch {
+          // Ignore
+        }
+      }
+
+      if (!posterUrl) return null;
+
+      // The meta ID matches the representative item to support progress-based navigation target
+      const targetId = `simkl:${representative.simklId}`;
+
+      return {
+        id: targetId,
+        type: "series" as const,
+        name: f.name,
+        poster: posterUrl,
+        releaseInfo: f.yearStart ? String(f.yearStart) : undefined,
+      } as Meta;
     }),
   );
   return metas.filter((m): m is Meta => !!m && !!m.poster);
@@ -278,14 +342,27 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
         }
 
         let matchedSimklId: number | null = null;
-        if (cdnItem.ids?.simkl_id && cache.items[String(cdnItem.ids.simkl_id)]) {
-          matchedSimklId = cdnItem.ids.simkl_id;
-        } else if (cdnItem.ids?.imdb && cache.imdbToSimkl[cdnItem.ids.imdb]) {
-          matchedSimklId = cache.imdbToSimkl[cdnItem.ids.imdb];
-        } else if (cdnItem.ids?.tmdb) {
-          const tmdbKey = `tv:${cdnItem.ids.tmdb}`;
-          if (cache.tmdbToSimkl[tmdbKey]) {
-            matchedSimklId = cache.tmdbToSimkl[tmdbKey];
+        if (cdnItem.ids) {
+          const { simkl_id, imdb, tmdb, mal, kitsu } = cdnItem.ids;
+          if (simkl_id && cache.items[String(simkl_id)]) {
+            matchedSimklId = simkl_id;
+          }
+          if (!matchedSimklId && imdb && cache.imdbToSimkl[imdb]) {
+            matchedSimklId = cache.imdbToSimkl[imdb];
+          }
+          if (!matchedSimklId && tmdb) {
+            const tmdbStr = String(tmdb);
+            if (cache.tmdbToSimkl[`tv:${tmdbStr}`]) {
+              matchedSimklId = cache.tmdbToSimkl[`tv:${tmdbStr}`];
+            } else if (cache.tmdbToSimkl[`movie:${tmdbStr}`]) {
+              matchedSimklId = cache.tmdbToSimkl[`movie:${tmdbStr}`];
+            }
+          }
+          if (!matchedSimklId && mal && cache.malToSimkl[String(mal)]) {
+            matchedSimklId = cache.malToSimkl[String(mal)];
+          }
+          if (!matchedSimklId && kitsu && cache.kitsuToSimkl[String(kitsu)]) {
+            matchedSimklId = cache.kitsuToSimkl[String(kitsu)];
           }
         }
 
@@ -346,17 +423,21 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
   ]);
 
   // Split items by type for individual rails
-  // Anime items have type "show" but possess mal/anidb IDs
-  const isAnimeType = (it: SimklItem) => it.ids.mal != null || it.ids.anidb != null;
+  // Anime items possess mal, anidb, or kitsu IDs
+  const isAnimeType = (it: SimklItem) => it.ids.mal != null || it.ids.anidb != null || it.ids.kitsu != null;
   const watchingShows = watching.filter((it) => it.type === "show" && !isAnimeType(it));
-  const watchingAnimeRaw = watching.filter((it) => it.type === "show" && isAnimeType(it));
-  const planMovies = plan.filter((it) => it.type === "movie");
+  const watchingAnimeRaw = watching.filter((it) => (it.type === "show" || it.type === "movie") && isAnimeType(it));
+  const planMovies = plan.filter((it) => it.type === "movie" && !isAnimeType(it));
   const planShows = plan.filter((it) => it.type === "show" && !isAnimeType(it));
-  const planAnimeRaw = plan.filter((it) => it.type === "show" && isAnimeType(it));
+  const planAnimeRaw = plan.filter((it) => (it.type === "show" || it.type === "movie") && isAnimeType(it));
 
   // Group anime by franchise so seasons appear as a single card
-  const watchingAnime = groupSimklItemsByFranchise(watchingAnimeRaw);
-  const planAnime = groupSimklItemsByFranchise(planAnimeRaw);
+  let watchingAnime = groupSimklItemsByFranchise(watchingAnimeRaw);
+  let planAnime = groupSimklItemsByFranchise(planAnimeRaw);
+
+  // Enhance groups with relations asynchronously (awaited)
+  watchingAnime = await enhanceGroupsWithRelations(watchingAnime).catch(() => watchingAnime);
+  planAnime = await enhanceGroupsWithRelations(planAnime).catch(() => planAnime);
 
   // Hydrate metas for all individual rails
   const [
@@ -462,7 +543,7 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
   }
 
   // Rail 6: Up Next on Simkl (combined, with its own toggle)
-  if (upcomingMetas.length >= 4 && settings.simklUpNextRailEnabled) {
+  if (upcomingMetas.length >= 1 && settings.simklUpNextRailEnabled) {
     rows.push({
       key: "simkl-upcoming",
       type: "series",

--- a/src/lib/simkl/home-rails.ts
+++ b/src/lib/simkl/home-rails.ts
@@ -309,7 +309,7 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
     return hydrateSimklItems(slice, tmdbKey);
   };
 
-  if (watchMetas.length >= 4) {
+  if (watchMetas.length >= 4 && (settings.simklGranularFilters.shows.watching || settings.simklGranularFilters.anime.watching)) {
     rows.push({
       key: "simkl-watching",
       type: watching[0]?.type === "show" ? "series" : "movie",
@@ -322,7 +322,7 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
     });
   }
 
-  if (upcomingMetas.length >= 4) {
+  if (upcomingMetas.length >= 4 && (settings.simklGranularFilters.shows.watching || settings.simklGranularFilters.shows.plantowatch || settings.simklGranularFilters.anime.watching || settings.simklGranularFilters.anime.plantowatch)) {
     rows.push({
       key: "simkl-upcoming",
       type: "series",
@@ -335,7 +335,7 @@ export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]>
     });
   }
 
-  if (planMetas.length >= 4) {
+  if (planMetas.length >= 4 && (settings.simklGranularFilters.movies.plantowatch || settings.simklGranularFilters.shows.plantowatch || settings.simklGranularFilters.anime.plantowatch)) {
     rows.push({
       key: "simkl-plantowatch",
       type: plan[0]?.type === "show" ? "series" : "movie",

--- a/src/lib/simkl/home-rails.ts
+++ b/src/lib/simkl/home-rails.ts
@@ -5,9 +5,142 @@ import { externalToKitsu } from "@/lib/providers/anime-mapping";
 import { kitsuAnime } from "@/lib/providers/kitsu";
 import type { HomeRow } from "@/views/home/home-types";
 import { fetchWatchingItems, fetchWatchlist } from "./watchlist";
-import type { SimklItem } from "./types";
+import type { SimklItem, SimklIds } from "./types";
+import { safeFetch } from "@/lib/safe-fetch";
+import { SIMKL_CLIENT_ID } from "./config";
+import { getLocalCache } from "./activities";
+import type { Settings } from "@/lib/settings";
 
 const PER_RAIL = 24;
+
+interface SimklCdnItem {
+  title: string;
+  poster?: string;
+  date: string;
+  release_date?: string;
+  ids?: {
+    simkl_id?: number;
+    slug?: string;
+    tmdb?: string | number;
+    imdb?: string;
+  };
+  episode?: {
+    season?: number;
+    episode?: number;
+  };
+}
+
+let cachedTrending: SimklItem[] | null = null;
+let cachedTrendingTime = 0;
+const TRENDING_CACHE_DURATION = 60 * 60 * 1000; // 1 hour
+
+async function fetchSimklTrending(): Promise<SimklItem[]> {
+  const now = Date.now();
+  if (cachedTrending && now - cachedTrendingTime < TRENDING_CACHE_DURATION) {
+    return cachedTrending;
+  }
+
+  const url = `https://data.simkl.in/discover/trending/today_100.json?client_id=${SIMKL_CLIENT_ID}&app-name=harbor&app-version=0.9.19`;
+  try {
+    const res = await safeFetch(url, { headers: { "User-Agent": "harbor/0.9.19" } });
+    if (!res.ok) return cachedTrending || [];
+    const data = (await res.json()) as {
+      tv?: any[];
+      movies?: any[];
+      anime?: any[];
+    };
+
+    const tv = data.tv || [];
+    const movies = data.movies || [];
+    const anime = data.anime || [];
+
+    const items: SimklItem[] = [];
+    const maxLen = Math.max(tv.length, movies.length, anime.length);
+
+    for (let i = 0; i < maxLen; i++) {
+      if (i < tv.length) {
+        const x = tv[i];
+        items.push({
+          type: "show",
+          title: x.title,
+          year: x.release_date ? parseInt(x.release_date.split("/").pop() || "", 10) || null : null,
+          ids: {
+            simkl: x.ids?.simkl_id,
+            imdb: x.ids?.imdb || undefined,
+            tmdb: x.ids?.tmdb ? Number(x.ids.tmdb) : undefined,
+            tvdb: x.ids?.tvdb ? Number(x.ids.tvdb) : undefined,
+          },
+        });
+      }
+      if (i < movies.length) {
+        const x = movies[i];
+        items.push({
+          type: "movie",
+          title: x.title,
+          year: x.release_date ? parseInt(x.release_date.split("/").pop() || "", 10) || null : null,
+          ids: {
+            simkl: x.ids?.simkl_id,
+            imdb: x.ids?.imdb || undefined,
+            tmdb: x.ids?.tmdb ? Number(x.ids.tmdb) : undefined,
+            tvdb: x.ids?.tvdb ? Number(x.ids.tvdb) : undefined,
+          },
+        });
+      }
+      if (i < anime.length) {
+        const x = anime[i];
+        items.push({
+          type: x.anime_type === "movie" ? "movie" : "show",
+          title: x.title,
+          year: x.release_date ? parseInt(x.release_date.split("/").pop() || "", 10) || null : null,
+          ids: {
+            simkl: x.ids?.simkl_id,
+            imdb: x.ids?.imdb || undefined,
+            tmdb: x.ids?.tmdb ? Number(x.ids.tmdb) : undefined,
+            mal: x.ids?.mal ? Number(x.ids.mal) : undefined,
+            kitsu: x.ids?.kitsu ? Number(x.ids.kitsu) : undefined,
+            anidb: x.ids?.anidb ? Number(x.ids.anidb) : undefined,
+            tvdb: x.ids?.tvdb ? Number(x.ids.tvdb) : undefined,
+          },
+        });
+      }
+    }
+
+    cachedTrending = items;
+    cachedTrendingTime = now;
+    return items;
+  } catch (err) {
+    console.error("Failed to fetch SIMKL trending CDN", err);
+    return cachedTrending || [];
+  }
+}
+
+let cachedCalendar: SimklCdnItem[] | null = null;
+let cachedCalendarTime = 0;
+const CALENDAR_CACHE_DURATION = 30 * 60 * 1000; // 30 minutes
+
+async function fetchCdnCalendarCombined(): Promise<SimklCdnItem[]> {
+  const now = Date.now();
+  if (cachedCalendar && now - cachedCalendarTime < CALENDAR_CACHE_DURATION) {
+    return cachedCalendar;
+  }
+
+  const fetchCatalog = async (catalog: "tv" | "anime"): Promise<SimklCdnItem[]> => {
+    const url = `https://data.simkl.in/calendar/${catalog}.json?client_id=${SIMKL_CLIENT_ID}&app-name=harbor&app-version=0.9.19`;
+    try {
+      const res = await safeFetch(url, { headers: { "User-Agent": "harbor/0.9.19" } });
+      if (!res.ok) return [];
+      return (await res.json()) as SimklCdnItem[];
+    } catch {
+      return [];
+    }
+  };
+
+  const [tv, anime] = await Promise.all([fetchCatalog("tv"), fetchCatalog("anime")]);
+  const combined = [...tv, ...anime];
+  cachedCalendar = combined;
+  cachedCalendarTime = now;
+  return combined;
+}
 
 function toHydratable(items: SimklItem[]): TraktItem[] {
   return items.map((it) => ({
@@ -58,17 +191,124 @@ export async function hydrateSimklItems(items: SimklItem[], tmdbKey: string): Pr
   return metas.filter((m): m is Meta => !!m && !!m.poster);
 }
 
-export async function buildSimklHomeRows(tmdbKey: string): Promise<HomeRow[]> {
-  const [plan, watching] = await Promise.all([
+export async function buildSimklHomeRows(settings: Settings): Promise<HomeRow[]> {
+  // If settings.simklHomeRailsEnabled is false, do not return/display any SIMKL rows
+  // (but you can still keep background cache updates active).
+  if (!settings.simklHomeRailsEnabled) {
+    void fetchWatchlist().catch(() => []);
+    void fetchWatchingItems().catch(() => []);
+    return [];
+  }
+
+  const tmdbKey = settings.tmdbKey;
+
+  // Compute Up Next Shows
+  const cache = getLocalCache();
+  const upcomingShows: SimklItem[] = [];
+
+  if (cache) {
+    try {
+      const calendarItems = await fetchCdnCalendarCombined();
+      // Sort by date ascending so we grab the earliest upcoming episode of a show
+      calendarItems.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const limitDate = new Date();
+      limitDate.setDate(today.getDate() + 30); // 30 days upcoming lookahead
+
+      const matchedIds = new Set<number>();
+
+      for (const cdnItem of calendarItems) {
+        const epDate = new Date(cdnItem.date);
+        if (isNaN(epDate.getTime()) || epDate < today || epDate > limitDate) {
+          continue;
+        }
+
+        let matchedSimklId: number | null = null;
+        if (cdnItem.ids?.simkl_id && cache.items[String(cdnItem.ids.simkl_id)]) {
+          matchedSimklId = cdnItem.ids.simkl_id;
+        } else if (cdnItem.ids?.imdb && cache.imdbToSimkl[cdnItem.ids.imdb]) {
+          matchedSimklId = cache.imdbToSimkl[cdnItem.ids.imdb];
+        } else if (cdnItem.ids?.tmdb) {
+          const tmdbKey = `tv:${cdnItem.ids.tmdb}`;
+          if (cache.tmdbToSimkl[tmdbKey]) {
+            matchedSimklId = cache.tmdbToSimkl[tmdbKey];
+          }
+        }
+
+        if (matchedSimklId && !matchedIds.has(matchedSimklId)) {
+          const cachedItem = cache.items[String(matchedSimklId)];
+          if (
+            cachedItem &&
+            (cachedItem.type === "show" || cachedItem.type === "anime") &&
+            (cachedItem.status === "watching" || cachedItem.status === "plantowatch")
+          ) {
+            matchedIds.add(matchedSimklId);
+
+            const ids: SimklIds = {
+              simkl: cachedItem.simklId,
+            };
+            for (const [imdbId, sId] of Object.entries(cache.imdbToSimkl)) {
+              if (sId === cachedItem.simklId) ids.imdb = imdbId;
+            }
+            for (const [tmdbKey, sId] of Object.entries(cache.tmdbToSimkl)) {
+              if (sId === cachedItem.simklId) {
+                const parts = tmdbKey.split(":");
+                if (parts.length === 2) {
+                  ids.tmdb = Number.isFinite(Number(parts[1])) ? Number(parts[1]) : parts[1];
+                }
+              }
+            }
+            for (const [malId, sId] of Object.entries(cache.malToSimkl)) {
+              if (sId === cachedItem.simklId) ids.mal = Number(malId);
+            }
+            for (const kitsuId of Object.keys(cache.kitsuToSimkl)) {
+              if (cache.kitsuToSimkl[kitsuId] === cachedItem.simklId) {
+                ids.kitsu = Number(kitsuId);
+              }
+            }
+
+            if (!ids.imdb && cdnItem.ids?.imdb) ids.imdb = cdnItem.ids.imdb;
+            if (!ids.tmdb && cdnItem.ids?.tmdb) ids.tmdb = Number(cdnItem.ids.tmdb);
+
+            upcomingShows.push({
+              type: "show",
+              title: cachedItem.title,
+              year: cachedItem.year,
+              ids,
+            });
+          }
+        }
+      }
+    } catch (e) {
+      console.error("Failed to compute Up Next shows on SIMKL", e);
+    }
+  }
+
+  // Fetch Watchlist, Watching, Trending
+  const [plan, watching, trendingItems] = await Promise.all([
     fetchWatchlist().catch(() => []),
     fetchWatchingItems().catch(() => []),
+    fetchSimklTrending().catch(() => []),
   ]);
-  const [planMetas, watchMetas] = await Promise.all([
+
+  // Hydrate metas
+  const [planMetas, watchMetas, upcomingMetas, trendingMetas] = await Promise.all([
     hydrateSimklItems(plan.slice(0, PER_RAIL), tmdbKey),
     hydrateSimklItems(watching.slice(0, PER_RAIL), tmdbKey),
+    hydrateSimklItems(upcomingShows.slice(0, PER_RAIL), tmdbKey),
+    hydrateSimklItems(trendingItems.slice(0, PER_RAIL), tmdbKey),
   ]);
 
   const rows: HomeRow[] = [];
+
+  const pager = (items: SimklItem[]) => async (page: number) => {
+    const slice = items.slice((page - 1) * PER_RAIL, page * PER_RAIL);
+    if (slice.length === 0) return [];
+    return hydrateSimklItems(slice, tmdbKey);
+  };
+
   if (watchMetas.length >= 4) {
     rows.push({
       key: "simkl-watching",
@@ -76,10 +316,25 @@ export async function buildSimklHomeRows(tmdbKey: string): Promise<HomeRow[]> {
       name: "Watching on Simkl",
       metas: watchMetas,
       page: 1,
-      hasMore: false,
+      hasMore: watching.length > PER_RAIL,
       noDedup: true,
+      fetcher: pager(watching),
     });
   }
+
+  if (upcomingMetas.length >= 4) {
+    rows.push({
+      key: "simkl-upcoming",
+      type: "series",
+      name: "Up Next on Simkl",
+      metas: upcomingMetas,
+      page: 1,
+      hasMore: upcomingShows.length > PER_RAIL,
+      noDedup: true,
+      fetcher: pager(upcomingShows),
+    });
+  }
+
   if (planMetas.length >= 4) {
     rows.push({
       key: "simkl-plantowatch",
@@ -87,9 +342,31 @@ export async function buildSimklHomeRows(tmdbKey: string): Promise<HomeRow[]> {
       name: "Your Simkl Plan to Watch",
       metas: planMetas,
       page: 1,
-      hasMore: false,
+      hasMore: plan.length > PER_RAIL,
       noDedup: true,
+      fetcher: pager(plan),
     });
   }
+
+  if (trendingMetas.length >= 4) {
+    rows.push({
+      key: "simkl-trending",
+      type: trendingItems[0]?.type === "show" ? "series" : "movie",
+      name: "Simkl Trending Today",
+      metas: trendingMetas,
+      page: 1,
+      hasMore: trendingItems.length > PER_RAIL,
+      noDedup: true,
+      fetcher: pager(trendingItems),
+    });
+  }
+
   return rows;
+}
+
+export function clearHomeRailsCache() {
+  cachedTrending = null;
+  cachedTrendingTime = 0;
+  cachedCalendar = null;
+  cachedCalendarTime = 0;
 }

--- a/src/lib/simkl/ids.ts
+++ b/src/lib/simkl/ids.ts
@@ -39,14 +39,73 @@ export function stremioIdToSimklTarget(
   if (!metaId) return { ok: false, reason: "unrecognized" };
 
   if (metaId.startsWith("mal:")) {
-    const n = Number(metaId.split(":")[1]);
-    if (!Number.isFinite(n)) return { ok: false, reason: "unrecognized" };
-    if (episode) return { ok: false, reason: "anime" };
-    return { ok: true, target: { kind: "show", ids: { mal: n } } };
+    const parts = metaId.split(":");
+    const malId = Number(parts[1]);
+    if (!Number.isFinite(malId)) return { ok: false, reason: "unrecognized" };
+
+    if (parts.length >= 3) {
+      const episodeNum = Number(parts[2]);
+      if (Number.isFinite(episodeNum)) {
+        return {
+          ok: true,
+          target: {
+            kind: "anime-episode",
+            anime: { ids: { mal: malId } },
+            season: 1,
+            number: episodeNum,
+          },
+        };
+      }
+    }
+
+    if (episode) {
+      return {
+        ok: true,
+        target: {
+          kind: "anime-episode",
+          anime: { ids: { mal: malId } },
+          season: episode.season,
+          number: episode.episode,
+        },
+      };
+    }
+
+    return { ok: true, target: { kind: "anime", ids: { mal: malId } } };
   }
 
   if (metaId.startsWith("kitsu:")) {
-    return { ok: false, reason: "anime" };
+    const parts = metaId.split(":");
+    const kitsuId = Number(parts[1]);
+    if (!Number.isFinite(kitsuId)) return { ok: false, reason: "unrecognized" };
+
+    if (parts.length >= 3) {
+      const episodeNum = Number(parts[2]);
+      if (Number.isFinite(episodeNum)) {
+        return {
+          ok: true,
+          target: {
+            kind: "anime-episode",
+            anime: { ids: { kitsu: kitsuId } },
+            season: 1,
+            number: episodeNum,
+          },
+        };
+      }
+    }
+
+    if (episode) {
+      return {
+        ok: true,
+        target: {
+          kind: "anime-episode",
+          anime: { ids: { kitsu: kitsuId } },
+          season: episode.season,
+          number: episode.episode,
+        },
+      };
+    }
+
+    return { ok: true, target: { kind: "anime", ids: { kitsu: kitsuId } } };
   }
 
   if (metaId.startsWith("tt")) {

--- a/src/lib/simkl/list-status.ts
+++ b/src/lib/simkl/list-status.ts
@@ -1,6 +1,7 @@
 import { simklRequest } from "./client";
-import { subscribeSession } from "./session";
+import { subscribeSession, getSession } from "./session";
 import type { SimklTarget } from "./types";
+import { getCachedSimklData, updateCachedStatusByTarget, clearLocalCache } from "./activities";
 
 export type WatchlistStatus = "watching" | "plantowatch" | "hold" | "completed" | "dropped";
 
@@ -30,15 +31,6 @@ type RawIds = {
   anilist?: number | string;
   anidb?: number | string;
 };
-type RawEpisode = { number?: number; watched_at?: string | null };
-type RawSeason = { number?: number; episodes?: RawEpisode[] };
-type RawEntry = {
-  status?: string;
-  movie?: { ids?: RawIds };
-  show?: { ids?: RawIds };
-  seasons?: RawSeason[];
-};
-type RawAllItems = { movies?: RawEntry[]; shows?: RawEntry[]; anime?: RawEntry[] };
 
 type SimklData = {
   statuses: Map<string, WatchlistStatus>;
@@ -64,7 +56,12 @@ function idKeys(ids: RawIds | undefined, kind: "movie" | "show"): string[] {
 }
 
 function targetKeys(target: SimklTarget): string[] {
-  const ids = target.kind === "episode" ? target.show.ids : target.ids;
+  const ids =
+    target.kind === "episode"
+      ? target.show.ids
+      : target.kind === "anime-episode"
+        ? target.anime.ids
+        : target.ids;
   return idKeys(ids as RawIds, target.kind === "movie" ? "movie" : "show");
 }
 
@@ -72,37 +69,18 @@ let cache: Promise<SimklData> | null = null;
 
 subscribeSession(() => {
   cache = null;
+  const session = getSession();
+  if (!session) {
+    clearLocalCache();
+  }
 });
 
+export function invalidateListStatusCache() {
+  cache = null;
+}
+
 async function pull(): Promise<SimklData> {
-  const data = await simklRequest<RawAllItems>(
-    "/sync/all-items/all/all?extended=full&episode_watched_at=yes",
-  ).catch(() => ({}) as RawAllItems);
-  const statuses = new Map<string, WatchlistStatus>();
-  const watched = new Map<string, Set<string>>();
-  const add = (entries: RawEntry[] | undefined, kind: "movie" | "show") => {
-    for (const e of entries ?? []) {
-      const node = kind === "movie" ? e.movie : e.show;
-      const keys = idKeys(node?.ids, kind);
-      if (keys.length === 0) continue;
-      if (isStatus(e.status)) for (const k of keys) statuses.set(k, e.status);
-      if (kind === "show" && e.seasons) {
-        const eps = new Set<string>();
-        for (const s of e.seasons) {
-          for (const ep of s.episodes ?? []) {
-            if (ep.watched_at && s.number != null && ep.number != null) {
-              eps.add(`${s.number}:${ep.number}`);
-            }
-          }
-        }
-        if (eps.size > 0) for (const k of keys) watched.set(k, eps);
-      }
-    }
-  };
-  add(data.movies, "movie");
-  add(data.shows, "show");
-  add(data.anime, "show");
-  return { statuses, watched };
+  return getCachedSimklData();
 }
 
 function loadData(): Promise<SimklData> {
@@ -141,8 +119,17 @@ export async function setSimklStatus(
   target: SimklTarget,
   status: WatchlistStatus,
 ): Promise<WatchlistStatus> {
-  const ids = target.kind === "episode" ? target.show.ids : target.ids;
-  const bucket = target.kind === "movie" ? "movies" : "shows";
+  const ids =
+    target.kind === "episode"
+      ? target.show.ids
+      : target.kind === "anime-episode"
+        ? target.anime.ids
+        : target.ids;
+  const isAnime =
+    target.kind === "anime" ||
+    target.kind === "anime-episode" ||
+    (ids && (ids.mal != null || ids.kitsu != null || ids.anidb != null));
+  const bucket = target.kind === "movie" ? "movies" : isAnime ? "anime" : "shows";
   const r = await simklRequest<{ added?: Record<string, Array<{ to?: string }>> }>(
     "/sync/add-to-list",
     { method: "POST", body: { to: status, [bucket]: [{ to: status, ids }] } },
@@ -151,13 +138,24 @@ export async function setSimklStatus(
   const final = isStatus(echoed) ? echoed : status;
   const statuses = (await loadData()).statuses;
   for (const k of targetKeys(target)) statuses.set(k, final);
+  updateCachedStatusByTarget(target, final);
   return final;
 }
 
 export async function clearSimklStatus(target: SimklTarget): Promise<void> {
-  const ids = target.kind === "episode" ? target.show.ids : target.ids;
-  const bucket = target.kind === "movie" ? "movies" : "shows";
+  const ids =
+    target.kind === "episode"
+      ? target.show.ids
+      : target.kind === "anime-episode"
+        ? target.anime.ids
+        : target.ids;
+  const isAnime =
+    target.kind === "anime" ||
+    target.kind === "anime-episode" ||
+    (ids && (ids.mal != null || ids.kitsu != null || ids.anidb != null));
+  const bucket = target.kind === "movie" ? "movies" : isAnime ? "anime" : "shows";
   await simklRequest("/sync/history/remove", { method: "POST", body: { [bucket]: [{ ids }] } });
   const statuses = (await loadData()).statuses;
   for (const k of targetKeys(target)) statuses.delete(k);
+  updateCachedStatusByTarget(target, null);
 }

--- a/src/lib/simkl/ratings.ts
+++ b/src/lib/simkl/ratings.ts
@@ -129,6 +129,256 @@ export function useSimklCommunityRating(
   return { rating, loading };
 }
 
+/* ─── SIMKL card scores hook (for poster badges) ───────────────────────────── */
+
+/**
+ * Module-level cache + in-flight deduplication for SIMKL community scores by IMDb ID.
+ * Shared across all poster cards to avoid redundant API calls.
+ */
+const cardScoreCache = new Map<string, number | null>();
+const cardScoreInFlight = new Map<string, Promise<number | null>>();
+
+/**
+ * Resolve a single IMDb ID to a SIMKL community rating.
+ * Uses the same /search/id fast-path as useSimklCommunityRating.
+ * Results are cached in-memory.
+ */
+async function resolveSimklCardScore(imdbId: string): Promise<number | null> {
+  if (cardScoreCache.has(imdbId)) {
+    return cardScoreCache.get(imdbId) ?? null;
+  }
+  if (cardScoreInFlight.has(imdbId)) {
+    return cardScoreInFlight.get(imdbId)!;
+  }
+
+  const promise = (async () => {
+    try {
+      const results = await simklRequest<SimklSearchIdItem[]>(
+        `/search/id?imdb=${encodeURIComponent(imdbId)}`,
+        { method: "GET", authed: false },
+      );
+      if (!Array.isArray(results) || results.length === 0) {
+        cardScoreCache.set(imdbId, null);
+        return null;
+      }
+      const item = results[0];
+      const directRating = item.ratings?.simkl?.rating;
+      if (directRating != null) {
+        cardScoreCache.set(imdbId, directRating);
+        return directRating;
+      }
+      const simklId = item.ids?.simkl;
+      if (simklId == null) {
+        cardScoreCache.set(imdbId, null);
+        return null;
+      }
+      const type = item.type;
+      const detailPath =
+        type === "movie" ? `/movies/${simklId}` : type === "anime" ? `/anime/${simklId}` : `/tv/${simklId}`;
+      const detail = await simklRequest<SimklDetailResponse>(detailPath, {
+        method: "GET",
+        authed: false,
+      });
+      const rating = detail.ratings?.simkl?.rating ?? null;
+      cardScoreCache.set(imdbId, rating);
+      return rating;
+    } catch {
+      cardScoreCache.set(imdbId, null);
+      return null;
+    } finally {
+      cardScoreInFlight.delete(imdbId);
+    }
+  })();
+
+  cardScoreInFlight.set(imdbId, promise);
+  return promise;
+}
+
+/**
+ * React hook that returns the SIMKL community score for a given IMDb ID.
+ * Designed for use in poster cards (PickCard). Independent of MDBList.
+ * Results are cached in-memory and shared across all cards.
+ */
+export function useSimklCardScores(imdbId: string | undefined): { score: number | null; loading: boolean } {
+  const [score, setScore] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!imdbId) {
+      setScore(null);
+      setLoading(false);
+      return;
+    }
+    if (cardScoreCache.has(imdbId)) {
+      setScore(cardScoreCache.get(imdbId) ?? null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    resolveSimklCardScore(imdbId).then((result) => {
+      if (!cancelled) {
+        setScore(result);
+        setLoading(false);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [imdbId]);
+
+  return { score, loading };
+}
+
+/* ─── SIMKL card scores by anime ID (MAL/Kitsu/AniDB/AniList) ─────────────── */
+
+/**
+ * Module-level cache + in-flight dedup for SIMKL community scores by anime ID.
+ * Keys are namespaced as "anime:{source}:{id}" to avoid collision with IMDb cache.
+ */
+const animeScoreCache = new Map<string, number | null>();
+const animeScoreInFlight = new Map<string, Promise<number | null>>();
+
+/**
+ * Map anime ID prefix to the SIMKL /search/id query parameter name.
+ */
+const ANIME_ID_PARAM: Record<string, string> = {
+  mal: "mal",
+  kitsu: "kitsu",
+  anidb: "anidb",
+  anilist: "anilist",
+};
+
+/**
+ * Resolve a single anime ID (e.g. "mal:16498") to a SIMKL community rating.
+ * Uses /search/id?{source}={id} — the SIMKL API supports mal, kitsu, anidb, anilist params.
+ * Results are cached in-memory.
+ */
+async function resolveSimklCardScoreByAnimeId(animeId: string): Promise<number | null> {
+  const cacheKey = `anime:${animeId}`;
+  if (animeScoreCache.has(cacheKey)) {
+    return animeScoreCache.get(cacheKey) ?? null;
+  }
+  if (animeScoreInFlight.has(cacheKey)) {
+    return animeScoreInFlight.get(cacheKey)!;
+  }
+
+  // Parse the anime ID prefix
+  const simklMatch = animeId.match(/^simkl:(\d+)$/);
+  const externalMatch = animeId.match(/^(mal|kitsu|anidb|anilist):(\d+)$/);
+
+  if (!simklMatch && !externalMatch) {
+    animeScoreCache.set(cacheKey, null);
+    return null;
+  }
+
+  // Capture resolved values before async closure (TypeScript null-safety)
+  const resolvedSimklId = simklMatch ? Number(simklMatch[1]) : null;
+  const resolvedParam = externalMatch ? ANIME_ID_PARAM[externalMatch[1]] : null;
+  const resolvedIdValue = externalMatch ? externalMatch[2] : null;
+
+  const promise = (async () => {
+    try {
+      // Direct SIMKL ID — skip /search/id, go straight to detail endpoint
+      if (resolvedSimklId != null) {
+        // Try anime endpoint first (most simkl: IDs in our context are anime)
+        const detail = await simklRequest<SimklDetailResponse>(
+          `/anime/${resolvedSimklId}`,
+          { method: "GET", authed: false },
+        );
+        const rating = detail.ratings?.simkl?.rating ?? null;
+        animeScoreCache.set(cacheKey, rating);
+        return rating;
+      }
+
+      // External ID (mal/kitsu/anidb/anilist) — resolve via /search/id
+      if (resolvedParam == null || resolvedIdValue == null) {
+        animeScoreCache.set(cacheKey, null);
+        return null;
+      }
+      const param = resolvedParam;
+      const idValue = resolvedIdValue;
+      const results = await simklRequest<SimklSearchIdItem[]>(
+        `/search/id?${param}=${encodeURIComponent(idValue)}`,
+        { method: "GET", authed: false },
+      );
+      if (!Array.isArray(results) || results.length === 0) {
+        animeScoreCache.set(cacheKey, null);
+        return null;
+      }
+      const item = results[0];
+      const directRating = item.ratings?.simkl?.rating;
+      if (directRating != null) {
+        animeScoreCache.set(cacheKey, directRating);
+        return directRating;
+      }
+      const simklId = item.ids?.simkl;
+      if (simklId == null) {
+        animeScoreCache.set(cacheKey, null);
+        return null;
+      }
+      const type = item.type;
+      const detailPath =
+        type === "movie" ? `/movies/${simklId}` : type === "anime" ? `/anime/${simklId}` : `/tv/${simklId}`;
+      const detail = await simklRequest<SimklDetailResponse>(detailPath, {
+        method: "GET",
+        authed: false,
+      });
+      const rating = detail.ratings?.simkl?.rating ?? null;
+      animeScoreCache.set(cacheKey, rating);
+      return rating;
+    } catch {
+      animeScoreCache.set(cacheKey, null);
+      return null;
+    } finally {
+      animeScoreInFlight.delete(cacheKey);
+    }
+  })();
+
+  animeScoreInFlight.set(cacheKey, promise);
+  return promise;
+}
+
+/**
+ * React hook that returns the SIMKL community score for a given anime ID
+ * (e.g. "mal:16498", "kitsu:12345"). Designed for use in poster cards (PickCard)
+ * for anime items that don't have IMDb IDs. Independent of MDBList.
+ * Results are cached in-memory and shared across all cards.
+ */
+export function useSimklCardScoresByAnimeId(
+  animeId: string | undefined,
+): { score: number | null; loading: boolean } {
+  const [score, setScore] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!animeId) {
+      setScore(null);
+      setLoading(false);
+      return;
+    }
+    const cacheKey = `anime:${animeId}`;
+    if (animeScoreCache.has(cacheKey)) {
+      setScore(animeScoreCache.get(cacheKey) ?? null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    resolveSimklCardScoreByAnimeId(animeId).then((result) => {
+      if (!cancelled) {
+        setScore(result);
+        setLoading(false);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [animeId]);
+
+  return { score, loading };
+}
+
 /* ─── User rating CRUD ─────────────────────────────────────────────────────── */
 
 function getRatingPayload(target: SimklTarget): { key: string; ids: SimklIds } {

--- a/src/lib/simkl/ratings.ts
+++ b/src/lib/simkl/ratings.ts
@@ -1,0 +1,54 @@
+import { simklRequest } from "./client";
+import type { SimklIds, SimklTarget } from "./types";
+import { updateCachedRatingByTarget, getCachedRatingByTarget } from "./activities";
+
+export { getCachedRatingByTarget };
+
+function getRatingPayload(target: SimklTarget): { key: string; ids: SimklIds } {
+  const isMovie = target.kind === "movie";
+  const isAnime = target.kind === "anime" || target.kind === "anime-episode";
+
+  const ids =
+    target.kind === "episode"
+      ? target.show.ids
+      : target.kind === "anime-episode"
+        ? target.anime.ids
+        : target.ids;
+
+  const key = isMovie ? "movies" : isAnime ? "anime" : "shows";
+  return { key, ids };
+}
+
+export async function addSimklRating(target: SimklTarget, rating: number): Promise<boolean> {
+  const { key, ids } = getRatingPayload(target);
+  try {
+    await simklRequest("/sync/ratings", {
+      method: "POST",
+      body: {
+        [key]: [{ rating, ids }],
+      },
+    });
+    updateCachedRatingByTarget(target, rating);
+    return true;
+  } catch (e) {
+    console.error("Failed to add SIMKL rating", e);
+    return false;
+  }
+}
+
+export async function removeSimklRating(target: SimklTarget): Promise<boolean> {
+  const { key, ids } = getRatingPayload(target);
+  try {
+    await simklRequest("/sync/ratings/remove", {
+      method: "POST",
+      body: {
+        [key]: [{ ids }],
+      },
+    });
+    updateCachedRatingByTarget(target, null);
+    return true;
+  } catch (e) {
+    console.error("Failed to remove SIMKL rating", e);
+    return false;
+  }
+}

--- a/src/lib/simkl/ratings.ts
+++ b/src/lib/simkl/ratings.ts
@@ -1,8 +1,135 @@
+import { useEffect, useState } from "react";
 import { simklRequest } from "./client";
 import type { SimklIds, SimklTarget } from "./types";
 import { updateCachedRatingByTarget, getCachedRatingByTarget } from "./activities";
 
 export { getCachedRatingByTarget };
+
+/* ─── SIMKL community rating hook ─────────────────────────────────────────── */
+
+/** Module-level cache: IMDb ID → community rating (or null when lookup failed). */
+const communityRatingCache = new Map<string, number | null>();
+
+interface SimklSearchIdItem {
+  type?: string;
+  ids?: { simkl?: number };
+  ratings?: { simkl?: { rating?: number } };
+}
+
+interface SimklDetailResponse {
+  ratings?: { simkl?: { rating?: number } };
+}
+
+/**
+ * Fetch the SIMKL community rating for a title by its IMDb ID, independently of
+ * MDBList.  Uses the public `/search/id` endpoint (only `client_id` required)
+ * to resolve the IMDb ID to a SIMKL ID + media type, then fetches the rating
+ * from the appropriate detail endpoint.
+ *
+ * Results are cached in-memory per IMDb ID to avoid repeated API calls.
+ */
+export function useSimklCommunityRating(
+  imdbId: string | null,
+): { rating: number | null; loading: boolean } {
+  const [rating, setRating] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!imdbId) {
+      setRating(null);
+      setLoading(false);
+      return;
+    }
+
+    // Serve from cache if available
+    if (communityRatingCache.has(imdbId)) {
+      setRating(communityRatingCache.get(imdbId) ?? null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    (async () => {
+      try {
+        // Step 1 — resolve IMDb ID → SIMKL ID + type via /search/id (public)
+        const results = await simklRequest<SimklSearchIdItem[]>(
+          `/search/id?imdb=${encodeURIComponent(imdbId)}`,
+          { method: "GET", authed: false },
+        );
+
+        if (!Array.isArray(results) || results.length === 0) {
+          if (!cancelled) {
+            communityRatingCache.set(imdbId, null);
+            setRating(null);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const item = results[0];
+
+        // Fast path: some responses include ratings directly
+        const directRating = item.ratings?.simkl?.rating;
+        if (directRating != null) {
+          if (!cancelled) {
+            communityRatingCache.set(imdbId, directRating);
+            setRating(directRating);
+            setLoading(false);
+          }
+          return;
+        }
+
+        // Step 2 — fetch from the detail endpoint for the media type
+        const simklId = item.ids?.simkl;
+        if (simklId == null) {
+          if (!cancelled) {
+            communityRatingCache.set(imdbId, null);
+            setRating(null);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const type = item.type; // "movie" | "tv" | "anime"
+        const detailPath =
+          type === "movie"
+            ? `/movies/${simklId}`
+            : type === "anime"
+              ? `/anime/${simklId}`
+              : `/tv/${simklId}`;
+
+        const detail = await simklRequest<SimklDetailResponse>(detailPath, {
+          method: "GET",
+          authed: false,
+        });
+
+        const communityRating = detail.ratings?.simkl?.rating ?? null;
+
+        if (!cancelled) {
+          communityRatingCache.set(imdbId, communityRating);
+          setRating(communityRating);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          communityRatingCache.set(imdbId, null);
+          setRating(null);
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imdbId]);
+
+  return { rating, loading };
+}
+
+/* ─── User rating CRUD ─────────────────────────────────────────────────────── */
 
 function getRatingPayload(target: SimklTarget): { key: string; ids: SimklIds } {
   const isMovie = target.kind === "movie";

--- a/src/lib/simkl/scrobble-hook.ts
+++ b/src/lib/simkl/scrobble-hook.ts
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from "react";
 import { useSimkl } from "./provider";
-import { simklScrobble } from "./scrobble";
+import { simklScrobble, buildBody } from "./scrobble";
 import { getPlaybackPosition } from "@/lib/player/playback-clock";
 import { useSettings } from "@/lib/settings";
 import type { PlayerSrc } from "@/lib/view";
+import { SIMKL_API_BASE, SIMKL_CLIENT_ID, SIMKL_WATCHED_RATIO } from "./config";
+import { getSession } from "./session";
 
 type Snap = {
   status: string;
@@ -11,56 +13,165 @@ type Snap = {
   durationSec: number;
 };
 
-const STUB_MAX_SEC = 150;
+type LastAction = "start" | "pause" | "stop" | null;
 
 export function useSimklScrobble({ src, snap }: { src: PlayerSrc; snap: Snap }): void {
   const { isConnected } = useSimkl();
   const { settings } = useSettings();
+  const enabled = isConnected && settings.simklScrobbleEnabled;
   const pauseOnPauseRef = useRef(settings.pauseListStatusOnPause);
   pauseOnPauseRef.current = settings.pauseListStatusOnPause;
+  const lastActionRef = useRef<LastAction>(null);
+  const lastKeyRef = useRef<string | null>(null);
+  const prevIdentityRef = useRef({ metaId: src.meta.id, episode: src.episode });
+
   const metaId = src.meta.id;
-  const key = `${metaId}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}`;
+  const season = src.episode?.season;
+  const episode = src.episode?.episode;
+  const key = `${metaId}|${season ?? ""}|${episode ?? ""}`;
 
-  const sentRef = useRef<{ key: string; action: "start" | "pause" | "stop" } | null>(null);
-  const latestRef = useRef<{ metaId: string; episode: PlayerSrc["episode"]; progress: number }>({
-    metaId,
-    episode: src.episode,
-    progress: 0,
-  });
+  const stopArgsRef = useRef({ metaId, episode: src.episode, snap });
+  stopArgsRef.current = { metaId, episode: src.episode, snap };
 
   useEffect(() => {
-    if (sentRef.current && sentRef.current.key !== key) sentRef.current = null;
-  }, [key]);
+    if (!enabled) return;
+    const onPageHide = () => {
+      const a = stopArgsRef.current;
+      if (a.snap.durationSec <= 0) return;
+      if (lastActionRef.current !== "start" && lastActionRef.current !== "pause") return;
+      const progress = Math.min(100, Math.max(0, (getPlaybackPosition() / a.snap.durationSec) * 100));
+      if (progress < SIMKL_WATCHED_RATIO * 100 && !pauseOnPauseRef.current) return;
+      const action = progress >= SIMKL_WATCHED_RATIO * 100 ? "stop" : "pause";
+      sendBeacon(a.metaId, a.episode, progress, action);
+      lastActionRef.current = action;
+    };
+    window.addEventListener("pagehide", onPageHide);
+    return () => window.removeEventListener("pagehide", onPageHide);
+  }, [enabled, metaId, src.episode]);
 
   useEffect(() => {
-    if (!isConnected || snap.durationSec <= 0) return;
-    if (snap.durationSec < STUB_MAX_SEC) return;
-    const pos = Math.max(snap.positionSec || 0, getPlaybackPosition());
-    const progress = Math.min(100, (pos / snap.durationSec) * 100);
-    latestRef.current = { metaId, episode: src.episode, progress };
-
-    let want: "start" | "pause" | "stop" | null = null;
-    if (snap.status === "ended") want = "stop";
-    else if (snap.status === "playing") want = "start";
-    else if (snap.status === "paused" && pauseOnPauseRef.current) want = "pause";
-    if (!want) return;
-
-    const last = sentRef.current;
-    if (last && last.key === key) {
-      if (last.action === want) return;
-      if (last.action === "stop") return;
+    if (!enabled) return;
+    if (lastKeyRef.current && lastKeyRef.current !== key) {
+      const prevPos = getPlaybackPosition();
+      const prevDur = snap.durationSec;
+      if (prevDur > 0 && pauseOnPauseRef.current) {
+        const progress = Math.min(100, (prevPos / prevDur) * 100);
+        const prev = prevIdentityRef.current;
+        void simklScrobble("pause", prev.metaId, prev.episode, progress);
+      }
+      lastActionRef.current = "pause";
     }
-    sentRef.current = { key, action: want };
-    void simklScrobble(want, metaId, src.episode, progress);
-  }, [isConnected, key, metaId, src.episode, snap.status, snap.positionSec, snap.durationSec]);
+    lastKeyRef.current = key;
+    prevIdentityRef.current = { metaId, episode: src.episode };
+  }, [enabled, key, metaId, src.episode, snap.durationSec]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (snap.durationSec <= 0) return;
+    const progress = Math.min(100, Math.max(0, (getPlaybackPosition() / snap.durationSec) * 100));
+
+    if (snap.status === "ended") {
+      if (lastActionRef.current === "start" || lastActionRef.current === "pause") {
+        void simklScrobble("stop", metaId, src.episode, 100);
+        lastActionRef.current = "stop";
+      }
+      return;
+    }
+    if (lastActionRef.current === "stop") return;
+
+    if (snap.status === "playing" && lastActionRef.current !== "start") {
+      void simklScrobble("start", metaId, src.episode, progress);
+      lastActionRef.current = "start";
+    } else if (snap.status === "paused" && lastActionRef.current === "start") {
+      if (pauseOnPauseRef.current) {
+        void simklScrobble("pause", metaId, src.episode, progress);
+      }
+      lastActionRef.current = "pause";
+    }
+  }, [
+    enabled,
+    metaId,
+    src.episode,
+    snap.status,
+    snap.durationSec,
+  ]);
+
+  const seekTrackRef = useRef({ pos: 0, at: 0, lastResyncAt: 0 });
+  useEffect(() => {
+    if (!enabled) return;
+    if (snap.durationSec <= 0) return;
+    if (lastActionRef.current !== "start") {
+      seekTrackRef.current = { pos: getPlaybackPosition(), at: Date.now(), lastResyncAt: 0 };
+      return;
+    }
+    const id = window.setInterval(() => {
+      if (lastActionRef.current !== "start") return;
+      const now = Date.now();
+      const ref = seekTrackRef.current;
+      const pos = getPlaybackPosition();
+      const dPos = pos - ref.pos;
+      const dT = (now - ref.at) / 1000;
+      ref.pos = pos;
+      ref.at = now;
+      const isSeek = Math.abs(dPos) > 8 && (dT < 1.5 || Math.abs(dPos / Math.max(0.001, dT)) > 4);
+      if (!isSeek) return;
+      if (now - ref.lastResyncAt < 30000) return;
+      ref.lastResyncAt = now;
+      const progress = Math.min(100, Math.max(0, (pos / snap.durationSec) * 100));
+      void simklScrobble("start", metaId, src.episode, progress);
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [enabled, metaId, src.episode, snap.status, snap.durationSec]);
 
   useEffect(() => {
     return () => {
-      const last = sentRef.current;
-      const cur = latestRef.current;
-      if (last && last.action !== "stop") {
-        void simklScrobble("stop", cur.metaId, cur.episode, cur.progress);
+      if (!enabled) return;
+      if (lastActionRef.current !== "start" && lastActionRef.current !== "pause") return;
+      const a = stopArgsRef.current;
+      if (a.snap.durationSec > 0) {
+        const progress = Math.min(100, (getPlaybackPosition() / a.snap.durationSec) * 100);
+        const action = progress >= SIMKL_WATCHED_RATIO * 100 ? "stop" : "pause";
+        if (action === "stop" || pauseOnPauseRef.current) {
+          void simklScrobble(action, a.metaId, a.episode, progress);
+        }
+        lastActionRef.current = action;
+      } else {
+        lastActionRef.current = "pause";
       }
     };
-  }, []);
+  }, [enabled]);
+}
+
+function sendBeacon(
+  metaId: string,
+  episode: PlayerSrc["episode"],
+  progress: number,
+  action: "stop" | "pause"
+): void {
+  const session = getSession();
+  if (!session) return;
+
+  const body = buildBody(metaId, episode, progress);
+  if (!body) return;
+
+  const url = new URL(`${SIMKL_API_BASE}/scrobble/${action}`);
+  url.searchParams.set("client_id", SIMKL_CLIENT_ID);
+  url.searchParams.set("app-name", "harbor");
+  url.searchParams.set("app-version", "0.9.19");
+
+  try {
+    void fetch(url.toString(), {
+      method: "POST",
+      keepalive: true,
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "harbor/0.9.19",
+        "simkl-api-key": SIMKL_CLIENT_ID,
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    /* noop */
+  }
 }

--- a/src/lib/simkl/scrobble.ts
+++ b/src/lib/simkl/scrobble.ts
@@ -2,9 +2,9 @@ import { simklRequest } from "./client";
 
 export type ScrobbleAction = "start" | "pause" | "stop";
 
-type EpisodeRef = { season?: number; episode?: number } | undefined;
+export type EpisodeRef = { season?: number; episode?: number } | undefined;
 
-function buildBody(metaId: string, episode: EpisodeRef, progress: number): Record<string, unknown> | null {
+export function buildBody(metaId: string, episode: EpisodeRef, progress: number): Record<string, unknown> | null {
   const p = Math.min(100, Math.max(0, progress));
 
   if (metaId.startsWith("tt")) {

--- a/src/lib/simkl/types.ts
+++ b/src/lib/simkl/types.ts
@@ -18,12 +18,15 @@ export type SimklIds = {
   tvdb?: number;
   mal?: number;
   anidb?: number;
+  kitsu?: number;
 };
 
 export type SimklTarget =
   | { kind: "movie"; ids: SimklIds }
   | { kind: "episode"; show: { ids: SimklIds }; season: number; number: number }
-  | { kind: "show"; ids: SimklIds };
+  | { kind: "show"; ids: SimklIds }
+  | { kind: "anime"; ids: SimklIds }
+  | { kind: "anime-episode"; anime: { ids: SimklIds }; season: number; number: number };
 
 export type SimklItem = {
   type: "movie" | "show";

--- a/src/lib/simkl/watchlist.ts
+++ b/src/lib/simkl/watchlist.ts
@@ -11,9 +11,6 @@ export type RawIds = {
   mal?: number;
   anidb?: number;
 };
-type RawNode = { title?: string; year?: number | null; ids?: RawIds };
-type RawEntry = { added_to_watchlist_at?: string; movie?: RawNode; show?: RawNode };
-type RawAllItems = { movies?: RawEntry[]; shows?: RawEntry[]; anime?: RawEntry[] };
 
 export function num(v: number | string | undefined): number | undefined {
   if (typeof v === "number") return v;

--- a/src/lib/simkl/watchlist.ts
+++ b/src/lib/simkl/watchlist.ts
@@ -1,5 +1,7 @@
 import { simklRequest } from "./client";
-import type { SimklIds, SimklItem, SimklTarget } from "./types";
+import type { SimklItem, SimklTarget, SimklIds } from "./types";
+import { getLocalCache, syncWatchlistCache, updateCachedStatusByTarget } from "./activities";
+import type { WatchlistStatus } from "./list-status";
 
 export type RawIds = {
   simkl?: number;
@@ -33,32 +35,43 @@ export function mapIds(ids: RawIds | undefined): SimklIds {
   };
 }
 
-async function fetchByStatus(status: string): Promise<SimklItem[]> {
-  const data = await simklRequest<RawAllItems>(`/sync/all-items/all/${status}`).catch(
-    () => ({}) as RawAllItems,
-  );
-  const out: SimklItem[] = [];
-  for (const e of data.movies ?? []) {
-    const m = e.movie;
-    if (!m) continue;
-    out.push({
-      type: "movie",
-      title: m.title ?? "",
-      year: m.year ?? null,
-      ids: mapIds(m.ids),
-      watchedAt: e.added_to_watchlist_at,
-    });
+async function fetchByStatus(status: WatchlistStatus): Promise<SimklItem[]> {
+  let cache = getLocalCache();
+  if (!cache || !cache.lastSync) {
+    cache = await syncWatchlistCache().catch(() => null);
   }
-  for (const e of [...(data.shows ?? []), ...(data.anime ?? [])]) {
-    const s = e.show;
-    if (!s) continue;
-    out.push({
-      type: "show",
-      title: s.title ?? "",
-      year: s.year ?? null,
-      ids: mapIds(s.ids),
-      watchedAt: e.added_to_watchlist_at,
-    });
+  if (!cache) return [];
+  const out: SimklItem[] = [];
+  for (const simklIdStr of Object.keys(cache.items)) {
+    const item = cache.items[simklIdStr];
+    if (item.status === status) {
+      const ids: any = { simkl: item.simklId };
+      for (const [imdbId, sId] of Object.entries(cache.imdbToSimkl)) {
+        if (sId === item.simklId) ids.imdb = imdbId;
+      }
+      for (const [tmdbKey, sId] of Object.entries(cache.tmdbToSimkl)) {
+        if (sId === item.simklId) {
+          const parts = tmdbKey.split(":");
+          if (parts.length === 2) {
+            ids.tmdb = Number.isFinite(Number(parts[1])) ? Number(parts[1]) : parts[1];
+          }
+        }
+      }
+      for (const [malId, sId] of Object.entries(cache.malToSimkl)) {
+        if (sId === item.simklId) ids.mal = Number(malId);
+      }
+      for (const [kitsuId, sId] of Object.entries(cache.kitsuToSimkl)) {
+        if (sId === item.simklId) ids.kitsu = Number(kitsuId);
+      }
+
+      out.push({
+        type: item.type === "movie" ? "movie" : "show",
+        title: item.title,
+        year: item.year,
+        ids,
+        watchedAt: item.watchedAt ?? undefined,
+      });
+    }
   }
   return out;
 }
@@ -78,13 +91,24 @@ export async function addToWatchlist(target: SimklTarget): Promise<boolean> {
         method: "POST",
         body: { movies: [{ to: "plantowatch", ids: target.ids }] },
       });
+      updateCachedStatusByTarget(target, "plantowatch");
       return true;
     }
-    const ids = target.kind === "show" ? target.ids : target.show.ids;
+    const isAnime = target.kind === "anime" || target.kind === "anime-episode";
+    const bucket = isAnime ? "anime" : "shows";
+    const ids =
+      target.kind === "anime"
+        ? target.ids
+        : target.kind === "anime-episode"
+          ? target.anime.ids
+          : target.kind === "show"
+            ? target.ids
+            : target.show.ids;
     await simklRequest("/sync/add-to-list", {
       method: "POST",
-      body: { shows: [{ to: "plantowatch", ids }] },
+      body: { [bucket]: [{ to: "plantowatch", ids }] },
     });
+    updateCachedStatusByTarget(target, "plantowatch");
     return true;
   } catch {
     return false;
@@ -98,13 +122,24 @@ export async function removeFromWatchlist(target: SimklTarget): Promise<boolean>
         method: "POST",
         body: { movies: [{ ids: target.ids }] },
       });
+      updateCachedStatusByTarget(target, null);
       return true;
     }
-    const ids = target.kind === "show" ? target.ids : target.show.ids;
+    const isAnime = target.kind === "anime" || target.kind === "anime-episode";
+    const bucket = isAnime ? "anime" : "shows";
+    const ids =
+      target.kind === "anime"
+        ? target.ids
+        : target.kind === "anime-episode"
+          ? target.anime.ids
+          : target.kind === "show"
+            ? target.ids
+            : target.show.ids;
     await simklRequest("/sync/history/remove", {
       method: "POST",
-      body: { shows: [{ ids }] },
+      body: { [bucket]: [{ ids }] },
     });
+    updateCachedStatusByTarget(target, null);
     return true;
   } catch {
     return false;

--- a/src/lib/view.tsx
+++ b/src/lib/view.tsx
@@ -183,6 +183,7 @@ type ViewValue = {
   recallRowScroll: (key: string) => number | null;
   chromeHidden: boolean;
   setChromeHidden: (b: boolean) => void;
+  setNavStack: (updater: (s: Frame[]) => Frame[]) => void;
 };
 
 const Ctx = createContext<ViewValue | null>(null);
@@ -829,6 +830,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       recallRowScroll,
       chromeHidden,
       setChromeHidden,
+      setNavStack,
     }),
     [
       view,
@@ -881,6 +883,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       rememberScroll,
       recallScroll,
       chromeHidden,
+      setNavStack,
     ],
   );
 

--- a/src/views/calendar.tsx
+++ b/src/views/calendar.tsx
@@ -81,9 +81,9 @@ export function CalendarView() {
   const libraryNames = useMemo(() => buildLibraryNameSet(libraryItems), [libraryItems]);
 
   const filtered = useMemo(() => {
-    if (source !== "all") return items;
+    if (source !== "all" && source !== "simkl-anticipated") return items;
     let out = applyCalendarFilter(items, filter);
-    if (watchlistOnly) {
+    if (source === "all" && watchlistOnly) {
       out = out.filter((i) => {
         const t = i.type === "tv" ? "tv" : "movie";
         return libraryNames.has(`${normalizeName(i.name)}::${t}`);
@@ -130,6 +130,7 @@ export function CalendarView() {
   const dayModalItems = dayModal ? grouped.get(dayModal) ?? [] : [];
 
   const showAllControls = source === "all";
+  const showPremiereFilters = source === "simkl-anticipated";
 
   let body: React.ReactNode;
   if (source === "library" && !authKey) {
@@ -200,7 +201,6 @@ export function CalendarView() {
             onChange={(s) => update({ calendarSource: s })}
             traktConnected={traktConnected}
             simklConnected={simklConnected}
-            simklCalendarPremieresEnabled={settings.simklCalendarPremieresEnabled}
           />
           <button
             onClick={() => update({ weekStartsMonday: !settings.weekStartsMonday })}
@@ -268,6 +268,40 @@ export function CalendarView() {
                   />
                   {t("Watchlist only")}
                 </button>
+              </div>
+            </>
+          )}
+          {showPremiereFilters && (
+            <>
+              <span className="mx-1 h-5 w-px bg-edge-soft" />
+              <div className="flex flex-wrap items-center gap-2">
+                {FILTERS.map((f) => {
+                  const active = filter === f.id;
+                  const count =
+                    f.id === "all"
+                      ? items.length
+                      : applyCalendarFilter(items, f.id).length;
+                  return (
+                    <button
+                      key={f.id}
+                      onClick={() => setFilter(f.id)}
+                      className={`flex items-center gap-2 rounded-full px-4 py-1.5 text-[13px] font-semibold transition-colors ${
+                        active
+                          ? "bg-ink text-canvas"
+                          : "border border-edge-soft text-ink-muted hover:border-edge hover:text-ink"
+                      }`}
+                    >
+                      {t(f.label)}
+                      <span
+                        className={`text-[11px] tabular-nums ${
+                          active ? "text-canvas/65" : "text-ink-subtle"
+                        }`}
+                      >
+                        {count}
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
             </>
           )}

--- a/src/views/calendar.tsx
+++ b/src/views/calendar.tsx
@@ -200,6 +200,7 @@ export function CalendarView() {
             onChange={(s) => update({ calendarSource: s })}
             traktConnected={traktConnected}
             simklConnected={simklConnected}
+            simklCalendarPremieresEnabled={settings.simklCalendarPremieresEnabled}
           />
           <button
             onClick={() => update({ weekStartsMonday: !settings.weekStartsMonday })}

--- a/src/views/calendar/source-switcher.tsx
+++ b/src/views/calendar/source-switcher.tsx
@@ -51,7 +51,7 @@ const OPTIONS: Option[] = [
     id: "simkl",
     label: "My Simkl",
     icon: SimklGlyph,
-    hint: "Upcoming episodes and movies from your Simkl plan-to-watch list",
+    hint: "Upcoming episodes and movies from your Simkl watching and plan-to-watch lists",
   },
   {
     id: "simkl-anticipated",
@@ -72,20 +72,18 @@ export function SourceSwitcher({
   onChange,
   traktConnected,
   simklConnected,
-  simklCalendarPremieresEnabled = true,
 }: {
   value: Source;
   onChange: (s: Source) => void;
   traktConnected: boolean;
   simklConnected: boolean;
-  simklCalendarPremieresEnabled?: boolean;
 }) {
   const t = useT();
   const visible = OPTIONS.filter(
     (o) =>
       (o.id !== "trakt" || traktConnected) &&
-      (o.id !== "simkl" || (simklConnected && simklCalendarPremieresEnabled)) &&
-      (o.id !== "simkl-anticipated" || (simklConnected && simklCalendarPremieresEnabled)),
+      (o.id !== "simkl" || simklConnected) &&
+      (o.id !== "simkl-anticipated" || simklConnected),
   );
   return (
     <div className="flex items-center gap-1 rounded-full border border-edge-soft bg-elevated/30 p-1">

--- a/src/views/calendar/source-switcher.tsx
+++ b/src/views/calendar/source-switcher.tsx
@@ -72,18 +72,20 @@ export function SourceSwitcher({
   onChange,
   traktConnected,
   simklConnected,
+  simklCalendarPremieresEnabled = true,
 }: {
   value: Source;
   onChange: (s: Source) => void;
   traktConnected: boolean;
   simklConnected: boolean;
+  simklCalendarPremieresEnabled?: boolean;
 }) {
   const t = useT();
   const visible = OPTIONS.filter(
     (o) =>
       (o.id !== "trakt" || traktConnected) &&
-      (o.id !== "simkl" || simklConnected) &&
-      (o.id !== "simkl-anticipated" || simklConnected),
+      (o.id !== "simkl" || (simklConnected && simklCalendarPremieresEnabled)) &&
+      (o.id !== "simkl-anticipated" || (simklConnected && simklCalendarPremieresEnabled)),
   );
   return (
     <div className="flex items-center gap-1 rounded-full border border-edge-soft bg-elevated/30 p-1">

--- a/src/views/calendar/use-calendar-data.ts
+++ b/src/views/calendar/use-calendar-data.ts
@@ -144,5 +144,11 @@ export function useCalendarData({
     month,
   ]);
 
+  useEffect(() => {
+    if (simklConnected) {
+      void fetchSimklPremieresCalendar(year, month).catch(() => {});
+    }
+  }, [simklConnected, year, month]);
+
   return { items, loading, error };
 }

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -51,6 +51,8 @@ import { AddToAnilistButton } from "./detail/add-to-anilist-button";
 import { AddToSimklButton } from "./detail/add-to-simkl-button";
 import { SimklRatingPicker } from "./detail/simkl-rating-picker";
 import { useSimkl } from "@/lib/simkl/provider";
+import { getLocalCache, saveLocalCache } from "@/lib/simkl/activities";
+import { simklRequest } from "@/lib/simkl/client";
 import { CollectionRow } from "./detail/collection-row";
 import { MediaGallery } from "./detail/media-gallery";
 import { useTitleBackdrop } from "@/lib/title-backdrop";
@@ -187,7 +189,7 @@ export function DetailView({
   );
   const scrollRef = useRef<HTMLElement>(null);
 
-  const { openPicker, openFilter, promoteMetaToRoot } = useView();
+  const { setNavStack, openPicker, openFilter, promoteMetaToRoot } = useView();
   const { snapshot: roomSnapshot, claimHost } = useTogether();
   const { isConnected: traktConnected } = useTrakt();
   const { isConnected: simklConnected } = useSimkl();
@@ -196,6 +198,115 @@ export function DetailView({
   const isFav = useIsFavorite(meta.id, [detail?.imdbId]);
   const inSession = roomSnapshot.state === "joined" && roomSnapshot.participants.length >= 2;
   useScrollMemory(`meta:${meta.id}`, scrollRef);
+
+  useEffect(() => {
+    if (!meta.id.startsWith("simkl:")) return;
+
+    let cancelled = false;
+    const simklIdStr = meta.id.slice(6);
+    const simklId = parseInt(simklIdStr, 10);
+
+    const resolveSimklId = async () => {
+      let resolvedId: string | null = null;
+      const cache = getLocalCache();
+
+      if (cache) {
+        // 1. IMDb mapping check
+        const imdbKey = Object.keys(cache.imdbToSimkl).find(
+          (k) => cache.imdbToSimkl[k] === simklId
+        );
+        if (imdbKey) resolvedId = imdbKey;
+
+        // 2. Kitsu mapping check
+        if (!resolvedId) {
+          const kitsuKey = Object.keys(cache.kitsuToSimkl).find(
+            (k) => cache.kitsuToSimkl[k] === simklId
+          );
+          if (kitsuKey) resolvedId = `kitsu:${kitsuKey}`;
+        }
+
+        // 3. MAL mapping check
+        if (!resolvedId) {
+          const malKey = Object.keys(cache.malToSimkl).find(
+            (k) => cache.malToSimkl[k] === simklId
+          );
+          if (malKey) resolvedId = `mal:${malKey}`;
+        }
+
+        // 4. TMDB mapping check
+        if (!resolvedId) {
+          const tmdbKey = Object.keys(cache.tmdbToSimkl).find(
+            (k) => cache.tmdbToSimkl[k] === simklId
+          );
+          if (tmdbKey) resolvedId = `tmdb:${tmdbKey}`;
+        }
+      }
+
+      // If not found in local cache, query the SIMKL detail endpoint
+      if (!resolvedId) {
+        const mediaType =
+          cache?.items[simklIdStr]?.type ||
+          (meta.type === "movie" ? "movie" : meta.type === "anime" ? "anime" : "show");
+        const path =
+          mediaType === "movie"
+            ? `/movies/${simklId}`
+            : mediaType === "anime"
+              ? `/anime/${simklId}`
+              : `/tv/${simklId}`;
+
+        try {
+          const data = await simklRequest<any>(path);
+          if (cancelled) return;
+          if (data && data.ids) {
+            const ids = data.ids;
+            if (ids.imdb) {
+              resolvedId = ids.imdb;
+            } else if (ids.kitsu) {
+              resolvedId = `kitsu:${ids.kitsu}`;
+            } else if (ids.mal) {
+              resolvedId = `mal:${ids.mal}`;
+            } else if (ids.tmdb) {
+              const tmdbType = mediaType === "movie" ? "movie" : "tv";
+              resolvedId = `tmdb:${tmdbType}:${ids.tmdb}`;
+            }
+
+            // Save to local cache indexes for future queries
+            if (resolvedId && cache) {
+              if (ids.imdb) cache.imdbToSimkl[ids.imdb] = simklId;
+              if (ids.kitsu) cache.kitsuToSimkl[String(ids.kitsu)] = simklId;
+              if (ids.mal) cache.malToSimkl[String(ids.mal)] = simklId;
+              if (ids.tmdb) {
+                const tmdbType = mediaType === "movie" ? "movie" : "tv";
+                cache.tmdbToSimkl[`${tmdbType}:${ids.tmdb}`] = simklId;
+              }
+              saveLocalCache(cache);
+            }
+          }
+        } catch (e) {
+          console.error("Failed to resolve SIMKL ID via API", e);
+        }
+      }
+
+      if (cancelled) return;
+
+      if (resolvedId) {
+        setNavStack((stack) =>
+          stack.map((frame) =>
+            frame.kind === "meta" && frame.meta.id === meta.id
+              ? { ...frame, meta: { ...frame.meta, id: resolvedId } }
+              : frame
+          )
+        );
+      }
+    };
+
+    resolveSimklId();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [meta.id, meta.type, setNavStack]);
+
   const idAnime = /^(kitsu|mal|anilist|anidb):/.test(meta.id);
   const isAnime = idAnime || detectedKitsu != null;
   const stickyAwardName = useRef<string | null>(null);
@@ -326,7 +437,7 @@ export function DetailView({
   useEffect(() => {
     if (meta.type !== "series") return;
     if (meta.addonOrigin?.base) return;
-    if (/^(tt\d|tmdb:|kitsu:|mal:|anilist:|anidb:)/.test(meta.id)) return;
+    if (/^(tt\d|tmdb:|kitsu:|mal:|anilist:|anidb:|simkl:)/.test(meta.id)) return;
     if (cinemetaFull?.videos && cinemetaFull.videos.length > 0) return;
     let cancelled = false;
     resolveMeta(authKey, narrowMediaType(meta.type), meta.id)
@@ -342,7 +453,7 @@ export function DetailView({
 
   useEffect(() => {
     setLibraryItem(null);
-    if (!authKey) return;
+    if (!authKey || meta.id.startsWith("simkl:")) return;
     const candidates: string[] = [];
     if (meta.id.startsWith("tt")) candidates.push(meta.id);
     if (detail?.imdbId?.startsWith("tt") && !candidates.includes(detail.imdbId)) {

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -49,6 +49,8 @@ import { useScrollMemory, useView } from "@/lib/view";
 import { useT } from "@/lib/i18n";
 import { AddToAnilistButton } from "./detail/add-to-anilist-button";
 import { AddToSimklButton } from "./detail/add-to-simkl-button";
+import { SimklRatingPicker } from "./detail/simkl-rating-picker";
+import { useSimkl } from "@/lib/simkl/provider";
 import { CollectionRow } from "./detail/collection-row";
 import { MediaGallery } from "./detail/media-gallery";
 import { useTitleBackdrop } from "@/lib/title-backdrop";
@@ -188,6 +190,7 @@ export function DetailView({
   const { openPicker, openFilter, promoteMetaToRoot } = useView();
   const { snapshot: roomSnapshot, claimHost } = useTogether();
   const { isConnected: traktConnected } = useTrakt();
+  const { isConnected: simklConnected } = useSimkl();
   const inWatchlist = useInWatchlist(meta.id, [detail?.imdbId]);
   const { toggle: toggleFavorite } = useMediaFavorites();
   const isFav = useIsFavorite(meta.id, [detail?.imdbId]);
@@ -1001,6 +1004,13 @@ export function DetailView({
                     harborId={isAnime ? (animeCanonicalId ?? meta.id) : meta.id}
                     title={title || meta.name}
                     type={meta.type === "movie" ? "movie" : "series"}
+                  />
+                )}
+                {actionStage < 2 && settings.simklEnableUserRatings && (
+                  <SimklRatingPicker
+                    harborId={isAnime ? (animeCanonicalId ?? meta.id) : meta.id}
+                    type={meta.type === "movie" ? "movie" : "series"}
+                    simklConnected={simklConnected}
                   />
                 )}
                 {actionStage >= 1 ? (

--- a/src/views/detail/add-to-simkl-button.tsx
+++ b/src/views/detail/add-to-simkl-button.tsx
@@ -62,9 +62,13 @@ export function AddToSimklButton({
         setTarget(null);
         return;
       }
+      if (type === "series" && tgt.kind === "movie") tgt = { kind: "show", ids: tgt.ids };
+      if (type === "movie" && (tgt.kind === "show" || tgt.kind === "anime")) tgt = { kind: "movie", ids: tgt.ids };
       setTarget(tgt);
       const malKey =
-        tgt.kind !== "episode" && tgt.ids.mal != null ? `mal:${tgt.ids.mal}` : null;
+        tgt.kind === "movie" || tgt.kind === "show" || tgt.kind === "anime"
+          ? (tgt.ids.mal != null ? `mal:${tgt.ids.mal}` : null)
+          : null;
       try {
         const map = await loadSimklStatusMap();
         if (cancelled) return;

--- a/src/views/detail/add-to-simkl-button.tsx
+++ b/src/views/detail/add-to-simkl-button.tsx
@@ -56,14 +56,17 @@ export function AddToSimklButton({
     let cancelled = false;
     setReady(false);
     void (async () => {
-      const tgt = await resolveSimklTarget(harborId, type);
+      let tgt = await resolveSimklTarget(harborId, type);
       if (cancelled) return;
       if (!tgt) {
         setTarget(null);
         return;
       }
-      if (type === "series" && tgt.kind === "movie") tgt = { kind: "show", ids: tgt.ids };
-      if (type === "movie" && (tgt.kind === "show" || tgt.kind === "anime")) tgt = { kind: "movie", ids: tgt.ids };
+      if (type === "series" && tgt.kind === "movie") {
+        tgt = { kind: "show", ids: tgt.ids };
+      } else if (type === "movie" && (tgt.kind === "show" || tgt.kind === "anime")) {
+        tgt = { kind: "movie", ids: tgt.ids };
+      }
       setTarget(tgt);
       const malKey =
         tgt.kind === "movie" || tgt.kind === "show" || tgt.kind === "anime"

--- a/src/views/detail/hero-ratings.tsx
+++ b/src/views/detail/hero-ratings.tsx
@@ -8,6 +8,7 @@ import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
 import type { OmdbScores } from "@/lib/providers/omdb";
 import type { MdblistScores } from "@/lib/providers/mdblist";
+import { useSimklCommunityRating } from "@/lib/simkl/ratings";
 import mdblistLogo from "@/assets/addon-logos/mdblist.png";
 import letterboxdLogo from "@/assets/addon-logos/letterboxd.png";
 import traktLogo from "@/assets/trakt.svg";
@@ -81,6 +82,10 @@ export function HeroRatings({
   const { settings } = useSettings();
   const metacritic = mdblist?.metacritic ?? scores?.metascore ?? null;
   const showPrimary = settings.showDetailRatings;
+
+  // Fetch SIMKL community rating directly from the SIMKL API (decoupled from MDBList).
+  // Always called to respect React hooks rules; the hook early-returns when imdbId is null.
+  const { rating: simklCommunityRating } = useSimklCommunityRating(imdbId);
 
   const items: ReactNode[] = [];
 
@@ -187,7 +192,11 @@ export function HeroRatings({
     );
   }
 
-  if (settings.showSimklBadge && settings.simklShowCommunityRatings && mdblist?.simkl != null) {
+  // Prefer the direct SIMKL API fetch; fall back to MDBList's simkl score if the
+  // hook returned null (e.g. API failure or no matching title).
+  const effectiveSimklRating = simklCommunityRating ?? mdblist?.simkl ?? null;
+
+  if (settings.showSimklBadge && settings.simklShowCommunityRatings && effectiveSimklRating != null) {
     items.push(
       <ScoreItem
         key="simkl"
@@ -200,7 +209,7 @@ export function HeroRatings({
           alt=""
           className="h-[14px] w-[14px] rounded-[3px] object-contain"
         />
-        <span>{mdblist.simkl.toFixed(1)}</span>
+        <span>{effectiveSimklRating.toFixed(1)}</span>
       </ScoreItem>,
     );
   }

--- a/src/views/detail/hero-ratings.tsx
+++ b/src/views/detail/hero-ratings.tsx
@@ -11,6 +11,7 @@ import type { MdblistScores } from "@/lib/providers/mdblist";
 import mdblistLogo from "@/assets/addon-logos/mdblist.png";
 import letterboxdLogo from "@/assets/addon-logos/letterboxd.png";
 import traktLogo from "@/assets/trakt.svg";
+import simklLogo from "@/assets/simkl.png";
 
 function ScoreItem({
   label,
@@ -182,6 +183,24 @@ export function HeroRatings({
       >
         <img src={traktLogo} alt="" className="h-[14px] w-[14px] object-contain" />
         <span>{Math.round(mdblist.trakt)}%</span>
+      </ScoreItem>,
+    );
+  }
+
+  if (settings.showSimklBadge && settings.simklShowCommunityRatings && mdblist?.simkl != null) {
+    items.push(
+      <ScoreItem
+        key="simkl"
+        label={t("SIMKL")}
+        sublabel={t("Average /10")}
+        onClick={imdbId ? () => onOpenUrl(`https://simkl.com/search/id/?i=${imdbId}`) : undefined}
+      >
+        <img
+          src={simklLogo}
+          alt=""
+          className="h-[14px] w-[14px] rounded-[3px] object-contain"
+        />
+        <span>{mdblist.simkl.toFixed(1)}</span>
       </ScoreItem>,
     );
   }

--- a/src/views/detail/overflow-sync-items.tsx
+++ b/src/views/detail/overflow-sync-items.tsx
@@ -121,10 +121,13 @@ export function SimklMenuItems({
     if (!isConnected) return;
     let cancelled = false;
     void (async () => {
-      const t = await resolveSimklTarget(harborId, type);
+      let t = await resolveSimklTarget(harborId, type);
       if (cancelled || !t) return;
-      if (type === "series" && t.kind === "movie") t = { kind: "show", ids: t.ids };
-      if (type === "movie" && (t.kind === "show" || t.kind === "anime")) t = { kind: "movie", ids: t.ids };
+      if (type === "series" && t.kind === "movie") {
+        t = { kind: "show", ids: t.ids };
+      } else if (type === "movie" && (t.kind === "show" || t.kind === "anime")) {
+        t = { kind: "movie", ids: t.ids };
+      }
       setTarget(t);
       const malKey =
         t.kind === "movie" || t.kind === "show" || t.kind === "anime"

--- a/src/views/detail/overflow-sync-items.tsx
+++ b/src/views/detail/overflow-sync-items.tsx
@@ -123,8 +123,13 @@ export function SimklMenuItems({
     void (async () => {
       const t = await resolveSimklTarget(harborId, type);
       if (cancelled || !t) return;
+      if (type === "series" && t.kind === "movie") t = { kind: "show", ids: t.ids };
+      if (type === "movie" && (t.kind === "show" || t.kind === "anime")) t = { kind: "movie", ids: t.ids };
       setTarget(t);
-      const malKey = t.kind !== "episode" && t.ids.mal != null ? `mal:${t.ids.mal}` : null;
+      const malKey =
+        t.kind === "movie" || t.kind === "show" || t.kind === "anime"
+          ? (t.ids.mal != null ? `mal:${t.ids.mal}` : null)
+          : null;
       try {
         const m = await loadSimklStatusMap();
         if (cancelled) return;

--- a/src/views/detail/series-episodes.tsx
+++ b/src/views/detail/series-episodes.tsx
@@ -310,7 +310,7 @@ export function SeriesEpisodes({
     );
     if (!simklConnected) return;
     const r = stremioIdToSimklTarget(meta.id, { season: active, episode: 1 });
-    const showIds = r.ok && r.target.kind === "episode" ? r.target.show.ids : null;
+    const showIds = r.ok && (r.target.kind === "episode" ? r.target.show.ids : r.target.kind === "anime-episode" ? r.target.anime.ids : null);
     if (!showIds) return;
     if (watched) {
       void markEpisodesWatched(showIds, active, enrichedEpisodes.map((e) => e.episodeNumber));

--- a/src/views/detail/simkl-rating-picker.tsx
+++ b/src/views/detail/simkl-rating-picker.tsx
@@ -1,0 +1,133 @@
+import { useState, useEffect } from "react";
+import { Star, Loader2 } from "lucide-react";
+import { stremioIdToSimklTarget } from "@/lib/simkl/ids";
+import { kitsuToMal } from "@/lib/providers/anime-mapping";
+import type { SimklTarget } from "@/lib/simkl/types";
+import { addSimklRating, removeSimklRating, getCachedRatingByTarget } from "@/lib/simkl/ratings";
+import { useT } from "@/lib/i18n";
+
+export function SimklRatingPicker({
+  harborId,
+  type,
+  simklConnected,
+}: {
+  harborId: string;
+  type: "movie" | "series";
+  simklConnected: boolean;
+}) {
+  const t = useT();
+  const [target, setTarget] = useState<SimklTarget | null>(null);
+  const [currentRating, setCurrentRating] = useState<number | null>(null);
+  const [hoverRating, setHoverRating] = useState<number>(0);
+  const [loading, setLoading] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!simklConnected) {
+      setTarget(null);
+      setCurrentRating(null);
+      setReady(false);
+      return;
+    }
+    let cancelled = false;
+    setReady(false);
+    void (async () => {
+      let tgt: SimklTarget | null = null;
+      const resolution = stremioIdToSimklTarget(harborId);
+      if (resolution.ok) {
+        tgt = resolution.target;
+      } else if (harborId.startsWith("kitsu:")) {
+        const n = Number(harborId.split(":")[1]);
+        const mal = Number.isFinite(n) ? await kitsuToMal(n).catch(() => null) : null;
+        if (mal != null) tgt = { kind: "show", ids: { mal } };
+      }
+      if (cancelled) return;
+      if (!tgt) {
+        setTarget(null);
+        return;
+      }
+      if (type === "series" && tgt.kind === "movie") tgt = { kind: "show", ids: tgt.ids };
+      if (type === "movie" && (tgt.kind === "show" || tgt.kind === "anime")) tgt = { kind: "movie", ids: tgt.ids };
+      
+      setTarget(tgt);
+      setCurrentRating(getCachedRatingByTarget(tgt));
+      setReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [harborId, type, simklConnected]);
+
+  if (!simklConnected || !target || !ready) return null;
+
+  const handleRatingClick = async (val: number) => {
+    if (loading) return;
+    setLoading(true);
+
+    if (currentRating === val) {
+      const ok = await removeSimklRating(target);
+      if (ok) setCurrentRating(null);
+    } else {
+      const ok = await addSimklRating(target, val);
+      if (ok) setCurrentRating(val);
+    }
+    setLoading(false);
+  };
+
+  const activeRating = hoverRating || currentRating || 0;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex items-center gap-1.5" role="group" aria-label="SIMKL rating picker">
+        {[1, 2, 3, 4, 5].map((n) => {
+          const isFilled = 2 * n <= activeRating;
+          const isHalf = 2 * n - 1 === activeRating;
+
+          return (
+            <div key={n} className="relative h-5 w-5 text-ink-subtle">
+              {/* Background Star (Empty) */}
+              <Star size={20} className="text-ink-muted/30" />
+
+              {/* Half Star Overlay */}
+              {isHalf && (
+                <div className="absolute inset-0 overflow-hidden w-[50%] pointer-events-none">
+                  <Star size={20} className="fill-amber-400 text-amber-400" />
+                </div>
+              )}
+
+              {/* Full Star Overlay */}
+              {isFilled && (
+                <div className="absolute inset-0 pointer-events-none">
+                  <Star size={20} className="fill-amber-400 text-amber-400" />
+                </div>
+              )}
+
+              {/* Hover / Click triggers */}
+              <div
+                className="absolute left-0 top-0 h-full w-1/2 cursor-pointer"
+                onMouseEnter={() => setHoverRating(2 * n - 1)}
+                onMouseLeave={() => setHoverRating(0)}
+                onClick={() => handleRatingClick(2 * n - 1)}
+              />
+              <div
+                className="absolute right-0 top-0 h-full w-1/2 cursor-pointer"
+                onMouseEnter={() => setHoverRating(2 * n)}
+                onMouseLeave={() => setHoverRating(0)}
+                onClick={() => handleRatingClick(2 * n)}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex items-center gap-1 text-[13px] font-semibold text-ink-muted">
+        {loading ? (
+          <Loader2 size={13} className="animate-spin text-ink-subtle" />
+        ) : currentRating !== null ? (
+          <span className="text-amber-400 font-bold">{currentRating}/10</span>
+        ) : (
+          <span className="text-ink-subtle">{t("Rate on SIMKL")}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -244,7 +244,7 @@ export function Home({ active = true }: { active?: boolean }) {
       return;
     }
     let cancelled = false;
-    buildSimklHomeRows(settings.tmdbKey)
+    buildSimklHomeRows(settings)
       .then((rs) => {
         if (!cancelled) setSimklRows(rs);
       })
@@ -252,7 +252,7 @@ export function Home({ active = true }: { active?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [simklConnected, settings.tmdbKey]);
+  }, [simklConnected, settings.tmdbKey, settings.simklHomeRailsEnabled]);
 
   useEffect(() => {
     if (!simklConnected) {

--- a/src/views/library/shared.tsx
+++ b/src/views/library/shared.tsx
@@ -47,6 +47,7 @@ export function FilterBar({
   setQuery,
   counts,
   trailing,
+  hideTypePills,
 }: {
   type: TypeKey;
   setType: (t: TypeKey) => void;
@@ -54,21 +55,24 @@ export function FilterBar({
   setQuery: (q: string) => void;
   counts: { all: number; movie: number; series: number };
   trailing?: React.ReactNode;
+  hideTypePills?: boolean;
 }) {
   const t = useT();
   return (
     <div className="flex flex-wrap items-center gap-3">
-      <div className="flex items-center gap-1 rounded-full bg-elevated/40 p-0.5 ring-1 ring-edge-soft/60">
-        <FilterPill active={type === "all"} onClick={() => setType("all")}>
-          {t("All")} <span className="ms-1 text-ink-subtle">{counts.all}</span>
-        </FilterPill>
-        <FilterPill active={type === "movie"} onClick={() => setType("movie")}>
-          {t("Movies")} <span className="ms-1 text-ink-subtle">{counts.movie}</span>
-        </FilterPill>
-        <FilterPill active={type === "series"} onClick={() => setType("series")}>
-          {t("Shows")} <span className="ms-1 text-ink-subtle">{counts.series}</span>
-        </FilterPill>
-      </div>
+      {!hideTypePills && (
+        <div className="flex items-center gap-1 rounded-full bg-elevated/40 p-0.5 ring-1 ring-edge-soft/60">
+          <FilterPill active={type === "all"} onClick={() => setType("all")}>
+            {t("All")} <span className="ms-1 text-ink-subtle">{counts.all}</span>
+          </FilterPill>
+          <FilterPill active={type === "movie"} onClick={() => setType("movie")}>
+            {t("Movies")} <span className="ms-1 text-ink-subtle">{counts.movie}</span>
+          </FilterPill>
+          <FilterPill active={type === "series"} onClick={() => setType("series")}>
+            {t("Shows")} <span className="ms-1 text-ink-subtle">{counts.series}</span>
+          </FilterPill>
+        </div>
+      )}
       <input
         type="search"
         value={query}

--- a/src/views/library/simkl-tab.tsx
+++ b/src/views/library/simkl-tab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useSettings } from "@/lib/settings";
 import { useT } from "@/lib/i18n";
 import { getLocalCache, syncWatchlistCache, type SimklCacheItem, type SimklCache } from "@/lib/simkl/activities";
-import { groupAnimeByFranchise, formatYearRange } from "@/lib/simkl/anime-grouping";
+import { groupAnimeByFranchise, enhanceGroupsWithRelations, type AnimeFranchise, formatYearRange } from "@/lib/simkl/anime-grouping";
 import type { Meta } from "@/lib/cinemeta";
 import {
   FilterBar,
@@ -63,6 +63,7 @@ function cacheItemToMeta(item: SimklCacheItem, cache: SimklCache): Meta | null {
     type: item.type === "movie" ? "movie" : "series",
     name: item.title || "Unknown Title",
     releaseInfo: item.year ? String(item.year) : undefined,
+    poster: item.poster ? `https://simkl.in/posters/${item.poster}_m.jpg` : undefined,
   };
 }
 
@@ -71,6 +72,41 @@ export function SimklTab() {
   const { settings } = useSettings();
   const [cache, setCache] = useState<SimklCache | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [enhancedFranchises, setEnhancedFranchises] = useState<AnimeFranchise[]>([]);
+
+  useEffect(() => {
+    if (!cache) {
+      setEnhancedFranchises([]);
+      return;
+    }
+
+    const animeItems = Object.values(cache.items).filter((item) => {
+      if (item.type === "anime") return true;
+      if (item.type === "movie") {
+        const simklId = item.simklId;
+        const hasMal = Object.values(cache.malToSimkl).includes(simklId);
+        const hasKitsu = Object.values(cache.kitsuToSimkl).includes(simklId);
+        return hasMal || hasKitsu;
+      }
+      return false;
+    });
+    const syncFranchises = groupAnimeByFranchise(animeItems);
+    setEnhancedFranchises(syncFranchises);
+
+    let cancelled = false;
+    enhanceGroupsWithRelations(syncFranchises)
+      .then((enhanced) => {
+        if (cancelled) return;
+        setEnhancedFranchises(enhanced);
+      })
+      .catch((err) => {
+        console.error("Failed to enhance groups with relations:", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cache]);
 
   useEffect(() => {
     let cancelled = false;
@@ -122,8 +158,7 @@ export function SimklTab() {
 
     if (subTab === "anime") {
       // For anime, count franchises per status (a franchise counts if ANY season has that status)
-      const animeItems = Object.values(cache.items).filter((item) => item.type === "anime");
-      const franchises = groupAnimeByFranchise(animeItems);
+      const franchises = enhancedFranchises;
       for (const franchise of franchises) {
         const statuses = new Set(franchise.items.map((i) => i.status));
         for (const status of statuses) {
@@ -137,7 +172,21 @@ export function SimklTab() {
       return counts;
     }
 
-    const targetType = subTab === "movies" ? "movie" : "show";
+    if (subTab === "movies") {
+      for (const item of Object.values(cache.items)) {
+        if (item.type !== "movie") continue;
+        const hasMal = Object.values(cache.malToSimkl).includes(item.simklId);
+        const hasKitsu = Object.values(cache.kitsuToSimkl).includes(item.simklId);
+        if (hasMal || hasKitsu) continue;
+        const meta = cacheItemToMeta(item, cache);
+        if (!meta) continue;
+
+        counts[item.status] = (counts[item.status] ?? 0) + 1;
+      }
+      return counts;
+    }
+
+    const targetType = "show";
     for (const item of Object.values(cache.items)) {
       if (item.type !== targetType) continue;
       const meta = cacheItemToMeta(item, cache);
@@ -146,7 +195,7 @@ export function SimklTab() {
       counts[item.status] = (counts[item.status] ?? 0) + 1;
     }
     return counts;
-  }, [cache, subTab]);
+  }, [cache, subTab, enhancedFranchises]);
 
   const [type, setType] = useState<TypeKey>("all");
   const [query, setQuery] = useState("");
@@ -156,8 +205,7 @@ export function SimklTab() {
 
     if (subTab === "anime") {
       // Group anime by franchise, then filter by status
-      const animeItems = Object.values(cache.items).filter((item) => item.type === "anime");
-      const franchises = groupAnimeByFranchise(animeItems);
+      const franchises = enhancedFranchises;
 
       return franchises
         .filter((franchise) => {
@@ -165,8 +213,22 @@ export function SimklTab() {
           return franchise.items.some((item) => item.status === statusFilter);
         })
         .map((franchise) => {
-          // Use the first item that has a valid meta as the representative
-          const representativeItem = franchise.items.find((item) => cacheItemToMeta(item, cache));
+          // Prioritize active progress representative (status === "watching")
+          const representativeItem = (() => {
+            const watching = franchise.items.filter(
+              (item) => item.status === "watching" && cacheItemToMeta(item, cache) !== null
+            );
+            if (watching.length > 0) {
+              watching.sort((a, b) => {
+                const tA = a.watchedAt ? new Date(a.watchedAt).getTime() : 0;
+                const tB = b.watchedAt ? new Date(b.watchedAt).getTime() : 0;
+                return tB - tA;
+              });
+              return watching[0];
+            }
+            return franchise.items.find((item) => cacheItemToMeta(item, cache) !== null);
+          })();
+
           if (!representativeItem) return null;
           const meta = cacheItemToMeta(representativeItem, cache);
           if (!meta) return null;
@@ -175,6 +237,15 @@ export function SimklTab() {
           meta.name = franchise.name;
           if (franchise.yearStart != null) {
             meta.releaseInfo = formatYearRange(franchise.yearStart, franchise.yearEnd);
+          }
+
+          // Use the representative item's poster if available.
+          // Fall back to other items in the franchise if needed.
+          if (!meta.poster) {
+            const fallbackItem = franchise.items.find((it) => it.poster && cacheItemToMeta(it, cache) !== null);
+            if (fallbackItem?.poster) {
+              meta.poster = `https://simkl.in/posters/${fallbackItem.poster}_m.jpg`;
+            }
           }
 
           // Use the latest watchedAt from any season in the franchise
@@ -192,7 +263,29 @@ export function SimklTab() {
         .filter((x): x is WatchlistMerged => x !== null);
     }
 
-    const targetType = subTab === "movies" ? "movie" : "show";
+    if (subTab === "movies") {
+      return Object.values(cache.items)
+        .filter((item) => {
+          if (item.type !== "movie") return false;
+          if (item.status !== statusFilter) return false;
+          const hasMal = Object.values(cache.malToSimkl).includes(item.simklId);
+          const hasKitsu = Object.values(cache.kitsuToSimkl).includes(item.simklId);
+          if (hasMal || hasKitsu) return false;
+          return true;
+        })
+        .map((item) => {
+          const meta = cacheItemToMeta(item, cache);
+          if (!meta) return null;
+          return {
+            key: `simkl-${item.simklId}`,
+            meta,
+            date: item.watchedAt ? parseTs(item.watchedAt) : null,
+          };
+        })
+        .filter((x): x is WatchlistMerged => x !== null);
+    }
+
+    const targetType = "show";
     return Object.values(cache.items)
       .filter((item) => {
         if (item.type !== targetType) return false;
@@ -209,7 +302,7 @@ export function SimklTab() {
         };
       })
       .filter((x): x is WatchlistMerged => x !== null);
-  }, [cache, subTab, statusFilter]);
+  }, [cache, subTab, statusFilter, enhancedFranchises]);
 
   const counts = useMemo(() => countByType(filteredItems), [filteredItems]);
   const visible = useMemo(() => applyFilter(filteredItems, type, query), [filteredItems, type, query]);

--- a/src/views/library/simkl-tab.tsx
+++ b/src/views/library/simkl-tab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useSettings } from "@/lib/settings";
 import { useT } from "@/lib/i18n";
 import { getLocalCache, syncWatchlistCache, type SimklCacheItem, type SimklCache } from "@/lib/simkl/activities";
+import { groupAnimeByFranchise, formatYearRange } from "@/lib/simkl/anime-grouping";
 import type { Meta } from "@/lib/cinemeta";
 import {
   FilterBar,
@@ -52,8 +53,10 @@ function cacheItemToMeta(item: SimklCacheItem, cache: SimklCache): Meta | null {
     const kitsuId = Object.keys(cache.kitsuToSimkl).find((k) => cache.kitsuToSimkl[k] === simklId);
     if (kitsuId) id = `kitsu:${kitsuId}`;
   }
-
-  if (!id) return null;
+  // 5. Fallback: use simkl:{id} — ensures all items are visible even without external IDs
+  if (!id) {
+    id = `simkl:${simklId}`;
+  }
 
   return {
     id,
@@ -117,7 +120,24 @@ export function SimklTab() {
     const counts: Record<string, number> = {};
     if (!cache) return counts;
 
-    const targetType = subTab === "movies" ? "movie" : subTab === "shows" ? "show" : "anime";
+    if (subTab === "anime") {
+      // For anime, count franchises per status (a franchise counts if ANY season has that status)
+      const animeItems = Object.values(cache.items).filter((item) => item.type === "anime");
+      const franchises = groupAnimeByFranchise(animeItems);
+      for (const franchise of franchises) {
+        const statuses = new Set(franchise.items.map((i) => i.status));
+        for (const status of statuses) {
+          // Only count if at least one item in the franchise has a valid meta
+          const hasValidMeta = franchise.items.some((item) => cacheItemToMeta(item, cache));
+          if (hasValidMeta) {
+            counts[status] = (counts[status] ?? 0) + 1;
+          }
+        }
+      }
+      return counts;
+    }
+
+    const targetType = subTab === "movies" ? "movie" : "show";
     for (const item of Object.values(cache.items)) {
       if (item.type !== targetType) continue;
       const meta = cacheItemToMeta(item, cache);
@@ -133,8 +153,46 @@ export function SimklTab() {
 
   const filteredItems = useMemo<WatchlistMerged[]>(() => {
     if (!cache) return [];
-    const targetType = subTab === "movies" ? "movie" : subTab === "shows" ? "show" : "anime";
 
+    if (subTab === "anime") {
+      // Group anime by franchise, then filter by status
+      const animeItems = Object.values(cache.items).filter((item) => item.type === "anime");
+      const franchises = groupAnimeByFranchise(animeItems);
+
+      return franchises
+        .filter((franchise) => {
+          // A franchise shows up under a status if ANY of its seasons has that status
+          return franchise.items.some((item) => item.status === statusFilter);
+        })
+        .map((franchise) => {
+          // Use the first item that has a valid meta as the representative
+          const representativeItem = franchise.items.find((item) => cacheItemToMeta(item, cache));
+          if (!representativeItem) return null;
+          const meta = cacheItemToMeta(representativeItem, cache);
+          if (!meta) return null;
+
+          // Override the title and year with franchise-level info
+          meta.name = franchise.name;
+          if (franchise.yearStart != null) {
+            meta.releaseInfo = formatYearRange(franchise.yearStart, franchise.yearEnd);
+          }
+
+          // Use the latest watchedAt from any season in the franchise
+          const dates = franchise.items
+            .map((i) => i.watchedAt)
+            .filter((d): d is string => d != null)
+            .sort((a, b) => b.localeCompare(a));
+
+          return {
+            key: `simkl-franchise-${franchise.key}`,
+            meta,
+            date: dates.length > 0 ? parseTs(dates[0]) : null,
+          };
+        })
+        .filter((x): x is WatchlistMerged => x !== null);
+    }
+
+    const targetType = subTab === "movies" ? "movie" : "show";
     return Object.values(cache.items)
       .filter((item) => {
         if (item.type !== targetType) return false;

--- a/src/views/library/simkl-tab.tsx
+++ b/src/views/library/simkl-tab.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { fetchWatchedHistory, type SimklHistoryItem } from "@/lib/simkl/history";
-import { fetchWatchlist } from "@/lib/simkl/watchlist";
-import { simklItemToMeta } from "@/lib/simkl/to-meta";
-import type { SimklItem } from "@/lib/simkl/types";
 import { useSettings } from "@/lib/settings";
 import { useT } from "@/lib/i18n";
+import { getLocalCache, syncWatchlistCache, type SimklCacheItem, type SimklCache } from "@/lib/simkl/activities";
+import type { Meta } from "@/lib/cinemeta";
 import {
-  applyFilter,
-  countByType,
   FilterBar,
   GroupedGrid,
   parseTs,
@@ -15,84 +11,280 @@ import {
   sortedGroups,
   type TypeKey,
   type WatchlistMerged,
+  countByType,
+  applyFilter,
 } from "./shared";
 
-function historyToDated(items: SimklHistoryItem[]): WatchlistMerged[] {
-  const seen = new Set<string>();
-  const out: WatchlistMerged[] = [];
-  for (const h of items) {
-    const id =
-      h.type === "movie"
-        ? h.imdb ?? (h.tmdb ? `tmdb:movie:${h.tmdb}` : null)
-        : h.showImdb ?? (h.showTmdb ? `tmdb:tv:${h.showTmdb}` : null);
-    if (!id || seen.has(id)) continue;
-    seen.add(id);
-    out.push({
-      key: `sh-${id}`,
-      meta: { id, type: h.type === "movie" ? "movie" : "series", name: h.title },
-      date: parseTs(h.watchedAt),
-    });
+const STATUS_LABELS: Record<string, string> = {
+  watching: "Watching",
+  plantowatch: "Plan to Watch",
+  completed: "Completed",
+  hold: "On Hold",
+  dropped: "Dropped",
+};
+
+function isStatusEnabled(
+  subTab: "movies" | "shows" | "anime",
+  status: string,
+  filters: any
+): boolean {
+  const group = filters[subTab];
+  if (!group) return false;
+  return !!group[status];
+}
+
+function cacheItemToMeta(item: SimklCacheItem, cache: SimklCache): Meta | null {
+  let id: string | null = null;
+  const simklId = item.simklId;
+
+  // 1. Search imdbToSimkl mapping
+  const imdbId = Object.keys(cache.imdbToSimkl).find((k) => cache.imdbToSimkl[k] === simklId);
+  if (imdbId) {
+    id = imdbId;
+  } else {
+    // 2. Search tmdbToSimkl mapping
+    const tmdbKey = Object.keys(cache.tmdbToSimkl).find((k) => cache.tmdbToSimkl[k] === simklId);
+    if (tmdbKey) {
+      const parts = tmdbKey.split(":");
+      if (parts.length === 2) {
+        id = `tmdb:${parts[0]}:${parts[1]}`;
+      }
+    }
   }
-  return out;
+
+  // 3. Search malToSimkl mapping
+  if (!id) {
+    const malId = Object.keys(cache.malToSimkl).find((k) => cache.malToSimkl[k] === simklId);
+    if (malId) id = `mal:${malId}`;
+  }
+  // 4. Search kitsuToSimkl mapping
+  if (!id) {
+    const kitsuId = Object.keys(cache.kitsuToSimkl).find((k) => cache.kitsuToSimkl[k] === simklId);
+    if (kitsuId) id = `kitsu:${kitsuId}`;
+  }
+
+  if (!id) return null;
+
+  return {
+    id,
+    type: item.type === "movie" ? "movie" : "series",
+    name: item.title || "Unknown Title",
+    releaseInfo: item.year ? String(item.year) : undefined,
+  };
 }
 
 export function SimklTab() {
   const tr = useT();
   const { settings } = useSettings();
-  const [watchlist, setWatchlist] = useState<SimklItem[]>([]);
-  const [history, setHistory] = useState<SimklHistoryItem[]>([]);
+  const [cache, setCache] = useState<SimklCache | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 
   useEffect(() => {
     let cancelled = false;
-    setStatus("loading");
-    Promise.all([fetchWatchlist(), fetchWatchedHistory(200)])
-      .then(([w, h]) => {
+    
+    const initial = getLocalCache();
+    if (initial) {
+      setCache(initial);
+      setStatus("ready");
+    } else {
+      setStatus("loading");
+    }
+
+    syncWatchlistCache()
+      .then((updated) => {
         if (cancelled) return;
-        setWatchlist(w);
-        setHistory(h);
+        setCache(updated);
         setStatus("ready");
       })
       .catch(() => {
-        if (!cancelled) setStatus("error");
+        if (!cancelled && !initial) setStatus("error");
       });
+
     return () => {
       cancelled = true;
     };
   }, []);
 
-  const watchlistEntries = useMemo<WatchlistMerged[]>(
-    () =>
-      watchlist
-        .map((t) => {
-          const meta = simklItemToMeta(t);
-          if (!meta) return null;
-          return { key: `sw-${meta.id}`, meta, date: parseTs(t.watchedAt) };
-        })
-        .filter((x): x is WatchlistMerged => !!x),
-    [watchlist],
-  );
-  const historyEntries = useMemo(() => historyToDated(history), [history]);
+  const isMoviesVisible = Object.values(settings.simklGranularFilters.movies).some((v) => v);
+  const isShowsVisible = Object.values(settings.simklGranularFilters.shows).some((v) => v);
+  const isAnimeVisible = Object.values(settings.simklGranularFilters.anime).some((v) => v);
+
+  const initialSubTab = useMemo(() => {
+    if (isMoviesVisible) return "movies";
+    if (isShowsVisible) return "shows";
+    if (isAnimeVisible) return "anime";
+    return "movies";
+  }, [isMoviesVisible, isShowsVisible, isAnimeVisible]);
+
+  const [subTab, setSubTab] = useState<"movies" | "shows" | "anime">("movies");
+
+  // Keep subTab updated if the active one gets hidden
+  useEffect(() => {
+    const isCurrentVisible =
+      subTab === "movies" ? isMoviesVisible : subTab === "shows" ? isShowsVisible : isAnimeVisible;
+    if (!isCurrentVisible) {
+      setSubTab(initialSubTab);
+    }
+  }, [initialSubTab, subTab, isMoviesVisible, isShowsVisible, isAnimeVisible]);
+
+  const allowedStatuses = useMemo(() => {
+    if (subTab === "movies") {
+      return ["plantowatch", "completed", "dropped"] as const;
+    }
+    return ["watching", "plantowatch", "completed", "hold", "dropped"] as const;
+  }, [subTab]);
+
+  const [statusFilter, setStatusFilter] = useState<string>("plantowatch");
+
+  // Keep statusFilter aligned when changing sub-tabs or filters
+  useEffect(() => {
+    const isCurrentAllowedAndEnabled =
+      (allowedStatuses as readonly string[]).includes(statusFilter) &&
+      isStatusEnabled(subTab, statusFilter, settings.simklGranularFilters);
+
+    if (!isCurrentAllowedAndEnabled) {
+      const firstActive = allowedStatuses.find((s) =>
+        isStatusEnabled(subTab, s, settings.simklGranularFilters)
+      );
+      if (firstActive) {
+        setStatusFilter(firstActive);
+      }
+    }
+  }, [subTab, settings.simklGranularFilters, allowedStatuses, statusFilter]);
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    if (!cache) return counts;
+
+    const targetType = subTab === "movies" ? "movie" : subTab === "shows" ? "show" : "anime";
+    for (const item of Object.values(cache.items)) {
+      if (item.type !== targetType) continue;
+      const meta = cacheItemToMeta(item, cache);
+      if (!meta) continue;
+
+      counts[item.status] = (counts[item.status] ?? 0) + 1;
+    }
+    return counts;
+  }, [cache, subTab]);
 
   const [type, setType] = useState<TypeKey>("all");
   const [query, setQuery] = useState("");
-  const combined = useMemo(
-    () => [...watchlistEntries, ...historyEntries],
-    [watchlistEntries, historyEntries],
-  );
-  const counts = useMemo(() => countByType(combined), [combined]);
-  const visibleW = useMemo(
-    () => applyFilter(watchlistEntries, type, query),
-    [watchlistEntries, type, query],
-  );
-  const visibleH = useMemo(
-    () => applyFilter(historyEntries, type, query),
-    [historyEntries, type, query],
-  );
+
+  const filteredItems = useMemo<WatchlistMerged[]>(() => {
+    if (!cache) return [];
+    const targetType = subTab === "movies" ? "movie" : subTab === "shows" ? "show" : "anime";
+
+    return Object.values(cache.items)
+      .filter((item) => {
+        if (item.type !== targetType) return false;
+        if (item.status !== statusFilter) return false;
+
+        const isEnabled = isStatusEnabled(subTab, item.status, settings.simklGranularFilters);
+        if (!isEnabled) return false;
+        return true;
+      })
+      .map((item) => {
+        const meta = cacheItemToMeta(item, cache);
+        if (!meta) return null;
+        return {
+          key: `simkl-${item.simklId}`,
+          meta,
+          date: item.watchedAt ? parseTs(item.watchedAt) : null,
+        };
+      })
+      .filter((x): x is WatchlistMerged => x !== null);
+  }, [cache, subTab, statusFilter, settings.simklGranularFilters]);
+
+  const counts = useMemo(() => countByType(filteredItems), [filteredItems]);
+  const visible = useMemo(() => applyFilter(filteredItems, type, query), [filteredItems, type, query]);
+
+  const allDisabled = !isMoviesVisible && !isShowsVisible && !isAnimeVisible;
+
+  if (allDisabled) {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-edge-soft bg-canvas/30 px-8 py-16 text-center">
+        <h2 className="text-[16px] font-semibold text-ink">{tr("All SIMKL sync filters are disabled")}</h2>
+        <p className="max-w-md text-[13px] leading-relaxed text-ink-muted">
+          {tr("Enable at least one watchlist status toggle in Settings to view your SIMKL library here.")}
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <section className="flex flex-col gap-10">
-      {watchlistEntries.length + historyEntries.length > 0 && (
+    <section className="flex flex-col gap-6">
+      {/* Sub-tabs Selector */}
+      <div className="flex gap-2 border-b border-edge-soft/60 pb-3">
+        {isMoviesVisible && (
+          <button
+            type="button"
+            onClick={() => setSubTab("movies")}
+            className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
+              subTab === "movies"
+                ? "bg-accent/15 text-accent border border-accent/30"
+                : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
+            }`}
+          >
+            {tr("Movies")}
+          </button>
+        )}
+        {isShowsVisible && (
+          <button
+            type="button"
+            onClick={() => setSubTab("shows")}
+            className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
+              subTab === "shows"
+                ? "bg-accent/15 text-accent border border-accent/30"
+                : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
+            }`}
+          >
+            {tr("TV Shows")}
+          </button>
+        )}
+        {isAnimeVisible && (
+          <button
+            type="button"
+            onClick={() => setSubTab("anime")}
+            className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
+              subTab === "anime"
+                ? "bg-accent/15 text-accent border border-accent/30"
+                : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
+            }`}
+          >
+            {tr("Anime")}
+          </button>
+        )}
+      </div>
+
+      {/* Status Pills */}
+      <div className="flex flex-wrap gap-2">
+        {allowedStatuses.map((statusKey) => {
+          const isEnabled = isStatusEnabled(subTab, statusKey, settings.simklGranularFilters);
+          if (!isEnabled) return null;
+
+          const count = statusCounts[statusKey] ?? 0;
+          const isActive = statusFilter === statusKey;
+
+          return (
+            <button
+              key={statusKey}
+              type="button"
+              onClick={() => setStatusFilter(statusKey)}
+              className={`rounded-full px-4 py-1.5 text-[13px] font-medium transition-all ${
+                isActive
+                  ? "bg-ink text-canvas font-semibold shadow-[0_2px_8px_rgba(0,0,0,0.15)]"
+                  : "bg-canvas/50 border border-edge-soft text-ink-muted hover:border-edge hover:text-ink"
+              }`}
+            >
+              {tr(STATUS_LABELS[statusKey])}
+              <span className="ms-1.5 text-[11px] opacity-70">({count})</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Search and Filters */}
+      {filteredItems.length > 0 && (
         <FilterBar
           type={type}
           setType={setType}
@@ -102,46 +294,24 @@ export function SimklTab() {
           trailing={<SortControl />}
         />
       )}
-      <div className="flex flex-col gap-4">
-        <div className="flex items-baseline gap-3">
-          <h2 className="text-[18px] font-semibold text-ink">{tr("Simkl plan to watch")}</h2>
-          <span className="text-[12px] text-ink-muted">
-            {tr("{shown} of {total}", { shown: visibleW.length, total: watchlistEntries.length })}
-          </span>
-        </div>
-        {status === "loading" ? (
-          <p className="text-[13px] text-ink-muted">{tr("Loading…")}</p>
-        ) : visibleW.length === 0 ? (
-          <p className="text-[13px] text-ink-muted">
-            {watchlistEntries.length === 0
-              ? tr("Nothing on your Simkl plan-to-watch yet.")
-              : tr("No matches for these filters.")}
-          </p>
-        ) : (
-          <GroupedGrid groups={sortedGroups(visibleW, settings.librarySort)} />
-        )}
-      </div>
-      <div className="flex flex-col gap-4">
-        <div className="flex items-baseline gap-3">
-          <h2 className="text-[18px] font-semibold text-ink">{tr("Simkl history")}</h2>
-          <span className="text-[12px] text-ink-muted">
-            {tr("{shown} of {total}", { shown: visibleH.length, total: historyEntries.length })}
-          </span>
-        </div>
-        {status === "loading" ? (
-          <p className="text-[13px] text-ink-muted">{tr("Loading…")}</p>
-        ) : visibleH.length === 0 ? (
-          <p className="text-[13px] text-ink-muted">
-            {historyEntries.length === 0 ? tr("No Simkl history yet.") : tr("No matches for these filters.")}
-          </p>
-        ) : (
-          <GroupedGrid groups={sortedGroups(visibleH, settings.librarySort)} />
-        )}
-      </div>
+
+      {status === "loading" && <p className="text-[13px] text-ink-muted">{tr("Loading…")}</p>}
       {status === "error" && (
         <p className="rounded-lg bg-danger/15 px-3 py-2 text-[12px] text-danger ring-1 ring-danger/30">
           {tr("Couldn't reach Simkl. Try refreshing.")}
         </p>
+      )}
+
+      {status === "ready" && visible.length === 0 && (
+        <p className="text-[13px] text-ink-muted">
+          {filteredItems.length === 0
+            ? tr("No items found in this section.")
+            : tr("No matches for these filters.")}
+        </p>
+      )}
+
+      {visible.length > 0 && (
+        <GroupedGrid groups={sortedGroups(visible, settings.librarySort)} />
       )}
     </section>
   );

--- a/src/views/library/simkl-tab.tsx
+++ b/src/views/library/simkl-tab.tsx
@@ -23,16 +23,6 @@ const STATUS_LABELS: Record<string, string> = {
   dropped: "Dropped",
 };
 
-function isStatusEnabled(
-  subTab: "movies" | "shows" | "anime",
-  status: string,
-  filters: any
-): boolean {
-  const group = filters[subTab];
-  if (!group) return false;
-  return !!group[status];
-}
-
 function cacheItemToMeta(item: SimklCacheItem, cache: SimklCache): Meta | null {
   let id: string | null = null;
   const simklId = item.simklId;
@@ -105,27 +95,7 @@ export function SimklTab() {
     };
   }, []);
 
-  const isMoviesVisible = Object.values(settings.simklGranularFilters.movies).some((v) => v);
-  const isShowsVisible = Object.values(settings.simklGranularFilters.shows).some((v) => v);
-  const isAnimeVisible = Object.values(settings.simklGranularFilters.anime).some((v) => v);
-
-  const initialSubTab = useMemo(() => {
-    if (isMoviesVisible) return "movies";
-    if (isShowsVisible) return "shows";
-    if (isAnimeVisible) return "anime";
-    return "movies";
-  }, [isMoviesVisible, isShowsVisible, isAnimeVisible]);
-
   const [subTab, setSubTab] = useState<"movies" | "shows" | "anime">("movies");
-
-  // Keep subTab updated if the active one gets hidden
-  useEffect(() => {
-    const isCurrentVisible =
-      subTab === "movies" ? isMoviesVisible : subTab === "shows" ? isShowsVisible : isAnimeVisible;
-    if (!isCurrentVisible) {
-      setSubTab(initialSubTab);
-    }
-  }, [initialSubTab, subTab, isMoviesVisible, isShowsVisible, isAnimeVisible]);
 
   const allowedStatuses = useMemo(() => {
     if (subTab === "movies") {
@@ -136,21 +106,12 @@ export function SimklTab() {
 
   const [statusFilter, setStatusFilter] = useState<string>("plantowatch");
 
-  // Keep statusFilter aligned when changing sub-tabs or filters
+  // Keep statusFilter aligned when changing sub-tabs
   useEffect(() => {
-    const isCurrentAllowedAndEnabled =
-      (allowedStatuses as readonly string[]).includes(statusFilter) &&
-      isStatusEnabled(subTab, statusFilter, settings.simklGranularFilters);
-
-    if (!isCurrentAllowedAndEnabled) {
-      const firstActive = allowedStatuses.find((s) =>
-        isStatusEnabled(subTab, s, settings.simklGranularFilters)
-      );
-      if (firstActive) {
-        setStatusFilter(firstActive);
-      }
+    if (!(allowedStatuses as readonly string[]).includes(statusFilter)) {
+      setStatusFilter(allowedStatuses[0]);
     }
-  }, [subTab, settings.simklGranularFilters, allowedStatuses, statusFilter]);
+  }, [subTab, allowedStatuses, statusFilter]);
 
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -178,9 +139,6 @@ export function SimklTab() {
       .filter((item) => {
         if (item.type !== targetType) return false;
         if (item.status !== statusFilter) return false;
-
-        const isEnabled = isStatusEnabled(subTab, item.status, settings.simklGranularFilters);
-        if (!isEnabled) return false;
         return true;
       })
       .map((item) => {
@@ -193,75 +151,53 @@ export function SimklTab() {
         };
       })
       .filter((x): x is WatchlistMerged => x !== null);
-  }, [cache, subTab, statusFilter, settings.simklGranularFilters]);
+  }, [cache, subTab, statusFilter]);
 
   const counts = useMemo(() => countByType(filteredItems), [filteredItems]);
   const visible = useMemo(() => applyFilter(filteredItems, type, query), [filteredItems, type, query]);
-
-  const allDisabled = !isMoviesVisible && !isShowsVisible && !isAnimeVisible;
-
-  if (allDisabled) {
-    return (
-      <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-edge-soft bg-canvas/30 px-8 py-16 text-center">
-        <h2 className="text-[16px] font-semibold text-ink">{tr("All SIMKL sync filters are disabled")}</h2>
-        <p className="max-w-md text-[13px] leading-relaxed text-ink-muted">
-          {tr("Enable at least one watchlist status toggle in Settings to view your SIMKL library here.")}
-        </p>
-      </div>
-    );
-  }
 
   return (
     <section className="flex flex-col gap-6">
       {/* Sub-tabs Selector */}
       <div className="flex gap-2 border-b border-edge-soft/60 pb-3">
-        {isMoviesVisible && (
-          <button
-            type="button"
-            onClick={() => setSubTab("movies")}
-            className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
-              subTab === "movies"
-                ? "bg-accent/15 text-accent border border-accent/30"
-                : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
-            }`}
-          >
-            {tr("Movies")}
-          </button>
-        )}
-        {isShowsVisible && (
-          <button
-            type="button"
-            onClick={() => setSubTab("shows")}
-            className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
-              subTab === "shows"
-                ? "bg-accent/15 text-accent border border-accent/30"
-                : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
-            }`}
-          >
-            {tr("TV Shows")}
-          </button>
-        )}
-        {isAnimeVisible && (
-          <button
-            type="button"
-            onClick={() => setSubTab("anime")}
-            className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
-              subTab === "anime"
-                ? "bg-accent/15 text-accent border border-accent/30"
-                : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
-            }`}
-          >
-            {tr("Anime")}
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={() => setSubTab("movies")}
+          className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
+            subTab === "movies"
+              ? "bg-accent/15 text-accent border border-accent/30"
+              : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
+          }`}
+        >
+          {tr("Movies")}
+        </button>
+        <button
+          type="button"
+          onClick={() => setSubTab("shows")}
+          className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
+            subTab === "shows"
+              ? "bg-accent/15 text-accent border border-accent/30"
+              : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
+          }`}
+        >
+          {tr("TV Shows")}
+        </button>
+        <button
+          type="button"
+          onClick={() => setSubTab("anime")}
+          className={`rounded-lg px-4 py-2 text-[14px] font-semibold transition-all ${
+            subTab === "anime"
+              ? "bg-accent/15 text-accent border border-accent/30"
+              : "text-ink-muted hover:text-ink border border-transparent hover:bg-canvas/50"
+          }`}
+        >
+          {tr("Anime")}
+        </button>
       </div>
 
       {/* Status Pills */}
       <div className="flex flex-wrap gap-2">
         {allowedStatuses.map((statusKey) => {
-          const isEnabled = isStatusEnabled(subTab, statusKey, settings.simklGranularFilters);
-          if (!isEnabled) return null;
-
           const count = statusCounts[statusKey] ?? 0;
           const isActive = statusFilter === statusKey;
 
@@ -292,6 +228,7 @@ export function SimklTab() {
           setQuery={setQuery}
           counts={counts}
           trailing={<SortControl />}
+          hideTypePills={true}
         />
       )}
 

--- a/src/views/settings/library-panel.tsx
+++ b/src/views/settings/library-panel.tsx
@@ -80,6 +80,7 @@ export function LibraryPanel({
     showMdblist: settings.showMdblistBadge && !!settings.mdblistKey,
     showTrakt: settings.showTraktBadge && !!settings.mdblistKey,
     showMal: settings.showMalBadge,
+    showSimkl: settings.showSimklBadge,
   };
   const enabledBadgeCount =
     (badgeFlags.showImdb || badgeFlags.showTmdb || badgeFlags.showMal ? 1 : 0) +
@@ -88,7 +89,8 @@ export function LibraryPanel({
     (badgeFlags.showMetacritic ? 1 : 0) +
     (badgeFlags.showLetterboxd ? 1 : 0) +
     (badgeFlags.showMdblist ? 1 : 0) +
-    (badgeFlags.showTrakt ? 1 : 0);
+    (badgeFlags.showTrakt ? 1 : 0) +
+    (badgeFlags.showSimkl ? 1 : 0);
 
   const prevBadgeCountRef = useRef(enabledBadgeCount);
   useEffect(() => {
@@ -664,11 +666,10 @@ export function LibraryPanel({
             />
             <ToggleRow
               label={t("Show SIMKL score on cards")}
-              sub={t("SIMKL community rating out of 10.")}
+              sub={t("SIMKL community rating. Works independently — no API key required.")}
               leading={<SimklBadge />}
               value={settings.showSimklBadge}
               onChange={(v) => update({ showSimklBadge: v, simklShowCommunityRatings: v })}
-              lockReason={!settings.mdblistKey ? t("Add an MDBList API key to unlock this.") : undefined}
             />
             <ToggleRow
               label={t("Mark watched button")}
@@ -864,6 +865,7 @@ type PreviewFlags = {
   showMdblist: boolean;
   showTrakt: boolean;
   showMal: boolean;
+  showSimkl: boolean;
 };
 
 function previewExtras(f: PreviewFlags): React.ReactNode[] {
@@ -900,6 +902,13 @@ function previewExtras(f: PreviewFlags): React.ReactNode[] {
       <span className="flex items-center gap-0.5">
         <img src={traktLogo} alt="" className="h-[10px] w-[10px] object-contain" />
         <span>88%</span>
+      </span>,
+    );
+  if (f.showSimkl)
+    out.push(
+      <span className="flex items-center gap-0.5">
+        <img src={simklLogo} alt="" className="h-[10px] w-[10px] rounded-[2px] object-contain" />
+        <span>8.5</span>
       </span>,
     );
   return out;

--- a/src/views/settings/library-panel.tsx
+++ b/src/views/settings/library-panel.tsx
@@ -3,6 +3,7 @@ import fanartLogo from "@/assets/addon-logos/fanarttv.svg";
 import mdblistLogo from "@/assets/addon-logos/mdblist.png";
 import letterboxdLogo from "@/assets/addon-logos/letterboxd.png";
 import traktLogo from "@/assets/trakt.svg";
+import simklLogo from "@/assets/simkl.png";
 import harborStyleImg from "@/assets/onboarding/harborstyle.png";
 import traditionalStyleImg from "@/assets/onboarding/traditional.png";
 import omdbLogo from "@/assets/addon-logos/omdb.png";
@@ -662,6 +663,14 @@ export function LibraryPanel({
               lockReason={!settings.mdblistKey ? t("Add an MDBList API key to unlock this.") : undefined}
             />
             <ToggleRow
+              label={t("Show SIMKL score on cards")}
+              sub={t("SIMKL community rating out of 10.")}
+              leading={<SimklBadge />}
+              value={settings.showSimklBadge}
+              onChange={(v) => update({ showSimklBadge: v, simklShowCommunityRatings: v })}
+              lockReason={!settings.mdblistKey ? t("Add an MDBList API key to unlock this.") : undefined}
+            />
+            <ToggleRow
               label={t("Mark watched button")}
               sub={t("Show a button on the detail page to mark a title or episode as watched. Syncs to Trakt and Simkl if connected.")}
               value={settings.showWatchedButton}
@@ -839,6 +848,10 @@ function MdblistBadge() {
 
 function TraktBadge() {
   return <img src={traktLogo} alt="" className="h-7 w-7 shrink-0 object-contain" />;
+}
+
+function SimklBadge() {
+  return <img src={simklLogo} alt="" className="h-7 w-7 shrink-0 rounded-md object-contain" />;
 }
 
 type PreviewFlags = {

--- a/src/views/settings/simkl-panel.tsx
+++ b/src/views/settings/simkl-panel.tsx
@@ -173,6 +173,21 @@ export function SimklPanel() {
               value={settings.simklEnableUserRatings}
               onChange={(val) => update({ simklEnableUserRatings: val })}
             />
+            <div className="flex flex-col gap-1.5 pt-1">
+              <p className="text-[13px] font-medium text-ink">{t("Anime Title Language")}</p>
+              <p className="text-[12px] leading-relaxed text-ink-subtle">
+                {t("Preferred language for anime titles displayed on poster cards.")}
+              </p>
+              <select
+                value={settings.simklAnimeTitleLanguage}
+                onChange={(e) => update({ simklAnimeTitleLanguage: e.target.value as "english" | "romaji" | "native" })}
+                className="h-11 w-full max-w-[340px] rounded-xl border border-edge-soft bg-canvas/40 px-3.5 text-[13.5px] text-ink outline-none transition-colors hover:border-edge focus:border-accent cursor-pointer"
+              >
+                <option value="english" className="bg-elevated text-ink">{t("English")}</option>
+                <option value="romaji" className="bg-elevated text-ink">{t("Romaji")}</option>
+                <option value="native" className="bg-elevated text-ink">{t("Native/Japanese")}</option>
+              </select>
+            </div>
             {!confirmDisconnect ? (
               <button
                 onClick={() => setConfirmDisconnect(true)}
@@ -208,6 +223,7 @@ export function SimklPanel() {
                         simklUpNextRailEnabled: true,
                         simklTrendingRailEnabled: true,
                         showSimklBadge: true,
+                        simklAnimeTitleLanguage: "english",
                         simklGranularFilters: {
                           movies: { plantowatch: true },
                           shows: { watching: true, plantowatch: true },

--- a/src/views/settings/simkl-panel.tsx
+++ b/src/views/settings/simkl-panel.tsx
@@ -10,6 +10,8 @@ import { useT } from "@/lib/i18n";
 import { Section, ToggleRow } from "./shared";
 import { clearCalendarCache } from "@/lib/simkl/calendar";
 import { clearHomeRailsCache } from "@/lib/simkl/home-rails";
+import { clearCalendarSourceCache } from "@/lib/calendar-sources";
+import { clearAnimeGroupingCache } from "@/lib/simkl/anime-grouping";
 
 export function SimklPanel() {
   const t = useT();
@@ -142,6 +144,18 @@ export function SimklPanel() {
               onChange={(val) => update({ simklHomeRailsEnabled: val })}
             />
             <ToggleRow
+              label={t("Show Up Next on Simkl rail")}
+              sub={t("Display upcoming episodes from your watching and plan-to-watch lists.")}
+              value={settings.simklUpNextRailEnabled}
+              onChange={(val) => update({ simklUpNextRailEnabled: val })}
+            />
+            <ToggleRow
+              label={t("Show Simkl Trending Today rail")}
+              sub={t("Display today's trending movies, TV shows, and anime from Simkl.")}
+              value={settings.simklTrendingRailEnabled}
+              onChange={(val) => update({ simklTrendingRailEnabled: val })}
+            />
+            <ToggleRow
               label={t("Scrobble to SIMKL")}
               sub={t("Automatically track what you are playing and save watch progress in real-time.")}
               value={settings.simklScrobbleEnabled}
@@ -188,19 +202,22 @@ export function SimklPanel() {
                         useSimklAvatar: false,
                         harborAvatar: null,
                         simklScrobbleEnabled: true,
-                        simklCalendarPremieresEnabled: true,
                         simklShowCommunityRatings: true,
                         simklEnableUserRatings: true,
                         simklHomeRailsEnabled: true,
+                        simklUpNextRailEnabled: true,
+                        simklTrendingRailEnabled: true,
                         showSimklBadge: true,
                         simklGranularFilters: {
-                          movies: { plantowatch: true, completed: true, dropped: true },
-                          shows: { watching: true, plantowatch: true, completed: true, hold: true, dropped: true },
-                          anime: { watching: true, plantowatch: true, completed: true, hold: true, dropped: true },
+                          movies: { plantowatch: true },
+                          shows: { watching: true, plantowatch: true },
+                          anime: { watching: true, plantowatch: true },
                         },
                       });
                       clearCalendarCache();
                       clearHomeRailsCache();
+                      clearCalendarSourceCache();
+                      clearAnimeGroupingCache();
                       disconnect();
                       setConfirmDisconnect(false);
                     }}
@@ -215,11 +232,11 @@ export function SimklPanel() {
           </Section>
 
           <Section
-            title={t("Granular Sync Settings")}
-            subtitle={t("Choose which list categories and statuses sync to your library.")}
+            title={t("Home Rail Settings")}
+            subtitle={t("Choose which Simkl rails appear on your home screen.")}
           >
             <div className="flex flex-col gap-6">
-              {/* Movies Granular */}
+              {/* Movies */}
               <div className="flex flex-col gap-2 rounded-xl border border-edge-soft/60 bg-canvas/30 p-4">
                 <h3 className="text-[14px] font-bold text-ink">{t("Movies")}</h3>
                 <ToggleRow
@@ -234,33 +251,9 @@ export function SimklPanel() {
                     })
                   }
                 />
-                <ToggleRow
-                  label={t("Completed")}
-                  value={settings.simklGranularFilters.movies.completed}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        movies: { ...settings.simklGranularFilters.movies, completed: val },
-                      },
-                    })
-                  }
-                />
-                <ToggleRow
-                  label={t("Dropped")}
-                  value={settings.simklGranularFilters.movies.dropped}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        movies: { ...settings.simklGranularFilters.movies, dropped: val },
-                      },
-                    })
-                  }
-                />
               </div>
 
-              {/* TV Shows Granular */}
+              {/* TV Shows */}
               <div className="flex flex-col gap-2 rounded-xl border border-edge-soft/60 bg-canvas/30 p-4">
                 <h3 className="text-[14px] font-bold text-ink">{t("TV Shows")}</h3>
                 <ToggleRow
@@ -287,45 +280,9 @@ export function SimklPanel() {
                     })
                   }
                 />
-                <ToggleRow
-                  label={t("Completed")}
-                  value={settings.simklGranularFilters.shows.completed}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        shows: { ...settings.simklGranularFilters.shows, completed: val },
-                      },
-                    })
-                  }
-                />
-                <ToggleRow
-                  label={t("On Hold")}
-                  value={settings.simklGranularFilters.shows.hold}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        shows: { ...settings.simklGranularFilters.shows, hold: val },
-                      },
-                    })
-                  }
-                />
-                <ToggleRow
-                  label={t("Dropped")}
-                  value={settings.simklGranularFilters.shows.dropped}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        shows: { ...settings.simklGranularFilters.shows, dropped: val },
-                      },
-                    })
-                  }
-                />
               </div>
 
-              {/* Anime Granular */}
+              {/* Anime */}
               <div className="flex flex-col gap-2 rounded-xl border border-edge-soft/60 bg-canvas/30 p-4">
                 <h3 className="text-[14px] font-bold text-ink">{t("Anime")}</h3>
                 <ToggleRow
@@ -348,42 +305,6 @@ export function SimklPanel() {
                       simklGranularFilters: {
                         ...settings.simklGranularFilters,
                         anime: { ...settings.simklGranularFilters.anime, plantowatch: val },
-                      },
-                    })
-                  }
-                />
-                <ToggleRow
-                  label={t("Completed")}
-                  value={settings.simklGranularFilters.anime.completed}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        anime: { ...settings.simklGranularFilters.anime, completed: val },
-                      },
-                    })
-                  }
-                />
-                <ToggleRow
-                  label={t("On Hold")}
-                  value={settings.simklGranularFilters.anime.hold}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        anime: { ...settings.simklGranularFilters.anime, hold: val },
-                      },
-                    })
-                  }
-                />
-                <ToggleRow
-                  label={t("Dropped")}
-                  value={settings.simklGranularFilters.anime.dropped}
-                  onChange={(val) =>
-                    update({
-                      simklGranularFilters: {
-                        ...settings.simklGranularFilters,
-                        anime: { ...settings.simklGranularFilters.anime, dropped: val },
                       },
                     })
                   }

--- a/src/views/settings/simkl-panel.tsx
+++ b/src/views/settings/simkl-panel.tsx
@@ -8,6 +8,8 @@ import { useSimkl } from "@/lib/simkl/provider";
 import { openUrl } from "@/lib/window";
 import { useT } from "@/lib/i18n";
 import { Section, ToggleRow } from "./shared";
+import { clearCalendarCache } from "@/lib/simkl/calendar";
+import { clearHomeRailsCache } from "@/lib/simkl/home-rails";
 
 export function SimklPanel() {
   const t = useT();
@@ -83,93 +85,313 @@ export function SimklPanel() {
           </div>
         </section>
       ) : (
-        <Section
-          title={t("Connected")}
-          subtitle={t("Harbor will mark what you finish as watched on Simkl and sync your plan-to-watch list.")}
-        >
-          <div className="flex items-center justify-between gap-4 rounded-xl border border-edge-soft bg-canvas/40 px-4 py-3">
-            <div className="flex items-center gap-3">
-              {simklAvatar ? (
-                <img
-                  src={simklAvatar}
-                  alt=""
-                  draggable={false}
-                  className="h-10 w-10 shrink-0 rounded-full object-cover ring-1 ring-edge"
-                />
-              ) : (
-                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-400/12 ring-1 ring-emerald-400/30 text-emerald-300">
-                  <Check size={16} strokeWidth={2.4} />
-                </span>
+        <>
+          <Section
+            title={t("Connected")}
+            subtitle={t("Harbor will mark what you finish as watched on Simkl and sync your plan-to-watch list.")}
+          >
+            <div className="flex items-center justify-between gap-4 rounded-xl border border-edge-soft bg-canvas/40 px-4 py-3">
+              <div className="flex items-center gap-3">
+                {simklAvatar ? (
+                  <img
+                    src={simklAvatar}
+                    alt=""
+                    draggable={false}
+                    className="h-10 w-10 shrink-0 rounded-full object-cover ring-1 ring-edge"
+                  />
+                ) : (
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-400/12 ring-1 ring-emerald-400/30 text-emerald-300">
+                    <Check size={16} strokeWidth={2.4} />
+                  </span>
+                )}
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-[14px] font-medium text-ink">{username || t("Connected")}</span>
+                  <span className="text-[12px] text-ink-subtle">{t("Authorized on this device")}</span>
+                </div>
+              </div>
+              {username && (
+                <button
+                  onClick={() => openUrl(`https://simkl.com/${encodeURIComponent(username)}`)}
+                  className="flex h-9 items-center gap-1.5 rounded-lg border border-edge-soft px-3 text-[12.5px] font-medium text-ink-muted transition-colors hover:border-edge hover:text-ink"
+                >
+                  {t("Open profile")}
+                  <ExternalLink size={11} strokeWidth={2.2} />
+                </button>
               )}
-              <div className="flex flex-col gap-0.5">
-                <span className="text-[14px] font-medium text-ink">{username || t("Connected")}</span>
-                <span className="text-[12px] text-ink-subtle">{t("Authorized on this device")}</span>
-              </div>
             </div>
-            {username && (
-              <button
-                onClick={() => openUrl(`https://simkl.com/${encodeURIComponent(username)}`)}
-                className="flex h-9 items-center gap-1.5 rounded-lg border border-edge-soft px-3 text-[12.5px] font-medium text-ink-muted transition-colors hover:border-edge hover:text-ink"
-              >
-                {t("Open profile")}
-                <ExternalLink size={11} strokeWidth={2.2} />
-              </button>
+            {simklAvatar && (
+              <ToggleRow
+                label={t("Use my Simkl avatar as my Harbor avatar")}
+                sub={t("Wear your Simkl profile picture across Harbor instead of the default.")}
+                value={settings.useSimklAvatar}
+                onChange={toggleSimklAvatar}
+                leading={
+                  <img
+                    src={simklAvatar}
+                    alt=""
+                    draggable={false}
+                    className="h-9 w-9 rounded-full object-cover"
+                  />
+                }
+              />
             )}
-          </div>
-          {simklAvatar && (
             <ToggleRow
-              label={t("Use my Simkl avatar as my Harbor avatar")}
-              sub={t("Wear your Simkl profile picture across Harbor instead of the default.")}
-              value={settings.useSimklAvatar}
-              onChange={toggleSimklAvatar}
-              leading={
-                <img
-                  src={simklAvatar}
-                  alt=""
-                  draggable={false}
-                  className="h-9 w-9 rounded-full object-cover"
-                />
-              }
+              label={t("Show Simkl rails on Home")}
+              sub={t("Display your Watching, Plan to Watch, Up Next, and Trending rows on the home screen.")}
+              value={settings.simklHomeRailsEnabled}
+              onChange={(val) => update({ simklHomeRailsEnabled: val })}
             />
-          )}
-          {!confirmDisconnect ? (
-            <button
-              onClick={() => setConfirmDisconnect(true)}
-              className="flex items-center gap-2 self-start rounded-lg px-2 py-1.5 text-[12.5px] font-medium text-ink-subtle transition-colors hover:text-red-300"
-            >
-              <Trash2 size={12} />
-              {t("Disconnect from Simkl")}
-            </button>
-          ) : (
-            <div className="flex items-center justify-between gap-3 rounded-lg border border-red-400/30 bg-red-400/5 p-3">
-              <span className="text-[12.5px] text-red-200">
-                {t("Disconnect Simkl? Syncing will stop until you reconnect.")}
-              </span>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => setConfirmDisconnect(false)}
-                  className="rounded-md px-2.5 py-1 text-[12px] text-ink-muted hover:text-ink"
-                >
-                  {t("Cancel")}
-                </button>
-                <button
-                  onClick={() => {
-                    if (settings.useSimklAvatar && settings.harborAvatar === simklAvatar) {
-                      pushAvatar(null);
-                    }
-                    update({ useSimklAvatar: false });
-                    disconnect();
-                    setConfirmDisconnect(false);
-                  }}
-                  className="flex items-center gap-1.5 rounded-md bg-red-400/20 px-3 py-1 text-[12px] font-semibold text-red-200 hover:bg-red-400/30"
-                >
-                  <LogOut size={11} strokeWidth={2.4} />
-                  {t("Disconnect")}
-                </button>
+            <ToggleRow
+              label={t("Scrobble to SIMKL")}
+              sub={t("Automatically track what you are playing and save watch progress in real-time.")}
+              value={settings.simklScrobbleEnabled}
+              onChange={(val) => update({ simklScrobbleEnabled: val })}
+            />
+            <ToggleRow
+              label={t("Display SIMKL Community Ratings")}
+              sub={t("Display SIMKL community score badge on details pages.")}
+              value={settings.simklShowCommunityRatings}
+              onChange={(val) => update({ simklShowCommunityRatings: val })}
+            />
+            <ToggleRow
+              label={t("Enable User Ratings")}
+              sub={t("Allow rating movies, shows, and anime directly using the star picker.")}
+              value={settings.simklEnableUserRatings}
+              onChange={(val) => update({ simklEnableUserRatings: val })}
+            />
+            {!confirmDisconnect ? (
+              <button
+                onClick={() => setConfirmDisconnect(true)}
+                className="flex items-center gap-2 self-start rounded-lg px-2 py-1.5 text-[12.5px] font-medium text-ink-subtle transition-colors hover:text-red-300"
+              >
+                <Trash2 size={12} />
+                {t("Disconnect from Simkl")}
+              </button>
+            ) : (
+              <div className="flex items-center justify-between gap-3 rounded-lg border border-red-400/30 bg-red-400/5 p-3">
+                <span className="text-[12.5px] text-red-200">
+                  {t("Disconnect Simkl? Syncing will stop until you reconnect.")}
+                </span>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setConfirmDisconnect(false)}
+                    className="rounded-md px-2.5 py-1 text-[12px] text-ink-muted hover:text-ink"
+                  >
+                    {t("Cancel")}
+                  </button>
+                  <button
+                    onClick={() => {
+                      if (settings.useSimklAvatar && activeProfile) {
+                        updateProfile(activeProfile.id, { avatar: null });
+                      }
+                      update({
+                        useSimklAvatar: false,
+                        harborAvatar: null,
+                        simklScrobbleEnabled: true,
+                        simklCalendarPremieresEnabled: true,
+                        simklShowCommunityRatings: true,
+                        simklEnableUserRatings: true,
+                        simklHomeRailsEnabled: true,
+                        showSimklBadge: true,
+                        simklGranularFilters: {
+                          movies: { plantowatch: true, completed: true, dropped: true },
+                          shows: { watching: true, plantowatch: true, completed: true, hold: true, dropped: true },
+                          anime: { watching: true, plantowatch: true, completed: true, hold: true, dropped: true },
+                        },
+                      });
+                      clearCalendarCache();
+                      clearHomeRailsCache();
+                      disconnect();
+                      setConfirmDisconnect(false);
+                    }}
+                    className="flex items-center gap-1.5 rounded-md bg-red-400/20 px-3 py-1 text-[12px] font-semibold text-red-200 hover:bg-red-400/30"
+                  >
+                    <LogOut size={11} strokeWidth={2.4} />
+                    {t("Disconnect")}
+                  </button>
+                </div>
+              </div>
+            )}
+          </Section>
+
+          <Section
+            title={t("Granular Sync Settings")}
+            subtitle={t("Choose which list categories and statuses sync to your library.")}
+          >
+            <div className="flex flex-col gap-6">
+              {/* Movies Granular */}
+              <div className="flex flex-col gap-2 rounded-xl border border-edge-soft/60 bg-canvas/30 p-4">
+                <h3 className="text-[14px] font-bold text-ink">{t("Movies")}</h3>
+                <ToggleRow
+                  label={t("Plan to Watch")}
+                  value={settings.simklGranularFilters.movies.plantowatch}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        movies: { ...settings.simklGranularFilters.movies, plantowatch: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Completed")}
+                  value={settings.simklGranularFilters.movies.completed}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        movies: { ...settings.simklGranularFilters.movies, completed: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Dropped")}
+                  value={settings.simklGranularFilters.movies.dropped}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        movies: { ...settings.simklGranularFilters.movies, dropped: val },
+                      },
+                    })
+                  }
+                />
+              </div>
+
+              {/* TV Shows Granular */}
+              <div className="flex flex-col gap-2 rounded-xl border border-edge-soft/60 bg-canvas/30 p-4">
+                <h3 className="text-[14px] font-bold text-ink">{t("TV Shows")}</h3>
+                <ToggleRow
+                  label={t("Watching")}
+                  value={settings.simklGranularFilters.shows.watching}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        shows: { ...settings.simklGranularFilters.shows, watching: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Plan to Watch")}
+                  value={settings.simklGranularFilters.shows.plantowatch}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        shows: { ...settings.simklGranularFilters.shows, plantowatch: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Completed")}
+                  value={settings.simklGranularFilters.shows.completed}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        shows: { ...settings.simklGranularFilters.shows, completed: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("On Hold")}
+                  value={settings.simklGranularFilters.shows.hold}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        shows: { ...settings.simklGranularFilters.shows, hold: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Dropped")}
+                  value={settings.simklGranularFilters.shows.dropped}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        shows: { ...settings.simklGranularFilters.shows, dropped: val },
+                      },
+                    })
+                  }
+                />
+              </div>
+
+              {/* Anime Granular */}
+              <div className="flex flex-col gap-2 rounded-xl border border-edge-soft/60 bg-canvas/30 p-4">
+                <h3 className="text-[14px] font-bold text-ink">{t("Anime")}</h3>
+                <ToggleRow
+                  label={t("Watching")}
+                  value={settings.simklGranularFilters.anime.watching}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        anime: { ...settings.simklGranularFilters.anime, watching: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Plan to Watch")}
+                  value={settings.simklGranularFilters.anime.plantowatch}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        anime: { ...settings.simklGranularFilters.anime, plantowatch: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Completed")}
+                  value={settings.simklGranularFilters.anime.completed}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        anime: { ...settings.simklGranularFilters.anime, completed: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("On Hold")}
+                  value={settings.simklGranularFilters.anime.hold}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        anime: { ...settings.simklGranularFilters.anime, hold: val },
+                      },
+                    })
+                  }
+                />
+                <ToggleRow
+                  label={t("Dropped")}
+                  value={settings.simklGranularFilters.anime.dropped}
+                  onChange={(val) =>
+                    update({
+                      simklGranularFilters: {
+                        ...settings.simklGranularFilters,
+                        anime: { ...settings.simklGranularFilters.anime, dropped: val },
+                      },
+                    })
+                  }
+                />
               </div>
             </div>
-          )}
-        </Section>
+          </Section>
+        </>
       )}
 
       {modalOpen && <SimklDeviceModal onClose={() => setModalOpen(false)} />}


### PR DESCRIPTION
# Full SIMKL API Integration — Delta Sync, Anime Scrobbling, CDN Calendars, Home Rails, Ratings, Library & Franchise Grouping

## Summary
This PR brings Harbor's SIMKL integration to full feature parity with Trakt. It adds a two-phase delta sync engine, anime scrobbling with MAL/Kitsu/AniDB/AniList ID mapping, CDN-based calendars, home discovery rails, detail-page community + user ratings, an expanded library tab with all 5 statuses and grid layout, anime franchise grouping (including movies, expanded normalizations, and Union-Find relations merging), fallback `simkl:` details redirects, and the new Anime Title Language setting.

**37 files changed**, +3,747 / −452 lines, **5 new files** created.

---

## Features

### 1. API Compliance & Delta Sync

#### API Compliance (`client.ts`)
All SIMKL API requests are routed through a centralized `simklRequest()` function that automatically appends:
- **Query params**: `client_id`, `app-name=harbor`, `app-version=0.9.20`
- **Headers**: `User-Agent: harbor/0.9.20`, `Content-Type: application/json` (for POST/PUT)
- **Auth**: `simkl-api-key` header (client ID) + `Authorization: Bearer {token}` when authenticated

OAuth PIN authentication in `device-auth.ts` is routed through the same compliant request function, ensuring PIN code polling and token exchange requests include proper compliance params.

#### Two-Phase Delta Sync (`activities.ts`)
Replaces pulling `/sync/all-items` on every boot with a lightweight activities-polling model:

**Phase 1 — Bootstrap (first login)**:
1. Sequentially fetches `/sync/all-items` for shows, movies, and anime
2. Fetches user ratings from `/sync/ratings`
3. Saves the `/sync/activities` response as the sync checkpoint

**Phase 2 — Delta (subsequent loads)**:
1. Polls `GET /sync/activities` (lightweight — returns timestamp objects only)
2. Compares `activities.all` to the cached `lastSync` timestamp
3. If unchanged → skips entirely (instant load from cache)
4. If changed → fetches `/sync/all-items?date_from={lastSync}` for incremental updates

**Deletion reconciliation**: When `removed_from_list` timestamps change, fetches `/sync/all-items?extended=simkl_ids_only` and prunes any cached items not present in the response.

**Anime parsing fix**: SIMKL's API returns anime series and films wrapped inside `show` and `movie` objects (not an `anime` key). The parser falls back to `entry.show` or `entry.movie` when `entry.anime` is undefined for media type `"anime"`.

#### Local Cache Structure (`harbor.simkl.cache.v2`)
The delta sync engine persists all user data in a single localStorage key: `harbor.simkl.cache.v2`.
```typescript
type SimklCache = {
  lastSync: string | null;                    // activities.all timestamp
  activities: {                               // per-type timestamps
    movies: string | null;
    shows: string | null;
    anime: string | null;
    ratings: string | null;
  } | null;
  items: Record<string, SimklCacheItem>;      // keyed by SIMKL ID as string
  imdbToSimkl: Record<string, number>;        // IMDb ID → SIMKL ID index
  tmdbToSimkl: Record<string, number>;        // "movie:123" or "tv:123" → SIMKL ID
  malToSimkl: Record<string, number>;         // MAL ID → SIMKL ID
  kitsuToSimkl: Record<string, number>;       // Kitsu ID → SIMKL ID
};

type SimklCacheItem = {
  simklId: number;
  type: "movie" | "show" | "anime";
  title: string;
  year: number | null;
  status: WatchlistStatus;                     // "watching" | "plantowatch" | "completed" | "hold" | "dropped"
  userRating: number | null;                   // 1–10 or null
  watchedAt: string | null;                    // ISO date
  watchedEpisodes?: string[];                  // ["season:episode", ...] for shows/anime
  poster?: string | null;                      // cached poster image path (e.g. "19/198249")
};
```
**Key cache APIs**:
- `getLocalCache(): SimklCache | null` — reads from `localStorage["harbor.simkl.cache.v2"]`
- `saveLocalCache(cache: SimklCache): void` — writes to localStorage
- `clearLocalCache(): void` — removes the cache key
- `fetchSimklActivities(): Promise<void>` — entry point for delta sync
- `updateCachedRatingByTarget(target, rating): void` — instant local rating update
- `getCachedRatingByTarget(target): number | null` — instant rating lookup

`list-status.ts` and `watchlist.ts` are re-wired to read from/write to this local cache instead of making API calls on every boot.

---

### 2. Hardened Anime Scrobbling

#### ID Mapping (`ids.ts`)
`stremioIdToSimklTarget()` resolves Stremio meta IDs to SIMKL API targets:
```typescript
type SimklTarget =
  | { kind: "movie"; ids: SimklIds }
  | { kind: "episode"; show: { ids: SimklIds }; season: number; number: number }
  | { kind: "show"; ids: SimklIds }
  | { kind: "anime"; ids: SimklIds }
  | { kind: "anime-episode"; anime: { ids: SimklIds }; season: number; number: number };
```
- `mal:{id}` and `kitsu:{id}` prefixes → resolved to `anime`/`anime-episode` targets using the local cache's `malToSimkl`/`kitsuToSimkl` indexes
- `anidb:{id}` and `anilist:{id}` prefixes → resolved via `/search/id?{source}={id}` API call
- Scrobbling, history, list-status, watchlist, and detail page buttons use the `"anime"` bucket key for anime targets.

#### Hardened Scrobble Lifecycle (`scrobble-hook.ts`)
`useSimklScrobble({ src, snap })` manages the full scrobble lifecycle:
- **`pagehide` beacon**: `sendBeacon()` sends a `keepalive: true` fetch on page hide, window close, or hook unmount:
  - Progress ≥ 80% → `POST /scrobble/stop`
  - Progress < 80% → `POST /scrobble/pause`
  - Beacon requests include full compliance headers
- **Seek clock (seek detection)**: A 1-second polling interval checks for absolute playback position changes > 8 seconds. On seek, re-triggers `POST /scrobble/start` to resync the scrobble session.
- **Episode transition**: When the media key changes (navigating to the next episode), pauses the previous scrobble session before starting the new one.
- **Threshold alignment**: SIMKL's watch threshold is 80% (`SIMKL_WATCHED_RATIO = 0.80` in `config.ts`), while Harbor's local watched ratio remains 85% (`WATCHED_RATIO = 0.85`). The SIMKL-specific constant avoids affecting local/Anilist tracking.
- **Settings guard**: When `simklScrobbleEnabled` is false, the hook early-returns and skips all listeners/polling.

---

### 3. CDN-Based Airing Calendars (`calendar.ts`)
Calendar premieres are fetched from SIMKL's CDN instead of per-user API routes:
- TV Premieres: `https://data.simkl.in/calendar/tv.json` (33-day TV premiere calendar)
- Anime Releases: `https://data.simkl.in/calendar/anime.json` (33-day anime calendar)
- Movie Releases: `https://data.simkl.in/calendar/movie_release.json` (33-day movie release calendar)
- Monthly Archives: `https://data.simkl.in/calendar/{year}/{month}/{type}.json`

No auth is required (Cloudflare-cached, updated every 6 hours). An in-memory `Map<string, Promise>` cache eliminates redundant fetches within a session.
`calendar-sources.ts` is refactored to use the CDN client. The personal "My Simkl" calendar source fetches both `fetchSimklWatchlist()` (plantowatch) and `fetchWatchingItems()` (watching) concurrently via `Promise.all` with `Set`-based deduplication.
A settings toggle (`simklCalendarPremieresEnabled`, default `true`) controls visibility in the calendar source switcher.

---

### 4. Home Discovery Rails (`home-rails.ts`)
Four SIMKL home rails are added to the Home screen:
- **Simkl Trending Today**: Combined trending movies + TV + anime via `https://data.simkl.in/discover/trending/today_100.json` with a 1-hour cache.
- **Up Next on Simkl**: Upcoming episodes within 30 days for watching/plantowatch items, cross-referencing CDN calendar data.
- **Watching on Simkl**: Currently watching shows + anime.
- **Your Simkl Plan to Watch**: Plan-to-watch items across all media types.

**Visibility-only toggles**: Home rail rows respect the Home Rail Settings toggles. Toggling OFF hides the rail (`rows.push()` is skipped), but background fetching/caching continues to ensure instant display when toggled back ON.

---

### 5. Detail Page Ratings

#### Community Rating Badge (`ratings.ts` + `hero-ratings.tsx`)
`useSimklCommunityRating(imdbId)` fetches the SIMKL community score independently of MDBList:
1. Calls `GET /search/id?imdb={imdbId}` (only `client_id` required). If the response includes `ratings.simkl.rating`, uses it.
2. If not, resolves the SIMKL ID + media type, then fetches the detail endpoint (`/movies/{id}`, `/tv/{id}`, or `/anime/{id}`).
3. A module-level `Map` cache prevents redundant API calls.
4. Prefers direct SIMKL API fetch, falling back to MDBList data if available.

#### Interactive Rating Picker (`simkl-rating-picker.tsx`)
A 1-10 star rating component:
- 5 star icons with half-star click detection (left half = odd, right half = even ratings)
- Text display shows selected rating (e.g. "8 / 10") and a `[Remove]` button
- Calls `POST /sync/ratings` or `POST /sync/ratings/remove` and updates the local delta-sync cache for instant UI feedback.

---

### 6. Expanded My Library Tab & Grid Layout (`simkl-tab.tsx`)
The My Library SIMKL tab is expanded:
- **Three sub-tabs**: Movies, TV Shows, Anime — each isolating its media type in a responsive grid layout.
- **All 5 statuses**: Watching, Plan to Watch, Completed, On Hold, Dropped (movies support 3).
- **Offline-first**: Reads from local `harbor.simkl.cache.v2` cache, with background refresh.
- **Redundant type filter pills hidden**: `FilterBar` accepts `hideTypePills?: boolean` prop; SIMKL tab passes `hideTypePills={true}`.
- **Sorting & Grouping**: `SortControl` with Recent / Alphabetical / Year. Uses `GroupedGrid` with `pagerFranchise()` for anime franchise grouping.

---

### 7. Anime Franchise Title Grouping (`anime-grouping.ts`)
Anime items are grouped by franchise in the library tab and home rails:

#### Title Normalization
`normalizeAnimeTitle(title: string)` strips common season/franchise suffixes:
- Season numbers (`Season 1`, `Season 2`, etc.)
- Year suffixes (`(2023)`, `2023`)
- `"Final Season"`, `"The Final"`, `"Final"`
- `"Shippuden"`, `"Gaiden"`, `"Side Story"`
- `"R"`, `"R2"`, `"TV"`
- Colons (stripped after other patterns)

#### Union-Find Merging & Relations API
1. Grouping is initially done by normalized title.
2. Identifies **singleton groups** (franchises with only 1 item).
3. Fetches relations for singletons via `GET /anime/{id}` (batched, max 50 concurrent requests).
4. Uses **Union-Find** data structure to merge groups that have direct relations (e.g., Code Geass and Code Geass R2 merge into one franchise).
5. Representative items are selected prioritizing active progress (status `"watching"`).

---

### 8. Fallback `simkl:` Details Redirects (`detail.tsx`)
When an item has only a SIMKL ID (no IMDb or TMDB ID mapping), its meta ID is formatted as `simkl:{simklId}`.
In `detail.tsx`, this triggers a direct fetch from the SIMKL details API:
- Resolves the media type (movie, show, or anime).
- Fetches `/movies/{id}`, `/tv/{id}`, or `/anime/{id}`.
- Hydrates the page metadata (title, poster, synopsis, episodes list, ratings) so users can browse details, rate, or add the item to their lists.

---

### 9. Anime Title Language Setting (`defaults.ts` + `types.ts` + `simkl-panel.tsx` + `pick-card.tsx`)
- **Preferred language setting**: Added `simklAnimeTitleLanguage` to settings, allowing users to choose between `"english"`, `"romaji"`, or `"native"`.
- **Poster Card Integration**: In `pick-card.tsx`, anime cards fetch the localized title using MAL ID or Kitsu ID from AniZip (`aniZipByMal`/`aniZipByKitsu`). If unavailable, it falls back to the Kitsu API details (`/api/edge/anime/{id}`). If still unavailable, it uses the default `meta.name`.

---

### 10. Clean Disconnect & Settings Toggles

#### Settings Toggles
- `simklScrobbleEnabled` (boolean, default `true`): Governs scrobble hook.
- `simklCalendarPremieresEnabled` (boolean, default `true`): Shows/hides SIMKL calendar sources.
- `simklShowCommunityRatings` (boolean, default `true`): Shows/hides community rating badge.
- `simklEnableUserRatings` (boolean, default `true`): Shows/hides star rating picker.
- `simklHomeRailsEnabled` (boolean, default `true`): Shows/hides SIMKL home rails.
- `showSimklBadge` (boolean, default `true`): Master toggle for SIMKL score badges on cards.
- `simklAnimeTitleLanguage` (string, default `"english"`): Title translation preference.
- `simklGranularFilters` (object): 5 home rail visibility toggles.

#### Clean Disconnect
Disconnection wipes all auth tokens (`harbor.simkl.session.v1`), local delta-sync cache (`harbor.simkl.cache.v2`), profile avatar overrides, resets all SIMKL settings to defaults, and clears all in-memory caches.

---

## Technical Metrics & Verification

### Files Summary
- **New Files**:
  1. [src/lib/simkl/activities.ts](file:///c:/Users/abd20/Desktop/Dev/Harbor/dev/src/lib/simkl/activities.ts)
  2. [src/lib/simkl/anime-grouping.ts](file:///c:/Users/abd20/Desktop/Dev/Harbor/dev/src/lib/simkl/anime-grouping.ts)
  3. [src/lib/simkl/calendar.ts](file:///c:/Users/abd20/Desktop/Dev/Harbor/dev/src/lib/simkl/calendar.ts)
  4. [src/lib/simkl/ratings.ts](file:///c:/Users/abd20/Desktop/Dev/Harbor/dev/src/lib/simkl/ratings.ts)
  5. [src/views/detail/simkl-rating-picker.tsx](file:///c:/Users/abd20/Desktop/Dev/Harbor/dev/src/views/detail/simkl-rating-picker.tsx)
- **Modified Files (32)**:
  `package.json`, `src/components/pick-card.tsx`, `src/lib/settings/defaults.ts`, `src/lib/settings/types.ts`, `src/lib/simkl/home-rails.ts`, `src/views/library/simkl-tab.tsx`, `src/views/settings/simkl-panel.tsx`, `src/lib/view.tsx`, `src/views/detail.tsx`, `src/components/episode-watched-menu.tsx`, `src/lib/calendar-sources.ts`, `src/lib/providers/mdblist.ts`, `src/lib/simkl/client.ts`, `src/lib/simkl/config.ts`, `src/lib/simkl/device-auth.ts`, `src/lib/simkl/history.ts`, `src/lib/simkl/ids.ts`, `src/lib/simkl/list-status.ts`, `src/lib/simkl/scrobble-hook.ts`, `src/lib/simkl/scrobble.ts`, `src/lib/simkl/types.ts`, `src/lib/simkl/watchlist.ts`, `src/views/calendar.tsx`, `src/views/calendar/source-switcher.tsx`, `src/views/calendar/use-calendar-data.ts`, `src/views/detail/add-to-simkl-button.tsx`, `src/views/detail/hero-ratings.tsx`, `src/views/detail/overflow-sync-items.tsx`, `src/views/detail/series-episodes.tsx`, `src/views/home.tsx`, `src/views/library/shared.tsx`, `src/views/settings/library-panel.tsx`.

### Build Verification
- ✅ TypeScript compilation: `tsc --noEmit` — 0 errors.
- ✅ Vite production build: `vite build` — successfully bundled.
- ✅ Tauri build: production NSIS installer built successfully.