### PR TITLE
i18n: Add Brazilian Portuguese (pt-BR) translation

### DIFF
--- a/src/lib/i18n/languages.ts
+++ b/src/lib/i18n/languages.ts
@@ -1,4 +1,4 @@
-export type UiLanguage = "en" | "ar";
+export type UiLanguage = "en" | "ar" | "pt";
 
 export type LanguageOption = {
   code: UiLanguage;
@@ -10,6 +10,7 @@ export type LanguageOption = {
 export const LANGUAGES: LanguageOption[] = [
   { code: "en", label: "English", nativeLabel: "English", rtl: false },
   { code: "ar", label: "Arabic", nativeLabel: "العربية", rtl: true },
+  { code: "pt", label: "Portuguese" nativeLabel: "Português", rtl: true},
 ];
 
 export function isRtl(lang: UiLanguage): boolean {

--- a/src/lib/i18n/store.ts
+++ b/src/lib/i18n/store.ts
@@ -16,7 +16,7 @@ export function getUiLanguage(): UiLanguage {
 }
 
 export function setUiLanguage(lang: UiLanguage): void {
-  const next: UiLanguage = lang === "ar" ? "ar" : "en";
+  const next: UiLanguage = lang === "ar" ? "ar" : "en" : "pt";
   applyDocument(next);
   if (next === current) return;
   current = next;


### PR DESCRIPTION
Hi there! 

I have translated the interface strings into Brazilian Portuguese (`pt-BR`) to help localize the application. 

I also added a File inside of locales folder called pt.ts, but I don't know if it went through. 

Please let me know if any adjustments are needed. Thanks!