### PR TITLE
fix(player): keep controls hidden after keyboard resume

### DIFF
--- a/src/views/player/hooks/use-chrome-visibility.ts
+++ b/src/views/player/hooks/use-chrome-visibility.ts
@@ -42,6 +42,8 @@ export function useChromeVisibility(params: {
       setChromeHidden(true);
     }, wait);
   }, [playing, drawMode, pipMode, setChromeHidden]);
+  const wakeChromeRef = useRef(wakeChrome);
+  wakeChromeRef.current = wakeChrome;
 
   const hideForResume = useCallback(() => {
     resumeHideRef.current = true;
@@ -144,9 +146,9 @@ export function useChromeVisibility(params: {
       setChromeVisible(true);
       if (hideTimer.current) window.clearTimeout(hideTimer.current);
     } else {
-      wakeChrome();
+      wakeChromeRef.current();
     }
-  }, [anyMenuOpen, wakeChrome]);
+  }, [anyMenuOpen]);
 
   const cursorStyle: CSSProperties = drawMode
     ? { cursor: "none" }


### PR DESCRIPTION
## Summary

- keep player controls hidden after keyboard pause and resume when the setting is disabled
- prevent the closed-menu visibility effect from re-waking the player chrome on playback-state changes
- preserve normal menu-close behavior by calling the latest chrome wake handler only when menu state changes

## Problem

The keyboard playback-transition effect correctly hid the player controls, but the closed-menu effect also watched `wakeChrome`. Because that callback changes whenever playback changes between paused and playing, the menu effect immediately ran afterward and showed the controls again.

## Solution

Keep the latest `wakeChrome` callback in a ref and make the menu visibility effect respond only to actual menu-state changes. Closing a menu still wakes the controls, while keyboard pause and resume can now keep them hidden.

## Verification

- [x] `pnpm build`
- [x] `pnpm tauri dev` on macOS
- [x] manual Space-key pause and resume with the setting disabled; controls remain hidden in both states

Closes #786
