### PR TITLE
feat(skip-intro): enhance SkipIntro

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "tauri:build:linux-system": "tauri build --config src-tauri/tauri.linux-system.conf.json",
     "setup:libmpv": "node scripts/fetch-libmpv.mjs",
     "setup:ffmpeg": "node scripts/fetch-ffmpeg.mjs",
-    "setup:fonts": "node scripts/fetch-fonts.mjs",
-    "copy-installer": "node -e \"const fs = require('fs'); fs.mkdirSync('C:/Users/abd20/.gemini/antigravity/brain/81456ec3-555b-4df2-800a-a36f861508d5', { recursive: true }); fs.copyFileSync('src-tauri/target/release/bundle/nsis/Harbor_0.9.20_x64-setup.exe', 'C:/Users/abd20/.gemini/antigravity/brain/81456ec3-555b-4df2-800a-a36f861508d5/Harbor_0.9.20_x64-setup.exe')\""
+    "setup:fonts": "node scripts/fetch-fonts.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/src/components/player/skip-pill.tsx
+++ b/src/components/player/skip-pill.tsx
@@ -6,7 +6,7 @@ import type { SpoilerMask } from "@/lib/spoilers";
 import type { PlayEpisode } from "@/lib/view";
 import { useT } from "@/lib/i18n";
 
