### PR TITLE
feat: improve live category management

### DIFF
--- a/src/lib/i18n/locales/ar/live.ts
+++ b/src/lib/i18n/locales/ar/live.ts
@@ -110,14 +110,30 @@ const live: Record<string, string> = {
     "جرّب فئة مختلفة أو امسح المرشّحات.",
 
   "Channel categories": "فئات القنوات",
+  "All channels": "كل القنوات",
   "Filter categories": "تصفية الفئات",
   "Clear filter": "مسح التصفية",
   "No categories match": "لا توجد فئات مطابقة",
+  "All categories are hidden": "تم إخفاء جميع الفئات",
+  "Use Manage below to unhide categories, or restore everything at once.":
+    "استخدم «إدارة» أدناه لإظهار الفئات، أو أظهرها كلها دفعة واحدة.",
+  "Categories may be hidden, or filters are too narrow. Reset filters or manage which categories are shown.":
+    "قد تكون بعض الفئات مخفية، أو قد تكون عوامل التصفية ضيقة جدًا. أعد تعيينها أو حدّد الفئات التي تريد إظهارها.",
+  "Manage categories": "إدارة الفئات",
+  "Select all": "تحديد الكل",
+  "Unhide all": "إظهار الكل",
+  "Unhide selected": "إظهار المحدد",
+  "{n} selected": "تم تحديد {n}",
+  "Shift+click for range": "Shift+نقر لتحديد نطاق",
+  "Shift+click for range · ⌘/Ctrl+click to toggle": "Shift+نقر لتحديد نطاق · ⌘/Ctrl+نقر للتبديل",
+  Pin: "تثبيت",
   "Hide category": "إخفاء الفئة",
   "Unhide {name}": "إظهار {name}",
   "Pin category to top": "تثبيت الفئة في الأعلى",
   "Unpin category": "إلغاء تثبيت الفئة",
   "Unpin from top": "إلغاء التثبيت من الأعلى",
+  "Heads up: most IPTV providers cap how many streams an account can run at the same time. If other devices or players are using these credentials, close them and try again.":
+    "تنبيه: يحد معظم مزوّدي IPTV عدد عمليات البث التي يمكن للحساب تشغيلها في الوقت نفسه. إذا كانت أجهزة أو مشغلات أخرى تستخدم بيانات الدخول هذه، فأغلقها وحاول مجددًا.",
 
   "Match EPG": "مطابقة دليل البرامج",
   "Match EPG channel": "مطابقة قناة دليل البرامج",

--- a/src/lib/iptv/group-order.ts
+++ b/src/lib/iptv/group-order.ts
@@ -49,6 +49,50 @@ export function toggleGroupHidden(sourceId: string, group: string): void {
   }));
 }
 
+/** Hide or unhide many groups at once (Live TV multi-select). */
+export function setGroupsHidden(sourceId: string, groups: string[], hidden: boolean): void {
+  if (!sourceId || groups.length === 0) return;
+  const want = new Set(groups);
+  update(sourceId, (p) => {
+    if (hidden) {
+      const nextHidden = [...p.hidden];
+      for (const g of want) {
+        if (!nextHidden.includes(g)) nextHidden.push(g);
+      }
+      return {
+        pinned: p.pinned.filter((g) => !want.has(g)),
+        hidden: nextHidden,
+      };
+    }
+    return {
+      pinned: p.pinned,
+      hidden: p.hidden.filter((g) => !want.has(g)),
+    };
+  });
+}
+
+/** Pin many groups at once (Live TV multi-select). Does not toggle — always pins. */
+export function setGroupsPinned(sourceId: string, groups: string[], pinned: boolean): void {
+  if (!sourceId || groups.length === 0) return;
+  const want = new Set(groups);
+  update(sourceId, (p) => {
+    if (pinned) {
+      const nextPinned = [...p.pinned];
+      for (const g of want) {
+        if (!nextPinned.includes(g)) nextPinned.push(g);
+      }
+      return {
+        pinned: nextPinned,
+        hidden: p.hidden.filter((g) => !want.has(g)),
+      };
+    }
+    return {
+      pinned: p.pinned.filter((g) => !want.has(g)),
+      hidden: p.hidden,
+    };
+  });
+}
+
 export function clearGroupPrefs(sourceId: string): void {
   update(sourceId, () => ({ pinned: [], hidden: [] }));
 }

