### PR TITLE
fix(player): hide custom window controls with native title bar

### DIFF
--- a/src/components/player/transport/window-control-buttons.tsx
+++ b/src/components/player/transport/window-control-buttons.tsx
@@ -1,11 +1,13 @@
 import { Copy, Minus, Square, X } from "lucide-react";
+import { useSettings } from "@/lib/settings";
 import { close, minimize, toggleMaximize, useMaximized } from "@/lib/window";
 
 const IS_TAURI = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
 export function WindowControlButtons({ t }: { t: (key: string) => string }) {
+  const { settings } = useSettings();
   const maxed = useMaximized();
-  if (!IS_TAURI) return null;
+  if (!IS_TAURI || settings.useNativeTitleBar) return null;
   return (
     <div className="pointer-events-auto flex items-center gap-1">
       <button


### PR DESCRIPTION
## Summary
- hide Harbor player window controls when the native title bar is enabled
- keep the operating system responsible for the native title bar and border
- preserve custom player window controls when native decorations are disabled

## Verification
- `vp check src/components/player/transport/window-control-buttons.tsx`
- `vp exec tsc -b --pretty false`
- Windows appearance pending manual verification

Fixes #846