### PR TITLE
fix(iptv): load complete Xtream catalogs progressively

### DIFF
--- a/src/lib/iptv/catalog-publication-gate.ts
+++ b/src/lib/iptv/catalog-publication-gate.ts
@@ -1,0 +1,50 @@
+type Schedule = (task: () => void) => void;
+
+function scheduleNextPaint(task: () => void): void {
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(() => task());
+    return;
+  }
+  setTimeout(task, 0);
+}
+
+export function createCatalogPublicationGate<T>(
+  publish: (items: readonly T[]) => void,
+  schedule: Schedule = scheduleNextPaint,
+) {
+  let latest: readonly T[] | null = null;
+  let releaseRequested = false;
+  let released = false;
+  let scheduled = false;
+  let resolveReleased: (() => void) | null = null;
+  const releasedPromise = new Promise<void>((resolve) => {
+    resolveReleased = resolve;
+  });
+
+  const scheduleRelease = () => {
+    if (released || scheduled || !releaseRequested || latest == null) return;
+    scheduled = true;
+    schedule(() => {
+      scheduled = false;
+      released = true;
+      if (latest != null) publish(latest);
+      resolveReleased?.();
+      resolveReleased = null;
+    });
+  };
+
+  return {
+    update(items: readonly T[]) {
+      latest = items;
+      if (released) publish(items);
+      else scheduleRelease();
+    },
+    release() {
+      releaseRequested = true;
+      scheduleRelease();
+    },
+    whenReleased() {
+      return releasedPromise;
+    },
+  };
+}

--- a/src/lib/iptv/ingest/load.ts
+++ b/src/lib/iptv/ingest/load.ts
@@ -1,11 +1,5 @@
 import { parseM3u } from "../m3u";
-import {
-  commitHydratedPlaylist,
-  fetchM3uText,
-  markVodHydrated,
-  shapePlaylist,
-  unmarkVodHydrated,
-} from "../store";
+import { fetchM3uText, shapePlaylist } from "../store";
 import { liveContainerPref } from "../settings-bridge";
 import type { IptvPlaylist, IptvPlaylistSource } from "../types";
 import {
@@ -15,7 +9,6 @@ import {
   XtreamEmptyError,
   type XtreamCreds,
 } from "../xtream";
-import { fetchXtreamVodAndSeries } from "../xtream-vod";
 import type { ProviderShape } from "./detect";
 
 const MIDDLEWARE_CANDIDATES = ["/iptv/m3u", "/m3u", "/playlist.m3u", "/get.php?type=m3u_plus"];
@@ -39,23 +32,7 @@ async function loadXtream(src: IptvPlaylistSource, creds: XtreamCreds): Promise<
       "Logged in to the Xtream server, but it returned no live channels. The account may have no active package.",
     );
   }
-  void hydrateXtreamVod(src, creds, live);
   return shapePlaylist(src, live);
