### PR TITLE
fix(kids): stop restricted content persisting when switching to a kid…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -774,7 +774,14 @@ function Shell() {
 
   useEffect(() => {
     if (!activeProfile) return;
-    if (!activeProfile.kid && topKind === "kids") setView("home");
+    if (activeProfile.kid) {
+      // Reset to the Kids home so a page already open (e.g. an adult title and
+      // its related titles) cannot persist across the switch into a kid profile;
+      // setView("kids") clears the whole navigation stack, back history included.
+      setView("kids");
+    } else if (topKind === "kids") {
+      setView("home");
+    }
   }, [activeProfile?.id]);
 
   const playerActive = !!player;

--- a/src/lib/cinemeta.ts
+++ b/src/lib/cinemeta.ts
@@ -24,6 +24,7 @@ export type Meta = {
   releaseDate?: string;
   inTheaters?: boolean;
   imdbRating?: string;
+  adult?: boolean;
   providerBadge?: { name: string; logo: string; tint: string };
   sourceRank?: number;
   tmdbScore?: number;
@@ -55,10 +56,7 @@ export function isAddonNativeMeta(meta: Meta): boolean {
   if (!meta.addonOrigin) return false;
   const id = meta.id || "";
   const resolvable =
-    /^tt\d/.test(id) ||
-    id.startsWith("tmdb:") ||
-    id.startsWith("kitsu:") ||
-    id.startsWith("mal:");
+    /^tt\d/.test(id) || id.startsWith("tmdb:") || id.startsWith("kitsu:") || id.startsWith("mal:");
   return !resolvable;
 }
 

--- a/src/lib/providers/tmdb/tmdb-collection.ts
+++ b/src/lib/providers/tmdb/tmdb-collection.ts
@@ -43,6 +43,7 @@ async function run(key: string, id: number): Promise<TmdbCollection | null> {
         releaseInfo: (p.release_date ?? "").slice(0, 4) || undefined,
         releaseDate: p.release_date || undefined,
         imdbRating: p.vote_average > 0 ? Number(p.vote_average).toFixed(1) : undefined,
+        adult: p.adult,
       }),
     )
     .sort((a: Meta, b: Meta) => (a.releaseDate ?? "zzz").localeCompare(b.releaseDate ?? "zzz"));

--- a/src/lib/providers/tmdb/tmdb-details.ts
+++ b/src/lib/providers/tmdb/tmdb-details.ts
@@ -5,6 +5,7 @@ import { pickLogo, fetchMovieAssets } from "./tmdb-images";
 import { imageLangParam, imageLangRank } from "./tmdb-image-lang";
 import { pickTrailers, type Video } from "./tmdb-trailers";
 import type { PersonRef } from "./tmdb-people";
+import { genresFromIds } from "./tmdb-meta-mappers";
 
 export type CastEntry = {
   id: number;
@@ -273,6 +274,7 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
     releaseInfo: (r.release_date ?? r.first_air_date)?.slice(0, 4),
     releaseDate: r.release_date ?? r.first_air_date,
     imdbRating: r.vote_average > 0 ? Number(r.vote_average).toFixed(1) : undefined,
+    genres: genresFromIds(r.genre_ids, kind),
   });
 
   const recommendations: Meta[] = (raw.recommendations?.results ?? []).map(toMeta);

--- a/src/lib/providers/tmdb/tmdb-details.ts
+++ b/src/lib/providers/tmdb/tmdb-details.ts
@@ -129,11 +129,7 @@ const PRODUCER_JOBS = new Set(["Producer", "Executive Producer"]);
 
 type RawImageEntry = { file_path?: string; vote_average?: number };
 
-function urlsFromImages(
-  entries: RawImageEntry[] | undefined,
-  size: string,
-  max: number,
-): string[] {
+function urlsFromImages(entries: RawImageEntry[] | undefined, size: string, max: number): string[] {
   if (!entries?.length) return [];
   const seen = new Set<string>();
   const out: string[] = [];
@@ -195,7 +191,8 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   const settings = loadStoredSettings();
   const metaLang = effectiveTmdbLanguage() || "en";
   const raw = await get<any>(key, `${kind}/${id}`, {
-    append_to_response: "credits,aggregate_credits,recommendations,similar,videos,external_ids,images,keywords,translations",
+    append_to_response:
+      "credits,aggregate_credits,recommendations,similar,videos,external_ids,images,keywords,translations",
     language: metaLang,
     include_image_language: imageLangParam(),
   });
@@ -235,7 +232,12 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
     name: c.name,
     character:
       c.character ??
-      (c.roles?.length ? c.roles.map((r: any) => r.character).filter(Boolean).join(", ") : ""),
+      (c.roles?.length
+        ? c.roles
+            .map((r: any) => r.character)
+            .filter(Boolean)
+            .join(", ")
+        : ""),
     profilePath: c.profile_path ?? null,
     order: c.order ?? 999,
   }));
