### PR TITLE
fix: update Google Fonts stylesheet URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,13 @@
       rel="stylesheet"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600&family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Fredoka:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Vazirmatn:wght@100..900&family=Inter:wght@100..900&family=IBM+Plex+Sans:wght@100..700&family=Plus+Jakarta+Sans:wght@100..800&family=Fredoka:wght@300..700&display=swap"
       rel="stylesheet"
     />
     <style>
-      html, body, #root {
+      html,
+      body,
+      #root {
         background: #0a0a0a;
         color-scheme: dark;
         margin: 0;
@@ -44,7 +46,9 @@
         pointer-events: none;
         transition: opacity 280ms ease-out;
       }
-      #harbor-boot.gone { opacity: 0; }
+      #harbor-boot.gone {
+        opacity: 0;
+      }
       #harbor-boot svg {
         width: 96px;
         height: auto;
@@ -56,24 +60,39 @@
           harborBootGlow 2400ms ease-in-out infinite;
       }
       @keyframes harborBootBob {
-        0%   { transform: translateY(0)    rotate(-2deg) scale(0.98); }
-        25%  { transform: translateY(-3px) rotate( 0deg) scale(1.00); }
-        50%  { transform: translateY(0)    rotate( 2deg) scale(1.02); }
-        75%  { transform: translateY(-3px) rotate( 0deg) scale(1.00); }
-        100% { transform: translateY(0)    rotate(-2deg) scale(0.98); }
+        0% {
+          transform: translateY(0) rotate(-2deg) scale(0.98);
+        }
+        25% {
+          transform: translateY(-3px) rotate(0deg) scale(1);
+        }
+        50% {
+          transform: translateY(0) rotate(2deg) scale(1.02);
+        }
+        75% {
+          transform: translateY(-3px) rotate(0deg) scale(1);
+        }
+        100% {
+          transform: translateY(0) rotate(-2deg) scale(0.98);
+        }
       }
       @keyframes harborBootGlow {
-        0%, 100% { opacity: 0.78; }
-        50%      { opacity: 1; }
+        0%,
+        100% {
+          opacity: 0.78;
+        }
+        50% {
+          opacity: 1;
+        }
       }
     </style>
     <script>
       (function () {
         try {
           var p = new URLSearchParams(window.location.search);
-          if (p.get('harbor-modal') === '1') {
-            var s = document.createElement('style');
-            s.textContent = '#harbor-boot{display:none !important}';
+          if (p.get("harbor-modal") === "1") {
+            var s = document.createElement("style");
+            s.textContent = "#harbor-boot{display:none !important}";
             document.head.appendChild(s);
           }
         } catch (e) {}
@@ -84,9 +103,15 @@
     <div id="harbor-boot">
       <svg viewBox="0 0 700 642.88" fill="currentColor" aria-hidden="true">
         <g transform="matrix(0.13333333,0,0,-0.13333333,0,642.88)">
-          <path d="m 72.0781,1534.27 c 0,0 1127.5819,922.03 1526.9319,2636.89 0,0 463.95,-1274.4 17.61,-2625.15 L 72.0781,1534.27" />
-          <path d="M 3975.59,2945.05 2812.18,2222.26 c -36.68,-22.79 -84.13,3.59 -84.13,46.78 v 1391.45 c 0,42.35 45.8,68.85 82.51,47.75 l 1163.41,-668.68 c 36.11,-20.75 37,-72.53 1.62,-94.51 z M 2021.85,4821.57 V 1438.84 l 2818.94,416.96 c 0,0 252.54,2501.82 -2818.94,2965.77" />
-          <path d="m 615.313,4.40234 c 0,0 -364.817,308.39866 -604.4224,706.25766 -28.3125,47.012 1.4922,107.77 55.8555,115.281 L 5090.13,1520.12 c 57.31,7.92 102.66,-47.69 82.95,-102.09 C 5065.81,1122 4746.77,351.742 4222.68,0 L 615.313,4.40234" />
+          <path
+            d="m 72.0781,1534.27 c 0,0 1127.5819,922.03 1526.9319,2636.89 0,0 463.95,-1274.4 17.61,-2625.15 L 72.0781,1534.27"
+          />
+          <path
+            d="M 3975.59,2945.05 2812.18,2222.26 c -36.68,-22.79 -84.13,3.59 -84.13,46.78 v 1391.45 c 0,42.35 45.8,68.85 82.51,47.75 l 1163.41,-668.68 c 36.11,-20.75 37,-72.53 1.62,-94.51 z M 2021.85,4821.57 V 1438.84 l 2818.94,416.96 c 0,0 252.54,2501.82 -2818.94,2965.77"
+          />
+          <path
+            d="m 615.313,4.40234 c 0,0 -364.817,308.39866 -604.4224,706.25766 -28.3125,47.012 1.4922,107.77 55.8555,115.281 L 5090.13,1520.12 c 57.31,7.92 102.66,-47.69 82.95,-102.09 C 5065.81,1122 4746.77,351.742 4222.68,0 L 615.313,4.40234"
+          />
         </g>
       </svg>
     </div>


### PR DESCRIPTION
## Summary

Replace the broken Google Fonts request with the supplied variable-font URL.

The new request includes:
- Fraunces roman and italic axes across weights 100–900
- Vazirmatn 100–900
- Inter 100–900
- IBM Plex Sans 100–700
- Plus Jakarta Sans 100–800
- Fredoka 300–700

## Verification

- Google Fonts endpoint returns HTTP 200.
- `git diff --check`: passes.
- `index.html` formatted with the project formatter.

No tests were added or run.