### PR TITLE
fix(player): unify embedded mpv geometry across platforms

### DIFF
--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -55,7 +55,7 @@ pub struct MpvStartArgs {
     pub extra_options: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MpvGeometry {
     pub css_left: f64,
@@ -64,6 +64,69 @@ pub struct MpvGeometry {
     pub css_height: f64,
     pub css_view_w: f64,
     pub css_view_h: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct NativeMpvRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+pub(crate) fn map_css_geometry(
+    css: &MpvGeometry,
+    native_width: f64,
+    native_height: f64,
+) -> NativeMpvRect {
+    let full_surface = NativeMpvRect {
+        x: 0.0,
+        y: 0.0,
+        width: native_width,
+        height: native_height,
+    };
+    if !css.css_left.is_finite()
+        || !css.css_top.is_finite()
+        || !css.css_width.is_finite()
+        || !css.css_height.is_finite()
+        || !css.css_view_w.is_finite()
+        || !css.css_view_h.is_finite()
+        || css.css_width <= 0.0
+        || css.css_height <= 0.0
+        || css.css_view_w <= 0.0
+        || css.css_view_h <= 0.0
+    {
+        return full_surface;
+    }
+
+    let scale_x = native_width / css.css_view_w;
+    let scale_y = native_height / css.css_view_h;
+    let mut x = css.css_left * scale_x;
+    let mut y = css.css_top * scale_y;
+    let mut width = css.css_width * scale_x;
+    let mut height = css.css_height * scale_y;
+
+    if css.css_left.abs() <= 2.0 {
+        width += x;
+        x = 0.0;
+    }
+    if css.css_top.abs() <= 2.0 {
+        height += y;
+        y = 0.0;
+    }
+    if css.css_left + css.css_width >= css.css_view_w - 2.0 {
+        width = native_width - x;
+    }
+    if css.css_top + css.css_height >= css.css_view_h - 2.0 {
+        height = native_height - y;
+    }
+
+    x = x.clamp(0.0, (native_width - 1.0).max(0.0));
+    y = y.clamp(0.0, (native_height - 1.0).max(0.0));
+    width = width.clamp(1.0, (native_width - x).max(1.0));
+    height = height.clamp(1.0, (native_height - y).max(1.0));
+
+    NativeMpvRect { x, y, width, height }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -894,30 +957,19 @@ pub async fn mpv_set_geometry(
             g.as_ref().map(|s| s.embedded).unwrap_or(false)
         };
         if embedded {
-            return position_embedded_mpv_child(
-                &app,
-                geom.css_left,
-                geom.css_top,
-                geom.css_width,
-                geom.css_height,
-                geom.css_view_w,
-                geom.css_view_h,
-            );
+            return position_embedded_mpv_child(&app, geom);
         }
     }
     #[cfg(target_os = "macos")]
     {
-        let x = geom.css_left;
-        let y = geom.css_top;
-        let w = geom.css_view_w;
-        let h = geom.css_view_h;
-        let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
-        let _ = app.run_on_main_thread(move || {
-            let _ = crate::mpv_render_mac::resize_to(x, y, w, h);
-            let _ = tx.send(());
-        });
-        let _ = rx.recv_timeout(std::time::Duration::from_millis(300));
-        return Ok(());
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        app.run_on_main_thread(move || {
+            let _ = tx.send(crate::mpv_render_mac::resize_to(geom));
+        })
+        .map_err(|error| format!("failed to schedule macOS mpv resize: {error}"))?;
+        return rx
+            .recv_timeout(std::time::Duration::from_millis(300))
+            .map_err(|error| format!("timed out waiting for macOS mpv resize: {error}"))?;
     }
     #[cfg(target_os = "linux")]
     {
@@ -926,15 +978,9 @@ pub async fn mpv_set_geometry(
             g.as_ref().map(|s| s.embedded).unwrap_or(false)
         };
         if embedded {
-            let x = geom.css_left;
-            let y = geom.css_top;
-            let w = geom.css_width;
-            let h = geom.css_height;
-            let css_view_w = geom.css_view_w;
-            let css_view_h = geom.css_view_h;
             let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
             let _ = app.run_on_main_thread(move || {
-                let _ = crate::mpv_render_linux::resize_to(x, y, w, h, css_view_w, css_view_h);
+                let _ = crate::mpv_render_linux::resize_to(geom);
                 let _ = tx.send(());
             });
             let _ = rx.recv_timeout(std::time::Duration::from_millis(300));
@@ -1723,12 +1769,7 @@ static MPV_HDR_STAGE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicB
 #[cfg(windows)]
 fn position_embedded_mpv_child(
     app: &AppHandle,
-    css_left: f64,
-    css_top: f64,
-    css_width: f64,
-    css_height: f64,
-    css_view_w: f64,
-    css_view_h: f64,
+    css: MpvGeometry,
 ) -> Result<(), String> {
     use windows::core::BOOL;
     use windows::Win32::Foundation::{HWND, LPARAM};
@@ -1754,30 +1795,16 @@ fn position_embedded_mpv_child(
         let mut rc = RECT::default();
         let ok = unsafe { GetClientRect(parent_hwnd, &mut rc).is_ok() };
         let (cw, ch) = (rc.right, rc.bottom);
-        if !(ok && cw > 0 && ch > 0 && css_view_w > 0.5 && css_view_h > 0.5) {
+        if !(ok && cw > 0 && ch > 0) {
             (0i32, 0i32, cw.max(1) as u32, ch.max(1) as u32)
         } else {
-            let sx = cw as f64 / css_view_w;
-            let sy = ch as f64 / css_view_h;
-            let mut x = (css_left * sx).round() as i32;
-            let mut y = (css_top * sy).round() as i32;
-            let mut w = (css_width * sx).round() as i32;
-            let mut h = (css_height * sy).round() as i32;
-            if x.abs() <= 2 {
-                w += x;
-                x = 0;
-            }
-            if y.abs() <= 2 {
-                h += y;
-                y = 0;
-            }
-            if (x + w - cw).abs() <= 4 || css_left + css_width >= css_view_w - 2.0 {
-                w = cw - x;
-            }
-            if (y + h - ch).abs() <= 4 || css_top + css_height >= css_view_h - 2.0 {
-                h = ch - y;
-            }
-            (x, y, w.max(1) as u32, h.max(1) as u32)
+            let native = map_css_geometry(&css, cw as f64, ch as f64);
+            (
+                native.x.round() as i32,
+                native.y.round() as i32,
+                native.width.round().max(1.0) as u32,
+                native.height.round().max(1.0) as u32,
+            )
         }
     };
 
@@ -1905,4 +1932,60 @@ fn position_embedded_mpv_child(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod geometry_tests {
+    use super::{map_css_geometry, MpvGeometry, NativeMpvRect};
+
+    #[test]
+    fn mpv_geometry_maps_a_zoomed_full_viewport_to_the_full_native_surface() {
+        let css = MpvGeometry {
+            css_left: 0.0,
+            css_top: 0.0,
+            css_width: 1221.428571,
+            css_height: 742.857143,
+            css_view_w: 1221.428571,
+            css_view_h: 742.857143,
+        };
+
+        assert_eq!(
+            map_css_geometry(&css, 1710.0, 1040.0),
+            NativeMpvRect { x: 0.0, y: 0.0, width: 1710.0, height: 1040.0 }
+        );
+    }
+
+    #[test]
+    fn mpv_geometry_scales_partial_rectangles_on_each_axis() {
+        let css = MpvGeometry {
+            css_left: 10.0,
+            css_top: 20.0,
+            css_width: 500.0,
+            css_height: 300.0,
+            css_view_w: 1000.0,
+            css_view_h: 800.0,
+        };
+
+        assert_eq!(
+            map_css_geometry(&css, 2000.0, 1200.0),
+            NativeMpvRect { x: 20.0, y: 30.0, width: 1000.0, height: 450.0 }
+        );
+    }
+
+    #[test]
+    fn mpv_geometry_falls_back_to_the_native_surface_for_invalid_viewports() {
+        let css = MpvGeometry {
+            css_left: 40.0,
+            css_top: 30.0,
+            css_width: 500.0,
+            css_height: 300.0,
+            css_view_w: 0.0,
+            css_view_h: f64::NAN,
+        };
+
+        assert_eq!(
+            map_css_geometry(&css, 1920.0, 1080.0),
+            NativeMpvRect { x: 0.0, y: 0.0, width: 1920.0, height: 1080.0 }
+        );
+    }
 }

--- a/src-tauri/src/mpv_render_linux.rs
+++ b/src-tauri/src/mpv_render_linux.rs
@@ -14,6 +14,8 @@ use gtk::prelude::*;
 use libmpv2::render::{OpenGLInitParams, RenderContext, RenderParam, RenderParamApiType};
 use libmpv2_sys::mpv_handle;
 
+use crate::mpv::{map_css_geometry, MpvGeometry};
+
 const GL_FRAMEBUFFER_BINDING: u32 = 0x8CA6;
 const GL_FRAMEBUFFER: u32 = 0x8D40;
 const GL_COLOR_ATTACHMENT0: u32 = 0x8CE0;
@@ -366,36 +368,24 @@ fn do_render(rc: &RenderContext, area: &gtk::GLArea) {
     let _ = rc.render::<()>(fbo, w, h, true);
 }
 
-pub fn resize_to(
-    x: f64,
-    y: f64,
-    w: f64,
-    h: f64,
-    css_view_w: f64,
-    css_view_h: f64,
-) -> Result<(), String> {
+pub fn resize_to(css: MpvGeometry) -> Result<(), String> {
     EMBED.with(|slot| {
         let guard = slot.borrow();
         let Some(embed) = guard.as_ref() else {
             return;
         };
-        let sx = if css_view_w > 0.0 {
-            embed.gtk_window.allocated_width().max(1) as f64 / css_view_w
-        } else {
-            1.0
-        };
-        let sy = if css_view_h > 0.0 {
-            embed.gtk_window.allocated_height().max(1) as f64 / css_view_h
-        } else {
-            1.0
-        };
-        let lw = (w * sx).round().max(1.0) as i32;
-        let lh = (h * sy).round().max(1.0) as i32;
+        let native = map_css_geometry(
+            &css,
+            embed.gtk_window.allocated_width().max(1) as f64,
+            embed.gtk_window.allocated_height().max(1) as f64,
+        );
+        let lw = native.width.round().max(1.0) as i32;
+        let lh = native.height.round().max(1.0) as i32;
         embed.area.set_size_request(lw, lh);
         if let Some(parent) = embed.area.parent() {
             if let Some(fixed) = parent.downcast_ref::<gtk::Fixed>() {
-                let lx = (x * sx).round() as i32;
-                let ly = (y * sy).round() as i32;
+                let lx = native.x.round() as i32;
+                let ly = native.y.round() as i32;
                 fixed.move_(&embed.area, lx, ly);
             }
         }

--- a/src-tauri/src/mpv_render_mac.rs
+++ b/src-tauri/src/mpv_render_mac.rs
@@ -15,6 +15,8 @@ use objc2_app_kit::{
 };
 use objc2_foundation::{MainThreadMarker, NSNumber, NSString};
 
+use crate::mpv::{map_css_geometry, MpvGeometry};
+
 const NSOPENGLPFA_OPENGL_PROFILE: u32 = 99;
 const NSOPENGLPFA_DOUBLEBUFFER: u32 = 5;
 const NSOPENGLPFA_COLOR_SIZE: u32 = 8;
@@ -314,7 +316,7 @@ pub fn make_resizable(ns_window_ptr: i64) -> Result<(), String> {
     Ok(())
 }
 
-pub fn resize_to(x: f64, y: f64, w: f64, h: f64) -> Result<(), String> {
+pub fn resize_to(css: MpvGeometry) -> Result<(), String> {
     let _mtm = MainThreadMarker::new()
         .ok_or_else(|| "resize_to must run on main thread".to_string())?;
     let guard = slot().lock().map_err(|e| format!("slot lock: {}", e))?;
@@ -326,11 +328,23 @@ pub fn resize_to(x: f64, y: f64, w: f64, h: f64) -> Result<(), String> {
         let parent = view_as_view
             .superview()
             .ok_or_else(|| "GL view has no superview".to_string())?;
-        let parent_h = parent.bounds().size.height;
-        let flipped_y = parent_h - y - h;
+        let parent_bounds = parent.bounds();
+        let native = map_css_geometry(
+            &css,
+            parent_bounds.size.width,
+            parent_bounds.size.height,
+        );
+        let native_y = if parent.isFlipped() {
+            native.y
+        } else {
+            parent_bounds.size.height - native.y - native.height
+        };
         let frame = objc2_foundation::NSRect {
-            origin: objc2_foundation::NSPoint { x, y: flipped_y },
-            size: objc2_foundation::NSSize { width: w, height: h },
+            origin: objc2_foundation::NSPoint { x: native.x, y: native_y },
+            size: objc2_foundation::NSSize {
+                width: native.width,
+                height: native.height,
+            },
         };
         view_as_view.setFrame(frame);
         let mask: usize = 0;


### PR DESCRIPTION
## Summary

- centralize CSS-to-native video geometry conversion in one shared function
- use the same conversion for the Win32, GTK, and AppKit embedded mpv adapters
- keep the native video surface aligned with the full WebView at non-default UI zoom levels
- add regression coverage for zoomed viewports, partial rectangles, and invalid viewport data

## Problem

Harbor applies UI scaling through WebView zoom. Embedded mpv is rendered by a separate native surface, so its CSS rectangle must be converted back into the coordinate system of the native host window.

Windows and Linux already performed versions of this conversion locally. The macOS adapter passed CSS viewport dimensions directly to `NSOpenGLView.setFrame`, treating CSS pixels as AppKit points. At UI scales above 100%, that made the native video surface smaller than the Harbor window and left unused black space on the right and bottom. WebView overlays such as subtitles continued to use the full window, which made the mismatch especially visible.

## Root cause

The CSS-to-native mapping had no shared contract. Each platform adapter owned a separate calculation, and the macOS path did not account for WebView zoom.

## Solution

Introduce a single geometry mapping function:

```text
scaleX = nativeViewportWidth  / cssViewportWidth
scaleY = nativeViewportHeight / cssViewportHeight

nativeX      = cssX      * scaleX
nativeY      = cssY      * scaleY
nativeWidth  = cssWidth  * scaleX
nativeHeight = cssHeight * scaleY
```

Each platform now only supplies its native surface size and applies the returned rectangle:

- Windows reads the Win32 client rectangle.
- Linux reads the GTK window allocation.
- macOS reads the parent `NSView` bounds and converts the top-left CSS origin to the AppKit coordinate orientation.

The shared mapper also snaps near-fullscreen edges to the native surface and falls back to the full native surface if the CSS viewport data is invalid.

## Behavior

- UI scale 100%: no intended visual change.
- UI scale above or below 100%: the embedded mpv surface follows the full Harbor viewport.
- Windowed and fullscreen layouts use the same mapping.
- Partial video rectangles remain supported.

## Testing

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- [x] 10 Rust tests passed
- [x] regression test for a full viewport at 140% UI scale
- [x] regression test for independently scaled X/Y partial rectangles
- [x] regression test for invalid viewport fallback
- [x] manual verification on macOS at 140% UI scale
- [ ] platform verification on Windows and Linux

## Screenshot
before
<img width="1701" height="841" alt="file-dead8220059caa911c10e6e8c1c651a1" src="https://github.com/user-attachments/assets/a2942fd5-9e95-42f1-a981-d7fa27005230" />
after 
<img width="1710" height="1112" alt="Screenshot 2026-07-13 at 6 51 38 AM" src="https://github.com/user-attachments/assets/8dc1b18b-f372-4951-9ced-c9092523cb31" />


