### PR TITLE
fix(linux): improve platform and media dependency handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-http": "^2.5.8",
     "@tauri-apps/plugin-opener": "^2.5.3",
+    "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",
     "gifenc": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.3
         version: 2.5.3
+      '@tauri-apps/plugin-os':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-process':
         specifier: ^2
         version: 2.3.1
@@ -389,24 +392,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -467,66 +474,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -596,24 +616,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -677,30 +701,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.1':
     resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
@@ -739,6 +768,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
+
+  '@tauri-apps/plugin-os@2.3.2':
+    resolution: {integrity: sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==}
 
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
@@ -1068,24 +1100,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1467,7 +1503,7 @@ packages:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webworkify-webpack@https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef:
-    resolution: {tarball: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef}
     version: 2.1.5
 
   whatwg-encoding@3.1.1:
@@ -1962,6 +1998,10 @@ snapshots:
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:
       '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-os@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-process@2.3.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -890,10 +890,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1317,6 +1332,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1775,6 +1802,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2065,7 @@ dependencies = [
  "futures-util",
  "gtk",
  "harbor-core",
+ "hickory-resolver",
  "hound",
  "libc",
  "libmpv2",
@@ -2052,6 +2090,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-opener",
+ "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
@@ -2143,6 +2182,52 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "home"
@@ -2530,6 +2615,19 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "leaky-cow",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry 0.6.1",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3240,6 +3338,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid 1.23.1",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,6 +3439,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nodrop"
@@ -3525,6 +3652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,8 +3777,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3666,6 +3822,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "open"
@@ -3747,6 +3907,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4612,6 +4788,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
+ "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -4624,6 +4801,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4686,6 +4864,12 @@ dependencies = [
  "wasm-streams 0.5.0",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfd"
