### PR TITLE
Security: Fix XSS -> RCE via malicious documentation

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
       }
     ],
     "security": {
-      "csp": null,
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost data: blob: https: http:; media-src 'self' asset: https://asset.localhost blob: https: http:; connect-src 'self' ipc: http://ipc.localhost https: http: ws: wss:; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]

--- a/src/views/addons/addon-documentation.tsx
+++ b/src/views/addons/addon-documentation.tsx
@@ -2,7 +2,6 @@ import { ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
 import { getAddon } from "@/lib/providers/stremio-addons";
 import { openUrl } from "@/lib/window";
 import { useT } from "@/lib/i18n";
@@ -63,8 +62,7 @@ export function AddonDocumentation({ slug }: { slug: string }) {
       >
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw]}
-            skipHtml={false}
+            skipHtml={true}
             components={{
               h1: (p) => (
                 <h3 className="mt-6 mb-2 font-display text-[20px] font-medium tracking-tight text-ink first:mt-0">


### PR DESCRIPTION
This is a band-aid fix that I didnt test, but this should fix the one vector of stored XSS by removing html from documentation since its meant to be pure markdown, and fixes the csp which allows for escalation to rce.

I didnt test any of this, but in theory it probably works? I'd recommend testing anyways.