### PR TITLE
feat: added list rows for MAL

### DIFF
--- a/src/lib/mal/lists.ts
+++ b/src/lib/mal/lists.ts
@@ -8,7 +8,7 @@ type RawNode = {
   alternative_titles: { synonyms: string[]; en: string; ja: string } | null;
   num_episodes: number | null;
   mean: number | null;
-  list_status: {
+  my_list_status: {
     status: string;
     score: number;
     num_episodes_watched: number;
@@ -21,13 +21,13 @@ type RawEntry = { node: RawNode };
 type ListResponse = { data: RawEntry[]; paging: { next?: string } | null };
 
 function parseNode(n: RawNode): MalListEntry | null {
-  if (!n.list_status) return null;
+  if (!n.my_list_status) return null;
   return {
-    status: n.list_status.status as MalListStatus,
-    score: n.list_status.score,
-    numEpisodesWatched: n.list_status.num_episodes_watched,
-    isRewatching: n.list_status.is_rewatching,
-    updatedAt: n.list_status.updated_at,
+    status: n.my_list_status.status as MalListStatus,
+    score: n.my_list_status.score,
+    numEpisodesWatched: n.my_list_status.num_episodes_watched,
+    isRewatching: n.my_list_status.is_rewatching,
+    updatedAt: n.my_list_status.updated_at,
     anime: {
       id: n.id,
       title: n.title,
@@ -40,7 +40,7 @@ function parseNode(n: RawNode): MalListEntry | null {
 
 export async function fetchMalList(): Promise<MalListGroup[]> {
   const all: MalListEntry[] = [];
-  let cursor: string | null = `/users/@me/animelist?fields=list_status,num_episodes,mean,main_picture,alternative_titles&nsfw=true&limit=1000`;
+  let cursor: string | null = `/users/@me/animelist?fields=my_list_status,num_episodes,mean,main_picture,alternative_titles&nsfw=true&limit=1000`;
   while (cursor) {
     const data: ListResponse = await malRequest(cursor);
     for (const entry of data.data) { const parsed = parseNode(entry.node); if (parsed) all.push(parsed); }

--- a/src/lib/use-mal-anime-rails.ts
+++ b/src/lib/use-mal-anime-rails.ts
@@ -9,6 +9,9 @@ export type MalRail = { key: string; title: string; metas: Meta[] };
 const RAIL_ORDER: Array<{ key: string; title: string; statuses: MalListStatus[] }> = [
   { key: "watching", title: "Watching", statuses: ["watching"] },
   { key: "planning", title: "Plan to Watch", statuses: ["plan_to_watch"] },
+  { key: "completed", title: "Completed", statuses: ["completed"] },
+  { key: "onhold", title: "On Hold", statuses: ["on_hold"] },
+  { key: "dropped", title: "Dropped", statuses: ["dropped"] },
 ];
 
 const MIN_PER_RAIL = 1;
@@ -22,7 +25,7 @@ function malEntryToMeta(entry: MalListEntry): Meta | null {
     name,
     poster: entry.anime.mainPicture ?? undefined,
     releaseInfo: undefined,
-    imdbRating: entry.anime.mean != null ? (entry.anime.mean / 10).toFixed(1) : undefined,
+    imdbRating: entry.anime.mean != null ? entry.anime.mean.toFixed(1) : undefined,
   };
 }
 
@@ -37,13 +40,24 @@ export function useMalAnimeRails(): MalRail[] {
     }
     let cancelled = false;
     (async () => {
-      const groups = await fetchMalList();
+      let groups: MalListGroup[];
+      try {
+        groups = await fetchMalList();
+      } catch (e) {
+        console.error("Failed to fetch MAL list", e);
+        return;
+      }
       if (cancelled) return;
       const entriesByStatus = new Map(groups.map((g) => [g.status, g.entries]));
 
       const out: MalRail[] = [];
       for (const rail of RAIL_ORDER) {
-        const entries = rail.statuses.flatMap((s) => entriesByStatus.get(s) ?? []);
+        let entries = rail.statuses.flatMap((s) => entriesByStatus.get(s) ?? []);
+        if (rail.key === "watching" || rail.key === "completed") {
+          entries = [...entries].sort(
+            (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+          );
+        }
         const metas = entries.map(malEntryToMeta).filter((m): m is Meta => m != null);
         if (metas.length >= MIN_PER_RAIL) out.push({ key: rail.key, title: rail.title, metas });
       }

--- a/src/views/anime.tsx
+++ b/src/views/anime.tsx
@@ -475,8 +475,8 @@ export function AnimeView({ active = true }: { active?: boolean }) {
               ))}
             </Row>
           )}
-          {!malRowsHidden.includes("yourMalLists") && <MalRows />}
           <MalRowControls />
+          {!malRowsHidden.includes("yourMalLists") && <MalRows />}
           {!anilistHidden.includes("yourLists") && <AnilistRows />}
           <AnilistRowControls />
           {!anilistHidden.includes("trending") && <AnilistTrendingRow />}


### PR DESCRIPTION
- Fixed MAL API v2 field name (list_status → my_list_status) so list data is actually parsed instead of silently returning empty
- Expanded from 2 rails (Watching, Plan to Watch) to all 5 statuses: Watching, Plan to Watch, Completed, On Hold, Dropped
- Watching and Completed rails sorted by updatedAt (most recent first)
- Added try/catch around the MAL fetch so a failure doesn't crash the whole Anime section
Closes the issue where MAL rows would not appear in the Anime tab despite successful auth.
<img width="2452" height="837" alt="image" src="https://github.com/user-attachments/assets/be373623-c5e8-4e07-aab2-ed5e68c9c443" />
