### PR TITLE
fix(linux): improve Flatpak playback and power inhibition

### DIFF
--- a/flatpak/cargo-sources.json
+++ b/flatpak/cargo-sources.json
@@ -1133,6 +1133,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/critical-section/critical-section-1.2.0.crate",
+        "sha256": "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b",
+        "dest": "cargo/vendor/critical-section-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b\", \"files\": {}}",
+        "dest": "cargo/vendor/critical-section-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.15.crate",
         "sha256": "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2",
         "dest": "cargo/vendor/crossbeam-channel-0.5.15"
@@ -1141,6 +1154,19 @@
         "type": "inline",
         "contents": "{\"package\": \"82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2\", \"files\": {}}",
         "dest": "cargo/vendor/crossbeam-channel-0.5.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.20.crate",
+        "sha256": "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1700,6 +1726,19 @@
         "type": "inline",
         "contents": "{\"package\": \"66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099\", \"files\": {}}",
         "dest": "cargo/vendor/endi-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enum-as-inner/enum-as-inner-0.6.1.crate",
+        "sha256": "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc",
+        "dest": "cargo/vendor/enum-as-inner-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc\", \"files\": {}}",
+        "dest": "cargo/vendor/enum-as-inner-0.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2641,6 +2680,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hickory-proto/hickory-proto-0.25.2.crate",
+        "sha256": "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502",
+        "dest": "cargo/vendor/hickory-proto-0.25.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502\", \"files\": {}}",
+        "dest": "cargo/vendor/hickory-proto-0.25.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hickory-resolver/hickory-resolver-0.25.2.crate",
+        "sha256": "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a",
+        "dest": "cargo/vendor/hickory-resolver-0.25.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a\", \"files\": {}}",
+        "dest": "cargo/vendor/hickory-resolver-0.25.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/home/home-0.5.12.crate",
         "sha256": "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d",
         "dest": "cargo/vendor/home-0.5.12"
@@ -3091,6 +3156,19 @@
         "type": "inline",
         "contents": "{\"package\": \"554b8c5d64ec09a3a520fe58e4d48a73e00ff32899cdcbe32a4877afd4968b8e\", \"files\": {}}",
         "dest": "cargo/vendor/io-surface-0.16.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ipconfig/ipconfig-0.3.4.crate",
+        "sha256": "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222",
+        "dest": "cargo/vendor/ipconfig-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222\", \"files\": {}}",
+        "dest": "cargo/vendor/ipconfig-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3910,6 +3988,19 @@
         "type": "inline",
         "contents": "{\"package\": \"50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1\", \"files\": {}}",
         "dest": "cargo/vendor/mio-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/moka/moka-0.12.15.crate",
+        "sha256": "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046",
+        "dest": "cargo/vendor/moka-0.12.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046\", \"files\": {}}",
+        "dest": "cargo/vendor/moka-0.12.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5644,6 +5735,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/resolv-conf/resolv-conf-0.7.6.crate",
+        "sha256": "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7",
+        "dest": "cargo/vendor/resolv-conf-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7\", \"files\": {}}",
+        "dest": "cargo/vendor/resolv-conf-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rfd/rfd-0.16.0.crate",
         "sha256": "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672",
         "dest": "cargo/vendor/rfd-0.16.0"
@@ -6731,6 +6835,19 @@
         "type": "inline",
         "contents": "{\"package\": \"a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349\", \"files\": {}}",
         "dest": "cargo/vendor/system-deps-6.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tagptr/tagptr-0.2.0.crate",
+        "sha256": "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417",
+        "dest": "cargo/vendor/tagptr-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417\", \"files\": {}}",
+        "dest": "cargo/vendor/tagptr-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -890,10 +890,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1317,6 +1332,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -2028,6 +2055,7 @@ dependencies = [
  "futures-util",
  "gtk",
  "harbor-core",
