### PR TITLE
fix: set_bundled_mpv commented out as it was removed in thumbs.rs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:build:linux-system": "tauri build --config src-tauri/tauri.linux-system.conf.json",
+    "setup": "node scripts/fetch-binaries.mjs",
     "setup:libmpv": "node scripts/fetch-libmpv.mjs",
     "setup:ffmpeg": "node scripts/fetch-ffmpeg.mjs",
     "setup:fonts": "node scripts/fetch-fonts.mjs"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:build:linux-system": "tauri build --config src-tauri/tauri.linux-system.conf.json",
-    "setup": "node scripts/fetch-binaries.mjs",
+    "setup:binaries": "node scripts/fetch-binaries.mjs",
     "setup:libmpv": "node scripts/fetch-libmpv.mjs",
     "setup:ffmpeg": "node scripts/fetch-ffmpeg.mjs",
     "setup:fonts": "node scripts/fetch-fonts.mjs"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -487,16 +487,6 @@ pub fn run() {
             make_main_transparent(&app.handle());
             #[cfg(windows)]
             install_maximize_guard(&app.handle());
-            #[cfg(windows)]
-            {
-                use tauri::Manager;
-                if let Ok(res) = app.path().resource_dir() {
-                    let mpv = res.join("mpv.exe");
-                    if mpv.exists() {
-                        // thumbs::set_bundled_mpv(mpv);
-                    }
-                }
-            }
             ensure_window_on_screen(&app.handle());
             #[cfg(target_os = "macos")]
             {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -493,7 +493,7 @@ pub fn run() {
                 if let Ok(res) = app.path().resource_dir() {
                     let mpv = res.join("mpv.exe");
                     if mpv.exists() {
-                        thumbs::set_bundled_mpv(mpv);
+                        // thumbs::set_bundled_mpv(mpv);
                     }
                 }
             }


### PR DESCRIPTION
thumbs.rs set_bundled_mpv function was gutted for clean-up, which caused an error when building due to lib.rs calling that function.