### PR TITLE
fix: remove stale keyboard focus state

### DIFF
--- a/src/lib/keyboard-navigation.ts
+++ b/src/lib/keyboard-navigation.ts
@@ -76,7 +76,6 @@ const LOCAL_KEYBOARD_SELECTOR = [
 const AXIS_TOLERANCE = 24;
 
 let activeSearchEditEl: HTMLElement | null = null;
-let lastFocusedEl: HTMLElement | null = null;
 let focusStylesInjected = false;
 
 function isEditable(el: HTMLElement | null) {
@@ -494,7 +493,6 @@ function focusElement(el: HTMLElement, scroll: "center" | "nearest" | "none" = "
   clearTvFocusRing(el);
 
   el.setAttribute("data-tv-focused", "true");
-  lastFocusedEl = el;
 
   if (isSearchLikeField(el) && activeSearchEditEl !== el) {
     // Navigation focus is not editing mode.
@@ -540,8 +538,6 @@ function clearTvFocusRing(except?: HTMLElement) {
   });
 
   clearSearchVisualFocus();
-
-  if (!except) lastFocusedEl = null;
 }
 
 function setSearchNavMode(el: HTMLElement) {
@@ -578,7 +574,6 @@ function enterSearchEditMode(el: HTMLElement) {
     visual.setAttribute("data-tv-search-editing-focused", "true");
   }
 
-  lastFocusedEl = null;
   el.focus({ preventScroll: true });
 
   if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {


### PR DESCRIPTION
## Summary

Remove the unused `lastFocusedEl` state from keyboard navigation.

The variable was assigned when TV focus changed and cleared when focus/edit mode was reset, but it was never read. The DOM `data-tv-focused` marker is the actual source of truth, so retaining the write-only variable only caused `TS6133` and blocked the frontend typecheck.

## Verification

- `vp run typecheck`: passes.
- `vp check src/lib/keyboard-navigation.ts`: 0 errors (5 pre-existing React compiler warnings remain).
- `git diff --check`: passes.

Per request, no tests were added or run.