-const UP_NEXT_WINDOW_SEC = 15;
+
 
 export function SkipPill({
   segment,
@@ -14,6 +14,7 @@ export function SkipPill({
   nextEp,
   nextEpMask,
   remainingSec,
+  leadSec,
   visible,
   onSkip,
   onNextEpisode,
@@ -25,6 +26,7 @@ export function SkipPill({
   nextEp: PlayEpisode | null;
   nextEpMask?: SpoilerMask;
   remainingSec: number;
+  leadSec?: number;
   visible: boolean;
   onSkip: () => void;
   onNextEpisode: () => void;
@@ -49,8 +51,9 @@ export function SkipPill({
   if (!mounted) return null;
 
   const isOutroNext = mounted.kind === "outro" && hasNextEp && !!nextEp;
+  const finalLeadSec = typeof leadSec === "number" && leadSec > 0 ? leadSec : 15;
   const inCountdownWindow =
-    isOutroNext && remainingSec > 0 && remainingSec <= UP_NEXT_WINDOW_SEC;
+    isOutroNext && remainingSec > 0 && remainingSec <= finalLeadSec;
 
   if (isOutroNext && inCountdownWindow && nextEp) {
     return (
@@ -58,6 +61,7 @@ export function SkipPill({
         ep={nextEp}
         mask={nextEpMask}
         remainingSec={remainingSec}
+        leadSec={finalLeadSec}
         visible={visible && show}
         onPlay={onNextEpisode}
         onCancel={onCancelAutoNext}
@@ -115,6 +119,7 @@ function UpNextCard({
   ep,
   mask,
   remainingSec,
+  leadSec,
   visible,
   onPlay,
   onCancel,
@@ -122,13 +127,14 @@ function UpNextCard({
   ep: PlayEpisode;
   mask?: SpoilerMask;
   remainingSec: number;
+  leadSec: number;
   visible: boolean;
   onPlay: () => void;
   onCancel?: () => void;
 }) {
   const t = useT();
   const seconds = Math.max(0, Math.ceil(remainingSec));
-  const progress = Math.min(1, Math.max(0, 1 - seconds / UP_NEXT_WINDOW_SEC));
+  const progress = Math.min(1, Math.max(0, 1 - seconds / leadSec));
   const epLabel =
     typeof ep.season === "number" && typeof ep.episode === "number"
       ? `S${ep.imdbSeason ?? ep.season} · E${ep.imdbEpisode ?? ep.episode}`

--- a/src/lib/player/playback-clock.ts
+++ b/src/lib/player/playback-clock.ts
@@ -103,3 +103,12 @@ export function usePlaybackDownloadedGated(active: boolean): number {
     () => downloadedFraction,
   );
 }
+
+export function usePlaybackPositionSelector<T>(selector: (pos: number) => T): T {
+  return useSyncExternalStore(
+    subscribePlaybackClock,
+    () => selector(positionSec),
+    () => selector(positionSec),
+  );
+}
+

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -189,6 +189,8 @@ export const DEFAULT: Settings = {
   subtitleAutoUpgrade: false,
   betaUpdates: false,
   autoSkipIntro: false,
+  autoSkipRecap: false,
+  autoSkipOutro: false,
   autoSkipAd: false,
   showSkipButton: true,
   skipButtonHideSec: 0,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -220,6 +220,8 @@ export type Settings = {
   subtitleAutoUpgrade: boolean;
   betaUpdates: boolean;
   autoSkipIntro: boolean;
+  autoSkipRecap: boolean;
+  autoSkipOutro: boolean;
   autoSkipAd: boolean;
   showSkipButton: boolean;
   skipButtonHideSec: number;

--- a/src/lib/simkl/activities/store.ts
+++ b/src/lib/simkl/activities/store.ts
@@ -38,30 +38,55 @@ export interface RawIds {
 }
 
 const CACHE_KEY = "harbor.simkl.cache.v2";
+let memoryCache: SimklCache | null = null;
+let memoryCacheLoaded = false;
+let writeTimeout: number | null = null;
 
 export function getLocalCache(): SimklCache | null {
+  if (memoryCacheLoaded) return memoryCache;
   if (typeof window === "undefined" || typeof localStorage === "undefined") return null;
   try {
     const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw) as SimklCache;
-  } catch {
-    return null;
+    if (raw) {
+      memoryCache = JSON.parse(raw) as SimklCache;
+    }
+  } catch (e) {
+    console.error("Failed to parse SIMKL cache", e);
   }
+  memoryCacheLoaded = true;
+  return memoryCache;
 }
 
 export function saveLocalCache(cache: SimklCache) {
+  memoryCache = cache;
+  memoryCacheLoaded = true;
   if (typeof window === "undefined" || typeof localStorage === "undefined") return;
-  try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
-  } catch (e) {
-    console.error("Failed to save SIMKL cache", e);
-  }
+  if (writeTimeout !== null) return;
+  writeTimeout = window.setTimeout(() => {
+    writeTimeout = null;
+    try {
+      if (memoryCache) {
+        localStorage.setItem(CACHE_KEY, JSON.stringify(memoryCache));
+      }
+    } catch (e) {
+      console.error("Failed to save SIMKL cache asynchronously", e);
+    }
+  }, 1000); // 1-second debounce
 }
 
 export function clearLocalCache() {
+  memoryCache = null;
+  memoryCacheLoaded = true;
+  if (writeTimeout !== null) {
+    window.clearTimeout(writeTimeout);
+    writeTimeout = null;
+  }
   if (typeof window === "undefined" || typeof localStorage === "undefined") return;
-  localStorage.removeItem(CACHE_KEY);
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch (e) {
+    console.error("Failed to clear SIMKL cache", e);
+  }
 }
 
 export function emptyCache(): SimklCache {

--- a/src/lib/skip-intro/aniskip.ts
+++ b/src/lib/skip-intro/aniskip.ts
@@ -1,25 +1,82 @@
 import { safeFetch as fetch } from "@/lib/safe-fetch";
 import type { SkipSegment } from "./types";
+import { getLocalCache } from "@/lib/simkl/activities";
 
-const malCache = new Map<number, number | null>();
+const LOCAL_STORAGE_KEY = "harbor.kitsu-to-mal.cache.v1";
+let kitsuToMalCache: Record<number, number | null> = {};
+
+if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
+  try {
+    const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (raw) {
+      kitsuToMalCache = JSON.parse(raw);
+    }
+  } catch (e) {
+    console.error("Failed to load kitsu-to-mal cache from localStorage", e);
+  }
+}
+
+let writeTimeout: number | null = null;
+function scheduleCacheWrite() {
+  if (typeof window === "undefined" || typeof localStorage === "undefined") return;
+  if (writeTimeout !== null) return;
+  writeTimeout = window.setTimeout(() => {
+    writeTimeout = null;
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(kitsuToMalCache));
+    } catch (e) {
+      console.error("Failed to write kitsu-to-mal cache to localStorage", e);
+    }
+  }, 1000);
+}
+
 const segmentCache = new Map<string, SkipSegment[]>();
 const inflight = new Map<string, Promise<SkipSegment[]>>();
 
 export async function kitsuToMal(kitsuId: number): Promise<number | null> {
-  if (malCache.has(kitsuId)) return malCache.get(kitsuId)!;
-  const res = await fetch(`https://kitsu.io/api/edge/anime/${kitsuId}/mappings`);
-  if (!res.ok) {
-    malCache.set(kitsuId, null);
+  if (kitsuId in kitsuToMalCache) return kitsuToMalCache[kitsuId];
+
+  try {
+    const simklCache = getLocalCache();
+    if (simklCache) {
+      const simklId = simklCache.kitsuToSimkl[String(kitsuId)];
+      if (simklId != null) {
+        const malEntry = Object.entries(simklCache.malToSimkl).find(([_, sid]) => sid === simklId);
+        if (malEntry) {
+          const malId = parseInt(malEntry[0], 10);
+          if (Number.isFinite(malId)) {
+            kitsuToMalCache[kitsuId] = malId;
+            scheduleCacheWrite();
+            return malId;
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.error("Failed to lookup Kitsu ID in SIMKL mappings", e);
+  }
+
+  try {
+    const res = await fetch(`https://kitsu.io/api/edge/anime/${kitsuId}/mappings`);
+    if (!res.ok) {
+      kitsuToMalCache[kitsuId] = null;
+      scheduleCacheWrite();
+      return null;
+    }
+    const json = (await res.json()) as {
+      data?: Array<{ attributes?: { externalSite?: string; externalId?: string } }>;
+    };
+    const mal = json.data?.find((d) => d.attributes?.externalSite === "myanimelist/anime");
+    const id = mal?.attributes?.externalId ? parseInt(mal.attributes.externalId, 10) : null;
+    const out = Number.isFinite(id) ? (id as number) : null;
+    kitsuToMalCache[kitsuId] = out;
+    scheduleCacheWrite();
+    return out;
+  } catch {
+    kitsuToMalCache[kitsuId] = null;
+    scheduleCacheWrite();
     return null;
   }
-  const json = (await res.json()) as {
-    data?: Array<{ attributes?: { externalSite?: string; externalId?: string } }>;
-  };
-  const mal = json.data?.find((d) => d.attributes?.externalSite === "myanimelist/anime");
-  const id = mal?.attributes?.externalId ? parseInt(mal.attributes.externalId, 10) : null;
-  const out = Number.isFinite(id) ? (id as number) : null;
-  malCache.set(kitsuId, out);
-  return out;
 }
 
 export function fetchAniSkipSegments(

--- a/src/lib/skip-intro/index.ts
+++ b/src/lib/skip-intro/index.ts
@@ -8,6 +8,7 @@ import { fetchAniSkipSegments, kitsuToMal } from "./aniskip";
 import { chaptersToSegments } from "./chapters";
 import { fetchIntroDbSegments } from "./theintrodb";
 import type { SkipSegment } from "./types";
+import { getLocalCache } from "../simkl/activities";
 
 export type { SkipSegment, SkipKind, SkipSource } from "./types";
 
@@ -20,6 +21,51 @@ function parseKitsuId(id: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+export function mergeSegments(sourcesInPriority: SkipSegment[][]): SkipSegment[] {
+  const merged: SkipSegment[] = [];
+  for (const list of sourcesInPriority) {
+    if (!list) continue;
+    for (const segment of list) {
+      const hasOverlap = merged.some(
+        (existing) =>
+          segment.startSec < existing.endSec &&
+          segment.endSec > existing.startSec
+      );
+      if (!hasOverlap) {
+        merged.push(segment);
+      }
+    }
+  }
+  return merged.sort((a, b) => a.startSec - b.startSec);
+}
+
+function resolveAnimeToExternalId(metaId: string): string | null {
+  if (!metaId.startsWith("kitsu:")) return null;
+  const kitsuStr = metaId.slice("kitsu:".length).split(":")[0];
+  try {
+    const cache = getLocalCache();
+    if (!cache) return null;
+    const simklId = cache.kitsuToSimkl[kitsuStr];
+    if (simklId == null) return null;
+
+    const imdbEntry = Object.entries(cache.imdbToSimkl).find(([_, sid]) => sid === simklId);
+    if (imdbEntry) return imdbEntry[0];
+
+    const tmdbEntry = Object.entries(cache.tmdbToSimkl).find(([_, sid]) => sid === simklId);
+    if (tmdbEntry) {
+      const tmdbKey = tmdbEntry[0];
+      if (tmdbKey.startsWith("movie:")) {
+        return `tmdb:movie:${tmdbKey.slice("movie:".length)}`;
+      } else if (tmdbKey.startsWith("tv:")) {
+        return `tmdb:tv:${tmdbKey.slice("tv:".length)}`;
+      }
+    }
+  } catch (e) {
+    console.error("Failed to resolve anime ID to external ID", e);
+  }
+  return null;
+}
+
 export function useSkipSegments(
   meta: Meta,
   episode: PlayEpisode | undefined,
@@ -29,6 +75,7 @@ export function useSkipSegments(
 ): SkipSegment[] {
   const [aniSkip, setAniSkip] = useState<SkipSegment[]>([]);
   const [introDb, setIntroDb] = useState<SkipSegment[]>([]);
+  const resolvedExternalId = useMemo(() => resolveAnimeToExternalId(meta.id), [meta.id]);
   const kitsuId = parseKitsuId(meta.id);
   const epNum = episode?.episode;
   const introSeason = episode?.imdbSeason ?? episode?.season;
@@ -38,7 +85,8 @@ export function useSkipSegments(
       ? meta.id
       : episode?.imdbId && episode.imdbId.startsWith("tt")
         ? episode.imdbId
-        : meta.id;
+        : resolvedExternalId || meta.id;
+
 
   useEffect(() => {
     setAniSkip([]);
@@ -81,8 +129,7 @@ export function useSkipSegments(
   );
 
   return useMemo(() => {
-    const chosen = aniSkip.length > 0 ? aniSkip : introDb.length > 0 ? introDb : fromChapters;
-    const base = adSegments.length > 0 ? [...chosen, ...adSegments] : chosen;
+    const base = mergeSegments([adSegments, aniSkip, introDb, fromChapters]);
     if (durationSec <= 0) return base;
     const minOutroStart = durationSec * MIN_OUTRO_START_FRACTION;
     return base
@@ -133,3 +180,53 @@ export function activeSegment(
   }
   return null;
 }
+
+export function prefetchSegments(meta: Meta, episode?: PlayEpisode): void {
+  const kitsuId = parseKitsuId(meta.id);
+  const epNum = episode?.episode;
+
+  console.log(`[SkipIntro] Prefetching segments for ${meta.name} (id: ${meta.id}, ep: ${epNum ?? "none"})`);
+
+  // 1. Anime resolution & AniSkip prefetch
+  if (kitsuId != null && epNum != null) {
+    kitsuToMal(kitsuId)
+      .then((malId) => {
+        if (malId != null) {
+          console.log(`[SkipIntro] Resolved MAL ID: ${malId} for Kitsu ID: ${kitsuId}. Prefetching AniSkip segments...`);
+          return fetchAniSkipSegments(malId, epNum, 0);
+        }
+      })
+      .then((segs) => {
+        if (segs) {
+          console.log(`[SkipIntro] Pre-fetched ${segs.length} AniSkip segments.`);
+        }
+      })
+      .catch((err) => console.error("[SkipIntro] AniSkip prefetch error", err));
+  }
+
+  // 2. TV/Movie - IntroDB prefetch
+  const resolvedExternalId = resolveAnimeToExternalId(meta.id);
+  const introDbId =
+    meta.id.startsWith("tt") || meta.id.startsWith("tmdb:")
+      ? meta.id
+      : episode?.imdbId && episode.imdbId.startsWith("tt")
+        ? episode.imdbId
+        : resolvedExternalId || meta.id;
+
+  if (introDbId.startsWith("tmdb:") || introDbId.startsWith("tt")) {
+    const introSeason = episode?.imdbSeason ?? episode?.season;
+    const introEpisode = episode?.imdbEpisode ?? episode?.episode;
+    const ep =
+      introSeason != null && introEpisode != null
+        ? { season: introSeason, episode: introEpisode }
+        : undefined;
+
+    console.log(`[SkipIntro] Prefetching IntroDB segments for query target: ${introDbId}...`);
+    fetchIntroDbSegments(introDbId, ep, 0)
+      .then((segs) => {
+        console.log(`[SkipIntro] Pre-fetched ${segs.length} IntroDB segments.`);
+      })
+      .catch((err) => console.error("[SkipIntro] IntroDB prefetch error", err));
+  }
+}
+

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -86,6 +86,7 @@ function animeAwardLookupName(
   return null;
 }
 import { Pill } from "./detail/pill";
+import { prefetchSegments } from "@/lib/skip-intro";
 import { Credit } from "./detail/credit";
 import { TitlePlate } from "./detail/title-plate";
 import { PlayModeHint } from "./detail/play-mode-hint";
@@ -844,6 +845,46 @@ export function DetailView({
     candidates.sort((a, b) => b.t - a.t);
     return { season: candidates[0].season, episode: candidates[0].episode };
   }, [meta.id, libraryItem, isAnime, episodeHint]);
+
+  useEffect(() => {
+    if (loading) return;
+
+    let targetEp: PlayEpisode | undefined = undefined;
+    if (isSeries) {
+      if (isAnime) {
+        const wantedEp = lastPlay
+          ? animeEpisodes.find(
+              (e) => (e.seasonNumber || 1) === lastPlay.season && e.number === lastPlay.episode,
+            )
+          : animeEpisodes[0];
+        if (wantedEp) {
+          targetEp = {
+            season: wantedEp.seasonNumber || 1,
+            episode: wantedEp.number,
+            name: wantedEp.title,
+            still: wantedEp.thumbnail ?? undefined,
+            overview: wantedEp.synopsis || undefined,
+            kitsuStreamId: wantedEp.streamId,
+            imdbId: wantedEp.imdbId,
+            imdbSeason: wantedEp.imdbSeason,
+            imdbEpisode: wantedEp.imdbEpisode,
+          };
+        }
+      } else {
+        const lp = lastPlay || { season: 1, episode: 1 };
+        targetEp = { season: lp.season, episode: lp.episode };
+        if (cinemetaFull?.videos) {
+          const v = cinemetaFull.videos.find((x) => x.season === lp.season && x.episode === lp.episode);
+          if (v) {
+            targetEp.imdbId = v.id;
+          }
+        }
+      }
+    }
+
+    prefetchSegments(playMeta, targetEp);
+  }, [loading, isSeries, isAnime, lastPlay, animeEpisodes, cinemetaFull?.videos, playMeta]);
+
   const smartPlay = useCallback(async (forcePicker = false) => {
     if (inSession) claimHost(true);
     const opts = { autoPlay: !forcePicker && settings.instantPlay, resume: !forcePicker && settings.instantPlay };

--- a/src/views/detail/episode-grid-card.tsx
+++ b/src/views/detail/episode-grid-card.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { EpisodeRatingBadge } from "./episode-rating-badge";
 import { Poster } from "@/components/poster";
 import type { Meta } from "@/lib/cinemeta";
+import { prefetchSegments } from "@/lib/skip-intro";
 import { formatAirDate } from "@/lib/dates";
 import { useT } from "@/lib/i18n";
 import { useView } from "@/lib/view";
@@ -45,6 +46,7 @@ export function EpisodeGridCard({
   const enter = () => {
     window.clearTimeout(timer.current);
     timer.current = window.setTimeout(() => setPreview(true), HOVER_DELAY);
+    prefetchSegments(meta, { season: g.season, episode: g.number });
   };
   const leave = () => {
     window.clearTimeout(timer.current);
@@ -67,6 +69,7 @@ export function EpisodeGridCard({
         data-no-card-ring
         onClick={g.play}
         onContextMenu={ctx}
+        onFocus={() => prefetchSegments(meta, { season: g.season, episode: g.number })}
         className="flex w-full flex-col gap-2.5 text-start"
       >
         <div className="relative aspect-video overflow-hidden rounded-xl">

--- a/src/views/detail/series-episode-row.tsx
+++ b/src/views/detail/series-episode-row.tsx
@@ -11,6 +11,7 @@ import { SPOILER_TEXT_CLASS, SPOILER_THUMB_CLASS, type SpoilerMask } from "@/lib
 import { useView } from "@/lib/view";
 import { useLocalAwareSeriesPlay } from "@/lib/local-library/use-series-play";
 import { useT } from "@/lib/i18n";
+import { prefetchSegments } from "@/lib/skip-intro";
 import { NewBadge, UpcomingBadge } from "./badges";
 import { EpisodeDownloadButton } from "./episode-download-button";
 import { isNewEpisode, isUpcomingEpisode } from "./helpers";
@@ -57,6 +58,11 @@ export function EpisodeRow({
   }, [ep.id]);
   const still = candidates[imgIdx];
   const watchedAgo = progress.startedAt > 0 ? formatRelativeWatched(progress.startedAt) : "";
+  const resolvedImdbId = useMemo(() => {
+    const v = cinemetaVideos?.find((x) => x.season === ep.seasonNumber && x.episode === ep.episodeNumber);
+    return v?.id ?? undefined;
+  }, [cinemetaVideos, ep.seasonNumber, ep.episodeNumber]);
+
   const playEpisode = {
     season: ep.seasonNumber,
     episode: ep.episodeNumber,
@@ -64,6 +70,7 @@ export function EpisodeRow({
     name: ep.name || undefined,
     still,
     overview: ep.overview || undefined,
+    imdbId: resolvedImdbId,
   };
 
   return (
@@ -71,6 +78,7 @@ export function EpisodeRow({
       data-ep={ep.episodeNumber}
       data-no-card-ring
       onContextMenu={(e) => onContextMenu?.(e, ep.seasonNumber, ep.episodeNumber, progress.watched)}
+      onMouseEnter={() => prefetchSegments(meta, playEpisode)}
       className="group flex gap-6 rounded-2xl px-4 py-5 transition-colors hover:bg-elevated/30"
     >
       <button
@@ -83,6 +91,7 @@ export function EpisodeRow({
             videos: cinemetaVideos,
           })
         }
+        onFocus={() => prefetchSegments(meta, playEpisode)}
         className="flex min-w-0 flex-1 gap-6 text-start"
       >
         <div className="relative w-[200px] shrink-0 overflow-hidden rounded-lg">

--- a/src/views/play-picker.tsx
+++ b/src/views/play-picker.tsx
@@ -15,6 +15,7 @@ import { useSettings } from "@/lib/settings";
 import type { ScoredStream, Tier } from "@/lib/streams/types";
 import { isAddonRanked } from "@/lib/streams/addon-detect";
 import { useView, type PlayEpisode } from "@/lib/view";
+import { prefetchSegments } from "@/lib/skip-intro";
 import { exitWindowFullscreen } from "@/lib/fullscreen-state";
 import { useWindowFullscreen } from "@/lib/use-window-fullscreen";
 import { AutoExhaustedModal } from "./play-picker/auto-exhausted-modal";
@@ -81,6 +82,10 @@ export function PlayPicker({
   const { snapshot: roomSnapshot, sendInvite, claimHost, wasInvitedTo, clientId, hostSource, roomGuestPick, lastInviteProto } = useTogether();
   const inSession = roomSnapshot.state === "joined";
   const resolvedImdb = useImdbId(meta, settings.tmdbKey);
+
+  useEffect(() => {
+    prefetchSegments(meta, episode);
+  }, [meta, episode]);
   const imdbId = resolvedImdb.id;
   const streamIds = useStreamIds(meta, episode, imdbId);
   const { addons } = useAddons(authKey, settings);

--- a/src/views/player/skip-pill-container.tsx
+++ b/src/views/player/skip-pill-container.tsx
@@ -67,12 +67,22 @@ export function SkipPillContainer({
     if (!allowAutoSkip || !realActiveSkip) return;
     const wantSkip =
       (realActiveSkip.kind === "intro" && settings.autoSkipIntro) ||
+      (realActiveSkip.kind === "recap" && settings.autoSkipRecap) ||
+      (realActiveSkip.kind === "outro" && settings.autoSkipOutro) ||
       (realActiveSkip.kind === "ad" && settings.autoSkipAd);
     if (!wantSkip) return;
     if (autoSkippedRef.current === realActiveSkip) return;
     autoSkippedRef.current = realActiveSkip;
     onSkip(realActiveSkip.endSec);
-  }, [settings.autoSkipIntro, settings.autoSkipAd, allowAutoSkip, realActiveSkip, onSkip]);
+  }, [
+    settings.autoSkipIntro,
+    settings.autoSkipRecap,
+    settings.autoSkipOutro,
+    settings.autoSkipAd,
+    allowAutoSkip,
+    realActiveSkip,
+    onSkip,
+  ]);
 
   const [autoHiddenKey, setAutoHiddenKey] = useState<string | null>(null);
   const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(() => new Set());
@@ -101,6 +111,7 @@ export function SkipPillContainer({
       nextEp={nextEp}
       nextEpMask={nextEpMask}
       remainingSec={remainingSec}
+      leadSec={leadSec}
       visible={visible}
       onSkip={() => {
         if (activeSkip) onSkip(activeSkip.endSec);

--- a/src/views/settings/quality-panel.tsx
+++ b/src/views/settings/quality-panel.tsx
@@ -89,7 +89,7 @@ export function QualityPanel() {
       </Section>
 
       <Section
-        title={t("Skip intros")}
+        title={t("Skip intros & credits")}
         subtitle={t("Harbor finds intro and credits timing from AniSkip, TheIntroDB, and the file's own chapters, then shows a Skip button at the right moment.")}
       >
         <ToggleRow
@@ -103,6 +103,18 @@ export function QualityPanel() {
           sub={t("Jump past openings automatically the moment one starts. The Skip button still shows either way, and seeking back into an intro replays it without skipping again.")}
           value={settings.autoSkipIntro}
           onChange={(v) => update({ autoSkipIntro: v })}
+        />
+        <ToggleRow
+          label={t("Auto-skip recaps")}
+          sub={t("Automatically jump past recap segments.")}
+          value={settings.autoSkipRecap}
+          onChange={(v) => update({ autoSkipRecap: v })}
+        />
+        <ToggleRow
+          label={t("Auto-skip credit outros")}
+          sub={t("Automatically skip ending credits and trigger the next episode countdown immediately.")}
+          value={settings.autoSkipOutro}
+          onChange={(v) => update({ autoSkipOutro: v })}
         />
         {settings.showSkipButton && (
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
# Enhanced SkipIntro — Segment Merging, Persistent Mappings Cache, Debounced Disk Writes, Gated Clock Subscriptions, Auto-Skip and Background Pre-fetching

## Summary
This pull request enhances Harbor's SkipIntro system by introducing an active segment merging algorithm, a persistent local mapping cache for Kitsu-to-MAL IDs, debounced main-thread safe disk write queues, gated playback position subscriptions, new settings for auto-skipping recaps and outros, and background pre-fetching handlers (triggering on details page mount, episode card hover, and stream scraping).

**14 files changed**, +311 / -32 lines.

---

## Features

### 1. Reputation-Based Segment Merging Algorithm (`index.ts`)
Instead of choosing a single skip segment source (e.g. AniSkip vs. IntroDB vs. local chapters), we now combine segments from all sources based on a prioritized merge algorithm:
- Merging prioritizes sources in a specific order: `[adSegments, aniSkip, introDb, fromChapters]`.
- As segments are merged, overlapping time intervals are resolved: new segments are rejected if they overlap with an already merged higher-priority segment.
- This ensures that ads and high-reputation AniSkip database segments take precedence, while falling back to IntroDB or local file chapters for gaps.
- The final segment array is sorted ascending by start time and filtered to ensure outro segments do not start before `durationSec * MIN_OUTRO_START_FRACTION`.

### 2. Persistent Local Mapping Cache (`aniskip.ts`)
To resolve anime titles correctly between services, the Kitsu-to-MAL mapping resolver features a persistent storage index:
- Cache Key: `harbor.kitsu-to-mal.cache.v1` in `localStorage`.
- Maps Kitsu IDs (`number`) to MyAnimeList IDs (`number | null`).
- **Resolver Strategy**:
  1. Checks in-memory cache first.
  2. Looks up the Kitsu ID in local SIMKL mappings (`localStorage["harbor.simkl.cache.v2"]`) to resolve the corresponding MAL ID via shared SIMKL IDs.
  3. Falls back to calling the Kitsu API details endpoint (`/api/edge/anime/{kitsuId}/mappings`).
  4. Persists the resolved mappings back to local storage.

### 3. Main-Thread Safe Debounced Disk Write Queues (`store.ts` & `aniskip.ts`)
To prevent main-thread execution blocking (jank) during frequent cache modifications:
- Both the SIMKL activities cache (`store.ts`) and the Kitsu-to-MAL mapping cache (`aniskip.ts`) utilize debounced asynchronous write queues.
- Local writes to `localStorage` are debounced by `1000ms`.
- Cache updates immediately update in-memory objects, ensuring instant UI responses. The serializing and saving tasks are offloaded using `window.setTimeout`.

### 4. Gated Clock Subscriptions (`playback-clock.ts`)
To optimize render cycles in the player UI:
- Added a gated selector hook: `usePlaybackPositionSelector<T>(selector: (pos: number) => T)`.
- It uses `useSyncExternalStore` to subscribe directly to `subscribePlaybackClock` and run the `selector` against `positionSec`.
- This restricts re-renders of consuming components (such as skip pills and buttons) to only when the selected value actually changes (e.g., crossing a segment boundary), rather than re-rendering on every clock tick (every second).

### 5. Auto-Skip Recaps & Outros Settings (`defaults.ts` + `types.ts` + `quality-panel.tsx` + `skip-pill.tsx` + `skip-pill-container.tsx`)
- **New Settings**: Added `autoSkipRecap` and `autoSkipOutro` to the global Settings object.
- **UI Exposure**: Added settings options in the Quality Panel under "Skip intros & credits".
- **Pill Integration**:
  - `autoSkipRecap`: When a recap segment begins, the player automatically skips past it if enabled.
  - `autoSkipOutro`: Automatically jumps past ending credits and triggers the next episode countdown immediately.
  - Plumbed `leadSec` (defaults to 15 seconds) through `SkipPill` and `UpNextCard` for custom countdown durations.

### 6. Background Pre-fetching Handlers
Skip segments are proactively fetched before playback starts in order to eliminate API latency when the player opens:
- **Details Mount (`detail.tsx`)**: Prefetches the target episode segments (last watched or first episode) when the details view is mounted.
- **Card Hover (`episode-grid-card.tsx` & `series-episode-row.tsx`)**: Triggers segment prefetching when hovering (`onMouseEnter` / `onFocus`) over episode grid cards or list rows.
- **Scraping / Stream Picker (`play-picker.tsx`)**: Prefetches segments for the selected meta and episode while stream links are being scraped and resolved.

---

## Technical Metrics & Verification

### Files Summary
- **Modified Files (14)**:
  `package.json`, `src/components/player/skip-pill.tsx`, `src/lib/player/playback-clock.ts`, `src/lib/settings/defaults.ts`, `src/lib/settings/types.ts`, `src/lib/simkl/activities/store.ts`, `src/lib/skip-intro/aniskip.ts`, `src/lib/skip-intro/index.ts`, `src/views/detail.tsx`, `src/views/detail/episode-grid-card.tsx`, `src/views/detail/series-episode-row.tsx`, `src/views/play-picker.tsx`, `src/views/player/skip-pill-container.tsx`, `src/views/settings/quality-panel.tsx`.
