### PR TITLE
fix: remove duplicate keyboard modal declaration

### DIFF
--- a/src/lib/use-keyboard-navigation.ts
+++ b/src/lib/use-keyboard-navigation.ts
@@ -328,8 +328,6 @@ export function useKeyboardNavigation(options: TVNavigationOptions = {}) {
 
       if (isEditable(target)) return;
 
-      const activeModal = getActiveModal(target);
-
       if (isBackKey(e)) {
         if (activeModal) return;
         e.preventDefault();


### PR DESCRIPTION
Fixes the TypeScript build failure on `main` caused by declaring `activeModal` twice in the keyboard-navigation handler.

  Validation:

  ```
  pnpm install --frozen-lockfile
  pnpm exec tsc -b
  npm run build 
  ```