### PR TITLE
Guard Tauri event listener cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import { MalProvider } from "@/lib/mal/provider";
 import { SimklProvider } from "@/lib/simkl/provider";
 import { LetterboxdProvider } from "@/lib/stremboxd/provider";
 import { useKeyboardNavigation } from './useKeyboardNavigation';
+import { onceUnlisten, safeUnlisten } from "@/lib/tauri-listener";
 
 const importAnime = () => import("@/views/anime");
 const importCalendar = () => import("@/views/calendar");
@@ -569,13 +570,13 @@ function Shell() {
         const { invoke } = await import("@tauri-apps/api/core");
         await invoke("harbor_flush_done").catch(() => {});
       }).then((u) => {
-        if (cancelled) u();
-        else unlisten = u;
+        if (cancelled) safeUnlisten(u);
+        else unlisten = onceUnlisten(u);
       }),
     );
     return () => {
       cancelled = true;
-      unlisten?.();
+      safeUnlisten(unlisten);
     };
   }, []);
 
@@ -605,6 +606,7 @@ function Shell() {
 
   useEffect(() => {
     let dispose: (() => void) | null = null;
+    let cancelled = false;
     void import("@/lib/deep-link").then(({ startDeepLinkBridge, onDeepLinkInstall, onDeepLinkOpen, onOpenLocalFile }) => {
       void startDeepLinkBridge().then((stopBridge) => {
         const stopListener = onDeepLinkInstall(() => {
@@ -619,16 +621,19 @@ function Shell() {
           const name = (path.replace(/\\/g, "/").split("/").pop() || "Video").replace(/\.[^.]+$/, "");
           openPlayer({ meta: { id: `local:${path}`, type: "movie", name }, url: path, title: name, notWebReady: true });
         });
-        dispose = () => {
-          stopBridge();
+        const stop = onceUnlisten(() => {
+          safeUnlisten(stopBridge);
           stopListener();
           stopOpen();
           stopFile();
-        };
+        });
+        if (cancelled) stop();
+        else dispose = stop;
       });
     });
     return () => {
-      dispose?.();
+      cancelled = true;
+      safeUnlisten(dispose);
     };
   }, [setView, openMeta, openPlayer]);
 

--- a/src/lib/deep-link.ts
+++ b/src/lib/deep-link.ts
@@ -1,3 +1,5 @@
+import { safeUnlisten } from "@/lib/tauri-listener";
+
 const EVENT = "harbor:deeplink-install";
 const OPEN_EVENT = "harbor:deeplink-open";
 
@@ -158,18 +160,10 @@ export async function startDeepLinkBridge(): Promise<() => void> {
       if (initial && initial.length > 0) handle(initial);
     } catch {}
     return () => {
-      try {
-        unlisten();
-      } catch {}
-      try {
-        unlistenNative();
-      } catch {}
-      try {
-        unlistenBrowserCap();
-      } catch {}
-      try {
-        unlistenOpenFile();
-      } catch {}
+      safeUnlisten(unlisten);
+      safeUnlisten(unlistenNative);
+      safeUnlisten(unlistenBrowserCap);
+      safeUnlisten(unlistenOpenFile);
     };
   } catch (e) {
     console.warn("[harbor] deep-link bridge failed", e);

--- a/src/lib/dvr/provider.tsx
+++ b/src/lib/dvr/provider.tsx
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 import type { DvrSession, DvrStartArgs } from "./types";
+import { onceUnlisten, safeUnlisten } from "../tauri-listener";
 
 const IS_TAURI = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
@@ -31,7 +32,12 @@ export function DvrProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!IS_TAURI) return;
+    let cancelled = false;
     const unlisteners: UnlistenFn[] = [];
+    const track = (u: UnlistenFn) => {
+      if (cancelled) safeUnlisten(u);
+      else unlisteners.push(onceUnlisten(u));
+    };
     listen<DvrSession>("dvr://progress", (e) => {
       setSessions((prev) => {
         const idx = prev.findIndex((s) => s.id === e.payload.id);
@@ -40,16 +46,19 @@ export function DvrProvider({ children }: { children: ReactNode }) {
         next[idx] = e.payload;
         return next;
       });
-    }).then((u) => unlisteners.push(u)).catch(() => {});
+    }).then(track).catch(() => {});
     listen<DvrSession>("dvr://done", (e) => {
       setSessions((prev) => prev.filter((s) => s.id !== e.payload.id));
       setTerminal((prev) => [...prev.filter((s) => s.id !== e.payload.id), e.payload]);
-    }).then((u) => unlisteners.push(u)).catch(() => {});
+    }).then(track).catch(() => {});
     listen<DvrSession>("dvr://error", (e) => {
       setSessions((prev) => prev.filter((s) => s.id !== e.payload.id));
       setTerminal((prev) => [...prev.filter((s) => s.id !== e.payload.id), e.payload]);
-    }).then((u) => unlisteners.push(u)).catch(() => {});
-    return () => { unlisteners.forEach((u) => u()); };
+    }).then(track).catch(() => {});
+    return () => {
+      cancelled = true;
+      unlisteners.forEach(safeUnlisten);
+    };
   }, []);
 
   const start = useCallback(async (args: DvrStartArgs) => {

--- a/src/lib/settings.tsx
+++ b/src/lib/settings.tsx
@@ -16,6 +16,7 @@ import {
   sourceKeyFor,
 } from "./settings/profile-store";
 import type { Settings, StreamingService } from "./settings/types";
+import { onceUnlisten, safeUnlisten } from "./tauri-listener";
 
 export type {
   ContentCategory,
@@ -269,8 +270,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
     const unlisteners: Array<() => void> = [];
     const track = (u: () => void) => {
-      if (cancelled) u();
-      else unlisteners.push(u);
+      if (cancelled) safeUnlisten(u);
+      else unlisteners.push(onceUnlisten(u));
     };
     void import("@tauri-apps/api/event").then(({ listen }) => {
       void listen<{ closeToTray: boolean; alwaysOnTop: boolean; pauseMinimized: boolean; pauseUnfocused: boolean }>(
@@ -297,7 +298,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     });
     return () => {
       cancelled = true;
-      unlisteners.forEach((u) => u());
+      unlisteners.forEach(safeUnlisten);
     };
   }, []);
 

--- a/src/lib/tauri-listener.ts
+++ b/src/lib/tauri-listener.ts
@@ -1,0 +1,17 @@
+type UnlistenLike = (() => unknown) | null | undefined;
+
+export function safeUnlisten(unlisten: UnlistenLike): void {
+  if (!unlisten) return;
+  try {
+    void Promise.resolve(unlisten()).catch(() => {});
+  } catch {}
+}
+
+export function onceUnlisten(unlisten: Exclude<UnlistenLike, null | undefined>): () => void {
+  let called = false;
+  return () => {
+    if (called) return;
+    called = true;
+    safeUnlisten(unlisten);
+  };
+}

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -3,6 +3,7 @@ import { getCurrentWindow, type Window } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
 import { getWindowFullscreen } from "@/lib/fullscreen-state";
+import { safeUnlisten } from "@/lib/tauri-listener";
 
 const win: Window | null = isTauri() ? getCurrentWindow() : null;
 
@@ -65,7 +66,7 @@ export function useMaximized(): boolean {
     return () => {
       cancelled = true;
       if (timer != null) window.clearTimeout(timer);
-      unlisten.then((fn) => fn());
+      void unlisten.then(safeUnlisten).catch(() => {});
     };
   }, []);
   return maxed;


### PR DESCRIPTION
## Summary

Prevent stale Tauri event-listener cleanup from surfacing as an unhandled promise rejection during React Strict Mode cleanup or Vite hot reload.

## Changes

- add a shared idempotent, rejection-safe Tauri unlisten helper
- guard root app, settings, DVR, window resize, and deep-link listener cleanup
- clean up listeners that finish registering after their React effect has already unmounted
- handle the runtime promise returned by Tauri unlisten even though `UnlistenFn` is typed as returning `void`

## Error addressed

```text
TypeError: undefined is not an object (evaluating listeners[eventId].handlerId)
```

## Verification

- idempotent cleanup regression check passes
- synchronous and rejected-promise cleanup failures are contained

## Current build note

A full build from current `main` is blocked by the pre-existing unresolved `./useKeyboardNavigation` import. That issue is fixed independently in #722. This PR contains no keyboard-navigation commits.