### PR TITLE
fix: repair regressions from dd274b7 merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@tauri-apps/cli": "^2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/three": "^0.185.1",
     "@vitejs/plugin-react": "^6.0.3",
     "cheerio": "^1.2.0",
     "typescript": "~5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: ^0.185.1
+        version: 0.185.1
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(@voidzero-dev/vite-plus-core@0.2.2(esbuild@0.27.7)(jiti@2.6.1)(typescript@5.8.3))
@@ -132,6 +135,9 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -889,6 +895,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -924,11 +933,20 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.185.1':
+    resolution: {integrity: sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -1252,6 +1270,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1465,6 +1486,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1889,6 +1913,8 @@ snapshots:
   '@babel/runtime@7.29.7': {}
 
   '@blazediff/core@1.9.1': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -2348,6 +2374,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
@@ -2385,9 +2413,22 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.185.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -2668,6 +2709,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   fsevents@2.3.3:
     optional: true
@@ -3002,6 +3045,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:

--- a/src/components/ThreeLiquidGlassSurface.tsx
+++ b/src/components/ThreeLiquidGlassSurface.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, type CSSProperties, type HTMLAttributes, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 import * as THREE from "three";
 
 type ThreeLiquidGlassSurfaceProps = HTMLAttributes<HTMLDivElement> & {
@@ -768,7 +775,7 @@ export function ThreeLiquidGlassSurface({
 
   const focusedRef = useRef(false);
 
-  const activate = () => {
+  const activate = useCallback(() => {
     const canvas = canvasRef.current;
 
     if (!canvas) return;
@@ -780,7 +787,7 @@ export function ThreeLiquidGlassSurface({
       spectralStrength,
       lensStrength,
     });
-  };
+  }, [intensity, lensStrength, refractionStrength, shaderRadius, spectralStrength]);
 
   const deactivateWhenIdle = () => {
     const canvas = canvasRef.current;
@@ -804,7 +811,7 @@ export function ThreeLiquidGlassSurface({
         sharedEngine?.release(canvas);
       }
     };
-  }, [alwaysActive, intensity, lensStrength, refractionStrength, shaderRadius, spectralStrength]);
+  }, [activate, alwaysActive]);
 
   const glassStyle: CSSProperties = {
     position: "relative",

--- a/src/components/row.tsx
+++ b/src/components/row.tsx
@@ -528,21 +528,6 @@ function EdgeArrow({
   const t = useT();
   const label = t(side === "left" ? "Scroll left" : "Scroll right");
 
-  const icon =
-    side === "left" ? (
-      <ChevronLeft
-        size={22}
-        strokeWidth={2.2}
-        className="dir-icon relative z-20 drop-shadow-[0_1px_2px_rgba(0,0,0,0.45)]"
-      />
-    ) : (
-      <ChevronRight
-        size={22}
-        strokeWidth={2.2}
-        className="dir-icon relative z-20 drop-shadow-[0_1px_2px_rgba(0,0,0,0.45)]"
-      />
-    );
-
   if (always) {
     return (
       <div

--- a/src/lib/sfx.ts
+++ b/src/lib/sfx.ts
@@ -75,15 +75,8 @@ class SoundEffects {
     modulator.stop(t0 + dur);
   }
 
-<<<<<<< HEAD
   navigate(dir: "up" | "down" | "left" | "right", soundType: "light" | "movie" = "light") {
     if (this.activeTheme === "none") return;
-=======
-
-
-  navigate(dir: "up" | "down" | "left" | "right", soundType: 'light' | 'movie' = 'light') {
-    if (this.activeTheme === 'none') return;
->>>>>>> origin/main
 
     const up = dir === "up" || dir === "left";
 
@@ -96,14 +89,7 @@ class SoundEffects {
     if (this.activeTheme === "glass") {
       if (soundType === "light") this.playGlass({ freq: 2000, dur: 0.08, vol: 0.012 });
       else this.playGlass({ freq: up ? 980 : 1120, dur: 0.22, vol: 0.03 });
-<<<<<<< HEAD
     } else if (this.activeTheme === "retro") {
-      this.playTone(soundType === "light" ? 600 : 440, "square", 0.06, 0.012);
-    } else if (this.activeTheme === "cinematic") {
-      this.playTone(soundType === "light" ? 250 : 130, "triangle", 0.2, 0.04);
-=======
-    }
-    else if (this.activeTheme === "retro") {
       this.playTone(880, "square", 0.018, 0.004);
 
       setTimeout(() => {
@@ -111,281 +97,133 @@ class SoundEffects {
       }, 12);
 
       return;
-    }
-    else if (this.activeTheme === "cinematic") {
-
-      this.playTone(
-        200,
-        "sine",
-        0.12,
-        0.01
-      );
+    } else if (this.activeTheme === "cinematic") {
+      this.playTone(200, "sine", 0.12, 0.01);
 
       return;
->>>>>>> origin/main
     }
   }
 
   open() {
     if (this.activeTheme === "none") return;
 
-<<<<<<< HEAD
     if (this.activeTheme === "glass")
       this.playGlass({ freq: 720, dur: 0.5, vol: 0.04, modRatio: 3 });
     else if (this.activeTheme === "modern") {
       this.playTone(523.25, "sine", 0.3, 0.03);
       this.playTone(659.25, "sine", 0.3, 0.025);
       this.playTone(783.99, "sine", 0.3, 0.02);
-    } else if (this.activeTheme === "retro") this.playTone(880, "square", 0.2, 0.02);
-    else if (this.activeTheme === "cinematic") {
-      this.playTone(75, "sine", 0.7, 0.08);
-      this.playTone(280, "triangle", 0.5, 0.03);
-=======
-    if (this.activeTheme === 'glass') this.playGlass({ freq: 720, dur: 0.5, vol: 0.04, modRatio: 3 });
-    else if (this.activeTheme === 'modern') {
-      this.playTone(523.25, 'sine', 0.3, 0.03);
-      this.playTone(659.25, 'sine', 0.3, 0.025);
-      this.playTone(783.99, 'sine', 0.3, 0.02);
     }
     if (this.activeTheme === "retro") {
+      this.playTone(523, "triangle", 0.06, 0.012);
 
-      this.playTone(
-        523,
-        "triangle",
-        0.06,
-        0.012
-      );
-      
-      
       setTimeout(() => {
-        this.playTone(
-          659,
-          "triangle",
-          0.045,
-          0.01
-        );
+        this.playTone(659, "triangle", 0.045, 0.01);
       }, 15);
 
-
       return;
-    }
-    
-    
-    
-
-
-    
-    else if (this.activeTheme === "cinematic") {
-
-
+    } else if (this.activeTheme === "cinematic") {
       const c = this.getCtx();
 
       if (!c || !this.masterGain) return;
 
-
       const t = c.currentTime;
-
-
 
       const bass = c.createOscillator();
 
       const bassGain = c.createGain();
 
-
-
       bass.type = "sine";
 
+      bass.frequency.setValueAtTime(100, t);
 
-      bass.frequency.setValueAtTime(
-        100,
-        t
-      );
+      bass.frequency.exponentialRampToValueAtTime(35, t + 0.35);
 
+      bassGain.gain.setValueAtTime(0.0001, t);
 
-      bass.frequency.exponentialRampToValueAtTime(
-        35,
-        t + 0.35
-      );
+      bassGain.gain.exponentialRampToValueAtTime(0.06, t + 0.04);
 
+      bassGain.gain.exponentialRampToValueAtTime(0.001, t + 1.2);
 
-
-      bassGain.gain.setValueAtTime(
-        0.0001,
-        t
-      );
-
-
-      bassGain.gain.exponentialRampToValueAtTime(
-        0.06,
-        t + 0.04
-      );
-
-
-      bassGain.gain.exponentialRampToValueAtTime(
-        0.001,
-        t + 1.2
-      );
-
-
-
-      bass
-        .connect(bassGain)
-        .connect(this.masterGain);
-
-
+      bass.connect(bassGain).connect(this.masterGain);
 
       bass.start(t);
       bass.stop(t + 1.3);
-
-
-
 
       const shimmer = c.createOscillator();
 
       const shimmerGain = c.createGain();
 
-
-
       shimmer.type = "sine";
-
 
       shimmer.frequency.value = 900;
 
+      shimmerGain.gain.setValueAtTime(0.0001, t);
 
+      shimmerGain.gain.exponentialRampToValueAtTime(0.012, t + 0.05);
 
-      shimmerGain.gain.setValueAtTime(
-        0.0001,
-        t
-      );
+      shimmerGain.gain.exponentialRampToValueAtTime(0.0001, t + 0.5);
 
-
-      shimmerGain.gain.exponentialRampToValueAtTime(
-        0.012,
-        t + 0.05
-      );
-
-
-      shimmerGain.gain.exponentialRampToValueAtTime(
-        0.0001,
-        t + 0.5
-      );
-
-
-
-      shimmer
-        .connect(shimmerGain)
-        .connect(this.masterGain);
-
-
+      shimmer.connect(shimmerGain).connect(this.masterGain);
 
       shimmer.start(t);
       shimmer.stop(t + 0.6);
 
-
       return;
->>>>>>> origin/main
     }
   }
 
   close() {
     if (this.activeTheme === "none") return;
 
-<<<<<<< HEAD
     if (this.activeTheme === "glass") this.playGlass({ freq: 560, dur: 0.3, vol: 0.03 });
     else if (this.activeTheme === "modern") {
       this.playTone(392.0, "sine", 0.22, 0.03);
       this.playTone(329.63, "sine", 0.22, 0.02);
-    } else if (this.activeTheme === "retro") this.playTone(440, "square", 0.18, 0.02);
-    else if (this.activeTheme === "cinematic") this.playTone(90, "sine", 0.4, 0.05);
-=======
-    if (this.activeTheme === 'glass') this.playGlass({ freq: 560, dur: 0.3, vol: 0.03 });
-    else if (this.activeTheme === 'modern') {
-      this.playTone(392.00, 'sine', 0.22, 0.03);
-      this.playTone(329.63, 'sine', 0.22, 0.02);
     }
     if (this.activeTheme === "retro") {
+      this.playTone(560, "triangle", 0.05, 0.01);
 
-      this.playTone(
-        560,
-        "triangle",
-        0.05,
-        0.01,
-      );
-      
-      
       setTimeout(() => {
-      
-        this.playTone(
-          430,
-          "triangle",
-          0.06,
-          0.008
-        );
-      
+        this.playTone(430, "triangle", 0.06, 0.008);
       }, 35);
 
-
       return;
-    }
-    else if (this.activeTheme === 'cinematic') this.playTone(90, 'sine', 0.4, 0.05);
->>>>>>> origin/main
+    } else if (this.activeTheme === "cinematic") this.playTone(90, "sine", 0.4, 0.05);
   }
 
   hover() {
     if (this.activeTheme === "none") return;
 
-<<<<<<< HEAD
     if (this.activeTheme === "glass") this.playGlass({ freq: 2200, dur: 0.05, vol: 0.015 });
     else if (this.activeTheme === "modern") this.playTone(1200, "sine", 0.015, 0.01);
-    else if (this.activeTheme === "retro") this.playTone(1000, "sawtooth", 0.02, 0.004);
-    else if (this.activeTheme === "cinematic") this.playTone(350, "sine", 0.04, 0.01);
-=======
-    if (this.activeTheme === 'glass') this.playGlass({ freq: 2200, dur: 0.05, vol: 0.015 });
-    else if (this.activeTheme === 'modern') this.playTone(1200, 'sine', 0.015, 0.01);
     else if (this.activeTheme === "retro") {
       this.playTone(740, "square", 0.016, 0.0035);
-    
+
       setTimeout(() => {
         this.playTone(880, "triangle", 0.018, 0.003);
       }, 10);
-    
+
       return;
-    }
-    else if (this.activeTheme === 'cinematic') this.playTone(350, 'sine', 0.04, 0.01);
->>>>>>> origin/main
+    } else if (this.activeTheme === "cinematic") this.playTone(350, "sine", 0.04, 0.01);
   }
 
   click() {
     if (this.activeTheme === "none") return;
 
-<<<<<<< HEAD
     if (this.activeTheme === "glass") this.playGlass({ freq: 1500, dur: 0.08, vol: 0.04 });
     else if (this.activeTheme === "modern") this.playTone(400, "sine", 0.05, 0.035);
-    else if (this.activeTheme === "retro") this.playTone(550, "square", 0.07, 0.015);
-    else if (this.activeTheme === "cinematic") this.playTone(180, "triangle", 0.12, 0.04);
-=======
-    if (this.activeTheme === 'glass') this.playGlass({ freq: 1500, dur: 0.08, vol: 0.04 });
-    else if (this.activeTheme === 'modern') this.playTone(400, 'sine', 0.05, 0.035);
     if (this.activeTheme === "retro") {
       this.playTone(520, "square", 0.022, 0.007);
-    
+
       setTimeout(() => {
         this.playTone(360, "triangle", 0.028, 0.005);
       }, 12);
-    
+
       return;
+    } else if (this.activeTheme === "cinematic") {
+      this.playTone(180, "sine", 0.12, 0.02);
     }
-    else if (this.activeTheme === "cinematic") {
-
-      this.playTone(
-        180,
-        "sine",
-        0.12,
-        0.02,
-      );
-
-    }
->>>>>>> origin/main
   }
 
   volumeChange(isUp: boolean) {
@@ -408,11 +246,7 @@ class SoundEffects {
   }
 
   init() {
-<<<<<<< HEAD
-    if (this.activeTheme === "none") return; // عدم تهيئة الصوت إذا كان معطلاً
-=======
-    if (this.activeTheme === 'none') return; 
->>>>>>> origin/main
+    if (this.activeTheme === "none") return;
     this.getCtx();
   }
 }


### PR DESCRIPTION
## Summary

This follow-up repairs merge commit `dd274b7` without reverting its intended liquid-glass UI or sound-theme work.

## Problems found

- `src/lib/sfx.ts` was committed with unresolved Git conflict markers in multiple methods.
- The new Three.js component imported `three` without its TypeScript declarations, causing `TS7016`.
- `src/components/row.tsx` retained an unused `icon` variable, causing `TS6133`.
- The liquid-glass activation callback was unstable and omitted from the effect dependency list.

## Fixes

- Resolved the sound conflicts in favor of the incoming sound implementations while preserving all existing themes.
- Added `@types/three` as a development dependency.
- Removed the dead row-arrow variable.
- Stabilized the liquid-glass activation callback and corrected its effect dependencies.

## Verification

- `git diff --check`: passes.
- `vp check` on all files changed by this repair: 0 errors (8 existing row/compiler warnings remain).
- `vp run typecheck`: the errors introduced by `dd274b7` are resolved; the command still stops on the unrelated pre-existing unused `lastFocusedEl` in `src/lib/keyboard-navigation.ts`.

Per request, no tests were added or run.