+ "hickory-resolver",
  "hound",
  "libc",
  "libmpv2",
@@ -2066,6 +2094,7 @@ dependencies = [
  "webview2-com 0.37.0",
  "window-vibrancy",
  "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]
@@ -2143,6 +2172,52 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "home"
@@ -2530,6 +2605,19 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "leaky-cow",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry 0.6.1",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3240,6 +3328,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid 1.23.1",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3771,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "open"
@@ -4612,6 +4721,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
+ "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -4624,6 +4734,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4686,6 +4797,12 @@ dependencies = [
  "wasm-streams 0.5.0",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfd"
@@ -5611,6 +5728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tao"
 version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6272,6 +6395,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -7938,6 +8062,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid 1.23.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,7 @@ webview2-com = "0.37"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
+zbus = { version = "5", default-features = false, features = ["tokio"] }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -462,11 +462,23 @@ pub fn run() {
 
     app_builder
         .setup(move |app| {
-            #[cfg(any(windows, target_os = "linux"))]
+            #[cfg(windows)]
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
                 if let Err(e) = app.deep_link().register_all() {
                     eprintln!("[harbor::deep-link] register_all failed: {:?}", e);
+                }
+            }
+            #[cfg(target_os = "linux")]
+            {
+                // Flatpak registers the URI handlers from the exported desktop
+                // entry. Runtime registration attempts to write host integration
+                // files and is not permitted inside the sandbox.
+                if std::env::var_os("FLATPAK_ID").is_none() {
+                    use tauri_plugin_deep_link::DeepLinkExt;
+                    if let Err(e) = app.deep_link().register_all() {
+                        eprintln!("[harbor::deep-link] register_all failed: {:?}", e);
+                    }
                 }
             }
             #[cfg(windows)]

--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -268,7 +268,10 @@ fn apply_pre_init(
     set("input-default-bindings", "no")?;
     set("input-media-keys", "no")?;
     set("input-cursor", "no")?;
-    set("osc", "no")?;
+    // `osc` is provided by mpv's optional on-screen-controller script. Some
+    // libmpv builds, including the Flatpak build, do not ship that script, so
+    // its option is unavailable. Harbor supplies its own controls either way.
+    let _ = set("osc", "no");
     set("osd-level", "0")?;
     set("cursor-autohide", "200")?;
     set("volume-max", "600")?;

--- a/src-tauri/src/power.rs
+++ b/src-tauri/src/power.rs
@@ -37,8 +37,118 @@ mod mac {
 #[cfg(target_os = "macos")]
 static TOKEN: std::sync::Mutex<Option<mac::Token>> = std::sync::Mutex::new(None);
 
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::collections::HashMap;
+
+    use zbus::zvariant::{OwnedObjectPath, Value};
+
+    const SCREENSAVER_DESTINATION: &str = "org.freedesktop.ScreenSaver";
+    const SCREENSAVER_PATH: &str = "/org/freedesktop/ScreenSaver";
+    const SCREENSAVER_INTERFACE: &str = "org.freedesktop.ScreenSaver";
+    const PORTAL_DESTINATION: &str = "org.freedesktop.portal.Desktop";
+    const PORTAL_PATH: &str = "/org/freedesktop/portal/desktop";
+    const PORTAL_INHIBIT_INTERFACE: &str = "org.freedesktop.portal.Inhibit";
+    const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
+    const INHIBIT_SUSPEND_AND_IDLE: u32 = 4 | 8;
+
+    pub enum Token {
+        ScreenSaver {
+            connection: zbus::Connection,
+            cookie: u32,
+        },
+        Portal {
+            connection: zbus::Connection,
+            handle: OwnedObjectPath,
+        },
+    }
+
+    pub async fn begin() -> Option<Token> {
+        let connection = zbus::Connection::session().await.ok()?;
+
+        if let Some(token) = begin_portal(&connection).await {
+            return Some(token);
+        }
+
+        begin_screensaver(&connection).await
+    }
+
+    async fn begin_screensaver(connection: &zbus::Connection) -> Option<Token> {
+        let proxy = zbus::Proxy::new(
+            connection,
+            SCREENSAVER_DESTINATION,
+            SCREENSAVER_PATH,
+            SCREENSAVER_INTERFACE,
+        )
+        .await
+        .ok()?;
+        let cookie = proxy
+            .call("Inhibit", &("Harbor", "Harbor playback"))
+            .await
+            .ok()?;
+
+        Some(Token::ScreenSaver {
+            connection: connection.clone(),
+            cookie,
+        })
+    }
+
+    async fn begin_portal(connection: &zbus::Connection) -> Option<Token> {
+        let proxy = zbus::Proxy::new(
+            connection,
+            PORTAL_DESTINATION,
+            PORTAL_PATH,
+            PORTAL_INHIBIT_INTERFACE,
+        )
+        .await
+        .ok()?;
+        let options = HashMap::from([("reason", Value::from("Harbor playback"))]);
+        let handle = proxy
+            .call("Inhibit", &("", INHIBIT_SUSPEND_AND_IDLE, options))
+            .await
+            .ok()?;
+
+        Some(Token::Portal {
+            connection: connection.clone(),
+            handle,
+        })
+    }
+
+    pub async fn end(token: Token) {
+        match token {
+            Token::ScreenSaver { connection, cookie } => {
+                if let Ok(proxy) = zbus::Proxy::new(
+                    &connection,
+                    SCREENSAVER_DESTINATION,
+                    SCREENSAVER_PATH,
+                    SCREENSAVER_INTERFACE,
+                )
+                .await
+                {
+                    let _ = proxy.call::<_, _, ()>("UnInhibit", &(cookie,)).await;
+                }
+            }
+            Token::Portal { connection, handle } => {
+                if let Ok(proxy) = zbus::Proxy::new(
+                    &connection,
+                    PORTAL_DESTINATION,
+                    handle.as_str(),
+                    PORTAL_REQUEST_INTERFACE,
+                )
+                .await
+                {
+                    let _ = proxy.call::<_, _, ()>("Close", &()).await;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+static TOKEN: tokio::sync::Mutex<Option<linux::Token>> = tokio::sync::Mutex::const_new(None);
+
 #[tauri::command]
-pub fn power_inhibit(on: bool) {
+pub async fn power_inhibit(on: bool) {
     #[cfg(target_os = "macos")]
     {
         let mut guard = TOKEN.lock().unwrap();
@@ -49,7 +159,17 @@ pub fn power_inhibit(on: bool) {
             (false, None) => {}
         }
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    {
+        let mut guard = TOKEN.lock().await;
+        match (on, guard.take()) {
+            (true, None) => *guard = linux::begin().await,
+            (true, Some(token)) => *guard = Some(token),
+            (false, Some(token)) => linux::end(token).await,
+            (false, None) => {}
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         let _ = on;
     }


### PR DESCRIPTION
## Summary
- inhibit automatic suspend and idle display sleep during playback via the XDG portal, with a ScreenSaver D-Bus fallback
- make the optional mpv OSC setting non-fatal for Flatpak’s libmpv build
- skip forbidden runtime URI-handler registration in Flatpak; its exported desktop entry already declares the schemes
- add the generated Cargo sources required for Flatpak’s offline build

## Validation
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`
- `pnpm run build`
- native Linux playback: GNOME inhibitor reported `Harbor playback`, flags `12` (`Suspend | Idle`)
- Flatpak playback: portal inhibitor reported app ID `site.harbor.Harbor`, reason `Harbor playback`, flags `12`
- Flatpak video playback succeeded on Wayland

The lockfile and generated Flatpak-source entries include the already-declared `hickory-resolver` dependency graph that was absent from the existing lockfile, keeping locked and offline builds valid.

Fixes #750