-}
-
-async function hydrateXtreamVod(
-  src: IptvPlaylistSource,
-  creds: XtreamCreds,
-  live: IptvPlaylist["channels"],
-): Promise<void> {
-  if (!markVodHydrated(src.id)) return;
-  try {
-    const vod = await fetchXtreamVodAndSeries(creds, src.id);
-    if (vod.length === 0) return;
-    commitHydratedPlaylist(src, [...live, ...vod]);
-  } catch {
-    unmarkVodHydrated(src.id);
-  }
 }
 
 async function loadM3u(

--- a/src/lib/iptv/persistent-cache.ts
+++ b/src/lib/iptv/persistent-cache.ts
@@ -1,0 +1,140 @@
+import type { IptvPlaylistSource } from "./types";
+
+export const IPTV_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+const DB_NAME = "harbor-iptv-cache";
+const STORE_NAME = "entries";
+const DB_VERSION = 1;
+const SCHEMA_VERSION = 1;
+
+export type IptvCacheKind = "playlist" | "xtream-vod";
+
+export type PersistentIptvCacheEntry<T> = {
+  sourceSignature: string;
+  savedAt: number;
+  value: T;
+};
+
+type StoredEntry<T> = PersistentIptvCacheEntry<T> & {
+  schemaVersion: number;
+};
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+        request.result.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(null);
+    request.onblocked = () => resolve(null);
+  });
+  return dbPromise;
+}
+
+function entryKey(kind: IptvCacheKind, sourceId: string): string {
+  return `${kind}:${sourceId}`;
+}
+
+export function isPersistentCacheFresh(
+  fetchedAt: number | null | undefined,
+  now = Date.now(),
+): boolean {
+  return typeof fetchedAt === "number" && now - fetchedAt < IPTV_CACHE_TTL_MS;
+}
+
+export function iptvSourceSignature(source: IptvPlaylistSource): string {
+  const input = JSON.stringify([
+    source.kind ?? "m3u",
+    source.url,
+    source.epgUrl ?? "",
+    source.xtream?.server ?? "",
+    source.xtream?.username ?? "",
+    source.xtream?.password ?? "",
+  ]);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `v1:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+export async function readIptvCache<T>(
+  kind: IptvCacheKind,
+  sourceId: string,
+): Promise<PersistentIptvCacheEntry<T> | null> {
+  try {
+    const db = await openDb();
+    if (!db) return null;
+    return await new Promise((resolve) => {
+      const transaction = db.transaction(STORE_NAME, "readonly");
+      const request = transaction.objectStore(STORE_NAME).get(entryKey(kind, sourceId));
+      request.onsuccess = () => {
+        const entry = request.result as StoredEntry<T> | undefined;
+        if (
+          !entry ||
+          entry.schemaVersion !== SCHEMA_VERSION ||
+          typeof entry.sourceSignature !== "string" ||
+          typeof entry.savedAt !== "number"
+        ) {
+          resolve(null);
+          return;
+        }
+        resolve({
+          sourceSignature: entry.sourceSignature,
+          savedAt: entry.savedAt,
+          value: entry.value,
+        });
+      };
+      request.onerror = () => resolve(null);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function writeIptvCache<T>(
+  kind: IptvCacheKind,
+  sourceId: string,
+  entry: PersistentIptvCacheEntry<T>,
+): Promise<void> {
+  try {
+    const db = await openDb();
+    if (!db) return;
+    await new Promise<void>((resolve) => {
+      const transaction = db.transaction(STORE_NAME, "readwrite");
+      transaction.objectStore(STORE_NAME).put(
+        { ...entry, schemaVersion: SCHEMA_VERSION } satisfies StoredEntry<T>,
+        entryKey(kind, sourceId),
+      );
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => resolve();
+      transaction.onabort = () => resolve();
+    });
+  } catch {
+    /* ignore cache write failures */
+  }
+}
+
+export async function deleteIptvCache(kind: IptvCacheKind, sourceId: string): Promise<void> {
+  try {
+    const db = await openDb();
+    if (!db) return;
+    await new Promise<void>((resolve) => {
+      const transaction = db.transaction(STORE_NAME, "readwrite");
+      transaction.objectStore(STORE_NAME).delete(entryKey(kind, sourceId));
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => resolve();
+      transaction.onabort = () => resolve();
+    });
+  } catch {
+    /* ignore cache delete failures */
+  }
+}

--- a/src/lib/iptv/source-cleanup.ts
+++ b/src/lib/iptv/source-cleanup.ts
@@ -4,6 +4,7 @@ import { clearEpg } from "./epg-store";
 import { removeEpgOverridesForSource } from "./epg-map";
 import { removeGroupPrefs } from "./group-order";
 import { removePinsForSource } from "./pins";
+import { deleteIptvCache } from "./persistent-cache";
 import { clearPlaylistCache } from "./store";
 
 export function purgePlaylistState(
@@ -12,6 +13,7 @@ export function purgePlaylistState(
 ): void {
   if (!id) return;
   clearPlaylistCache(id);
+  void deleteIptvCache("xtream-vod", id);
   clearEpg(id);
   removeStatsForSource(id);
   removePinsForSource(id);

--- a/src/lib/iptv/store.ts
+++ b/src/lib/iptv/store.ts
@@ -1,13 +1,19 @@
 import { filterChannelsForDisplay } from "./divider-filter";
 import { loadFromShape } from "./ingest/load";
 import { detectProviderShape } from "./ingest/detect";
+import {
+  deleteIptvCache,
+  iptvSourceSignature,
+  isPersistentCacheFresh,
+  readIptvCache,
+  writeIptvCache,
+} from "./persistent-cache";
 import type { IptvChannel, IptvPlaylist, IptvPlaylistSource } from "./types";
 import { clearSeriesInfoCache } from "./xtream-vod";
 
-const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
-
 const cache = new Map<string, IptvPlaylist>();
 const inflight = new Map<string, Promise<IptvPlaylist>>();
+const restoring = new Map<string, Promise<IptvPlaylist | null>>();
 const listeners = new Set<() => void>();
 const vodHydrated = new Set<string>();
 
@@ -35,11 +41,14 @@ export function getCachedPlaylist(id: string): IptvPlaylist | null {
 export function clearPlaylistCache(id?: string) {
   if (id) {
     cache.delete(id);
+    restoring.delete(id);
     vodHydrated.delete(id);
     inflight.delete(id);
     clearSeriesInfoCache(id);
+    void deleteIptvCache("playlist", id);
   } else {
     cache.clear();
+    restoring.clear();
     vodHydrated.clear();
     inflight.clear();
     clearSeriesInfoCache();
@@ -51,24 +60,74 @@ export async function loadPlaylist(
   src: IptvPlaylistSource,
   opts?: { force?: boolean },
 ): Promise<IptvPlaylist> {
-  const existing = cache.get(src.id);
-  if (!opts?.force && existing && Date.now() - existing.fetchedAt < CACHE_TTL_MS) {
+  if (opts?.force) return fetchPlaylist(src, true);
+
+  const existing = cache.get(src.id) ?? (await restorePlaylist(src));
+  if (existing) {
+    if (!isPersistentCacheFresh(existing.fetchedAt)) {
+      void fetchPlaylist(src).catch(() => {});
+    }
     return existing;
   }
+  return fetchPlaylist(src);
+}
+
+async function restorePlaylist(src: IptvPlaylistSource): Promise<IptvPlaylist | null> {
+  const existing = cache.get(src.id);
+  if (existing) return existing;
+  const pending = restoring.get(src.id);
+  if (pending) return pending;
+
+  const promise = readIptvCache<IptvPlaylist>("playlist", src.id)
+    .then((entry) => {
+      if (!entry) return null;
+      if (entry.sourceSignature !== iptvSourceSignature(src) || !isPlaylist(entry.value)) {
+        void deleteIptvCache("playlist", src.id);
+        return null;
+      }
+      cache.set(src.id, entry.value);
+      notify();
+      return entry.value;
+    })
+    .finally(() => {
+      if (restoring.get(src.id) === promise) restoring.delete(src.id);
+    });
+  restoring.set(src.id, promise);
+  return promise;
+}
+
+function fetchPlaylist(src: IptvPlaylistSource, force = false): Promise<IptvPlaylist> {
   const pending = inflight.get(src.id);
-  if (pending && !opts?.force) return pending;
+  if (pending && !force) return pending;
   const promise = loadFromShape(src, detectProviderShape(src));
   inflight.set(src.id, promise);
-  try {
-    const result = await promise;
-    if (inflight.get(src.id) === promise) {
-      cache.set(src.id, result);
-      notify();
-    }
-    return result;
-  } finally {
-    if (inflight.get(src.id) === promise) inflight.delete(src.id);
-  }
+  return promise
+    .then((result) => {
+      if (inflight.get(src.id) === promise) {
+        cache.set(src.id, result);
+        notify();
+        void writeIptvCache("playlist", src.id, {
+          sourceSignature: iptvSourceSignature(src),
+          savedAt: result.fetchedAt,
+          value: result,
+        });
+      }
+      return result;
+    })
+    .finally(() => {
+      if (inflight.get(src.id) === promise) inflight.delete(src.id);
+    });
+}
+
+function isPlaylist(value: unknown): value is IptvPlaylist {
+  if (!value || typeof value !== "object") return false;
+  const playlist = value as Partial<IptvPlaylist>;
+  return (
+    typeof playlist.id === "string" &&
+    Array.isArray(playlist.channels) &&
+    Array.isArray(playlist.groups) &&
+    typeof playlist.fetchedAt === "number"
+  );
 }
 
 export function markVodHydrated(id: string): boolean {

--- a/src/lib/iptv/vod.ts
+++ b/src/lib/iptv/vod.ts
@@ -30,6 +30,7 @@ export type VodSeries = {
   playlistName: string;
   episodes: VodEpisode[];
   seasons: number[];
+  xtreamSeriesId?: string;
 };
 
 export type VodLibrary = { movies: VodMovie[]; series: VodSeries[] };
@@ -39,7 +40,10 @@ export function isExternalPlaylistId(id: string): boolean {
 }
 
 function norm(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 function numberFallbackEpisodes(episodes: VodEpisode[]): void {
@@ -85,11 +89,14 @@ export function buildVodLibrary(
       }
 
       const show = showTitleFromEpisode(ch.name) || cleanTitle(ch.name);
-      const key = `${pl.id}|${norm(show)}`;
+      const xtreamSeriesId = ch.attrs["xtream-series-id"]?.trim();
+      const key = xtreamSeriesId ? `${pl.id}|xtream:${xtreamSeriesId}` : `${pl.id}|${norm(show)}`;
       let series = seriesMap.get(key);
       if (!series) {
         series = {
-          id: `vod:series:${pl.id}:${norm(show)}`,
+          id: xtreamSeriesId
+            ? `vod:series:${pl.id}:${xtreamSeriesId}`
+            : `vod:series:${pl.id}:${norm(show)}`,
           title: show,
           logo: ch.logo,
           group: ch.group,
@@ -97,10 +104,15 @@ export function buildVodLibrary(
           playlistName: plName,
           episodes: [],
           seasons: [],
+          xtreamSeriesId: xtreamSeriesId || undefined,
         };
         seriesMap.set(key, series);
       }
       if (!series.logo && ch.logo) series.logo = ch.logo;
+      if (xtreamSeriesId) {
+        series.xtreamSeriesId = xtreamSeriesId;
+        continue;
+      }
       const se = parseSeriesEpisode(ch.name);
       series.episodes.push({
         season: se?.season ?? 1,

--- a/src/lib/iptv/xtream-batches.ts
+++ b/src/lib/iptv/xtream-batches.ts
@@ -1,0 +1,46 @@
+export type BatchProgress = {
+  processed: number;
+  total: number;
+};
+
+type BatchOptions<T, R> = {
+  batchSize: number;
+  map: (value: T, index: number) => R | null | undefined;
+  onBatch?: (batch: readonly R[], progress: BatchProgress) => boolean | void;
+  yieldControl?: () => Promise<void>;
+};
+
+function yieldToBrowser(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+      return;
+    }
+    setTimeout(resolve, 0);
+  });
+}
+
+export async function processInBatches<T, R>(
+  values: readonly T[],
+  options: BatchOptions<T, R>,
+): Promise<R[]> {
+  const batchSize = Math.max(1, Math.floor(options.batchSize));
+  const result: R[] = [];
+
+  for (let start = 0; start < values.length; start += batchSize) {
+    const end = Math.min(start + batchSize, values.length);
+    const batch: R[] = [];
+    for (let index = start; index < end; index += 1) {
+      const mapped = options.map(values[index], index);
+      if (mapped == null) continue;
+      batch.push(mapped);
+      result.push(mapped);
+    }
+
+    const keepGoing = options.onBatch?.(batch, { processed: end, total: values.length });
+    if (keepGoing === false) break;
+    if (end < values.length) await (options.yieldControl ?? yieldToBrowser)();
+  }
+
+  return result;
+}

--- a/src/lib/iptv/xtream-vod.ts
+++ b/src/lib/iptv/xtream-vod.ts
@@ -1,15 +1,23 @@
 import { apiUrl, xtreamFetch, type XtreamCreds } from "./xtream";
 import type { IptvChannel } from "./types";
+import { processInBatches, type BatchProgress } from "./xtream-batches";
 
 type CategoryRow = { category_id: string; category_name?: string };
 type VodRow = {
   stream_id: number;
   name?: string;
+  stream_type?: string;
   stream_icon?: string;
   category_id?: string;
   container_extension?: string;
 };
-type SeriesRow = { series_id: number; name?: string; cover?: string; category_id?: string };
+type SeriesRow = {
+  series_id: number;
+  name?: string;
+  stream_type?: string;
+  cover?: string;
+  category_id?: string;
+};
 type EpisodeRow = {
   id: string | number;
   episode_num?: string | number;
@@ -19,8 +27,16 @@ type EpisodeRow = {
   info?: { movie_image?: string };
 };
 type SeriesInfo = { episodes?: Record<string, EpisodeRow[]> };
+type XtreamSeries = Pick<SeriesRow, "series_id" | "name" | "cover" | "category_id">;
+
+export type XtreamCatalogBatchOptions = {
+  batchSize?: number;
+  onStart?: (total: number) => void;
+  onBatch?: (batch: readonly IptvChannel[], progress: BatchProgress) => boolean | void;
+};
 
 const seriesInfoCache = new Map<string, SeriesInfo>();
+const CATALOG_BATCH_SIZE = 256;
 
 export function clearSeriesInfoCache(baseId?: string): void {
   if (!baseId) {
@@ -55,110 +71,111 @@ function buildSeriesUrl(creds: XtreamCreds, episodeId: number | string, ext?: st
   return e ? `${base}.${e}` : base;
 }
 
-async function mapLimit<T, R>(items: T[], limit: number, fn: (t: T) => Promise<R>): Promise<R[]> {
-  const out: R[] = new Array(items.length);
-  let cursor = 0;
-  const worker = async () => {
-    while (cursor < items.length) {
-      const idx = cursor;
-      cursor += 1;
-      out[idx] = await fn(items[idx]);
-    }
-  };
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-  return out;
-}
-
-export async function fetchXtreamVod(creds: XtreamCreds, baseId: string): Promise<IptvChannel[]> {
+export async function fetchXtreamVod(
+  creds: XtreamCreds,
+  baseId: string,
+  options?: XtreamCatalogBatchOptions,
+): Promise<IptvChannel[]> {
   const [catsRaw, streamsRaw] = await Promise.all([
     xtreamFetch(apiUrl(creds, "get_vod_categories")),
     xtreamFetch(apiUrl(creds, "get_vod_streams")),
   ]);
   const cats = catMap(catsRaw);
   const rows: VodRow[] = Array.isArray(streamsRaw) ? (streamsRaw as VodRow[]) : [];
-  const out: IptvChannel[] = [];
-  for (const r of rows) {
-    if (!r || r.stream_id == null) continue;
-    out.push({
-      id: `${baseId}::xtvod::${r.stream_id}`,
-      tvgId: null,
-      name: r.name?.trim() || `Movie ${r.stream_id}`,
-      logo: r.stream_icon?.trim() || null,
-      group: r.category_id ? cats.get(String(r.category_id)) ?? null : null,
-      url: buildVodUrl(creds, r.stream_id, r.container_extension),
-      catchupSource: null,
-      durationSec: null,
-      attrs: { "tvg-type": "movie" },
-    });
-  }
-  return out;
+  options?.onStart?.(rows.length);
+  return processInBatches(rows, {
+    batchSize: options?.batchSize ?? CATALOG_BATCH_SIZE,
+    map: (row) => {
+      if (!row || row.stream_id == null) return null;
+      const type = row.stream_type?.trim().toLowerCase();
+      if (type && type !== "movie" && type !== "vod") return null;
+      return {
+        id: `${baseId}::xtvod::${row.stream_id}`,
+        tvgId: null,
+        name: row.name?.trim() || `Movie ${row.stream_id}`,
+        logo: row.stream_icon?.trim() || null,
+        group: row.category_id ? (cats.get(String(row.category_id)) ?? null) : null,
+        url: buildVodUrl(creds, row.stream_id, row.container_extension),
+        catchupSource: null,
+        durationSec: null,
+        attrs: { "tvg-type": "movie" },
+      } satisfies IptvChannel;
+    },
+    onBatch: options?.onBatch,
+  });
 }
 
-const MAX_SERIES_EXPANDED = 1200;
-
-export async function fetchXtreamSeries(creds: XtreamCreds, baseId: string): Promise<IptvChannel[]> {
+export async function fetchXtreamSeries(
+  creds: XtreamCreds,
+  baseId: string,
+  options?: XtreamCatalogBatchOptions,
+): Promise<IptvChannel[]> {
   const [catsRaw, seriesRaw] = await Promise.all([
     xtreamFetch(apiUrl(creds, "get_series_categories")),
     xtreamFetch(apiUrl(creds, "get_series")),
   ]);
   const cats = catMap(catsRaw);
-  const all: SeriesRow[] = Array.isArray(seriesRaw) ? (seriesRaw as SeriesRow[]) : [];
-  const series = all.slice(0, MAX_SERIES_EXPANDED);
-  let throttled = false;
-  const perSeries = await mapLimit(series, 6, async (s): Promise<IptvChannel[]> => {
-    if (!s || s.series_id == null) return [];
-    const seriesName = s.name?.trim() || `Series ${s.series_id}`;
-    const group = s.category_id ? cats.get(String(s.category_id)) ?? null : null;
-    const cover = s.cover?.trim() || null;
-    const cacheKey = `${baseId}::${s.series_id}`;
-    let info = seriesInfoCache.get(cacheKey);
-    if (!info) {
-      if (throttled) return [];
-      try {
-        info = (await xtreamFetch(
-          apiUrl(creds, "get_series_info", { series_id: String(s.series_id) }),
-        )) as SeriesInfo;
-      } catch (e) {
-        if (/HTTP (?:429|403)/.test(String(e))) throttled = true;
-        return [];
-      }
-      seriesInfoCache.set(cacheKey, info);
-    }
-    const episodes = info?.episodes;
-    if (!episodes || typeof episodes !== "object") return [];
-    const eps: IptvChannel[] = [];
-    for (const seasonKey of Object.keys(episodes)) {
-      const list = episodes[seasonKey];
-      if (!Array.isArray(list)) continue;
-      for (const ep of list) {
-        if (!ep || ep.id == null) continue;
-        const season = Number(ep.season) || Number(seasonKey) || 1;
-        const epNum = Number(ep.episode_num) || 0;
-        eps.push({
-          id: `${baseId}::xtep::${ep.id}`,
-          tvgId: null,
-          name: `${seriesName} S${season}E${epNum}`,
-          logo: ep.info?.movie_image?.trim() || cover,
-          group,
-          url: buildSeriesUrl(creds, ep.id, ep.container_extension),
-          catchupSource: null,
-          durationSec: null,
-          attrs: { "tvg-type": "series" },
-        });
-      }
-    }
-    return eps;
+  const series: SeriesRow[] = Array.isArray(seriesRaw) ? (seriesRaw as SeriesRow[]) : [];
+  options?.onStart?.(series.length);
+  return processInBatches(series, {
+    batchSize: options?.batchSize ?? CATALOG_BATCH_SIZE,
+    map: (item) => {
+      if (!item || item.series_id == null) return null;
+      const type = item.stream_type?.trim().toLowerCase();
+      if (type && type !== "series") return null;
+      return {
+        id: `${baseId}::xtseries::${item.series_id}`,
+        tvgId: null,
+        name: item.name?.trim() || `Series ${item.series_id}`,
+        logo: item.cover?.trim() || null,
+        group: item.category_id ? (cats.get(String(item.category_id)) ?? null) : null,
+        url: "",
+        catchupSource: null,
+        durationSec: null,
+        attrs: { "tvg-type": "series", "xtream-series-id": String(item.series_id) },
+      } satisfies IptvChannel;
+    },
+    onBatch: options?.onBatch,
   });
-  return perSeries.flat();
 }
 
-export async function fetchXtreamVodAndSeries(
+export async function fetchXtreamSeriesEpisodes(
   creds: XtreamCreds,
   baseId: string,
+  series: XtreamSeries,
 ): Promise<IptvChannel[]> {
-  const [vod, series] = await Promise.all([
-    fetchXtreamVod(creds, baseId).catch(() => [] as IptvChannel[]),
-    fetchXtreamSeries(creds, baseId).catch(() => [] as IptvChannel[]),
-  ]);
-  return [...vod, ...series];
+  const seriesName = series.name?.trim() || `Series ${series.series_id}`;
+  const cacheKey = `${baseId}::${series.series_id}`;
+  let info = seriesInfoCache.get(cacheKey);
+  if (!info) {
+    info = (await xtreamFetch(
+      apiUrl(creds, "get_series_info", { series_id: String(series.series_id) }),
+    )) as SeriesInfo;
+    seriesInfoCache.set(cacheKey, info);
+  }
+  const episodes = info?.episodes;
+  if (!episodes || typeof episodes !== "object") return [];
+
+  const out: IptvChannel[] = [];
+  for (const seasonKey of Object.keys(episodes)) {
+    const list = episodes[seasonKey];
+    if (!Array.isArray(list)) continue;
+    for (const ep of list) {
+      if (!ep || ep.id == null) continue;
+      const season = Number(ep.season) || Number(seasonKey) || 1;
+      const epNum = Number(ep.episode_num) || 0;
+      out.push({
+        id: `${baseId}::xtep::${ep.id}`,
+        tvgId: null,
+        name: `${seriesName} S${season}E${epNum}`,
+        logo: ep.info?.movie_image?.trim() || series.cover?.trim() || null,
+        group: series.category_id ?? null,
+        url: buildSeriesUrl(creds, ep.id, ep.container_extension),
+        catchupSource: null,
+        durationSec: null,
+        attrs: { "tvg-type": "series" },
+      });
+    }
+  }
+  return out;
 }

--- a/src/views/live/hooks/use-playlist-mutations.ts
+++ b/src/views/live/hooks/use-playlist-mutations.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useSettings, type Settings } from "@/lib/settings";
 import { clearPlaylistCache } from "@/lib/iptv/store";
 import { clearEpg } from "@/lib/iptv/epg-store";
+import { deleteIptvCache } from "@/lib/iptv/persistent-cache";
 import { purgePlaylistState } from "@/lib/iptv/source-cleanup";
 import { useFavorites } from "@/lib/iptv/favorites";
 import { buildXtreamUrls, type PlaylistFormValue } from "../source-picker/playlist-form";
@@ -65,6 +66,7 @@ export function usePlaylistMutations(params: {
       const next = playlists.map((s) => (s.id === id ? materializePlaylistEntry(id, entry) : s));
       update({ iptvPlaylists: next });
       clearPlaylistCache(id);
+      void deleteIptvCache("xtream-vod", id);
       clearEpg(id);
       if (activeId === id) refresh();
     },

--- a/src/views/playlist-vod.tsx
+++ b/src/views/playlist-vod.tsx
@@ -1,57 +1,103 @@
 import { Film, Search, Tv } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import { useT } from "@/lib/i18n";
 import { getCachedPlaylist } from "@/lib/iptv/store";
 import type { IptvPlaylistSource } from "@/lib/iptv/types";
 import { buildVodLibrary, type VodEpisode, type VodMovie, type VodSeries } from "@/lib/iptv/vod";
+import { credsFromServer } from "@/lib/iptv/xtream";
+import { fetchXtreamSeriesEpisodes } from "@/lib/iptv/xtream-vod";
 import { useSettings } from "@/lib/settings";
 import { useScrollMemory, useView } from "@/lib/view";
 import { SourcePicker } from "./live/source-picker";
 import { PlaylistEmpty } from "./live/playlist-empty";
 import { useIptvPlaylist } from "./live/hooks/use-iptv-playlist";
 import { SeriesDetail } from "./playlist-vod/series-detail";
+import { useXtreamVodLibrary } from "./playlist-vod/use-xtream-vod-library";
 import { useVodSources } from "./playlist-vod/use-vod-sources";
 import { VodCard } from "./playlist-vod/vod-card";
 
 type Tab = "movies" | "series";
 
-const RENDER_CAP = 500;
+const PAGE_SIZE = 60;
+const SCROLL_SETTLE_DELAY_MS = 250;
 
 export function PlaylistVodView({ active }: { active: boolean }) {
   const t = useT();
   const { settings } = useSettings();
   const { openPlayer } = useView();
-  const { sources, activeId, selectId, addPlaylist, editPlaylist, removePlaylist } = useVodSources();
+  const { sources, activeId, selectId, addPlaylist, editPlaylist, removePlaylist } =
+    useVodSources();
 
   const activeSource = useMemo<IptvPlaylistSource | null>(
     () => sources.find((s) => s.id === activeId) ?? null,
     [sources, activeId],
   );
 
-  const { state, refresh } = useIptvPlaylist(active ? activeSource : null);
-  const playlist = state.kind === "ready" ? state.playlist : getCachedPlaylist(activeSource?.id ?? "");
+  const isXtream = activeSource?.kind === "xtream";
+  const { state, refresh: refreshPlaylist } = useIptvPlaylist(
+    active && !isXtream ? activeSource : null,
+  );
+  const xtream = useXtreamVodLibrary(active && isXtream ? activeSource : null);
+  const refresh = isXtream ? xtream.refresh : refreshPlaylist;
+  const playlist =
+    state.kind === "ready" ? state.playlist : getCachedPlaylist(activeSource?.id ?? "");
 
   const names = useMemo(() => new Map(sources.map((s) => [s.id, s.name] as const)), [sources]);
-  const library = useMemo(
-    () => (playlist ? buildVodLibrary([playlist], names) : { movies: [], series: [] }),
-    [playlist, names],
-  );
+  const library = useMemo(() => {
+    if (isXtream) return xtream.library;
+    return playlist ? buildVodLibrary([playlist], names) : { movies: [], series: [] };
+  }, [isXtream, names, playlist, xtream.library]);
+  const loading = isXtream ? xtream.loading : state.kind === "loading";
+  const error = isXtream ? xtream.error : state.kind === "error" ? state.message : null;
+  const fetchedAt = isXtream ? xtream.fetchedAt : (playlist?.fetchedAt ?? null);
 
   const [tab, setTab] = useState<Tab>("movies");
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<VodSeries | null>(null);
+  const [loadingSeriesId, setLoadingSeriesId] = useState<string | null>(null);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const loadMoreTimer = useRef<number | null>(null);
 
   const chooseTab = useCallback((t: Tab) => {
     setTab(t);
     setSelected(null);
   }, []);
+  const viewError = isXtream
+    ? tab === "movies"
+      ? xtream.movieError
+      : xtream.seriesError
+    : error;
+  const tabLoading = isXtream
+    ? tab === "movies"
+      ? xtream.moviesLoading
+      : xtream.seriesLoading
+    : loading;
+  const providerTotal = isXtream
+    ? tab === "movies"
+      ? xtream.movieTotal
+      : xtream.seriesTotal
+    : null;
+  const tabItemCount = tab === "movies" ? library.movies.length : library.series.length;
 
   useEffect(() => {
     setSelected(null);
+    setVisibleCount(PAGE_SIZE);
   }, [activeId]);
 
-  const q = query.trim().toLowerCase();
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [query, tab]);
+
+  useEffect(
+    () => () => {
+      if (loadMoreTimer.current != null) window.clearTimeout(loadMoreTimer.current);
+    },
+    [],
+  );
+
+  const deferredQuery = useDeferredValue(query);
+  const q = deferredQuery.trim().toLowerCase();
   const movies = useMemo(
     () => (q ? library.movies.filter((m) => m.title.toLowerCase().includes(q)) : library.movies),
     [library.movies, q],
@@ -60,6 +106,8 @@ export function PlaylistVodView({ active }: { active: boolean }) {
     () => (q ? library.series.filter((s) => s.title.toLowerCase().includes(q)) : library.series),
     [library.series, q],
   );
+  const visibleMovies = movies.slice(0, visibleCount);
+  const visibleSeries = series.slice(0, visibleCount);
 
   const playMovie = useCallback(
     (m: VodMovie) => {
@@ -88,6 +136,48 @@ export function PlaylistVodView({ active }: { active: boolean }) {
     [openPlayer],
   );
 
+  const openSeries = useCallback(
+    (series: VodSeries) => {
+      setSelected(series);
+      if (!series.xtreamSeriesId || activeSource?.kind !== "xtream" || !activeSource.xtream) return;
+      const creds = credsFromServer(
+        activeSource.xtream.server,
+        activeSource.xtream.username,
+        activeSource.xtream.password,
+      );
+      if (!creds) return;
+
+      setLoadingSeriesId(series.id);
+      void fetchXtreamSeriesEpisodes(creds, activeSource.id, {
+        series_id: Number(series.xtreamSeriesId),
+        name: series.title,
+        cover: series.logo ?? undefined,
+        category_id: series.group ?? undefined,
+      })
+        .then((channels) => {
+          const episodes = channels.map((channel) => {
+            const match = /S(\d+)E(\d+)$/i.exec(channel.name);
+            return {
+              season: Number(match?.[1]) || 1,
+              episode: Number(match?.[2]) || 0,
+              title: channel.name,
+              url: channel.url,
+              logo: channel.logo,
+            };
+          });
+          const seasons = [...new Set(episodes.map((episode) => episode.season))].sort(
+            (a, b) => a - b,
+          );
+          setSelected((current) =>
+            current?.id === series.id ? { ...current, episodes, seasons } : current,
+          );
+        })
+        .catch(() => {})
+        .finally(() => setLoadingSeriesId((current) => (current === series.id ? null : current)));
+    },
+    [activeSource],
+  );
+
   const scrollRef = useRef<HTMLDivElement>(null);
   useScrollMemory("vod", scrollRef, active);
 
@@ -102,10 +192,21 @@ export function PlaylistVodView({ active }: { active: boolean }) {
   const gridStyle = {
     gridTemplateColumns: `repeat(auto-fill, minmax(${Math.round(150 * (settings.posterScale ?? 1))}px, 1fr))`,
   };
+  const total = tab === "movies" ? movies.length : series.length;
+  const loadMore = () => setVisibleCount((count) => Math.min(count + PAGE_SIZE, total));
+  const onScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    const el = event.currentTarget;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight >= 420) return;
+    if (loadMoreTimer.current != null) window.clearTimeout(loadMoreTimer.current);
+    loadMoreTimer.current = window.setTimeout(() => {
+      loadMoreTimer.current = null;
+      loadMore();
+    }, SCROLL_SETTLE_DELAY_MS);
+  };
 
   return (
     <main data-rail-flush className="relative flex min-h-0 flex-1 flex-col pt-20">
-      <header className="relative z-[40] flex shrink-0 flex-wrap items-center gap-2.5 border-b border-edge-soft/40 bg-surface px-6 py-2.5">
+      <header className="relative z-40 flex shrink-0 flex-wrap items-center gap-2.5 border-b border-edge-soft/40 bg-surface px-6 py-2.5">
         <SourcePicker
           sources={sources}
           activeId={activeId}
@@ -116,13 +217,25 @@ export function PlaylistVodView({ active }: { active: boolean }) {
           onRemove={removePlaylist}
           onRefresh={refresh}
           onExport={() => {}}
-          fetchedAt={playlist?.fetchedAt ?? null}
+          fetchedAt={fetchedAt}
           channelCount={null}
-          loading={state.kind === "loading"}
+          loading={loading}
         />
         <div className="flex h-11 items-center gap-0.5 rounded-xl border border-edge-soft/55 bg-elevated p-1">
-          <TabButton active={tab === "movies"} onClick={() => chooseTab("movies")} icon={<Film size={14} strokeWidth={2} />} label={t("Movies")} count={library.movies.length} />
-          <TabButton active={tab === "series"} onClick={() => chooseTab("series")} icon={<Tv size={14} strokeWidth={2} />} label={t("Shows")} count={library.series.length} />
+          <TabButton
+            active={tab === "movies"}
+            onClick={() => chooseTab("movies")}
+            icon={<Film size={14} strokeWidth={2} />}
+            label={t("Movies")}
+            count={library.movies.length}
+          />
+          <TabButton
+            active={tab === "series"}
+            onClick={() => chooseTab("series")}
+            icon={<Tv size={14} strokeWidth={2} />}
+            label={t("Shows")}
+            count={library.series.length}
+          />
         </div>
         <div className="flex h-11 flex-1 min-w-[220px] items-center gap-2.5 rounded-xl border border-edge-soft/55 bg-elevated px-3.5">
           <Search size={15} strokeWidth={2} className="text-ink-subtle" />
@@ -134,29 +247,53 @@ export function PlaylistVodView({ active }: { active: boolean }) {
             className="flex-1 bg-transparent text-[14px] text-ink placeholder:text-ink-subtle focus:outline-none"
           />
           {query && (
-            <button onClick={() => setQuery("")} className="text-[12.5px] font-medium text-ink-subtle transition-colors hover:text-ink">
+            <button
+              onClick={() => setQuery("")}
+              className="text-[12.5px] font-medium text-ink-subtle transition-colors hover:text-ink"
+            >
               {t("Clear")}
             </button>
           )}
         </div>
       </header>
 
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 pt-6 pb-16">
-        {state.kind === "error" ? (
-          <Notice text={state.message} onRetry={refresh} />
-        ) : state.kind === "loading" && !playlist ? (
+      <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto px-6 pt-6 pb-16">
+        {viewError && tabItemCount === 0 ? (
+          <Notice text={viewError} onRetry={refresh} />
+        ) : tabLoading && (tab === "movies" ? movies.length === 0 : series.length === 0) ? (
           <Notice text={t("Loading playlist...")} />
         ) : selected ? (
-          <SeriesDetail series={selected} onBack={() => setSelected(null)} onPlay={(ep) => playEpisode(selected, ep)} />
+          <SeriesDetail
+            key={`${selected.id}:${selected.seasons.join(",")}`}
+            series={selected}
+            loading={loadingSeriesId === selected.id}
+            onBack={() => setSelected(null)}
+            onPlay={(ep) => playEpisode(selected, ep)}
+          />
         ) : tab === "movies" ? (
           movies.length === 0 ? (
             <Notice text={emptyMoviesText(t, library.movies.length, q)} />
           ) : (
             <>
-              <CapNote shown={Math.min(movies.length, RENDER_CAP)} total={movies.length} kind="movies" />
+              {viewError && <CatalogWarning text={viewError} onRetry={refresh} />}
+              <CatalogProgress
+                loading={tabLoading}
+                loaded={library.movies.length}
+                total={providerTotal}
+                kind="movies"
+              />
+              <CapNote shown={visibleMovies.length} total={movies.length} kind="movies" />
               <div className="grid gap-x-4 gap-y-6" style={gridStyle}>
-                {movies.slice(0, RENDER_CAP).map((m) => (
-                  <VodCard key={m.id} kind="movie" title={m.title} year={m.year} logo={m.logo} seed={m.title} onClick={() => playMovie(m)} />
+                {visibleMovies.map((m) => (
+                  <VodCard
+                    key={m.id}
+                    kind="movie"
+                    title={m.title}
+                    year={m.year}
+                    logo={m.logo}
+                    seed={m.title}
+                    onClick={() => playMovie(m)}
+                  />
                 ))}
               </div>
             </>
@@ -165,9 +302,16 @@ export function PlaylistVodView({ active }: { active: boolean }) {
           <Notice text={emptyShowsText(t, library.series.length, q)} />
         ) : (
           <>
-            <CapNote shown={Math.min(series.length, RENDER_CAP)} total={series.length} kind="shows" />
+            {viewError && <CatalogWarning text={viewError} onRetry={refresh} />}
+            <CatalogProgress
+              loading={tabLoading}
+              loaded={library.series.length}
+              total={providerTotal}
+              kind="shows"
+            />
+            <CapNote shown={visibleSeries.length} total={series.length} kind="shows" />
             <div className="grid gap-x-4 gap-y-6" style={gridStyle}>
-              {series.slice(0, RENDER_CAP).map((s) => (
+              {visibleSeries.map((s) => (
                 <VodCard
                   key={s.id}
                   kind="series"
@@ -176,11 +320,13 @@ export function PlaylistVodView({ active }: { active: boolean }) {
                   logo={s.logo}
                   seed={s.title}
                   subtitle={
-                    s.episodes.length === 1
-                      ? t("{n} episode", { n: 1 })
-                      : t("{n} episodes", { n: s.episodes.length })
+                    s.xtreamSeriesId
+                      ? (s.group ?? t("Open to load episodes"))
+                      : s.episodes.length === 1
+                        ? t("{n} episode", { n: 1 })
+                        : t("{n} episodes", { n: s.episodes.length })
                   }
-                  onClick={() => setSelected(s)}
+                  onClick={() => openSeries(s)}
                 />
               ))}
             </div>
@@ -211,7 +357,13 @@ function emptyShowsText(t: Translate, total: number, query: string): string {
   return t("No shows here.");
 }
 
-function vodMeta(id: string, type: "movie" | "series", name: string, logo: string | null, year: number | null): Meta {
+function vodMeta(
+  id: string,
+  type: "movie" | "series",
+  name: string,
+  logo: string | null,
+  year: number | null,
+): Meta {
   return {
     id,
     type,
@@ -222,7 +374,19 @@ function vodMeta(id: string, type: "movie" | "series", name: string, logo: strin
   };
 }
 
-function TabButton({ active, onClick, icon, label, count }: { active: boolean; onClick: () => void; icon: React.ReactNode; label: string; count: number }) {
+function TabButton({
+  active,
+  onClick,
+  icon,
+  label,
+  count,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  count: number;
+}) {
   return (
     <button
       onClick={onClick}
@@ -233,7 +397,9 @@ function TabButton({ active, onClick, icon, label, count }: { active: boolean; o
       {icon}
       {label}
       {count > 0 && (
-        <span className={`rounded-full px-1.5 text-[10.5px] tabular-nums ${active ? "bg-canvas/25" : "bg-canvas/70 text-ink-subtle"}`}>
+        <span
+          className={`rounded-full px-1.5 text-[10.5px] tabular-nums ${active ? "bg-canvas/25" : "bg-canvas/70 text-ink-subtle"}`}
+        >
           {count.toLocaleString()}
         </span>
       )}
@@ -241,16 +407,69 @@ function TabButton({ active, onClick, icon, label, count }: { active: boolean; o
   );
 }
 
-function CapNote({ shown, total, kind }: { shown: number; total: number; kind: "movies" | "shows" }) {
+function CatalogProgress({
+  loading,
+  loaded,
+  total,
+  kind,
+}: {
+  loading: boolean;
+  loaded: number;
+  total: number | null;
+  kind: "movies" | "shows";
+}) {
+  const t = useT();
+  if (!loading) return null;
+  const label =
+    total == null
+      ? kind === "movies"
+        ? t("Loading movies...")
+        : t("Loading shows...")
+      : kind === "movies"
+        ? t("Loaded {loaded} of {total} movies...", {
+            loaded: loaded.toLocaleString(),
+            total: Math.max(total, loaded).toLocaleString(),
+          })
+        : t("Loaded {loaded} of {total} shows...", {
+            loaded: loaded.toLocaleString(),
+            total: Math.max(total, loaded).toLocaleString(),
+          });
+  return <p className="mb-4 text-[12.5px] tabular-nums text-ink-subtle">{label}</p>;
+}
+
+function CatalogWarning({ text, onRetry }: { text: string; onRetry: () => void }) {
+  const t = useT();
+  return (
+    <div className="mb-4 flex items-center justify-between gap-4 rounded-xl border border-edge-soft bg-elevated px-4 py-3">
+      <p className="min-w-0 text-[12.5px] text-ink-muted">{text}</p>
+      <button
+        onClick={onRetry}
+        className="shrink-0 text-[12.5px] font-semibold text-ink transition-colors hover:text-accent"
+      >
+        {t("Try again")}
+      </button>
+    </div>
+  );
+}
+
+function CapNote({
+  shown,
+  total,
+  kind,
+}: {
+  shown: number;
+  total: number;
+  kind: "movies" | "shows";
+}) {
   const t = useT();
   if (total <= shown) return null;
   const text =
     kind === "movies"
-      ? t("Showing {shown} of {total} movies. Search to find the rest.", {
+      ? t("Showing {shown} of {total} movies. Scroll to load more.", {
           shown: shown.toLocaleString(),
           total: total.toLocaleString(),
         })
-      : t("Showing {shown} of {total} shows. Search to find the rest.", {
+      : t("Showing {shown} of {total} shows. Scroll to load more.", {
           shown: shown.toLocaleString(),
           total: total.toLocaleString(),
         });
@@ -263,7 +482,10 @@ function Notice({ text, onRetry }: { text: string; onRetry?: () => void }) {
     <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-edge px-6 py-16 text-center">
       <p className="max-w-[520px] text-[14.5px] leading-relaxed text-ink-muted">{text}</p>
       {onRetry && (
-        <button onClick={onRetry} className="h-9 rounded-lg bg-elevated px-4 text-[13px] font-semibold text-ink transition-colors hover:bg-raised">
+        <button
+          onClick={onRetry}
+          className="h-9 rounded-lg bg-elevated px-4 text-[13px] font-semibold text-ink transition-colors hover:bg-raised"
+        >
           {t("Try again")}
         </button>
       )}

--- a/src/views/playlist-vod/series-detail.tsx
+++ b/src/views/playlist-vod/series-detail.tsx
@@ -6,11 +6,12 @@ import type { VodEpisode, VodSeries } from "@/lib/iptv/vod";
 
 type Props = {
   series: VodSeries;
+  loading?: boolean;
   onBack: () => void;
   onPlay: (ep: VodEpisode) => void;
 };
 
-export function SeriesDetail({ series, onBack, onPlay }: Props) {
+export function SeriesDetail({ series, loading = false, onBack, onPlay }: Props) {
   const t = useT();
   const [season, setSeason] = useState<number>(series.seasons[0] ?? 1);
   const episodes = series.episodes.filter((e) => e.season === season);
@@ -29,12 +30,18 @@ export function SeriesDetail({ series, onBack, onPlay }: Props) {
           <Poster src={series.logo ?? undefined} seed={series.title} className="w-full" />
         </div>
         <div className="min-w-0 pt-1">
-          <h2 className="truncate text-[22px] font-semibold tracking-tight text-ink">{series.title}</h2>
+          <h2 className="truncate text-[22px] font-semibold tracking-tight text-ink">
+            {series.title}
+          </h2>
           <p className="mt-1 text-[13px] text-ink-muted">
-            {series.episodes.length === 1
-              ? t("{n} episode", { n: 1 })
-              : t("{n} episodes", { n: series.episodes.length })}
-            {series.seasons.length > 1 ? ` · ${t("{n} seasons", { n: series.seasons.length })}` : ""}
+            {loading
+              ? t("Loading episodes...")
+              : series.episodes.length === 1
+                ? t("{n} episode", { n: 1 })
+                : t("{n} episodes", { n: series.episodes.length })}
+            {series.seasons.length > 1
+              ? ` · ${t("{n} seasons", { n: series.seasons.length })}`
+              : ""}
             {series.group ? ` · ${series.group}` : ""}
           </p>
         </div>
@@ -47,7 +54,9 @@ export function SeriesDetail({ series, onBack, onPlay }: Props) {
               key={s}
               onClick={() => setSeason(s)}
               className={`h-9 rounded-lg px-3.5 text-[13px] font-semibold transition-colors ${
-                season === s ? "bg-ink text-canvas" : "bg-elevated text-ink-muted hover:bg-raised hover:text-ink"
+                season === s
+                  ? "bg-ink text-canvas"
+                  : "bg-elevated text-ink-muted hover:bg-raised hover:text-ink"
               }`}
             >
               {t("Season {n}", { n: s })}
@@ -57,21 +66,25 @@ export function SeriesDetail({ series, onBack, onPlay }: Props) {
       )}
 
       <div className="flex flex-col gap-1">
-        {episodes.map((ep) => (
-          <button
-            key={`${ep.season}-${ep.episode}`}
-            onClick={() => onPlay(ep)}
-            className="group flex items-center gap-3.5 rounded-xl px-3 py-2.5 text-start transition-colors hover:bg-elevated"
-          >
-            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-elevated text-[13px] font-semibold tabular-nums text-ink-muted group-hover:bg-raised group-hover:text-ink">
-              {ep.episode}
-            </span>
-            <span className="min-w-0 flex-1 truncate text-[14px] text-ink">{ep.title}</span>
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-ink-subtle opacity-0 transition-opacity group-hover:opacity-100">
-              <Play size={15} fill="currentColor" />
-            </span>
-          </button>
-        ))}
+        {loading ? (
+          <p className="px-3 py-4 text-[14px] text-ink-muted">{t("Loading episodes...")}</p>
+        ) : (
+          episodes.map((ep) => (
+            <button
+              key={`${ep.season}-${ep.episode}`}
+              onClick={() => onPlay(ep)}
+              className="group flex items-center gap-3.5 rounded-xl px-3 py-2.5 text-start transition-colors hover:bg-elevated"
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-elevated text-[13px] font-semibold tabular-nums text-ink-muted group-hover:bg-raised group-hover:text-ink">
+                {ep.episode}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-[14px] text-ink">{ep.title}</span>
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-ink-subtle opacity-0 transition-opacity group-hover:opacity-100">
+                <Play size={15} fill="currentColor" />
+              </span>
+            </button>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/views/playlist-vod/use-vod-sources.ts
+++ b/src/views/playlist-vod/use-vod-sources.ts
@@ -6,6 +6,7 @@ import { purgePlaylistState } from "@/lib/iptv/source-cleanup";
 import { useFavorites } from "@/lib/iptv/favorites";
 import type { IptvPlaylistSource } from "@/lib/iptv/types";
 import { buildXtreamUrls, type PlaylistFormValue } from "@/views/live/source-picker/playlist-form";
+import { clearXtreamVodLibraryCache } from "./use-xtream-vod-library";
 
 const ACTIVE_KEY = "harbor.vod.active";
 
@@ -28,7 +29,11 @@ function writeActive(id: string | null) {
 
 function materialize(id: string, entry: PlaylistFormValue) {
   if (entry.kind === "xtream") {
-    const { m3u, epg } = buildXtreamUrls(entry.xtream.server, entry.xtream.username, entry.xtream.password);
+    const { m3u, epg } = buildXtreamUrls(
+      entry.xtream.server,
+      entry.xtream.username,
+      entry.xtream.password,
+    );
     return {
       id,
       name: entry.name,
@@ -59,7 +64,14 @@ export function useVodSources() {
     () =>
       settings.iptvPlaylists
         .filter((p) => (p.kind ?? "m3u") !== "epg")
-        .map((p) => ({ id: p.id, name: p.name, url: p.url, epgUrl: p.epgUrl, kind: p.kind, xtream: p.xtream })),
+        .map((p) => ({
+          id: p.id,
+          name: p.name,
+          url: p.url,
+          epgUrl: p.epgUrl,
+          kind: p.kind,
+          xtream: p.xtream,
+        })),
     [settings.iptvPlaylists],
   );
 
@@ -101,6 +113,7 @@ export function useVodSources() {
       const next = settings.iptvPlaylists.map((s) => (s.id === id ? materialize(id, entry) : s));
       update({ iptvPlaylists: next });
       clearPlaylistCache(id);
+      clearXtreamVodLibraryCache(id);
       clearEpg(id);
     },
     [settings.iptvPlaylists, update],
@@ -115,6 +128,7 @@ export function useVodSources() {
         writeActive(fallback);
       }
       update({ iptvPlaylists: next });
+      clearXtreamVodLibraryCache(id);
       purgePlaylistState(id, favorites.removeForSource);
     },
     [settings.iptvPlaylists, update, activeId, favorites.removeForSource],

--- a/src/views/playlist-vod/use-xtream-vod-library.ts
+++ b/src/views/playlist-vod/use-xtream-vod-library.ts
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useState } from "react";
+import { createCatalogPublicationGate } from "@/lib/iptv/catalog-publication-gate";
+import {
+  deleteIptvCache,
+  iptvSourceSignature,
+  isPersistentCacheFresh,
+  readIptvCache,
+  writeIptvCache,
+} from "@/lib/iptv/persistent-cache";
+import type { IptvChannel, IptvPlaylist, IptvPlaylistSource } from "@/lib/iptv/types";
+import { buildVodLibrary, type VodLibrary, type VodMovie, type VodSeries } from "@/lib/iptv/vod";
+import { credsFromServer } from "@/lib/iptv/xtream";
+import { fetchXtreamSeries, fetchXtreamVod } from "@/lib/iptv/xtream-vod";
+
+type Snapshot = {
+  library: VodLibrary;
+  fetchedAt: number | null;
+  moviesLoading: boolean;
+  seriesLoading: boolean;
+  movieError: string | null;
+  seriesError: string | null;
+  movieTotal: number | null;
+  seriesTotal: number | null;
+};
+
+type PersistedSnapshot = Pick<
+  Snapshot,
+  "library" | "fetchedAt" | "movieTotal" | "seriesTotal"
+>;
+
+type SnapshotPatch = Partial<Omit<Snapshot, "library">> & {
+  library?: Partial<VodLibrary>;
+};
+
+type Inflight = {
+  revision: number;
+  promise: Promise<void>;
+};
+
+const EMPTY_LIBRARY: VodLibrary = { movies: [], series: [] };
+const EMPTY: Snapshot = {
+  library: EMPTY_LIBRARY,
+  fetchedAt: null,
+  moviesLoading: false,
+  seriesLoading: false,
+  movieError: null,
+  seriesError: null,
+  movieTotal: null,
+  seriesTotal: null,
+};
+const cache = new Map<string, Snapshot>();
+const cacheSignatures = new Map<string, string>();
+const inflight = new Map<string, Inflight>();
+const listeners = new Set<() => void>();
+const revisions = new Map<string, number>();
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+function getSnapshot(id?: string): Snapshot {
+  return (id ? cache.get(id) : undefined) ?? EMPTY;
+}
+
+function makeLibrary(source: IptvPlaylistSource, channels: readonly IptvChannel[]): VodLibrary {
+  const playlist: IptvPlaylist = {
+    id: source.id,
+    name: source.name,
+    url: source.url,
+    epgUrl: source.epgUrl ?? null,
+    channels: [...channels],
+    fetchedAt: Date.now(),
+    groups: [],
+  };
+  return buildVodLibrary([playlist], new Map([[source.id, source.name]]));
+}
+
+function appendUnique<T extends { id: string }>(target: T[], seen: Set<string>, items: readonly T[]) {
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    target.push(item);
+  }
+}
+
+async function load(source: IptvPlaylistSource, force = false): Promise<void> {
+  if (source.kind !== "xtream" || !source.xtream) return;
+  const sourceSignature = iptvSourceSignature(source);
+  const previousSignature = cacheSignatures.get(source.id);
+  if (previousSignature && previousSignature !== sourceSignature) {
+    cache.delete(source.id);
+    revisions.set(source.id, (revisions.get(source.id) ?? 0) + 1);
+    void deleteIptvCache("xtream-vod", source.id);
+  }
+  cacheSignatures.set(source.id, sourceSignature);
+  const revision = revisions.get(source.id) ?? 0;
+  const pending = inflight.get(source.id);
+  if (pending?.revision === revision) return pending.promise;
+
+  const creds = credsFromServer(
+    source.xtream.server,
+    source.xtream.username,
+    source.xtream.password,
+  );
+  if (!creds) return;
+
+  const isCurrent = () => (revisions.get(source.id) ?? 0) === revision;
+  const publish = (patch: SnapshotPatch): boolean => {
+    if (!isCurrent()) return false;
+    const current = getSnapshot(source.id);
+    cache.set(source.id, {
+      ...current,
+      ...patch,
+      library: patch.library ? { ...current.library, ...patch.library } : current.library,
+    });
+    notify();
+    return true;
+  };
+
+  const promise = (async () => {
+    if (!force && !cache.has(source.id)) {
+      const stored = await readIptvCache<PersistedSnapshot>("xtream-vod", source.id);
+      if (!isCurrent()) return;
+      if (
+        stored?.sourceSignature === sourceSignature &&
+        isPersistedSnapshot(stored.value)
+      ) {
+        cache.set(source.id, {
+          ...EMPTY,
+          ...stored.value,
+          library: stored.value.library,
+        });
+        notify();
+      } else if (stored) {
+        void deleteIptvCache("xtream-vod", source.id);
+      }
+    }
+
+    const restored = getSnapshot(source.id);
+    if (!force && isPersistentCacheFresh(restored.fetchedAt)) return;
+
+    publish({
+      moviesLoading: true,
+      seriesLoading: true,
+      movieError: null,
+      seriesError: null,
+    });
+
+    const movies: VodMovie[] = [];
+    const movieIds = new Set<string>();
+    const series: VodSeries[] = [];
+    const seriesIds = new Set<string>();
+    let moviesSucceeded = false;
+    let seriesSucceeded = false;
+
+    const seriesGate = createCatalogPublicationGate<VodSeries>((items) => {
+      publish({ library: { series: [...items] } });
+    });
+
+    const movieTask = fetchXtreamVod(creds, source.id, {
+      onStart: (total) => {
+        publish({ movieTotal: total });
+        if (total === 0) {
+          publish({ library: { movies: [] } });
+          seriesGate.release();
+        }
+      },
+      onBatch: (channels) => {
+        appendUnique(movies, movieIds, makeLibrary(source, channels).movies);
+        const accepted = publish({ library: { movies: movies.slice() } });
+        if (accepted) seriesGate.release();
+        return accepted;
+      },
+    })
+      .then(() => {
+        moviesSucceeded = true;
+        return publish({ moviesLoading: false });
+      })
+      .catch((error) => {
+        if (restored.library.movies.length > 0) {
+          publish({ library: { movies: restored.library.movies } });
+        }
+        seriesGate.release();
+        return publish({
+          moviesLoading: false,
+          movieError: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+    const seriesTask = fetchXtreamSeries(creds, source.id, {
+      onStart: (total) => {
+        publish({ seriesTotal: total });
+        if (total === 0) seriesGate.update([]);
+      },
+      onBatch: (channels) => {
+        if (!isCurrent()) return false;
+        appendUnique(series, seriesIds, makeLibrary(source, channels).series);
+        seriesGate.update(series.slice());
+        return true;
+      },
+    })
+      .then(() => {
+        seriesSucceeded = true;
+      })
+      .catch((error) => {
+        seriesGate.update(restored.library.series);
+        return publish({
+          seriesError: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+    await Promise.all([movieTask, seriesTask]);
+    if (!isCurrent()) return;
+    await seriesGate.whenReleased();
+    if (!isCurrent()) return;
+    publish({ seriesLoading: false });
+    if (moviesSucceeded && seriesSucceeded) publish({ fetchedAt: Date.now() });
+
+    const current = cache.get(source.id);
+    if (!current) return;
+    const persisted: PersistedSnapshot = {
+      library: current.library,
+      fetchedAt: current.fetchedAt,
+      movieTotal: current.movieTotal,
+      seriesTotal: current.seriesTotal,
+    };
+    await writeIptvCache("xtream-vod", source.id, {
+      sourceSignature,
+      savedAt: current.fetchedAt ?? Date.now(),
+      value: persisted,
+    });
+  })().finally(() => {
+    if (inflight.get(source.id)?.promise === promise) inflight.delete(source.id);
+  });
+
+  inflight.set(source.id, { revision, promise });
+  return promise;
+}
+
+function isPersistedSnapshot(value: unknown): value is PersistedSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const snapshot = value as Partial<PersistedSnapshot>;
+  return (
+    !!snapshot.library &&
+    Array.isArray(snapshot.library.movies) &&
+    Array.isArray(snapshot.library.series) &&
+    (snapshot.fetchedAt == null || typeof snapshot.fetchedAt === "number")
+  );
+}
+
+export function clearXtreamVodLibraryCache(id?: string) {
+  if (id) {
+    cache.delete(id);
+    cacheSignatures.delete(id);
+    revisions.set(id, (revisions.get(id) ?? 0) + 1);
+    void deleteIptvCache("xtream-vod", id);
+  } else {
+    const ids = new Set([...cache.keys(), ...inflight.keys()]);
+    cache.clear();
+    cacheSignatures.clear();
+    for (const sourceId of ids) {
+      revisions.set(sourceId, (revisions.get(sourceId) ?? 0) + 1);
+      void deleteIptvCache("xtream-vod", sourceId);
+    }
+  }
+  notify();
+}
+
+export function useXtreamVodLibrary(source: IptvPlaylistSource | null) {
+  const [snapshot, setSnapshot] = useState<Snapshot>(() => getSnapshot(source?.id));
+
+  useEffect(() => {
+    if (!source || source.kind !== "xtream") {
+      setSnapshot(EMPTY);
+      return;
+    }
+    const sync = () => setSnapshot(getSnapshot(source.id));
+    listeners.add(sync);
+    sync();
+    void load(source);
+    return () => {
+      listeners.delete(sync);
+    };
+  }, [
+    source?.id,
+    source?.name,
+    source?.url,
+    source?.epgUrl,
+    source?.kind,
+    source?.xtream?.server,
+    source?.xtream?.username,
+    source?.xtream?.password,
+  ]);
+
+  const refresh = useCallback(() => {
+    if (source) void load(source, true);
+  }, [source]);
+
+  return {
+    ...snapshot,
+    loading: snapshot.moviesLoading || snapshot.seriesLoading,
+    error: snapshot.movieError,
+    refresh,
+  };
+}

--- a/tests/iptv-persistence.test.ts
+++ b/tests/iptv-persistence.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  IPTV_CACHE_TTL_MS,
+  iptvSourceSignature,
+  isPersistentCacheFresh,
+} from "../src/lib/iptv/persistent-cache.ts";
+import { createCatalogPublicationGate } from "../src/lib/iptv/catalog-publication-gate.ts";
+import type { IptvPlaylistSource } from "../src/lib/iptv/types.ts";
+
+test("treats a six-hour cache as fresh only before the TTL boundary", () => {
+  const now = 10 * IPTV_CACHE_TTL_MS;
+
+  assert.equal(isPersistentCacheFresh(now - IPTV_CACHE_TTL_MS + 1, now), true);
+  assert.equal(isPersistentCacheFresh(now - IPTV_CACHE_TTL_MS, now), false);
+  assert.equal(isPersistentCacheFresh(null, now), false);
+});
+
+test("source signatures invalidate changed credentials without storing them", () => {
+  const source: IptvPlaylistSource = {
+    id: "provider",
+    name: "Provider",
+    url: "https://example.com/get.php?username=alice&password=secret",
+    kind: "xtream",
+    xtream: {
+      server: "https://example.com",
+      username: "alice",
+      password: "secret",
+    },
+  };
+
+  const signature = iptvSourceSignature(source);
+  const changed = iptvSourceSignature({
+    ...source,
+    xtream: { ...source.xtream!, password: "new-secret" },
+  });
+
+  assert.notEqual(signature, changed);
+  assert.equal(signature.includes("secret"), false);
+  assert.match(signature, /^v1:[a-f0-9]{8}$/);
+});
+
+test("buffers shows until the movie catalog has painted once", () => {
+  const scheduled: Array<() => void> = [];
+  const published: number[][] = [];
+  const gate = createCatalogPublicationGate<number>(
+    (items) => published.push([...items]),
+    (task) => scheduled.push(task),
+  );
+
+  gate.update([1, 2]);
+  assert.deepEqual(published, []);
+
+  gate.release();
+  gate.update([1, 2, 3]);
+  assert.deepEqual(published, []);
+  assert.equal(scheduled.length, 1);
+
+  scheduled.shift()?.();
+  assert.deepEqual(published, [[1, 2, 3]]);
+
+  gate.update([1, 2, 3, 4]);
+  assert.deepEqual(published, [
+    [1, 2, 3],
+    [1, 2, 3, 4],
+  ]);
+});
+
+test("lets persistence wait until the buffered catalog is published", async () => {
+  const scheduled: Array<() => void> = [];
+  const published: number[][] = [];
+  const gate = createCatalogPublicationGate<number>(
+    (items) => published.push([...items]),
+    (task) => scheduled.push(task),
+  );
+
+  gate.update([1, 2, 3]);
+  gate.release();
+
+  let settled = false;
+  void gate.whenReleased().then(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  assert.equal(settled, false);
+
+  scheduled.shift()?.();
+  await gate.whenReleased();
+  assert.equal(settled, true);
+  assert.deepEqual(published, [[1, 2, 3]]);
+});

--- a/tests/xtream-batches.test.ts
+++ b/tests/xtream-batches.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { processInBatches } from "../src/lib/iptv/xtream-batches.ts";
+
+test("publishes mapped rows in order and yields between batches", async () => {
+  const events: string[] = [];
+  const published: number[][] = [];
+
+  const result = await processInBatches([1, 2, 3, 4, 5], {
+    batchSize: 2,
+    map: (value) => value * 10,
+    onBatch: (batch, progress) => {
+      published.push([...batch]);
+      events.push(`publish:${progress.processed}/${progress.total}`);
+    },
+    yieldControl: async () => {
+      events.push("yield");
+    },
+  });
+
+  assert.deepEqual(result, [10, 20, 30, 40, 50]);
+  assert.deepEqual(published, [
+    [10, 20],
+    [30, 40],
+    [50],
+  ]);
+  assert.deepEqual(events, ["publish:2/5", "yield", "publish:4/5", "yield", "publish:5/5"]);
+});
+
+test("skips rejected rows without losing progress", async () => {
+  const progress: string[] = [];
+
+  const result = await processInBatches([1, 2, 3, 4], {
+    batchSize: 2,
+    map: (value) => (value % 2 === 0 ? value : null),
+    onBatch: (_batch, state) => progress.push(`${state.processed}/${state.total}`),
+    yieldControl: async () => {},
+  });
+
+  assert.deepEqual(result, [2, 4]);
+  assert.deepEqual(progress, ["2/4", "4/4"]);
+});
+
+test("stops processing when the publisher rejects a stale request", async () => {
+  let yields = 0;
+
+  const result = await processInBatches([1, 2, 3, 4, 5, 6], {
+    batchSize: 2,
+    map: (value) => value,
+    onBatch: (_batch, progress) => progress.processed < 4,
+    yieldControl: async () => {
+      yields += 1;
+    },
+  });
+
+  assert.deepEqual(result, [1, 2, 3, 4]);
+  assert.equal(yields, 1);
+});
+
+test("processes a 16,113-item provider catalog without an implicit cap", async () => {
+  const rows = Array.from({ length: 16_113 }, (_, index) => index);
+  let batches = 0;
+
+  const result = await processInBatches(rows, {
+    batchSize: 256,
+    map: (value) => value,
+    onBatch: () => {
+      batches += 1;
+    },
+    yieldControl: async () => {},
+  });
+
+  assert.equal(result.length, 16_113);
+  assert.equal(batches, 63);
+});


### PR DESCRIPTION
## Summary

- Remove the Xtream series import limit and load the complete provider catalog.
- Fetch movie and series catalogs concurrently.
- Publish movies progressively in batches before displaying the series catalog.
- Load series episode details lazily when a show is opened, avoiding thousands of eager API requests and provider rate limits.
- Persist Live TV playlists and Xtream VOD catalogs in IndexedDB.
- Restore cached content immediately after restarting the application.
- Refresh stale cached content in the background after six hours.
- Force channel and catalog updates when the Refresh action is used.
- Invalidate persisted cache when a playlist source is edited or removed.
- Keep cached content visible if a background refresh fails.
- Limit rendered cards and progressively load more while scrolling to keep large catalogs responsive.
- Defer catalog search updates to reduce UI blocking on large libraries.

## Problem

Xtream series were previously capped and eagerly expanded by requesting episode details for every show. Large providers could trigger rate limiting before the import completed, causing Harbor to display only part of the available series catalog.

## Solution

The initial import now uses lightweight series summaries without a catalog limit. Episode details are requested only when the user opens a series.

Movie and series requests still run in parallel, but movie batches are published first so content becomes visible without waiting for the complete catalog to finish processing.

## Testing

- Added progressive batch-processing tests.
- Added cache freshness and source invalidation tests.
- Added publication-order tests to ensure movies are displayed before series.
- Verified processing a catalog containing 16,113 series without an implicit limit.
- All 8 tests pass.
- Production TypeScript and Vite build passes.

Closes #708