@@ -5577,6 +5761,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5609,6 +5802,12 @@ dependencies = [
  "toml 0.8.2",
  "version-compare",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tao"
@@ -5920,6 +6119,24 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset", "tray-icon"] }
 tauri-plugin-opener = "2"
+tauri-plugin-os = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-http = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main", "harbor-pip", "harbor-browser", "harbor-modal-overlay"],
   "permissions": [
     "core:default",
+    "os:default",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",

--- a/src-tauri/src/binary_lookup.rs
+++ b/src-tauri/src/binary_lookup.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+/// Common locations for command-line media tools on a Linux desktop. The
+/// caller should add app-bundled paths first, then use these candidates.
+pub(crate) fn linux_binary_candidates(binary: &str) -> Vec<PathBuf> {
+    let mut candidates = vec![PathBuf::from(binary)];
+
+    if let Some(home) = std::env::var_os("HOME") {
+        candidates.push(PathBuf::from(home).join(".local/bin").join(binary));
+    }
+
+    candidates.extend([
+        PathBuf::from("/usr/local/bin").join(binary),
+        PathBuf::from("/usr/bin").join(binary),
+        PathBuf::from("/snap/bin").join(binary),
+    ]);
+
+    candidates
+}

--- a/src-tauri/src/dvr.rs
+++ b/src-tauri/src/dvr.rs
@@ -64,15 +64,18 @@ impl DvrState {
 
 pub(crate) fn locate_mpv() -> Option<PathBuf> {
     let candidates = if cfg!(windows) {
-        vec!["mpv.exe", "mpv"]
+        vec![PathBuf::from("mpv.exe"), PathBuf::from("mpv")]
     } else if cfg!(target_os = "macos") {
-        vec!["/opt/homebrew/bin/mpv", "/usr/local/bin/mpv", "mpv"]
+        vec![
+            PathBuf::from("/opt/homebrew/bin/mpv"),
+            PathBuf::from("/usr/local/bin/mpv"),
+            PathBuf::from("mpv"),
+        ]
     } else {
-        vec!["mpv", "/usr/bin/mpv"]
+        crate::binary_lookup::linux_binary_candidates("mpv")
     };
     for c in candidates {
-        let p = PathBuf::from(c);
-        let mut cmd = std::process::Command::new(&p);
+        let mut cmd = std::process::Command::new(&c);
         cmd.arg("--version");
         #[cfg(windows)]
         {
@@ -81,7 +84,7 @@ pub(crate) fn locate_mpv() -> Option<PathBuf> {
         }
         if let Ok(out) = cmd.output() {
             if out.status.success() {
-                return Some(p);
+                return Some(c);
             }
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod anime4k;
+mod binary_lookup;
 mod browser;
 mod cast;
 mod cast_hls;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -421,6 +421,7 @@ pub fn run() {
             }
         }))
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/thumbs.rs
+++ b/src-tauri/src/thumbs.rs
@@ -100,8 +100,11 @@ pub(crate) fn locate_mpv() -> Option<PathBuf> {
         candidates.push("/usr/local/bin/mpv".into());
         candidates.push("mpv".into());
     } else {
-        candidates.push("mpv".into());
-        candidates.push("/usr/bin/mpv".into());
+        candidates.extend(
+            crate::binary_lookup::linux_binary_candidates("mpv")
+                .into_iter()
+                .map(|path| path.to_string_lossy().into_owned()),
+        );
     }
     for c in candidates {
         let p = PathBuf::from(&c);

--- a/src-tauri/src/transcode.rs
+++ b/src-tauri/src/transcode.rs
@@ -99,8 +99,8 @@ pub fn locate_ffmpeg() -> Option<std::path::PathBuf> {
                 );
             }
         }
-        for p in ["ffmpeg", "/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg"] {
-            owned.push(p.into());
+        for path in crate::binary_lookup::linux_binary_candidates("ffmpeg") {
+            owned.push(path.to_string_lossy().into_owned());
         }
     }
     let candidates: Vec<&str> = owned.iter().map(|s| s.as_str()).collect();

--- a/src/lib/download/downloads-store.ts
+++ b/src/lib/download/downloads-store.ts
@@ -6,6 +6,7 @@ import type { Meta } from "@/lib/cinemeta";
 import type { PlayEpisode } from "@/lib/view";
 import { buildDefaultFilename, sanitizeName } from "./filename";
 import { startDownload, type DownloadHandle } from "./video-download";
+import { isWindowsDesktop } from "@/lib/platform";
 
 export type DownloadItem = {
   id: string;
@@ -86,7 +87,7 @@ function patch(id: string, next: Partial<DownloadItem>) {
 }
 
 function sep(): string {
-  return navigator.platform.toLowerCase().includes("win") ? "\\" : "/";
+  return isWindowsDesktop() ? "\\" : "/";
 }
 
 async function resolveDir(): Promise<string> {

--- a/src/lib/ffmpeg-install.ts
+++ b/src/lib/ffmpeg-install.ts
@@ -1,0 +1,13 @@
+import { isLinuxDesktop, isMacDesktop, isWeb } from "@/lib/platform";
+
+export function ffmpegInstallStep(): string {
+  const userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent;
+  const isMac = isMacDesktop() || (isWeb() && /Mac/.test(userAgent));
+  const isLinux = isLinuxDesktop() || (isWeb() && /Linux/.test(userAgent));
+
+  if (isMac) return "Open a terminal and run: brew install ffmpeg";
+  if (isLinux) {
+    return "Install ffmpeg using your system package manager (apt, dnf, pacman, zypper, etc.).";
+  }
+  return "Open a terminal and run: winget install Gyan.FFmpeg";
+}

--- a/src/lib/multiview/bridge.ts
+++ b/src/lib/multiview/bridge.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { isWindowsDesktop } from "@/lib/platform";
 
 export const MAX_SLOTS = 4;
 
@@ -23,8 +24,7 @@ export type OpenRect = {
 
 export function multiviewSupported(): boolean {
   if (typeof window === "undefined") return false;
-  if (!("__TAURI__" in window || "__TAURI_INTERNALS__" in window)) return false;
-  return navigator.userAgent.toLowerCase().includes("windows");
+  return isWindowsDesktop();
 }
 
 export async function mvOpen(

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,5 +1,19 @@
+import { platform as nativePlatform } from "@tauri-apps/plugin-os";
+
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+type DesktopPlatform = "linux" | "macos" | "windows" | null;
+
+function detectedDesktopPlatform(): DesktopPlatform {
+  if (!isTauri()) return null;
+
+  const platform = nativePlatform();
+  if (platform === "linux" || platform === "macos" || platform === "windows") {
+    return platform;
+  }
+  return null;
 }
 
 export function isWeb(): boolean {
@@ -7,24 +21,15 @@ export function isWeb(): boolean {
 }
 
 export function isLinuxDesktop(): boolean {
-  if (!isTauri()) return false;
-  const ua = (navigator.userAgent || "").toLowerCase();
-  const plat = (navigator.platform || "").toLowerCase();
-  if (ua.includes("android")) return false;
-  if (ua.includes("windows") || ua.includes("macintosh") || ua.includes("mac os")) return false;
-  return ua.includes("linux") || plat.includes("linux");
+  return detectedDesktopPlatform() === "linux";
 }
 
 export function isMacDesktop(): boolean {
-  if (!isTauri()) return false;
-  const ua = (navigator.userAgent || "").toLowerCase();
-  const plat = (navigator.platform || "").toLowerCase();
-  return ua.includes("macintosh") || ua.includes("mac os") || plat.includes("mac");
+  return detectedDesktopPlatform() === "macos";
 }
 
 export function isWindowsDesktop(): boolean {
-  if (!isTauri()) return false;
-  return (navigator.userAgent || "").toLowerCase().includes("windows");
+  return detectedDesktopPlatform() === "windows";
 }
 
 export function isMobileDevice(): boolean {

--- a/src/lib/player/mpv-forward.ts
+++ b/src/lib/player/mpv-forward.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { emptySnapshot, type PlayerBridge, type PlayerCapabilities, type PlayerSnapshot } from "./bridge";
+import { isWindowsDesktop } from "@/lib/platform";
 
 export type ForwardingBridge = PlayerBridge & {
   pushSnapshot: (snap: PlayerSnapshot) => void;
@@ -73,7 +74,7 @@ export function createForwardingMpvBridge(): ForwardingBridge {
       void set(name, value);
     },
     setAnime4kShaders(shaders) {
-      const sep = typeof navigator !== "undefined" && navigator.userAgent.toLowerCase().includes("windows") ? ";" : ":";
+      const sep = isWindowsDesktop() ? ";" : ":";
       void set("glsl-shaders", shaders.filter(Boolean).join(sep));
     },
     async addSubtitle(url, lang, title, select) {

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { isWindowsDesktop } from "@/lib/platform";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   emptySnapshot,
@@ -491,7 +492,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       invoke("mpv_set_property", { name, value }).catch(() => {});
     },
     setAnime4kShaders(shaders) {
-      const sep = typeof navigator !== "undefined" && navigator.userAgent.toLowerCase().includes("windows") ? ";" : ":";
+      const sep = isWindowsDesktop() ? ";" : ":";
       invoke("mpv_set_property", { name: "glsl-shaders", value: shaders.filter(Boolean).join(sep) }).catch(() => {});
     },
     async addSubtitle(url, lang, title, select): Promise<boolean> {

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -4,7 +4,7 @@ import type { Settings } from "./types";
 export const STORAGE_KEY = "harbor.settings";
 
 export const DEFAULT: Settings = {
-  soundTheme: 'glass',
+  soundTheme: 'none',
   blurComments: false,
   blurEpisodes: false,
   tmdbKey: "",

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -3,11 +3,11 @@ import { getCurrentWindow, type Window } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
 import { getWindowFullscreen } from "@/lib/fullscreen-state";
+import { isMacDesktop } from "@/lib/platform";
 
 const win: Window | null = isTauri() ? getCurrentWindow() : null;
 
-const IS_MAC =
-  typeof navigator !== "undefined" && /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent);
+const IS_MAC = isMacDesktop();
 
 function isTauri() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;

--- a/src/views/player/hooks/use-cast-pick.ts
+++ b/src/views/player/hooks/use-cast-pick.ts
@@ -6,6 +6,7 @@ import {
   type CastSubStyle,
 } from "@/lib/cast";
 import { useDebridClients } from "@/lib/debrid/registry";
+import { ffmpegInstallStep } from "@/lib/ffmpeg-install";
 import type { PlayerBridge, PlayerSnapshot, TrackInfo } from "@/lib/player/bridge";
 import { getPlaybackPosition } from "@/lib/player/playback-clock";
 import type { Settings } from "@/lib/settings";
@@ -105,16 +106,11 @@ export function useCastPick(params: {
         return;
       }
       if (resolved.kind === "needs-ffmpeg") {
-        const installCmd = navigator.userAgent.includes("Mac")
-          ? "brew install ffmpeg"
-          : navigator.userAgent.includes("Linux")
-            ? "sudo apt install ffmpeg"
-            : "winget install Gyan.FFmpeg";
         setCastErrorInfo({
           title: "Install ffmpeg",
           message: `${resolved.caps.label} can't decode this stream natively (${resolved.reasons.join(", ")}). Harbor uses ffmpeg to convert it into a format your TV understands.`,
           steps: [
-            `Open a terminal and run: ${installCmd}`,
+            ffmpegInstallStep(),
             "Restart Harbor after the install completes.",
             "Open the cast menu and try this device again.",
           ],

--- a/src/views/player/hooks/use-cast-session.ts
+++ b/src/views/player/hooks/use-cast-session.ts
@@ -11,6 +11,7 @@ import {
   type CastSubStyle,
   type TranscodeProfile,
 } from "@/lib/cast";
+import { ffmpegInstallStep } from "@/lib/ffmpeg-install";
 import type { PlayerBridge } from "@/lib/player/bridge";
 import type { CastErrorInfo } from "../cast-error-modal";
 
@@ -76,18 +77,12 @@ function buildActionableCastError(
     };
   }
   if (/ffmpeg/i.test(err)) {
-    const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
-    const installCmd = /Mac/.test(ua)
-      ? "brew install ffmpeg"
-      : /Linux/.test(ua)
-        ? "sudo apt install ffmpeg"
-        : "winget install Gyan.FFmpeg";
     return {
       title: "Install ffmpeg",
       message:
         "Harbor uses ffmpeg to convert streams into formats TVs can play. It's a one-time install and Harbor will pick it up automatically.",
       steps: [
-        `Open a terminal and run: ${installCmd}`,
+        ffmpegInstallStep(),
         "Restart Harbor after the install completes.",
         "Open the cast menu and try this device again.",
       ],

--- a/src/views/player/hooks/use-video-download.ts
+++ b/src/views/player/hooks/use-video-download.ts
@@ -14,6 +14,7 @@ import {
   type DownloadProgress,
 } from "@/lib/download/video-download";
 import { useSettings } from "@/lib/settings";
+import { isWindowsDesktop } from "@/lib/platform";
 import type { PlayEpisode } from "@/lib/view";
 
 export type DownloadStatus =
@@ -46,7 +47,7 @@ export function useVideoDownload({ url, meta, episode }: Args) {
     setStatus({ kind: "preparing" });
     const defaultFilename = buildDefaultFilename(meta, episode, url);
     const ext = extensionFromUrl(url);
-    const sep = navigator.platform.toLowerCase().includes("win") ? "\\" : "/";
+    const sep = isWindowsDesktop() ? "\\" : "/";
     const settingsDir = settings.downloadDir.trim();
     const dir = settingsDir || (await downloadDir().catch(() => "")) || "";
     const defaultPath = dir ? `${dir}${dir.endsWith(sep) ? "" : sep}${defaultFilename}` : defaultFilename;

--- a/src/views/player/player-utils.ts
+++ b/src/views/player/player-utils.ts
@@ -1,7 +1,7 @@
 import { createHtml5Bridge } from "@/lib/player/html5";
 import { createMpvBridge, probeMpv, type MpvRect } from "@/lib/player/mpv";
 import type { PlayerBridge } from "@/lib/player/bridge";
-import { isLinuxDesktop, isMacDesktop } from "@/lib/platform";
+import { isLinuxDesktop, isMacDesktop, isWindowsDesktop } from "@/lib/platform";
 
 export const SYNC_DRIFT_TOLERANCE_S = 0.6;
 export const SYNC_SUPPRESS_MS = 1400;
@@ -33,10 +33,7 @@ export function embedFlags(
   videoHeight: number,
 ): { mpvEmbedWindowsActive: boolean; stageBg: string } {
   const embedOn = engine === "mpv" && mpvEmbed;
-  const mpvEmbedWindowsActive =
-    embedOn &&
-    typeof navigator !== "undefined" &&
-    navigator.userAgent.toLowerCase().includes("windows");
+  const mpvEmbedWindowsActive = embedOn && isWindowsDesktop();
   const hasFrame = videoWidth > 0 && videoHeight > 0;
   const macShowing = embedOn && isMacDesktop() && hasFrame;
   const linuxShowing = embedOn && isLinuxDesktop() && hasFrame;


### PR DESCRIPTION
## Summary

- replace browser-derived desktop OS detection with Tauri’s native OS plugin
- use distro-neutral Linux ffmpeg installation guidance when casting
- expand Linux ffmpeg/mpv discovery to PATH, user-local, standard system, and Snap locations
 - Default UI sound effects to disabled (none). Harbor is primarily used as a desktop application, where hover sounds can feel unexpected and distracting. The sound themes remain available as an opt-in setting. Existing users’ saved preference is unchanged, this only affects new/default settings.
## Validation

- `pnpm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml` with the Linux-system bundle override
- runtime verification on Linux: `tauri-plugin-os` reports `linux`

Fixes #752
Fixes #753
Fixes #754

