### PR TITLE
feat: native FSRCNNX x2 shader support

### DIFF
--- a/src-tauri/src/fsrcnnx.rs
+++ b/src-tauri/src/fsrcnnx.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+use tauri::Manager;
+
+// Latest FSRCNNX 8-0-4-1 release from igv/FSRCNN-TensorFlow
+const FSRCNNX_URL: &str =
+    "https://github.com/igv/FSRCNN-TensorFlow/releases/download/1.1/FSRCNNX_x2_8-0-4-1.glsl";
+const FSRCNNX_FILE: &str = "FSRCNNX_x2_8-0-4-1.glsl";
+
+fn shaders_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let base = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(base.join("fsrcnnx"))
+}
+
+/// Returns the fsrcnnx shaders directory path if the shader file is present, else None.
+#[tauri::command]
+pub fn fsrcnnx_dir(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let dir = shaders_dir(&app)?;
+    let shader = dir.join(FSRCNNX_FILE);
+    if shader.exists() {
+        Ok(Some(dir.to_string_lossy().into_owned()))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Downloads FSRCNNX shader file into app_data/fsrcnnx/.
+/// Set force=true to re-download even if already present.
+#[tauri::command]
+pub async fn fsrcnnx_download(app: tauri::AppHandle, force: bool) -> Result<String, String> {
+    let dir = shaders_dir(&app)?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create dir: {}", e))?;
+    let dest = dir.join(FSRCNNX_FILE);
+    if !force {
+        if let Ok(meta) = std::fs::metadata(&dest) {
+            if meta.len() > 0 {
+                return Ok(dir.to_string_lossy().into_owned());
+            }
+        }
+    }
+    let client = reqwest::Client::builder()
+        .user_agent("Harbor")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let resp = client
+        .get(FSRCNNX_URL)
+        .send()
+        .await
+        .map_err(|e| format!("download FSRCNNX: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("download FSRCNNX: HTTP {}", resp.status()));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("read FSRCNNX: {}", e))?;
+    if bytes.is_empty() {
+        return Err("FSRCNNX shader file was empty".into());
+    }
+    std::fs::write(&dest, &bytes).map_err(|e| format!("write FSRCNNX: {}", e))?;
+    Ok(dir.to_string_lossy().into_owned())
+}
+
+/// Applies FSRCNNX shader to the running mpv instance via glsl-shaders and
+/// enforces rgba16f fbo-format which FSRCNNX requires for correct operation.
+#[tauri::command]
+pub fn fsrcnnx_set(app: tauri::AppHandle, mpv: tauri::State<crate::MpvHandle>) -> Result<(), String> {
+    let dir = shaders_dir(&app)?;
+    let shader_path = dir.join(FSRCNNX_FILE);
+    if !shader_path.exists() {
+        return Err("FSRCNNX shader not downloaded yet. Call fsrcnnx_download first.".into());
+    }
+    let path_str = shader_path.to_string_lossy().into_owned();
+    // FSRCNNX requires a float FBO; set it before loading the shader.
+    crate::mpv_set_property_raw(&mpv, "fbo-format", "rgba16f")?;
+    crate::mpv_set_property_raw(&mpv, "glsl-shaders", &path_str)?;
+    Ok(())
+}
+
+/// Clears FSRCNNX shader and resets fbo-format to the mpv default.
+#[tauri::command]
+pub fn fsrcnnx_clear(mpv: tauri::State<crate::MpvHandle>) -> Result<(), String> {
+    crate::mpv_set_property_raw(&mpv, "glsl-shaders", "")?;
+    crate::mpv_set_property_raw(&mpv, "fbo-format", "auto")?;
+    Ok(())
+}

--- a/src/components/player/fsrcnnx-indicator.tsx
+++ b/src/components/player/fsrcnnx-indicator.tsx
@@ -1,0 +1,45 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+
+function isFsrcnnxActive(shaders: unknown): boolean {
+  if (!shaders) return false;
+  const s = String(shaders);
+  return s.toLowerCase().includes("fsrcnnx");
+}
+
+export function FsrcnnxIndicator() {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      const shaders = await invoke("mpv_get_property", {
+        name: "glsl-shaders",
+      }).catch(() => null);
+      if (!cancelled) setActive(isFsrcnnxActive(shaders));
+    };
+    void tick();
+    const id = setInterval(tick, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!active) return null;
+
+  return (
+    <div
+      className="pointer-events-none select-none rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-widest"
+      style={{
+        background: "rgba(0,0,0,0.55)",
+        color: "#e0b84e",
+        border: "1px solid rgba(224,184,78,0.45)",
+        backdropFilter: "blur(4px)",
+      }}
+      title="FSRCNNX x2 upscaling active"
+    >
+      FSRCNNX
+    </div>
+  );
+}

--- a/src/components/player/fsrcnnx-toggle.tsx
+++ b/src/components/player/fsrcnnx-toggle.tsx
@@ -1,0 +1,99 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+
+type Status = "idle" | "downloading" | "ready" | "error";
+
+export function FsrcnnxToggle() {
+  const [enabled, setEnabled] = useState(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  // On mount check if shader is already downloaded
+  useEffect(() => {
+    invoke<string | null>("fsrcnnx_dir")
+      .then((dir) => {
+        if (dir) setStatus("ready");
+      })
+      .catch(() => {});
+  }, []);
+
+  // Sync enabled state with current mpv glsl-shaders
+  useEffect(() => {
+    const tick = async () => {
+      const shaders = await invoke<string>("mpv_get_property", {
+        name: "glsl-shaders",
+      }).catch(() => "");
+      setEnabled(shaders.toLowerCase().includes("fsrcnnx"));
+    };
+    void tick();
+    const id = setInterval(tick, 2000);
+    return () => clearInterval(id);
+  }, []);
+
+  async function handleToggle() {
+    if (enabled) {
+      await invoke("fsrcnnx_clear").catch(() => {});
+      setEnabled(false);
+      return;
+    }
+    // Need shader downloaded first
+    if (status !== "ready") {
+      setStatus("downloading");
+      setErrorMsg("");
+      try {
+        await invoke("fsrcnnx_download", { force: false });
+        setStatus("ready");
+      } catch (e) {
+        setStatus("error");
+        setErrorMsg(String(e));
+        return;
+      }
+    }
+    try {
+      await invoke("fsrcnnx_set");
+      setEnabled(true);
+    } catch (e) {
+      setStatus("error");
+      setErrorMsg(String(e));
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-semibold text-white">
+            FSRCNNX Upscaling
+          </p>
+          <p className="text-xs text-white/50">
+            Real-time x2 luma upscaling for live-action content (480p→1080p,
+            720p→4K). Disable for native 4K. Mutually exclusive with Anime4K.
+          </p>
+        </div>
+        <button
+          onClick={handleToggle}
+          disabled={status === "downloading"}
+          className={[
+            "relative ml-4 h-6 w-11 flex-shrink-0 rounded-full transition-colors duration-200",
+            enabled ? "bg-yellow-500" : "bg-white/20",
+            status === "downloading" ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+          ].join(" ")}
+          aria-label={enabled ? "Disable FSRCNNX" : "Enable FSRCNNX"}
+        >
+          <span
+            className={[
+              "absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform duration-200",
+              enabled ? "translate-x-5" : "translate-x-0.5",
+            ].join(" ")}
+          />
+        </button>
+      </div>
+      {status === "downloading" && (
+        <p className="text-xs text-yellow-400">Downloading FSRCNNX shader…</p>
+      )}
+      {status === "error" && (
+        <p className="text-xs text-red-400">Error: {errorMsg}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## FSRCNNX Native Shader Support

This PR adds first-class FSRCNNX upscaling support to Harbor's libmpv player, following the same architecture as the existing Anime4K integration.

### What's added

#### `src-tauri/src/fsrcnnx.rs` — Rust backend
- `fsrcnnx_dir` — returns shader directory path if shader is present
- `fsrcnnx_download(force)` — downloads `FSRCNNX_x2_8-0-4-1.glsl` from the [igv/FSRCNN-TensorFlow releases](https://github.com/igv/FSRCNN-TensorFlow/releases) into `app_data/fsrcnnx/`
- `fsrcnnx_set` — applies the shader via `glsl-shaders` and enforces `fbo-format=rgba16f` (required for correct FSRCNNX operation)
- `fsrcnnx_clear` — clears the shader and resets `fbo-format` to `auto`

#### `src/components/player/fsrcnnx-indicator.tsx` — Player HUD badge
- Polls `glsl-shaders` every 2 s and shows a gold **FSRCNNX** badge when active
- Mirrors the `anime4k-indicator` pattern

#### `src/components/player/fsrcnnx-toggle.tsx` — Settings toggle
- Toggle switch in Settings → Player
- Auto-downloads shader on first enable (no manual file copy needed)
- Shows download progress and error states
- Disabling clears both `glsl-shaders` and `fbo-format`

### Integration needed by maintainers

1. Add `mod fsrcnnx;` and register the four commands in `src-tauri/src/lib.rs` `invoke_handler`:
   ```rust
   fsrcnnx::fsrcnnx_dir,
   fsrcnnx::fsrcnnx_download,
   fsrcnnx::fsrcnnx_set,
   fsrcnnx::fsrcnnx_clear,
   ```
2. Place `<FsrcnnxToggle />` inside the Player settings section (alongside the Anime4K toggle).
3. Place `<FsrcnnxIndicator />` in the player HUD overlay (alongside `<Anime4kIndicator />`).

### Notes
- FSRCNNX is a **live-action** upscaler; Anime4K is for animation. They should not be stacked — enabling one should ideally disable the other (the toggle components are independent for now, maintainers can add mutual exclusion).
- Only applies when the player engine is **native libmpv**.
- The shader file (~50 KB) is downloaded on demand; nothing is bundled.