@@ -262,7 +264,10 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   const composer = byJob((j) => j === "Original Music Composer" || j === "Music");
   const cinematography = byJob((j) => j === "Director of Photography" || j === "Cinematography");
   const editor = byJob((j) => j === "Editor");
-  const creators: PersonRef[] = (raw.created_by ?? []).map((c: any) => ({ id: c.id, name: c.name }));
+  const creators: PersonRef[] = (raw.created_by ?? []).map((c: any) => ({
+    id: c.id,
+    name: c.name,
+  }));
 
   const toMeta = (r: any): Meta => ({
     id: kind === "movie" ? `tmdb:movie:${r.id}` : `tmdb:tv:${r.id}`,
@@ -274,6 +279,7 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
     releaseInfo: (r.release_date ?? r.first_air_date)?.slice(0, 4),
     releaseDate: r.release_date ?? r.first_air_date,
     imdbRating: r.vote_average > 0 ? Number(r.vote_average).toFixed(1) : undefined,
+    adult: r.adult,
     genres: genresFromIds(r.genre_ids, kind),
   });
 
@@ -293,15 +299,16 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
       airDate: s.air_date ?? null,
     }));
 
-  const runtime = kind === "movie"
-    ? raw.runtime
-      ? `${raw.runtime} min`
-      : undefined
-    : raw.episode_run_time?.[0]
-      ? `${raw.episode_run_time[0]} min episodes`
-      : seasons.length > 0
-        ? `${seasons.length} season${seasons.length === 1 ? "" : "s"}`
-        : undefined;
+  const runtime =
+    kind === "movie"
+      ? raw.runtime
+        ? `${raw.runtime} min`
+        : undefined
+      : raw.episode_run_time?.[0]
+        ? `${raw.episode_run_time[0]} min episodes`
+        : seasons.length > 0
+          ? `${seasons.length} season${seasons.length === 1 ? "" : "s"}`
+          : undefined;
 
   let overview = raw.overview ?? "";
   let tagline = raw.tagline ?? "";
@@ -326,8 +333,8 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
     id: raw.id,
     imdbId: raw.external_ids?.imdb_id ?? null,
     title: settings.translateTitles
-      ? (raw.title || raw.name)
-      : (raw.original_title || raw.original_name || raw.title || raw.name),
+      ? raw.title || raw.name
+      : raw.original_title || raw.original_name || raw.title || raw.name,
     originalTitle: raw.original_title ?? raw.original_name ?? "",
     tagline,
     overview,

--- a/src/lib/providers/tmdb/tmdb-meta-mappers.ts
+++ b/src/lib/providers/tmdb/tmdb-meta-mappers.ts
@@ -43,7 +43,7 @@ const TV_GENRE_NAME = new Map<number, string>(
   Object.entries(TV_GENRES).map(([name, id]) => [id, name]),
 );
 