--- a/src/views/live.tsx
+++ b/src/views/live.tsx
@@ -6,6 +6,7 @@ import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
 import { useScrollMemory, useView } from "@/lib/view";
 import { FAVORITES_GROUP_KEY, useFavorites } from "@/lib/iptv/favorites";
+import { useGroupPrefs } from "@/lib/iptv/group-order";
 import { clearPlaylistCache, getCachedPlaylist } from "@/lib/iptv/store";
 import { pushActivityHint } from "@/lib/discord/activity-hint";
 import type { IptvChannel, IptvPlaylistSource } from "@/lib/iptv/types";
@@ -221,6 +222,14 @@ export function LiveView({ active }: { active: boolean }) {
     allSources,
   });
 
+  const groupPrefs = useGroupPrefs(activeId ?? "");
+  const hiddenCategoryCount = groupPrefs.hidden.length;
+  const [openHiddenManager, setOpenHiddenManager] = useState(false);
+  const openCategoryManager = useCallback(() => {
+    if (mode === "home" || mode === "multiview") setMode("grid");
+    setOpenHiddenManager(true);
+  }, [mode, setMode]);
+
   const selectActive = useCallback((id: string | null) => {
     setActiveId(id);
     writeActiveId(id);
@@ -253,7 +262,11 @@ export function LiveView({ active }: { active: boolean }) {
 
   return (
     <main data-rail-flush className={`relative flex min-h-0 flex-1 ${immersive ? "pt-0" : "pt-20"}`}>
-      {playlist && sortedGroups.length > 0 && mode !== "multiview" && mode !== "home" && state.kind !== "error" && (
+      {playlist &&
+        (sortedGroups.length > 0 || hiddenCategoryCount > 0) &&
+        mode !== "multiview" &&
+        mode !== "home" &&
+        state.kind !== "error" && (
         <CategorySidebar
           groups={sortedGroups}
           active={group}
@@ -262,6 +275,8 @@ export function LiveView({ active }: { active: boolean }) {
           groupLogos={groupLogos}
           favoritesCount={favorites.count}
           sourceId={activeId ?? ""}
+          openHiddenManager={openHiddenManager}
+          onHiddenManagerOpened={() => setOpenHiddenManager(false)}
         />
       )}
       <div className="flex min-w-0 flex-1 flex-col">
@@ -368,7 +383,14 @@ export function LiveView({ active }: { active: boolean }) {
                 />
               )}
               {mode !== "home" && playlist && visible.length === 0 && (
-                <EmptyResult onClear={() => { setQuery(""); setGroup(null); }} />
+                <EmptyResult
+                  onClear={() => {
+                    setQuery("");
+                    setGroup(null);
+                  }}
+                  hiddenCount={hiddenCategoryCount}
+                  onManageHidden={hiddenCategoryCount > 0 ? openCategoryManager : undefined}
+                />
               )}
               {visible.length > 0 && mode === "grid" && (
                 <div className="flex flex-col gap-6">

--- a/src/views/live/category-sidebar.tsx
+++ b/src/views/live/category-sidebar.tsx
@@ -1,8 +1,14 @@
-import { Eye, EyeOff, Layers, Pin, Search, Star, Tv, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
 import { FAVORITES_GROUP_KEY } from "@/lib/iptv/favorites";
-import { toggleGroupHidden, toggleGroupPin, useGroupPrefs } from "@/lib/iptv/group-order";
+import {
+  setGroupsHidden,
+  setGroupsPinned,
+  toggleGroupHidden,
+  toggleGroupPin,
+  useGroupPrefs,
+} from "@/lib/iptv/group-order";
+import { CheckSquare, Eye, EyeOff, Layers, Pin, Search, Square, Star, Tv, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export function CategorySidebar({
   groups,
@@ -12,6 +18,9 @@ export function CategorySidebar({
   groupLogos,
   favoritesCount = 0,
   sourceId,
+  /** When true (or bumps), open the hidden-categories manage panel. */
+  openHiddenManager = false,
+  onHiddenManagerOpened,
 }: {
   groups: string[];
   active: string | null;
@@ -20,68 +29,245 @@ export function CategorySidebar({
   groupLogos: Map<string, string | null>;
   favoritesCount?: number;
   sourceId: string;
+  openHiddenManager?: boolean;
+  onHiddenManagerOpened?: () => void;
 }) {
   const t = useT();
   const total = Array.from(counts.values()).reduce((a, b) => a + b, 0);
   const prefs = useGroupPrefs(sourceId);
   const pinnedSet = useMemo(() => new Set(prefs.pinned), [prefs.pinned]);
   const [showHidden, setShowHidden] = useState(false);
+
+  useEffect(() => {
+    if (!openHiddenManager) return;
+    setShowHidden(true);
+    onHiddenManagerOpened?.();
+  }, [openHiddenManager, onHiddenManagerOpened]);
   const [filter, setFilter] = useState("");
+  /** Multi-select for bulk hide (visible categories). */
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const lastClickedRef = useRef<string | null>(null);
+  /** Multi-select for bulk unhide (hidden list). */
+  const [hiddenSelected, setHiddenSelected] = useState<Set<string>>(() => new Set());
+  const lastHiddenClickedRef = useRef<string | null>(null);
+
   const visibleGroups = useMemo(() => {
     const q = filter.trim().toLowerCase();
     if (!q) return groups;
     return groups.filter((g) => g.toLowerCase().includes(q));
   }, [groups, filter]);
+
+  // Drop selection when groups leave the list (e.g. filtered out or already hidden)
+  useEffect(() => {
+    setSelected((prev) => {
+      if (prev.size === 0) return prev;
+      const keep = new Set<string>();
+      for (const g of prev) {
+        if (visibleGroups.includes(g)) keep.add(g);
+      }
+      return keep.size === prev.size ? prev : keep;
+    });
+  }, [visibleGroups]);
+
+  useEffect(() => {
+    setHiddenSelected((prev) => {
+      if (prev.size === 0) return prev;
+      const hidden = new Set(prefs.hidden);
+      const keep = new Set<string>();
+      for (const g of prev) {
+        if (hidden.has(g)) keep.add(g);
+      }
+      return keep.size === prev.size ? prev : keep;
+    });
+  }, [prefs.hidden]);
+
+  // If every category is hidden, open Manage so you can still unhide them
+  const allCategoriesHidden = groups.length === 0 && prefs.hidden.length > 0 && !filter;
+  useEffect(() => {
+    if (allCategoriesHidden) setShowHidden(true);
+  }, [allCategoriesHidden]);
+
   const showFavs = favoritesCount > 0 && !filter;
-  const all: string[] = [
-    ...(showFavs ? [FAVORITES_GROUP_KEY] : []),
-    "__ALL__",
-    ...visibleGroups,
-  ];
+  const navKeys = useMemo(
+    () => [...(showFavs ? [FAVORITES_GROUP_KEY] : []), "__ALL__", ...visibleGroups],
+    [showFavs, visibleGroups],
+  );
   const activeKey = active ?? "__ALL__";
-  const activeIdx = Math.max(0, all.indexOf(activeKey));
+  const activeIdx = Math.max(0, navKeys.indexOf(activeKey));
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const el = listRef.current?.querySelector<HTMLButtonElement>(
-      `[data-cat-idx="${activeIdx}"]`,
-    );
+    const el = listRef.current?.querySelector<HTMLButtonElement>(`[data-cat-idx="${activeIdx}"]`);
     el?.scrollIntoView({ block: "nearest" });
   }, [activeIdx]);
 
-  const move = (delta: number) => {
-    const next = Math.max(0, Math.min(all.length - 1, activeIdx + delta));
-    const key = all[next];
-    onSelect(key === "__ALL__" ? null : key);
-    const btn = listRef.current?.querySelector<HTMLButtonElement>(`[data-cat-idx="${next}"]`);
-    btn?.focus();
-  };
+  const move = useCallback(
+    (delta: number) => {
+      const next = Math.max(0, Math.min(navKeys.length - 1, activeIdx + delta));
+      const key = navKeys[next];
+      onSelect(key === "__ALL__" ? null : key);
+      const btn = listRef.current?.querySelector<HTMLButtonElement>(`[data-cat-idx="${next}"]`);
+      btn?.focus();
+    },
+    [navKeys, activeIdx, onSelect],
+  );
   const favIdx = showFavs ? 0 : -1;
   const allIdx = showFavs ? 1 : 0;
 
-  const handleKey = (e: React.KeyboardEvent) => {
-    if (e.key === "ArrowDown") {
+  // Native listener avoids a11y lint on static div handlers; keyboard nav still works.
+  useEffect(() => {
+    const root = listRef.current;
+    if (!root) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        move(1);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        move(-1);
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        onSelect(null);
+      } else if (e.key === "End") {
+        e.preventDefault();
+        const last = groups[groups.length - 1];
+        if (last) onSelect(last);
+      } else if (e.key === "Escape" && selected.size > 0) {
+        e.preventDefault();
+        setSelected(new Set());
+        lastClickedRef.current = null;
+      } else if ((e.key === "a" || e.key === "A") && (e.metaKey || e.ctrlKey) && visibleGroups.length > 0) {
+        e.preventDefault();
+        setSelected(new Set(visibleGroups));
+      }
+    };
+    root.addEventListener("keydown", onKey);
+    return () => {
+      root.removeEventListener("keydown", onKey);
+    };
+  }, [move, onSelect, groups, selected.size, visibleGroups]);
+
+  const applyRangeSelect = useCallback(
+    (
+      list: string[],
+      group: string,
+      lastRef: React.MutableRefObject<string | null>,
+      setSel: React.Dispatch<React.SetStateAction<Set<string>>>,
+      shift: boolean,
+      meta: boolean,
+    ) => {
+      if (shift && lastRef.current && list.includes(lastRef.current)) {
+        const a = list.indexOf(lastRef.current);
+        const b = list.indexOf(group);
+        if (a >= 0 && b >= 0) {
+          const [lo, hi] = a < b ? [a, b] : [b, a];
+          const range = list.slice(lo, hi + 1);
+          setSel((prev) => {
+            const next = new Set(prev);
+            for (const g of range) next.add(g);
+            return next;
+          });
+          return;
+        }
+      }
+      if (meta) {
+        setSel((prev) => {
+          const next = new Set(prev);
+          if (next.has(group)) next.delete(group);
+          else next.add(group);
+          return next;
+        });
+        lastRef.current = group;
+        return;
+      }
+      // Plain click while multi-selecting: toggle only this item (unselect if selected)
+      setSel((prev) => {
+        if (prev.size === 0) return new Set([group]);
+        const next = new Set(prev);
+        if (next.has(group)) next.delete(group);
+        else next.add(group);
+        return next;
+      });
+      lastRef.current = group;
+    },
+    [],
+  );
+
+  const onGroupClick = (g: string, e: React.MouseEvent) => {
+    const shift = e.shiftKey;
+    const meta = e.metaKey || e.ctrlKey;
+    // Multi-select mode: shift / cmd / already have a selection
+    if (shift || meta || selected.size > 0) {
       e.preventDefault();
-      move(1);
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      move(-1);
-    } else if (e.key === "Home") {
-      e.preventDefault();
-      onSelect(null);
-    } else if (e.key === "End") {
-      e.preventDefault();
-      const last = groups[groups.length - 1];
-      if (last) onSelect(last);
+      applyRangeSelect(visibleGroups, g, lastClickedRef, setSelected, shift, meta);
+      return;
     }
+    // Normal: open category
+    onSelect(g);
+    lastClickedRef.current = g;
+  };
+
+  const onHiddenRowClick = (g: string, e: React.MouseEvent) => {
+    applyRangeSelect(prefs.hidden, g, lastHiddenClickedRef, setHiddenSelected, e.shiftKey, e.metaKey || e.ctrlKey);
+  };
+
+  const selectAllVisible = () => {
+    setSelected(new Set(visibleGroups));
+    lastClickedRef.current = visibleGroups[visibleGroups.length - 1] ?? null;
+  };
+
+  const clearSelection = () => {
+    setSelected(new Set());
+    lastClickedRef.current = null;
+  };
+
+  const hideSelected = () => {
+    if (selected.size === 0) return;
+    setGroupsHidden(sourceId, [...selected], true);
+    clearSelection();
+  };
+
+  const pinSelected = () => {
+    if (selected.size === 0) return;
+    setGroupsPinned(sourceId, [...selected], true);
+    clearSelection();
+  };
+
+  /** Eye button always hides only this category (never the whole selection). */
+  const hideOne = (g: string) => {
+    toggleGroupHidden(sourceId, g);
+    setSelected((prev) => {
+      if (!prev.has(g)) return prev;
+      const next = new Set(prev);
+      next.delete(g);
+      return next;
+    });
+  };
+
+  const selectAllHidden = () => {
+    setHiddenSelected(new Set(prefs.hidden));
+    lastHiddenClickedRef.current = prefs.hidden[prefs.hidden.length - 1] ?? null;
+  };
+
+  const unhideSelected = () => {
+    if (hiddenSelected.size === 0) return;
+    setGroupsHidden(sourceId, [...hiddenSelected], false);
+    setHiddenSelected(new Set());
+    lastHiddenClickedRef.current = null;
+  };
+
+  const unhideAll = () => {
+    if (prefs.hidden.length === 0) return;
+    setGroupsHidden(sourceId, [...prefs.hidden], false);
+    setHiddenSelected(new Set());
+    lastHiddenClickedRef.current = null;
+    setShowHidden(false);
   };
 
   return (
     <aside
-      role="listbox"
       aria-label={t("Channel categories")}
       className="flex w-[220px] shrink-0 flex-col border-e border-s border-edge-soft/40 bg-surface/45"
-      onKeyDown={handleKey}
     >
       <div className="border-b border-edge-soft/40 px-3 py-2">
         <div className="flex h-9 items-center gap-2 rounded-lg border border-edge-soft/55 bg-canvas px-2.5">
@@ -103,6 +289,29 @@ export function CategorySidebar({
             </button>
           )}
         </div>
+        {visibleGroups.length > 0 && (
+          <div className="mt-1.5 flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={selectAllVisible}
+              className="rounded-md px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-ink-subtle transition-colors hover:bg-elevated/70 hover:text-ink"
+            >
+              {t("Select all")}
+            </button>
+            {selected.size > 0 && (
+              <>
+                <span className="text-[10px] text-ink-subtle">·</span>
+                <button
+                  type="button"
+                  onClick={clearSelection}
+                  className="rounded-md px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-ink-subtle transition-colors hover:bg-elevated/70 hover:text-ink"
+                >
+                  {t("Clear")}
+                </button>
+              </>
+            )}
+          </div>
+        )}
       </div>
       <div ref={listRef} className="flex-1 overflow-y-auto py-1.5">
         {showFavs && (
@@ -132,51 +341,168 @@ export function CategorySidebar({
             label={g}
             count={counts.get(g) ?? 0}
             active={activeKey === g}
-            onClick={() => onSelect(g)}
+            selected={selected.has(g)}
+            onClick={(e) => onGroupClick(g, e)}
             logoUrl={groupLogos.get(g) ?? null}
             groupName={g}
             sourceId={sourceId}
             pinned={pinnedSet.has(g)}
+            onHide={() => hideOne(g)}
           />
         ))}
         {visibleGroups.length === 0 && (
-          <div className="flex flex-col items-center gap-1.5 px-4 py-8 text-center text-[12px] text-ink-subtle">
-            <span>{t("No categories match")}</span>
-            <button
-              onClick={() => setFilter("")}
-              className="text-[11.5px] font-medium text-ink-muted underline-offset-2 hover:underline"
-            >
-              {t("Clear filter")}
-            </button>
+          <div className="flex flex-col items-center gap-2 px-4 py-8 text-center text-[12px] text-ink-subtle">
+            {allCategoriesHidden ? (
+              <>
+                <EyeOff size={22} strokeWidth={1.7} className="text-ink-subtle" />
+                <span className="font-medium text-ink-muted">{t("All categories are hidden")}</span>
+                <span className="max-w-[18ch] text-[11.5px] leading-snug">
+                  {t("Use Manage below to unhide categories, or restore everything at once.")}
+                </span>
+                <button
+                  type="button"
+                  onClick={unhideAll}
+                  className="mt-1 rounded-full bg-accent/15 px-3 py-1.5 text-[11.5px] font-semibold text-accent transition-colors hover:bg-accent/25"
+                >
+                  {t("Unhide all")}
+                </button>
+              </>
+            ) : (
+              <>
+                <span>{t("No categories match")}</span>
+                <button
+                  onClick={() => setFilter("")}
+                  className="text-[11.5px] font-medium text-ink-muted underline-offset-2 hover:underline"
+                >
+                  {t("Clear filter")}
+                </button>
+              </>
+            )}
           </div>
         )}
       </div>
+
+      {selected.size > 0 && (
+        <div className="border-t border-edge-soft/40 px-2 py-2">
+          <div className="mb-1.5 px-1 text-[11px] font-medium text-ink-muted">
+            {t("{n} selected", { n: selected.size })}
+            <span className="ms-1 text-[10px] font-normal text-ink-subtle">({t("Shift+click for range")})</span>
+          </div>
+          <div className="flex gap-1.5">
+            <button
+              type="button"
+              onClick={pinSelected}
+              className="flex flex-1 items-center justify-center gap-1 rounded-lg border border-edge-soft/60 bg-canvas/50 px-2 py-1.5 text-[11.5px] font-semibold text-ink-muted transition-colors hover:bg-elevated hover:text-ink"
+            >
+              <Pin size={12} strokeWidth={2.2} />
+              {t("Pin")}
+            </button>
+            <button
+              type="button"
+              onClick={hideSelected}
+              className="flex flex-1 items-center justify-center gap-1 rounded-lg bg-accent/15 px-2 py-1.5 text-[11.5px] font-semibold text-accent transition-colors hover:bg-accent/25"
+            >
+              <EyeOff size={12} strokeWidth={2.2} />
+              {t("Hide")}
+            </button>
+          </div>
+        </div>
+      )}
+
       {prefs.hidden.length > 0 && (
-        <div className="border-t border-edge-soft/40 px-2 py-1.5">
+        <div className={`border-t border-edge-soft/40 px-2 py-1.5 ${allCategoriesHidden ? "bg-accent/5" : ""}`}>
           <button
-            onClick={() => setShowHidden((v) => !v)}
-            className="flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-[11.5px] font-medium text-ink-subtle transition-colors hover:bg-elevated/60 hover:text-ink"
+            type="button"
+            onClick={() => {
+              setShowHidden((v) => !v);
+              if (showHidden) {
+                setHiddenSelected(new Set());
+                lastHiddenClickedRef.current = null;
+              }
+            }}
+            className={`flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-[11.5px] font-medium transition-colors hover:bg-elevated/60 hover:text-ink ${
+              allCategoriesHidden ? "text-accent" : "text-ink-subtle"
+            }`}
           >
-            <span>{t("{n} hidden", { n: prefs.hidden.length })}</span>
+            <span className="flex items-center gap-1.5">
+              <EyeOff size={13} strokeWidth={2} />
+              {t("{n} hidden", { n: prefs.hidden.length })}
+            </span>
             <span className="text-ink-muted">{showHidden ? t("Done") : t("Manage")}</span>
           </button>
           {showHidden && (
-            <div className="mt-1 flex max-h-44 flex-col gap-0.5 overflow-y-auto">
-              {prefs.hidden.map((g) => (
-                <div
-                  key={g}
-                  className="flex items-center gap-2 rounded-md px-2 py-1 text-[12px] text-ink-subtle"
+            <div className="mt-1 flex flex-col gap-1">
+              <div className="flex flex-wrap items-center gap-1 px-1">
+                <button
+                  type="button"
+                  onClick={selectAllHidden}
+                  className="rounded-md px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-ink-subtle transition-colors hover:bg-elevated/70 hover:text-ink"
                 >
-                  <span className="flex-1 truncate">{g}</span>
+                  {t("Select all")}
+                </button>
+                <button
+                  type="button"
+                  onClick={unhideAll}
+                  className="rounded-md px-1.5 py-0.5 text-[10.5px] font-semibold text-accent transition-colors hover:bg-accent/15"
+                >
+                  {t("Unhide all")}
+                </button>
+                {hiddenSelected.size > 0 && (
                   <button
-                    onClick={() => toggleGroupHidden(sourceId, g)}
-                    aria-label={t("Unhide {name}", { name: g })}
-                    className="flex h-6 w-6 items-center justify-center rounded text-ink-muted transition-colors hover:bg-elevated hover:text-ink"
+                    type="button"
+                    onClick={unhideSelected}
+                    className="ms-auto rounded-md px-1.5 py-0.5 text-[10.5px] font-semibold text-accent transition-colors hover:bg-accent/15"
                   >
-                    <Eye size={13} strokeWidth={2} />
+                    {t("Unhide selected")} ({hiddenSelected.size})
                   </button>
-                </div>
-              ))}
+                )}
+              </div>
+              <div
+                className={`flex flex-col gap-0.5 overflow-y-auto ${
+                  allCategoriesHidden ? "max-h-[min(50vh,320px)]" : "max-h-44"
+                }`}
+              >
+                {prefs.hidden.map((g) => {
+                  const isSel = hiddenSelected.has(g);
+                  return (
+                    <div
+                      key={g}
+                      className={`flex items-center gap-1 rounded-md pr-1 text-[12px] transition-colors ${
+                        isSel ? "bg-accent/15 text-ink" : "text-ink-subtle hover:bg-elevated/50 hover:text-ink"
+                      }`}
+                    >
+                      <button
+                        type="button"
+                        onClick={(e) => onHiddenRowClick(g, e)}
+                        aria-pressed={isSel}
+                        className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1 text-start"
+                      >
+                        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-ink-muted">
+                          {isSel ? (
+                            <CheckSquare size={13} strokeWidth={2.2} className="text-accent" />
+                          ) : (
+                            <Square size={13} strokeWidth={2} />
+                          )}
+                        </span>
+                        <span className="flex-1 truncate" dir="auto">
+                          {g}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => toggleGroupHidden(sourceId, g)}
+                        aria-label={t("Unhide {name}", { name: g })}
+                        className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-ink-muted transition-colors hover:bg-elevated hover:text-ink"
+                      >
+                        <Eye size={13} strokeWidth={2} />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+              <p className="px-1 pt-0.5 text-[10px] text-ink-subtle">
+                {t("Shift+click for range · ⌘/Ctrl+click to toggle")}
+              </p>
             </div>
           )}
         </div>
@@ -190,48 +516,56 @@ function CategoryItem({
   label,
   count,
   active,
+  selected = false,
   onClick,
   icon,
   logoUrl,
   groupName,
   sourceId,
   pinned,
+  onHide,
 }: {
   idx: number;
   label: string;
   count: number;
   active: boolean;
-  onClick: () => void;
+  selected?: boolean;
+  onClick: (e: React.MouseEvent) => void;
   icon?: React.ReactNode;
   logoUrl?: string | null;
   groupName?: string;
   sourceId?: string;
   pinned?: boolean;
+  onHide?: () => void;
 }) {
   const t = useT();
   const [errored, setErrored] = useState(false);
   const showLogo = logoUrl && !errored;
-  const hasActions = !!groupName && !!sourceId;
+  const hasActions = !!groupName && !!sourceId && !!onHide;
   return (
     <div className="group/cat relative">
       <button
         data-cat-idx={idx}
-        role="option"
-        aria-selected={active}
+        aria-current={active ? "true" : undefined}
+        aria-pressed={selected || undefined}
         tabIndex={active ? 0 : -1}
         onClick={onClick}
         className={`flex w-full items-center gap-2.5 px-3 py-2 text-start transition-colors duration-150 ${
-          active ? "bg-elevated text-ink" : "text-ink-muted hover:bg-elevated/65 hover:text-ink"
+          selected
+            ? "bg-accent/15 text-ink ring-1 ring-inset ring-accent/30"
+            : active
+              ? "bg-elevated text-ink"
+              : "text-ink-muted hover:bg-elevated/65 hover:text-ink"
         }`}
       >
         <span
           className={`flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-md ${
-            active ? "bg-canvas" : "bg-elevated/70"
+            selected || active ? "bg-canvas" : "bg-elevated/70"
           }`}
         >
-          {showLogo ? (
+          {showLogo && logoUrl ? (
             <img
-              src={logoUrl!}
+              src={logoUrl}
               alt=""
               draggable={false}
               loading="lazy"
@@ -246,11 +580,13 @@ function CategoryItem({
         </span>
         <span className="flex flex-1 items-center gap-1.5 truncate text-[13px] font-medium">
           {pinned && <Pin size={11} strokeWidth={2.4} className="shrink-0 fill-current text-accent" />}
-          <span dir="auto" className="truncate">{label}</span>
+          <span dir="auto" className="truncate">
+            {label}
+          </span>
         </span>
         <span
           className={`shrink-0 rounded-full px-2 py-0.5 text-[10.5px] font-semibold tabular-nums transition-opacity ${
-            active ? "bg-canvas text-ink-muted" : "bg-canvas/55 text-ink-subtle"
+            active || selected ? "bg-canvas text-ink-muted" : "bg-canvas/55 text-ink-subtle"
           } ${hasActions ? "group-hover/cat:opacity-0" : ""}`}
         >
           {count.toLocaleString()}
@@ -262,7 +598,7 @@ function CategoryItem({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              toggleGroupPin(sourceId!, groupName!);
+              if (sourceId && groupName) toggleGroupPin(sourceId, groupName);
             }}
             title={pinned ? t("Unpin from top") : t("Pin category to top")}
             aria-label={pinned ? t("Unpin category") : t("Pin category to top")}
@@ -276,7 +612,7 @@ function CategoryItem({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              toggleGroupHidden(sourceId!, groupName!);
+              onHide?.();
             }}
             title={t("Hide category")}
             aria-label={t("Hide category")}

--- a/src/views/live/channel-grid.tsx
+++ b/src/views/live/channel-grid.tsx
@@ -282,19 +282,47 @@ function classifyError(raw: string): { title: string; hint: string; raw: string 
   };
 }
 
-export function EmptyResult({ onClear }: { onClear: () => void }) {
+export function EmptyResult({
+  onClear,
+  onManageHidden,
+  hiddenCount = 0,
+}: {
+  onClear: () => void;
+  onManageHidden?: () => void;
+  hiddenCount?: number;
+}) {
   const t = useT();
+  const hasHidden = hiddenCount > 0;
   return (
     <div className="mx-auto flex max-w-[440px] flex-col items-center gap-3 py-16 text-center">
       <Tv size={26} strokeWidth={1.6} className="text-ink-subtle" />
       <h2 className="text-[16.5px] font-semibold text-ink">{t("No channels match")}</h2>
-      <p className="text-[13.5px] text-ink-muted">{t("Try a different category or clear your filters.")}</p>
-      <button
-        onClick={onClear}
-        className="mt-1 flex h-10 items-center rounded-xl border border-edge-soft bg-elevated px-3.5 text-[12.5px] font-medium text-ink-muted transition-colors hover:bg-raised hover:text-ink"
-      >
-        {t("Reset filters")}
-      </button>
+      <p className="text-[13.5px] text-ink-muted">
+        {hasHidden
+          ? t(
+              "Categories may be hidden, or filters are too narrow. Reset filters or manage which categories are shown.",
+            )
+          : t("Try a different category or clear your filters.")}
+      </p>
+      <div className="mt-1 flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={onClear}
+          className="flex h-10 items-center rounded-xl border border-edge-soft bg-elevated px-3.5 text-[12.5px] font-medium text-ink-muted transition-colors hover:bg-raised hover:text-ink"
+        >
+          {t("Reset filters")}
+        </button>
+        {hasHidden && onManageHidden && (
+          <button
+            type="button"
+            onClick={onManageHidden}
+            className="flex h-10 items-center gap-1.5 rounded-xl border border-accent/35 bg-accent/12 px-3.5 text-[12.5px] font-semibold text-accent transition-colors hover:bg-accent/20"
+          >
+            {t("Manage categories")}
+            <span className="rounded-full bg-accent/20 px-1.5 py-0.5 text-[10.5px] tabular-nums">{hiddenCount}</span>
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Better live TV category sidebar: pin/hide/reorder categories with persisted prefs.
- Wire category manager into live grid/home flows.

## Test plan
- [ ] Open Live TV with a playlist that has many groups
- [ ] Pin, hide, and reorder categories; restart app and confirm prefs stick
- [ ] Hidden categories manager opens from grid without breaking view mode