### PR TITLE
fix: make Tauri listener cleanup idempotent

### DIFF
--- a/src/lib/tauri-listener.ts
+++ b/src/lib/tauri-listener.ts
@@ -1,0 +1,17 @@
+type Unlisten = () => void | Promise<void>;
+
+export function onceUnlisten(unlisten: Unlisten): () => void {
+  let called = false;
+
+  return () => {
+    if (called) return;
+    called = true;
+
+    try {
+      const result = unlisten();
+      if (result && typeof result.catch === "function") {
+        void result.catch(() => {});
+      }
+    } catch {}
+  };
+}

--- a/src/views/player/hooks/use-pause-on-inactive.ts
+++ b/src/views/player/hooks/use-pause-on-inactive.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
 import { useSettings } from "@/lib/settings";
+import { onceUnlisten } from "@/lib/tauri-listener";
 
 const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
@@ -24,8 +25,9 @@ export function usePauseOnInactive({
       listen("harbor://window-activity", () => {
         window.dispatchEvent(new Event("harbor:mpv-force-geom"));
       }).then((u) => {
-        if (cancelled) u();
-        else unlisten = u;
+        const cleanup = onceUnlisten(u);
+        if (cancelled) cleanup();
+        else unlisten = cleanup;
       }),
     );
     return () => {
@@ -55,8 +57,9 @@ export function usePauseOnInactive({
           if (snapRef.current.status === "paused") void bridge.play();
         }
       }).then((u) => {
-        if (cancelled) u();
-        else unlisten = u;
+        const cleanup = onceUnlisten(u);
+        if (cancelled) cleanup();
+        else unlisten = cleanup;
       }),
     );
     return () => {


### PR DESCRIPTION
## Summary
- Ensure Tauri event listener unlisten is safe to call more than once.
- Apply in pause-on-inactive player hook to avoid double-unlisten races.

## Test plan
- [ ] Open/close player and background the app repeatedly
- [ ] No console errors from unlisten / dispose