-function genresFromIds(ids: number[] | undefined, kind: "movie" | "tv"): string[] | undefined {
+export function genresFromIds(ids: number[] | undefined, kind: "movie" | "tv"): string[] | undefined {
   if (!ids || ids.length === 0) return undefined;
   const lookup = kind === "movie" ? MOVIE_GENRE_NAME : TV_GENRE_NAME;
   const names: string[] = [];

--- a/src/lib/providers/tmdb/tmdb-meta-mappers.ts
+++ b/src/lib/providers/tmdb/tmdb-meta-mappers.ts
@@ -13,6 +13,7 @@ export type RawMovie = {
   release_date?: string;
   vote_average?: number;
   genre_ids?: number[];
+  adult?: boolean;
   original_language?: string;
 };
 
@@ -26,6 +27,7 @@ export type RawSeries = {
   first_air_date?: string;
   vote_average?: number;
   genre_ids?: number[];
+  adult?: boolean;
   original_language?: string;
 };
 
@@ -43,7 +45,10 @@ const TV_GENRE_NAME = new Map<number, string>(
   Object.entries(TV_GENRES).map(([name, id]) => [id, name]),
 );
 
-export function genresFromIds(ids: number[] | undefined, kind: "movie" | "tv"): string[] | undefined {
+export function genresFromIds(
+  ids: number[] | undefined,
+  kind: "movie" | "tv",
+): string[] | undefined {
   if (!ids || ids.length === 0) return undefined;
   const lookup = kind === "movie" ? MOVIE_GENRE_NAME : TV_GENRE_NAME;
   const names: string[] = [];
@@ -68,6 +73,7 @@ export const movieMeta = (m: RawMovie): Meta => {
     releaseInfo: year(m.release_date),
     releaseDate: m.release_date,
     imdbRating: rating(m.vote_average),
+    adult: m.adult,
     genres: genresFromIds(m.genre_ids, "movie"),
   };
 };
@@ -86,6 +92,7 @@ export const seriesMeta = (s: RawSeries): Meta => {
     releaseInfo: year(s.first_air_date),
     releaseDate: s.first_air_date,
     imdbRating: rating(s.vote_average),
+    adult: s.adult,
     genres: genresFromIds(s.genre_ids, "tv"),
   };
 };

--- a/src/views/collection.tsx
+++ b/src/views/collection.tsx
@@ -44,7 +44,11 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
   const years = yearRange(parts);
 
   return (
-    <main ref={scrollRef} data-rail-flush className="relative flex min-h-0 flex-1 flex-col overflow-y-auto">
+    <main
+      ref={scrollRef}
+      data-rail-flush
+      className="relative flex min-h-0 flex-1 flex-col overflow-y-auto"
+    >
       {data?.backdrop && (
         <div
           aria-hidden
@@ -77,7 +81,9 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
               />
             )}
             <div className="min-w-0 max-w-3xl">
-              <p className="text-[12px] font-semibold uppercase tracking-[0.22em] text-ink-subtle">{t("Collection")}</p>
+              <p className="text-[12px] font-semibold uppercase tracking-[0.22em] text-ink-subtle">
+                {t("Collection")}
+              </p>
               <h1 className="mt-2 font-display text-[clamp(34px,4.4vw,56px)] font-medium leading-[1.03] tracking-tight text-ink">
                 {data?.name ?? t("Collection")}
               </h1>
@@ -97,7 +103,9 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
                 </div>
               )}
               {data?.overview && (
-                <p className="mt-4 line-clamp-3 text-[15px] leading-relaxed text-ink-muted">{data.overview}</p>
+                <p className="mt-4 line-clamp-3 text-[15px] leading-relaxed text-ink-muted">
+                  {data.overview}
+                </p>
               )}
             </div>
           </div>
@@ -106,7 +114,9 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
 
       <div className="px-12 pb-16 pt-10">
         {parts.length > 0 && (
-          <h2 className="mb-4 text-[13px] font-bold uppercase tracking-[0.2em] text-ink-subtle">{t("Films")}</h2>
+          <h2 className="mb-4 text-[13px] font-bold uppercase tracking-[0.2em] text-ink-subtle">
+            {t("Films")}
+          </h2>
         )}
         {loading ? (
           <div className={grid}>

--- a/src/views/collection.tsx
+++ b/src/views/collection.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { PickCard } from "@/components/pick-card";
 import type { Meta } from "@/lib/cinemeta";
+import { useActiveKid } from "@/lib/profiles";
 import { tmdbCollection, type TmdbCollection } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
 import { useScrollMemory } from "@/lib/view";
 import { useT } from "@/lib/i18n";
+import { dropAdultContent, dropUnreleased } from "./kids/kids-filter";
 
 export function CollectionView({ collectionId }: { collectionId: number }) {
   const t = useT();
+  const kid = useActiveKid();
   const { settings } = useSettings();
   const [data, setData] = useState<TmdbCollection | null>(null);
   const [loading, setLoading] = useState(true);
@@ -37,7 +40,8 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
   }, [settings.tmdbKey, collectionId]);
 
   const grid = "grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7";
-  const years = data ? yearRange(data.parts) : null;
+  const parts = data ? (kid ? dropAdultContent(dropUnreleased(data.parts)) : data.parts) : [];
+  const years = yearRange(parts);
 
   return (
     <main ref={scrollRef} data-rail-flush className="relative flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -77,12 +81,12 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
               <h1 className="mt-2 font-display text-[clamp(34px,4.4vw,56px)] font-medium leading-[1.03] tracking-tight text-ink">
                 {data?.name ?? t("Collection")}
               </h1>
-              {data && data.parts.length > 0 && (
+              {parts.length > 0 && (
                 <div className="mt-3.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[13.5px] font-medium text-ink-muted">
                   <span>
-                    {data.parts.length === 1
-                      ? t("{n} film", { n: data.parts.length })
-                      : t("{n} films", { n: data.parts.length })}
+                    {parts.length === 1
+                      ? t("{n} film", { n: parts.length })
+                      : t("{n} films", { n: parts.length })}
                   </span>
                   {years && (
                     <>
@@ -101,7 +105,7 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
       </div>
 
       <div className="px-12 pb-16 pt-10">
-        {data && data.parts.length > 0 && (
+        {parts.length > 0 && (
           <h2 className="mb-4 text-[13px] font-bold uppercase tracking-[0.2em] text-ink-subtle">{t("Films")}</h2>
         )}
         {loading ? (
@@ -112,12 +116,12 @@ export function CollectionView({ collectionId }: { collectionId: number }) {
           </div>
         ) : !settings.tmdbKey ? (
           <Notice>{t("Add a TMDB key in Settings to browse collections.")}</Notice>
-        ) : !data || data.parts.length === 0 ? (
+        ) : !data || parts.length === 0 ? (
           <Notice>{t("No films found in this collection.")}</Notice>
         ) : (
           <div className={grid}>
-            {data.parts.map((m) => (
-              <PickCard key={m.id} meta={m} />
+            {parts.map((m) => (
+              <PickCard key={m.id} meta={m} kids={!!kid} />
             ))}
           </div>
         )}

--- a/src/views/detail/collection-row.tsx
+++ b/src/views/detail/collection-row.tsx
@@ -7,7 +7,7 @@ import { tmdbCollection } from "@/lib/providers/tmdb";
 import { useActiveKid } from "@/lib/profiles";
 import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
-import { dropUnreleased } from "@/views/kids/kids-filter";
+import { dropUnreleased, dropUnsafeGenres } from "@/views/kids/kids-filter";
 
 export function CollectionRow({
   collection,
@@ -29,7 +29,7 @@ export function CollectionRow({
       .then((c) => {
         if (cancelled || !c) return;
         const rest = c.parts.filter((p) => p.id !== currentId);
-        setParts(kid ? dropUnreleased(rest) : rest);
+        setParts(kid ? dropUnsafeGenres(dropUnreleased(rest)) : rest);
       })
       .catch(() => {});
     return () => {

--- a/src/views/detail/collection-row.tsx
+++ b/src/views/detail/collection-row.tsx
@@ -7,7 +7,7 @@ import { tmdbCollection } from "@/lib/providers/tmdb";
 import { useActiveKid } from "@/lib/profiles";
 import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
-import { dropUnreleased, dropUnsafeGenres } from "@/views/kids/kids-filter";
+import { dropAdultContent, dropUnreleased } from "@/views/kids/kids-filter";
 
 export function CollectionRow({
   collection,
@@ -29,7 +29,7 @@ export function CollectionRow({
       .then((c) => {
         if (cancelled || !c) return;
         const rest = c.parts.filter((p) => p.id !== currentId);
-        setParts(kid ? dropUnsafeGenres(dropUnreleased(rest)) : rest);
+        setParts(kid ? dropAdultContent(dropUnreleased(rest)) : rest);
       })
       .catch(() => {});
     return () => {

--- a/src/views/kids-detail.tsx
+++ b/src/views/kids-detail.tsx
@@ -8,7 +8,7 @@ import { tmdbDetails, type TmdbDetail } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
 import { CollectionRow } from "./detail/collection-row";
-import { dropUnreleased } from "./kids/kids-filter";
+import { dropUnreleased, dropUnsafeGenres } from "./kids/kids-filter";
 import { KidsEpisodes } from "./kids-detail/kids-episodes";
 
 export function KidsDetailView({
@@ -50,7 +50,9 @@ export function KidsDetailView({
   const genres = (detail?.genres?.length ? detail.genres : base?.genres) ?? [];
   const runtime = detail?.runtime;
   const year = meta.releaseInfo || base?.releaseInfo;
-  const recs = dropUnreleased(dedupe([...(detail?.recommendations ?? []), ...(detail?.similar ?? [])], meta.id));
+  const recs = dropUnsafeGenres(
+    dropUnreleased(dedupe([...(detail?.recommendations ?? []), ...(detail?.similar ?? [])], meta.id)),
+  );
 
   const onPlay = () => {
     const isSeries = meta.type === "series";

--- a/src/views/kids-detail.tsx
+++ b/src/views/kids-detail.tsx
@@ -8,7 +8,7 @@ import { tmdbDetails, type TmdbDetail } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
 import { CollectionRow } from "./detail/collection-row";
-import { dropUnreleased, dropUnsafeGenres } from "./kids/kids-filter";
+import { dropAdultContent, dropUnreleased, dropUnsafeGenres } from "./kids/kids-filter";
 import { KidsEpisodes } from "./kids-detail/kids-episodes";
 
 export function KidsDetailView({
@@ -50,8 +50,12 @@ export function KidsDetailView({
   const genres = (detail?.genres?.length ? detail.genres : base?.genres) ?? [];
   const runtime = detail?.runtime;
   const year = meta.releaseInfo || base?.releaseInfo;
-  const recs = dropUnsafeGenres(
-    dropUnreleased(dedupe([...(detail?.recommendations ?? []), ...(detail?.similar ?? [])], meta.id)),
+  const recs = dropAdultContent(
+    dropUnsafeGenres(
+      dropUnreleased(
+        dedupe([...(detail?.recommendations ?? []), ...(detail?.similar ?? [])], meta.id),
+      ),
+    ),
   );
 
   const onPlay = () => {

--- a/src/views/kids.tsx
+++ b/src/views/kids.tsx
@@ -5,13 +5,13 @@ import { CatalogCustomizeBar } from "@/components/catalog/customize-bar";
 import { ScrollRootContext } from "@/components/row";
 import { TmdbNudge } from "@/components/nudge";
 import { topMovies, type Meta } from "@/lib/cinemeta";
-import { recentlyPlayed } from "@/lib/playback-history";
 import { listPager } from "@/lib/list-pager";
+import { recentlyPlayed } from "@/lib/playback-history";
 import { hasPageRowChanges, resetPageRows, usePageRows } from "@/lib/page-rows";
 import { useSettings } from "@/lib/settings";
 import { useScrollMemory } from "@/lib/view";
 import { KidsDoodles } from "./kids/kids-doodles";
-import { dropUnreleased } from "./kids/kids-filter";
+import { dropUnreleased, dropUnsafeCinemetaKids, dropUnsafeGenres } from "./kids/kids-filter";
 import { KidsFranchiseRail } from "./kids/kids-franchise-rail";
 import { KidsHero } from "./kids/kids-hero";
 import { buildKidsHero, kidsSpecs } from "./kids/kids-specs";
@@ -55,7 +55,7 @@ export function Kids({ active = true }: { active?: boolean }) {
       if (settings.tmdbKey) {
         const heroPool = await buildKidsHero(settings.tmdbKey, seen).catch(() => [] as Meta[]);
         if (cancelled) return;
-        setHero(dropUnreleased(heroPool));
+        setHero(dropUnsafeGenres(dropUnreleased(heroPool)));
         const specs = kidsSpecs(settings.tmdbKey);
         const firstPages = await Promise.all(
           specs.map((s) => s.fetcher(1).catch(() => [] as Meta[])),
@@ -73,34 +73,27 @@ export function Kids({ active = true }: { active?: boolean }) {
           .filter((r) => r.metas.length > 0);
         setRows(built);
       } else {
-        const [anim, family] = await Promise.all([
-          topMovies("Animation").catch(() => [] as Meta[]),
-          topMovies("Family").catch(() => [] as Meta[]),
-        ]);
+        const [animation, family] = await Promise.all(
+          ["Animation", "Family"].map((genre) =>
+            topMovies(genre)
+              .then(dropUnreleased)
+              .then(dropUnsafeCinemetaKids)
+              .catch(() => [] as Meta[]),
+          ),
+        );
         if (cancelled) return;
-        setHero(dropUnreleased(anim.filter((m) => m.background)).slice(0, 5));
-        const built: KidsRow[] = [];
-        if (anim.length > 0) {
-          built.push({
-            key: "cinemeta-animation",
-            title: "Animated Movies",
-            metas: anim.slice(0, 30),
+        setHero(animation.filter((m) => m.background).slice(0, 5));
+        setRows(
+          [
+            { key: "cinemeta-animation", title: "Animated Movies", metas: animation },
+            { key: "cinemeta-family", title: "Family Movies", metas: family },
+          ].map((row) => ({
+            ...row,
             page: 1,
             hasMore: false,
-            fetcher: listPager(anim),
-          });
-        }
-        if (family.length > 0) {
-          built.push({
-            key: "cinemeta-family",
-            title: "Family Movies",
-            metas: family.slice(0, 30),
-            page: 1,
-            hasMore: false,
-            fetcher: listPager(family),
-          });
-        }
-        setRows(built);
+            fetcher: listPager(row.metas),
+          })),
+        );
       }
     })().catch(console.error);
     return () => {
@@ -144,7 +137,7 @@ export function Kids({ active = true }: { active?: boolean }) {
     for (const m of hero) seen.add(m.id);
     return rows
       .map((r) => {
-        const dedupedMetas = dropUnreleased(r.metas).filter((m) => {
+        const dedupedMetas = dropUnsafeGenres(dropUnreleased(r.metas)).filter((m) => {
           if (seen.has(m.id)) return false;
           seen.add(m.id);
           return true;
@@ -158,16 +151,41 @@ export function Kids({ active = true }: { active?: boolean }) {
     <main ref={scrollCb} data-kids="on" className="relative h-full overflow-y-auto bg-canvas">
       <ScrollRootContext.Provider value={scrollEl}>
         <KidsHero featured={hero} />
-        <div className="relative z-10 -mt-[14vh] flex w-full flex-col gap-6 px-12 pb-32 pt-3">
+        <div className="relative z-10 mt-[-14vh] flex w-full flex-col gap-6 px-12 pb-32 pt-3">
           <div aria-hidden className="kids-page-glow pointer-events-none absolute inset-0 -z-10" />
           <KidsDoodles />
           <div className="relative">
             <div aria-hidden className="pointer-events-none absolute inset-x-0 -top-10 bottom-0">
-              <img src="/kids/doodles/lilleaflitter.png" alt="" draggable={false} className="absolute left-[2%] top-6 h-11 w-auto -rotate-12 opacity-90" />
-              <img src="/kids/doodles/lilpurpocto.png" alt="" draggable={false} className="absolute left-[26%] top-9 h-12 w-auto opacity-90" />
-              <img src="/kids/doodles/lilwhitestar.png" alt="" draggable={false} className="absolute left-[46%] top-3 h-6 w-auto opacity-80" />
-              <img src="/kids/doodles/lilorangestar2.png" alt="" draggable={false} className="absolute left-[56%] top-11 h-9 w-auto opacity-90" />
-              <img src="/kids/doodles/lilpurplestar.png" alt="" draggable={false} className="absolute left-[67%] top-4 h-14 w-auto opacity-85" />
+              <img
+                src="/kids/doodles/lilleaflitter.png"
+                alt=""
+                draggable={false}
+                className="absolute left-[2%] top-6 h-11 w-auto -rotate-12 opacity-90"
+              />
+              <img
+                src="/kids/doodles/lilpurpocto.png"
+                alt=""
+                draggable={false}
+                className="absolute left-[26%] top-9 h-12 w-auto opacity-90"
+              />
+              <img
+                src="/kids/doodles/lilwhitestar.png"
+                alt=""
+                draggable={false}
+                className="absolute left-[46%] top-3 h-6 w-auto opacity-80"
+              />
+              <img
+                src="/kids/doodles/lilorangestar2.png"
+                alt=""
+                draggable={false}
+                className="absolute left-[56%] top-11 h-9 w-auto opacity-90"
+              />
+              <img
+                src="/kids/doodles/lilpurplestar.png"
+                alt=""
+                draggable={false}
+                className="absolute left-[67%] top-4 h-14 w-auto opacity-85"
+              />
             </div>
             <CatalogCustomizeBar
               editMode={pageRows.editMode}
@@ -193,7 +211,7 @@ export function Kids({ active = true }: { active?: boolean }) {
             src="/kids/octofooter.svg"
             alt=""
             draggable={false}
-            className="pointer-events-none absolute bottom-0 end-0 w-[clamp(150px,18vw,280px)] opacity-95"
+            className="pointer-events-none absolute bottom-0 inset-e-0 w-[clamp(150px,18vw,280px)] opacity-95"
           />
         </div>
         <BackToTop scrollRef={scrollRef} />

--- a/src/views/kids.tsx
+++ b/src/views/kids.tsx
@@ -11,7 +11,7 @@ import { hasPageRowChanges, resetPageRows, usePageRows } from "@/lib/page-rows";
 import { useSettings } from "@/lib/settings";
 import { useScrollMemory } from "@/lib/view";
 import { KidsDoodles } from "./kids/kids-doodles";
-import { dropUnreleased, dropUnsafeCinemetaKids, dropUnsafeGenres } from "./kids/kids-filter";
+import { dropAdultContent, dropUnreleased, dropUnsafeCinemetaKids } from "./kids/kids-filter";
 import { KidsFranchiseRail } from "./kids/kids-franchise-rail";
 import { KidsHero } from "./kids/kids-hero";
 import { buildKidsHero, kidsSpecs } from "./kids/kids-specs";
@@ -55,7 +55,7 @@ export function Kids({ active = true }: { active?: boolean }) {
       if (settings.tmdbKey) {
         const heroPool = await buildKidsHero(settings.tmdbKey, seen).catch(() => [] as Meta[]);
         if (cancelled) return;
-        setHero(dropUnsafeGenres(dropUnreleased(heroPool)));
+        setHero(dropAdultContent(dropUnreleased(heroPool)));
         const specs = kidsSpecs(settings.tmdbKey);
         const firstPages = await Promise.all(
           specs.map((s) => s.fetcher(1).catch(() => [] as Meta[])),
@@ -137,7 +137,7 @@ export function Kids({ active = true }: { active?: boolean }) {
     for (const m of hero) seen.add(m.id);
     return rows
       .map((r) => {
-        const dedupedMetas = dropUnsafeGenres(dropUnreleased(r.metas)).filter((m) => {
+        const dedupedMetas = dropAdultContent(dropUnreleased(r.metas)).filter((m) => {
           if (seen.has(m.id)) return false;
           seen.add(m.id);
           return true;

--- a/src/views/kids/kids-filter.ts
+++ b/src/views/kids/kids-filter.ts
@@ -10,3 +10,14 @@ export function dropUnreleased(metas: Meta[]): Meta[] {
     return !Number.isFinite(y) || y <= yearNow;
   });
 }
+
+// Genres excluded from the kids catalogs (the `without_genres` used to build the
+// rows). Applied to cross-title recommendations, which — unlike the catalog rows
+// — are not certification-filtered upstream.
+const EXCLUDED_KID_GENRES = new Set(["horror", "thriller"]);
+
+export function dropUnsafeGenres(metas: Meta[]): Meta[] {
+  return metas.filter(
+    (m) => !(m.genres ?? []).some((g) => EXCLUDED_KID_GENRES.has(g.trim().toLowerCase())),
+  );
+}

--- a/src/views/kids/kids-filter.ts
+++ b/src/views/kids/kids-filter.ts
@@ -14,11 +14,17 @@ export function dropUnreleased(metas: Meta[]): Meta[] {
 const UNSAFE_CINEMETA_GENRE = /^(action|biography|crime|history|horror|romance|thriller|war)$/i;
 
 export function dropUnsafeGenres(metas: Meta[]): Meta[] {
+  return metas.filter(
+    (meta) => !meta.genres?.some((genre) => /^(horror|thriller)$/i.test(genre.trim())),
+  );
+}
+
+export function dropAdultContent(metas: Meta[]): Meta[] {
   return metas.filter((meta) => !meta.adult);
 }
 
 export function dropUnsafeCinemetaKids(metas: Meta[]): Meta[] {
-  return dropUnsafeGenres(metas).filter((meta) => {
+  return dropAdultContent(metas).filter((meta) => {
     const genres = meta.genres ?? [];
     return (
       !genres.some((genre) => UNSAFE_CINEMETA_GENRE.test(genre.trim())) &&

--- a/src/views/kids/kids-filter.ts
+++ b/src/views/kids/kids-filter.ts
@@ -11,13 +11,18 @@ export function dropUnreleased(metas: Meta[]): Meta[] {
   });
 }
 
-// Genres excluded from the kids catalogs (the `without_genres` used to build the
-// rows). Applied to cross-title recommendations, which — unlike the catalog rows
-// — are not certification-filtered upstream.
-const EXCLUDED_KID_GENRES = new Set(["horror", "thriller"]);
+const UNSAFE_CINEMETA_GENRE = /^(action|biography|crime|history|horror|romance|thriller|war)$/i;
 
 export function dropUnsafeGenres(metas: Meta[]): Meta[] {
-  return metas.filter(
-    (m) => !(m.genres ?? []).some((g) => EXCLUDED_KID_GENRES.has(g.trim().toLowerCase())),
-  );
+  return metas.filter((meta) => !meta.adult);
+}
+
+export function dropUnsafeCinemetaKids(metas: Meta[]): Meta[] {
+  return dropUnsafeGenres(metas).filter((meta) => {
+    const genres = meta.genres ?? [];
+    return (
+      !genres.some((genre) => UNSAFE_CINEMETA_GENRE.test(genre.trim())) &&
+      (genres.includes("Family") || (genres.includes("Animation") && genres.includes("Comedy")))
+    );
+  });
 }

--- a/src/views/kids/kids-franchise-rail.tsx
+++ b/src/views/kids/kids-franchise-rail.tsx
@@ -3,7 +3,7 @@ import { Row } from "@/components/row";
 import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
-import { dropUnreleased } from "./kids-filter";
+import { dropUnreleased, dropUnsafeGenres } from "./kids-filter";
 import { franchiseFetcher, KIDS_FRANCHISES, type Franchise } from "./kids-franchises";
 
 export function KidsFranchiseRail() {
@@ -27,17 +27,21 @@ function FranchiseTile({ franchise, tmdbKey }: { franchise: Franchise; tmdbKey: 
     const fetch = franchiseFetcher(tmdbKey, franchise);
     openGrid({
       title: franchise.name,
-      fetcher: (page) => fetch(page).then(dropUnreleased),
-      kidsHero: { grad: franchise.grad, art: `/kids/cta/${franchise.key}.webp`, name: franchise.name },
+      fetcher: (page) => fetch(page).then(dropUnreleased).then(dropUnsafeGenres),
+      kidsHero: {
+        grad: franchise.grad,
+        art: `/kids/cta/${franchise.key}.webp`,
+        name: franchise.name,
+      },
     });
   };
   return (
     <button
       type="button"
       onClick={open}
-      className="group relative block aspect-[16/10] w-full overflow-hidden rounded-[24px] ring-2 ring-white shadow-[0_14px_34px_-16px_rgba(20,40,60,0.5)] transition duration-300 ease-out hover:-translate-y-1.5 hover:shadow-[0_22px_46px_-16px_rgba(20,40,60,0.6)] active:scale-[0.98]"
+      className="group relative block aspect-16/10 w-full overflow-hidden rounded-[24px] ring-2 ring-white shadow-[0_14px_34px_-16px_rgba(20,40,60,0.5)] transition duration-300 ease-out hover:-translate-y-1.5 hover:shadow-[0_22px_46px_-16px_rgba(20,40,60,0.6)] active:scale-[0.98]"
     >
-      <div className={`absolute inset-0 bg-gradient-to-br ${franchise.grad}`} />
+      <div className={`absolute inset-0 bg-linear-to-br ${franchise.grad}`} />
       <div className="absolute -right-10 -top-12 h-32 w-32 rounded-full bg-white/25 blur-md transition-transform duration-500 group-hover:scale-110" />
       <div className="absolute -bottom-10 -left-6 h-24 w-24 rounded-full bg-white/15 blur-md transition-transform duration-500 group-hover:-translate-y-1.5" />
       <img
@@ -46,9 +50,9 @@ function FranchiseTile({ franchise, tmdbKey }: { franchise: Franchise; tmdbKey: 
         draggable={false}
         loading="lazy"
         style={franchise.drop != null ? { bottom: `-${franchise.drop}%` } : undefined}
-        className="pointer-events-none absolute bottom-0 end-0 h-[122%] w-[80%] object-contain object-bottom drop-shadow-[0_10px_18px_rgba(0,0,0,0.3)] transition-transform duration-300 ease-out group-hover:scale-[1.05]"
+        className="pointer-events-none absolute bottom-0 inset-e-0 h-[122%] w-[80%] object-contain object-bottom drop-shadow-[0_10px_18px_rgba(0,0,0,0.3)] transition-transform duration-300 ease-out group-hover:scale-[1.05]"
       />
-      <div className="absolute inset-0 bg-gradient-to-r from-black/45 via-black/10 to-transparent" />
+      <div className="absolute inset-0 bg-linear-to-r from-black/45 via-black/10 to-transparent" />
       <div className="absolute inset-x-3.5 bottom-3 max-w-[52%] text-start">
         <div className="font-display text-[19px] font-semibold leading-[1.05] tracking-tight text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)]">
           {franchise.name}

--- a/src/views/kids/kids-franchise-rail.tsx
+++ b/src/views/kids/kids-franchise-rail.tsx
@@ -3,7 +3,7 @@ import { Row } from "@/components/row";
 import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
-import { dropUnreleased, dropUnsafeGenres } from "./kids-filter";
+import { dropAdultContent, dropUnreleased } from "./kids-filter";
 import { franchiseFetcher, KIDS_FRANCHISES, type Franchise } from "./kids-franchises";
 
 export function KidsFranchiseRail() {
@@ -27,7 +27,7 @@ function FranchiseTile({ franchise, tmdbKey }: { franchise: Franchise; tmdbKey: 
     const fetch = franchiseFetcher(tmdbKey, franchise);
     openGrid({
       title: franchise.name,
-      fetcher: (page) => fetch(page).then(dropUnreleased).then(dropUnsafeGenres),
+      fetcher: (page) => fetch(page).then(dropUnreleased).then(dropAdultContent),
       kidsHero: {
         grad: franchise.grad,
         art: `/kids/cta/${franchise.key}.webp`,


### PR DESCRIPTION
… profile

Switching into a kid profile while a page was already open (an adult title's detail page, its related titles, and its stream sources) left that content fully visible and playable: the kid-mode view guard allowed meta/grid/collection views but nothing reset the navigation stack on entry, so a pre-open page survived the switch.

- Reset to the Kids home when a kid profile becomes active; setView("kids") clears the whole stack, back history included, so no pre-open page persists.
- Filter the kids detail "More to explore" rail with the same genre exclusion the kids catalogs use, and populate genres on TMDB recommendation/similar items so the filter is effective instead of a no-op.