### PR TITLE
fix: keep React state updaters pure

### DIFF
--- a/src/components/hover-preview/crown.tsx
+++ b/src/components/hover-preview/crown.tsx
@@ -32,7 +32,8 @@ function CrownArt({ art, seed }: { art: PreviewArt; seed: string }) {
   useEffect(() => {
     if (sameArt(lastArt.current, art)) return;
     lastArt.current = art;
-    setStack((s) => [...s.slice(-1), { key: nextKey.current++, art }]);
+    const key = nextKey.current++;
+    setStack((s) => [...s.slice(-1), { key, art }]);
   }, [art]);
 
   useEffect(() => {
@@ -51,7 +52,11 @@ function CrownArt({ art, seed }: { art: PreviewArt; seed: string }) {
   return (
     <div data-stagger="0" className="absolute inset-0">
       {stack.map((item, i) => (
-        <div key={item.key} ref={i === stack.length - 1 && i > 0 ? incomingRef : undefined} className="absolute inset-0">
+        <div
+          key={item.key}
+          ref={i === stack.length - 1 && i > 0 ? incomingRef : undefined}
+          className="absolute inset-0"
+        >
           <ArtImage art={item.art} seed={seed} />
         </div>
       ))}
@@ -61,16 +66,17 @@ function CrownArt({ art, seed }: { art: PreviewArt; seed: string }) {
 
 function StateLine({ resume }: { resume: PreviewResume }) {
   const epLabel =
-    resume.season != null && resume.episode != null
-      ? `S${resume.season} E${resume.episode}`
-      : null;
+    resume.season != null && resume.episode != null ? `S${resume.season} E${resume.episode}` : null;
   const status = resume.upNext
     ? "Up Next"
     : resume.external || resume.remainingMs == null
       ? "In progress"
       : formatRemaining(resume.remainingMs);
   return (
-    <div data-stagger="1" className="flex items-baseline pb-3 text-[13px] font-semibold leading-[1.3] tabular-nums">
+    <div
+      data-stagger="1"
+      className="flex items-baseline pb-3 text-[13px] font-semibold leading-[1.3] tabular-nums"
+    >
       {epLabel && <span className="text-ink">{epLabel}</span>}
       {epLabel && <span className="text-ink-subtle">{" · "}</span>}
       <span className="text-accent">{status}</span>

--- a/src/components/memory-hud.tsx
+++ b/src/components/memory-hud.tsx
@@ -35,16 +35,16 @@ export function MemoryHud() {
   }, [open]);
 
   useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, open ? "1" : "0");
+    } catch {}
+  }, [open]);
+
+  useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.shiftKey && e.code === "KeyM") {
         e.preventDefault();
-        setOpen((v) => {
-          const next = !v;
-          try {
-            localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
-          } catch {}
-          return next;
-        });
+        setOpen((v) => !v);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -73,11 +73,10 @@ export function MemoryHud() {
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <span className="font-bold text-ink">PROFILER</span>
-          <span style={{ color: heapColor }}>
-            {heap.toFixed(1)}MB
-          </span>
+          <span style={{ color: heapColor }}>{heap.toFixed(1)}MB</span>
           <span className="text-ink-subtle">
-            (Δ{delta >= 0 ? "+" : ""}{delta.toFixed(1)} · peak {peak.toFixed(1)})
+            (Δ{delta >= 0 ? "+" : ""}
+            {delta.toFixed(1)} · peak {peak.toFixed(1)})
           </span>
         </div>
         <div className="flex items-center gap-1">
@@ -94,7 +93,9 @@ export function MemoryHud() {
             onClick={() => {
               const r = api.dumpReport();
               if (r) {
-                setToast(`Downloaded ${r.filename} (${r.events} events, ${(r.bytes / 1024).toFixed(1)} KB)`);
+                setToast(
+                  `Downloaded ${r.filename} (${r.events} events, ${(r.bytes / 1024).toFixed(1)} KB)`,
+                );
                 setTimeout(() => setToast(null), 4000);
               }
             }}
@@ -210,9 +211,7 @@ function EventList({ samples }: { samples: Sample[] }) {
         .filter((s) => s.kind !== "tick")
         .map((s, i) => (
           <div key={i} className="flex items-baseline justify-between gap-2 text-[10px]">
-            <span className="shrink-0 text-ink-subtle">
-              [{s.kind}]
-            </span>
+            <span className="shrink-0 text-ink-subtle">[{s.kind}]</span>
             <span className="flex-1 truncate text-ink-muted">{s.label}</span>
             <span className="shrink-0 text-ink">{s.heapMB.toFixed(0)}MB</span>
           </div>

--- a/src/components/player/live-channel-overlay/overlay.tsx
+++ b/src/components/player/live-channel-overlay/overlay.tsx
@@ -7,10 +7,7 @@ import {
   promoteTopChannelsToFront,
   rowsForRegion,
 } from "@/lib/iptv/top-networks";
-import {
-  sortChannelsByGroupRelevance,
-  sortGroupsByRelevance,
-} from "@/lib/iptv/group-relevance";
+import { sortChannelsByGroupRelevance, sortGroupsByRelevance } from "@/lib/iptv/group-relevance";
 import { computeTvgIdCounts, epgProgramsForChannel } from "@/lib/iptv/epg-resolver";
 import { FAVORITES_GROUP_KEY, useFavorites } from "@/lib/iptv/favorites";
 import { getCachedPlaylist } from "@/lib/iptv/store";
@@ -176,14 +173,13 @@ export function LiveChannelOverlay({
       return "timeline";
     }
   });
+  useEffect(() => {
+    try {
+      localStorage.setItem("harbor.guide.style", guideStyle);
+    } catch {}
+  }, [guideStyle]);
   const toggleGuideStyle = () => {
-    setGuideStyle((s) => {
-      const next = s === "timeline" ? "list" : "timeline";
-      try {
-        localStorage.setItem("harbor.guide.style", next);
-      } catch {}
-      return next;
-    });
+    setGuideStyle((s) => (s === "timeline" ? "list" : "timeline"));
   };
 
   useEffect(() => {
@@ -201,7 +197,10 @@ export function LiveChannelOverlay({
   useScrollMemory(`live-overlay:${source.id}`, scrollRef, true);
 
   return (
-    <div data-tv-focus-scope className="pointer-events-auto absolute inset-0 z-[60] flex flex-col bg-canvas/95 text-ink">
+    <div
+      data-tv-focus-scope
+      className="pointer-events-auto absolute inset-0 z-[60] flex flex-col bg-canvas/95 text-ink"
+    >
       <div className="flex shrink-0 items-start gap-3 px-6 pt-6">
         <button
           onClick={onClose}
@@ -215,11 +214,7 @@ export function LiveChannelOverlay({
         <CurrentChannelInfo channel={currentChannel} current={currentProgram} now={nowMs} />
       </div>
       <div className="flex shrink-0 items-center gap-2.5 px-6 pt-4 pb-3">
-        <InlineSourceSwitcher
-          sources={sources}
-          selectedId={source.id}
-          onSelect={onSelectSource}
-        />
+        <InlineSourceSwitcher sources={sources} selectedId={source.id} onSelect={onSelectSource} />
         <div className="flex h-11 flex-1 items-center gap-2.5 rounded-xl border border-edge-soft/55 bg-elevated px-3.5">
           <Search size={15} strokeWidth={2} className="text-ink-subtle" />
           <input
@@ -238,6 +233,7 @@ export function LiveChannelOverlay({
           />
           {query && (
             <button
+              type="button"
               onClick={() => setQuery("")}
               className="text-[12.5px] font-medium text-ink-subtle transition-colors hover:text-ink"
             >
@@ -246,12 +242,21 @@ export function LiveChannelOverlay({
           )}
         </div>
         <button
+          type="button"
           onClick={toggleGuideStyle}
-          title={guideStyle === "timeline" ? t("Switch to channel list (hide program guide)") : t("Switch to program guide")}
+          title={
+            guideStyle === "timeline"
+              ? t("Switch to channel list (hide program guide)")
+              : t("Switch to program guide")
+          }
           aria-label={t("Toggle guide layout")}
           className="flex h-11 shrink-0 items-center gap-2 rounded-xl border border-edge-soft/55 bg-elevated px-3.5 text-[13px] font-medium text-ink-muted transition-colors hover:text-ink"
         >
-          {guideStyle === "timeline" ? <List size={15} strokeWidth={2} /> : <CalendarRange size={15} strokeWidth={2} />}
+          {guideStyle === "timeline" ? (
+            <List size={15} strokeWidth={2} />
+          ) : (
+            <CalendarRange size={15} strokeWidth={2} />
+          )}
           {guideStyle === "timeline" ? t("List") : t("Guide")}
         </button>
       </div>
@@ -293,8 +298,8 @@ export function LiveChannelOverlay({
               {inFavorites && favorites.count === 0
                 ? t("No favorites yet. Star a channel to pin it here.")
                 : inFavorites && loadingFavorites
-                ? t("Loading favorites…")
-                : t("No channels match. Try a different category or clear the search.")}
+                  ? t("Loading favorites…")
+                  : t("No channels match. Try a different category or clear the search.")}
             </div>
           )}
         </div>

--- a/src/lib/profiles.tsx
+++ b/src/lib/profiles.tsx
@@ -76,7 +76,10 @@ type ProfilesValue = {
     color: ProfileColor;
     kid?: KidConfig | null;
   }) => Profile;
-  updateProfile: (id: string, patch: Partial<Omit<Profile, "id" | "createdAt" | "isPrimary">>) => void;
+  updateProfile: (
+    id: string,
+    patch: Partial<Omit<Profile, "id" | "createdAt" | "isPrimary">>,
+  ) => void;
   deleteProfile: (id: string) => void;
 };
 
@@ -158,7 +161,10 @@ function readProfilePromptInterval(): ProfilePromptInterval {
   try {
     const raw = readLaunchSettingsRaw();
     if (!raw) return "launch";
-    const parsed = JSON.parse(raw) as { profilePromptInterval?: unknown; skipProfileScreen?: unknown };
+    const parsed = JSON.parse(raw) as {
+      profilePromptInterval?: unknown;
+      skipProfileScreen?: unknown;
+    };
     const v = parsed.profilePromptInterval;
     if (v === "launch" || v === "15m" || v === "30m" || v === "never") return v;
     return parsed.skipProfileScreen === true ? "never" : "launch";
@@ -260,7 +266,11 @@ function readState(): ProfilesState {
           next.avatar = identity.avatar;
         }
       }
-      if (next.kid == null && typeof next.avatar === "string" && next.avatar.startsWith("/kids/avatars/")) {
+      if (
+        next.kid == null &&
+        typeof next.avatar === "string" &&
+        next.avatar.startsWith("/kids/avatars/")
+      ) {
         next.avatar = null;
       }
       return next;
@@ -385,28 +395,25 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
 
   const createProfile = useCallback<ProfilesValue["createProfile"]>(
     ({ name, avatar, color, kid }) => {
-      let created!: Profile;
-      setState((s) => {
-        const primary = s.profiles.find((p) => p.isPrimary) ?? s.profiles[0];
-        created = {
-          id: newId(),
-          name: name.trim().slice(0, 32) || "Profile",
-          avatar: avatar ?? null,
-          color,
-          isPrimary: false,
-          shareStremioWith: primary?.id ?? null,
-          passwordHash: null,
-          hideContent: null,
-          lockedTabs: null,
-          kid: kid ?? null,
-          settingsLinked: true,
-          createdAt: Date.now(),
-        };
-        return { ...s, profiles: [...s.profiles, created] };
-      });
+      const primary = state.profiles.find((p) => p.isPrimary) ?? state.profiles[0];
+      const created: Profile = {
+        id: newId(),
+        name: name.trim().slice(0, 32) || "Profile",
+        avatar: avatar ?? null,
+        color,
+        isPrimary: false,
+        shareStremioWith: primary?.id ?? null,
+        passwordHash: null,
+        hideContent: null,
+        lockedTabs: null,
+        kid: kid ?? null,
+        settingsLinked: true,
+        createdAt: Date.now(),
+      };
+      setState((s) => ({ ...s, profiles: [...s.profiles, created] }));
       return created;
     },
-    [],
+    [state.profiles],
   );
 
   const updateProfile = useCallback<ProfilesValue["updateProfile"]>((id, patch) => {
@@ -424,14 +431,10 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
     }));
   }, []);
 
-  const deleteProfile = useCallback<ProfilesValue["deleteProfile"]>((id) => {
-    setState((s) => {
-      const target = s.profiles.find((p) => p.id === id);
-      if (!target || target.isPrimary) return s;
-      const profiles = s.profiles
-        .filter((p) => p.id !== id)
-        .map((p) => (p.shareStremioWith === id ? { ...p, shareStremioWith: null } : p));
-      const activeId = s.activeId === id ? profiles[0]?.id ?? null : s.activeId;
+  const deleteProfile = useCallback<ProfilesValue["deleteProfile"]>(
+    (id) => {
+      const target = state.profiles.find((p) => p.id === id);
+      if (!target || target.isPrimary) return;
       try {
         localStorage.removeItem(`harbor.auth.${id}`);
         localStorage.removeItem(`harbor.favorites.v1.${id}`);
@@ -447,9 +450,16 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
       } catch {
         /* ignore */
       }
-      return { profiles, activeId };
-    });
-  }, []);
+      setState((s) => {
+        const profiles = s.profiles
+          .filter((p) => p.id !== id)
+          .map((p) => (p.shareStremioWith === id ? { ...p, shareStremioWith: null } : p));
+        const activeId = s.activeId === id ? (profiles[0]?.id ?? null) : s.activeId;
+        return { profiles, activeId };
+      });
+    },
+    [state.profiles],
+  );
 
   const value = useMemo<ProfilesValue>(
     () => ({
@@ -509,10 +519,7 @@ export function profileInitials(name: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-export function stremioSourceProfileId(
-  active: Profile | null,
-  profiles: Profile[],
-): string | null {
+export function stremioSourceProfileId(active: Profile | null, profiles: Profile[]): string | null {
   if (!active) return null;
   if (!active.shareStremioWith) return active.id;
   const exists = profiles.some((p) => p.id === active.shareStremioWith);

--- a/src/views/detail/hero-backdrop.tsx
+++ b/src/views/detail/hero-backdrop.tsx
@@ -39,9 +39,8 @@ export function HeroBackdrop({ url }: { url: string }) {
   const [layers, setLayers] = useState<{ id: number; url: string }[]>([{ id: 0, url }]);
   const nextId = useRef(1);
   useEffect(() => {
-    setLayers((prev) =>
-      prev[prev.length - 1]?.url === url ? prev : [...prev, { id: nextId.current++, url }],
-    );
+    const id = nextId.current++;
+    setLayers((prev) => (prev[prev.length - 1]?.url === url ? prev : [...prev, { id, url }]));
   }, [url]);
   const settle = (id: number) =>
     setLayers((prev) => {

--- a/src/views/detail/title-plate.tsx
+++ b/src/views/detail/title-plate.tsx
@@ -31,7 +31,15 @@ function LogoLayer({
   );
 }
 
-export function TitlePlate({ title, logo, loading }: { title: string; logo?: string; loading: boolean }) {
+export function TitlePlate({
+  title,
+  logo,
+  loading,
+}: {
+  title: string;
+  logo?: string;
+  loading: boolean;
+}) {
   const [failed, setFailed] = useState<Set<string>>(() => new Set());
   const active = logo && !failed.has(logo) ? logo : undefined;
   const [layers, setLayers] = useState<{ id: number; url: string }[]>([]);
@@ -49,8 +57,9 @@ export function TitlePlate({ title, logo, loading }: { title: string; logo?: str
       setLayers((prev) => (prev.length === 0 ? prev : []));
       return;
     }
+    const id = nextId.current++;
     setLayers((prev) =>
-      prev[prev.length - 1]?.url === active ? prev : [...prev, { id: nextId.current++, url: active }],
+      prev[prev.length - 1]?.url === active ? prev : [...prev, { id, url: active }],
     );
   }, [active]);
 

--- a/src/views/filter/cinemeta-fallback.tsx
+++ b/src/views/filter/cinemeta-fallback.tsx
@@ -39,11 +39,7 @@ export function CinemetaFallback({ filter }: { filter: MetaFilter }) {
         seenRef.current.add(m.id);
         return true;
       });
-      setItems((prev) => {
-        const combined = [...prev, ...fresh];
-        if (combined.length >= MAX_ITEMS) setExhausted(true);
-        return combined.slice(0, MAX_ITEMS);
-      });
+      setItems((prev) => [...prev, ...fresh].slice(0, MAX_ITEMS));
       if (batch.length < PAGE_SIZE) {
         setExhausted(true);
       } else {
@@ -55,6 +51,10 @@ export function CinemetaFallback({ filter }: { filter: MetaFilter }) {
       setLoading(false);
     }
   }, [exhausted, genre, loading, mediaType]);
+
+  useEffect(() => {
+    if (items.length >= MAX_ITEMS) setExhausted(true);
+  }, [items.length]);
 
   useEffect(() => {
     if (items.length === 0 && !loading && !exhausted && genre) {
@@ -99,10 +99,7 @@ export function CinemetaFallback({ filter }: { filter: MetaFilter }) {
         {items.length === 0 &&
           loading &&
           Array.from({ length: 14 }).map((_, i) => (
-            <div
-              key={i}
-              className="aspect-[2/3] w-full animate-pulse rounded-xl bg-elevated/40"
-            />
+            <div key={i} className="aspect-[2/3] w-full animate-pulse rounded-xl bg-elevated/40" />
           ))}
       </div>
       <div ref={sentinelRef} className="h-px w-full" aria-hidden />
@@ -120,9 +117,12 @@ export function CinemetaFallback({ filter }: { filter: MetaFilter }) {
       )}
       {exhausted && items.length === 0 && (
         <p className="rounded-xl border border-dashed border-edge bg-canvas/30 px-5 py-6 text-center text-[12.5px] text-ink-subtle">
-          {t("Cinemeta didn't return anything for {genre}. Try a different genre or add a TMDB key.", {
-            genre: genre ?? "",
-          })}
+          {t(
+            "Cinemeta didn't return anything for {genre}. Try a different genre or add a TMDB key.",
+            {
+              genre: genre ?? "",
+            },
+          )}
         </p>
       )}
     </div>

--- a/src/views/grid.tsx
+++ b/src/views/grid.tsx
@@ -37,12 +37,10 @@ export function GridView({ grid }: { grid: GridSpec }) {
               setDone(true);
               return;
             }
-            setMetas((prev) => {
-              const seen = new Set(prev.map((m) => m.id));
-              const fresh = batch.filter((m) => !seen.has(m.id));
-              if (fresh.length === 0) setDone(true);
-              return [...prev, ...fresh];
-            });
+            const seen = new Set(metas.map((m) => m.id));
+            const fresh = batch.filter((m) => !seen.has(m.id));
+            if (fresh.length === 0) setDone(true);
+            else setMetas((prev) => [...prev, ...fresh]);
           })
           .catch(() => setDone(true))
           .finally(() => {
@@ -53,7 +51,7 @@ export function GridView({ grid }: { grid: GridSpec }) {
     );
     io.observe(el);
     return () => io.disconnect();
-  }, [grid, page, done]);
+  }, [grid, page, done, metas]);
 
   const hero = grid.kidsHero;
   const bgArt = metas.find((m) => m.background)?.background?.replace("/t/p/w780/", "/t/p/w1280/");
@@ -70,8 +68,15 @@ export function GridView({ grid }: { grid: GridSpec }) {
         metas.length === 0 &&
         (hero ? (
           <div className="flex flex-col items-center gap-3 py-24 text-center">
-            <img src="/kids/doodles/lilpurpocto.png" alt="" draggable={false} className="h-20 w-auto opacity-80" />
-            <p className="font-display text-[24px] font-bold text-[#0e3a43]">{t("Nothing here yet!")}</p>
+            <img
+              src="/kids/doodles/lilpurpocto.png"
+              alt=""
+              draggable={false}
+              className="h-20 w-auto opacity-80"
+            />
+            <p className="font-display text-[24px] font-bold text-[#0e3a43]">
+              {t("Nothing here yet!")}
+            </p>
           </div>
         ) : (
           <p className="py-20 text-center text-[14px] text-ink-subtle">Nothing here yet.</p>
@@ -94,7 +99,9 @@ export function GridView({ grid }: { grid: GridSpec }) {
             ) : (
               <div className={`absolute inset-0 bg-gradient-to-br ${hero.grad}`} />
             )}
-            <div className={`pointer-events-none absolute inset-0 bg-gradient-to-tr ${hero.grad} opacity-25 mix-blend-overlay`} />
+            <div
+              className={`pointer-events-none absolute inset-0 bg-gradient-to-tr ${hero.grad} opacity-25 mix-blend-overlay`}
+            />
             <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-canvas via-canvas/35 to-transparent" />
             <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/45 via-black/10 to-transparent" />
             <img

--- a/src/views/library/history-tab.tsx
+++ b/src/views/library/history-tab.tsx
@@ -107,17 +107,16 @@ export function HistoryTab() {
   const [type, setType] = useState<TypeKey>("all");
   const [query, setQuery] = useState("");
   const [flat, setFlat] = useState(() => localStorage.getItem("harbor.history.flat") === "1");
+  useEffect(() => {
+    try {
+      localStorage.setItem("harbor.history.flat", flat ? "1" : "0");
+    } catch {}
+  }, [flat]);
   const toggleFlat = useCallback(() => {
-    setFlat((v) => {
-      const next = !v;
-      try {
-        localStorage.setItem("harbor.history.flat", next ? "1" : "0");
-      } catch {}
-      return next;
-    });
+    setFlat((v) => !v);
   }, []);
-  const [view, setView] = useState<HistoryView>(
-    () => (localStorage.getItem("harbor.history.view") === "episodes" ? "episodes" : "posters"),
+  const [view, setView] = useState<HistoryView>(() =>
+    localStorage.getItem("harbor.history.view") === "episodes" ? "episodes" : "posters",
   );
   const setViewPersist = useCallback((next: HistoryView) => {
     setView(next);
@@ -236,17 +235,23 @@ function HistoryViewToggle({
   return (
     <div className="flex items-center gap-1 rounded-full bg-elevated/40 p-0.5 ring-1 ring-edge-soft/60">
       <button
+        type="button"
         onClick={() => view !== "posters" && onChange("posters")}
         className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-semibold transition-colors ${
-          view === "posters" ? "bg-ink text-canvas" : "text-ink-muted hover:bg-raised hover:text-ink"
+          view === "posters"
+            ? "bg-ink text-canvas"
+            : "text-ink-muted hover:bg-raised hover:text-ink"
         }`}
       >
         {t("Posters")}
       </button>
       <button
+        type="button"
         onClick={() => view !== "episodes" && onChange("episodes")}
         className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-semibold transition-colors ${
-          view === "episodes" ? "bg-ink text-canvas" : "text-ink-muted hover:bg-raised hover:text-ink"
+          view === "episodes"
+            ? "bg-ink text-canvas"
+            : "text-ink-muted hover:bg-raised hover:text-ink"
         }`}
       >
         {t("Episodes")}
@@ -287,8 +292,7 @@ function filterHistory(items: LibraryItem[]): LibraryItem[] {
     .filter((i) => i.state?.flaggedWatched === 1 || (i.state?.timeOffset ?? 0) > 0)
     .sort(
       (a, b) =>
-        Date.parse(b.state?.lastWatched ?? b._mtime) -
-        Date.parse(a.state?.lastWatched ?? a._mtime),
+        Date.parse(b.state?.lastWatched ?? b._mtime) - Date.parse(a.state?.lastWatched ?? a._mtime),
     );
 }
 
@@ -341,7 +345,7 @@ function mergeHistory(stremio: LibraryItem[], trakt: HistoryItem[]): HistoryEntr
       meta: {
         id,
         type: h.type === "movie" ? "movie" : "series",
-        name: h.type === "movie" ? h.title : (h.showImdb ? "" : h.title),
+        name: h.type === "movie" ? h.title : h.showImdb ? "" : h.title,
       },
       date: parseTs(h.watchedAt),
       progress: 0,

--- a/src/views/library/watchlist-tab.tsx
+++ b/src/views/library/watchlist-tab.tsx
@@ -2,12 +2,23 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/lib/auth";
 import { useSettings } from "@/lib/settings";
 import { type Meta } from "@/lib/cinemeta";
-import { library, libraryMetaType, removeStremioLibraryItem, type LibraryItem } from "@/lib/stremio";
+import {
+  library,
+  libraryMetaType,
+  removeStremioLibraryItem,
+  type LibraryItem,
+} from "@/lib/stremio";
 import { fetchWatchlist } from "@/lib/trakt/watchlist";
 import { useTrakt } from "@/lib/trakt/provider";
 import { traktItemToMeta } from "@/lib/trakt/to-meta";
 import type { TraktItem } from "@/lib/trakt/types";
-import { readLocalEntries, removeFromWatchlist, setWatchlistAggregate, subscribeWatchlist, type LocalEntry } from "@/lib/watchlist";
+import {
+  readLocalEntries,
+  removeFromWatchlist,
+  setWatchlistAggregate,
+  subscribeWatchlist,
+  type LocalEntry,
+} from "@/lib/watchlist";
 import { useT } from "@/lib/i18n";
 import {
   applyFilter,
@@ -124,14 +135,13 @@ export function WatchlistTab() {
   const [type, setType] = useState<TypeKey>("all");
   const [query, setQuery] = useState("");
   const [flat, setFlat] = useState(() => localStorage.getItem("harbor.watchlist.flat") === "1");
+  useEffect(() => {
+    try {
+      localStorage.setItem("harbor.watchlist.flat", flat ? "1" : "0");
+    } catch {}
+  }, [flat]);
   const toggleFlat = useCallback(() => {
-    setFlat((v) => {
-      const next = !v;
-      try {
-        localStorage.setItem("harbor.watchlist.flat", next ? "1" : "0");
-      } catch {}
-      return next;
-    });
+    setFlat((v) => !v);
   }, []);
   const counts = useMemo(() => countByType(merged), [merged]);
   const visible = useMemo(() => applyFilter(merged, type, query), [merged, type, query]);
@@ -180,7 +190,12 @@ export function WatchlistTab() {
         <GroupedGrid groups={sortedGroups(visible, settings.librarySort)} onRemove={handleRemove} />
       ) : flat ? (
         <GroupedGrid
-          groups={[{ label: "Everything", items: [...visible].sort((a, b) => (b.date ?? -Infinity) - (a.date ?? -Infinity)) }]}
+          groups={[
+            {
+              label: "Everything",
+              items: [...visible].sort((a, b) => (b.date ?? -Infinity) - (a.date ?? -Infinity)),
+            },
+          ]}
           onRemove={handleRemove}
         />
       ) : (
@@ -229,7 +244,11 @@ function mergeWatchlist(
   stremio: LibraryItem[],
   trakt: TraktItem[],
 ): WatchlistMerged[] {
-  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "").trim();
+  const norm = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "")
+      .trim();
   const byKey = new Map<string, WatchlistMerged>();
   const setOrUpgrade = (key: string, entry: WatchlistMerged) => {
     const existing = byKey.get(key);
@@ -252,7 +271,12 @@ function mergeWatchlist(
       background: item.background,
     };
     const dedupKey = `${item.type}:${norm(item.name ?? "")}`;
-    setOrUpgrade(dedupKey, { key: item._id, meta, date: parseTs(item._mtime), stremioId: item._id });
+    setOrUpgrade(dedupKey, {
+      key: item._id,
+      meta,
+      date: parseTs(item._mtime),
+      stremioId: item._id,
+    });
   }
   for (const t of trakt) {
     const m = traktItemToMeta(t);
@@ -264,7 +288,10 @@ function mergeWatchlist(
   for (const e of localEntries) {
     let dupById = false;
     for (const v of byKey.values()) {
-      if (v.meta.id === e.id) { dupById = true; break; }
+      if (v.meta.id === e.id) {
+        dupById = true;
+        break;
+      }
     }
     if (dupById) continue;
     const nameKey = e.name ? `${e.type}:${norm(e.name)}` : null;

--- a/src/views/service.tsx
+++ b/src/views/service.tsx
@@ -23,19 +23,103 @@ type Category = {
 
 const CATEGORIES: Category[] = [
   { id: "all", label: "All", fetchMovies: true, fetchTv: true, movieGenres: [], tvGenres: [] },
-  { id: "movies", label: "Movies", fetchMovies: true, fetchTv: false, movieGenres: [], tvGenres: [] },
+  {
+    id: "movies",
+    label: "Movies",
+    fetchMovies: true,
+    fetchTv: false,
+    movieGenres: [],
+    tvGenres: [],
+  },
   { id: "tv", label: "TV Shows", fetchMovies: false, fetchTv: true, movieGenres: [], tvGenres: [] },
-  { id: "docs", label: "Documentaries", fetchMovies: true, fetchTv: true, movieGenres: [99], tvGenres: [99] },
-  { id: "anim", label: "Animation", fetchMovies: true, fetchTv: true, movieGenres: [16], tvGenres: [16] },
-  { id: "kids", label: "Kids & Family", fetchMovies: true, fetchTv: true, movieGenres: [10751], tvGenres: [10751] },
-  { id: "reality", label: "Reality", fetchMovies: false, fetchTv: true, movieGenres: [], tvGenres: [10764] },
-  { id: "action", label: "Action", fetchMovies: true, fetchTv: true, movieGenres: [28], tvGenres: [10759] },
-  { id: "comedy", label: "Comedy", fetchMovies: true, fetchTv: true, movieGenres: [35], tvGenres: [35] },
-  { id: "drama", label: "Drama", fetchMovies: true, fetchTv: true, movieGenres: [18], tvGenres: [18] },
-  { id: "horror", label: "Horror", fetchMovies: true, fetchTv: true, movieGenres: [27], tvGenres: [9648] },
-  { id: "scifi", label: "Sci-Fi & Fantasy", fetchMovies: true, fetchTv: true, movieGenres: [878], tvGenres: [10765] },
-  { id: "thriller", label: "Thriller", fetchMovies: true, fetchTv: false, movieGenres: [53], tvGenres: [] },
-  { id: "romance", label: "Romance", fetchMovies: true, fetchTv: false, movieGenres: [10749], tvGenres: [] },
+  {
+    id: "docs",
+    label: "Documentaries",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [99],
+    tvGenres: [99],
+  },
+  {
+    id: "anim",
+    label: "Animation",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [16],
+    tvGenres: [16],
+  },
+  {
+    id: "kids",
+    label: "Kids & Family",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [10751],
+    tvGenres: [10751],
+  },
+  {
+    id: "reality",
+    label: "Reality",
+    fetchMovies: false,
+    fetchTv: true,
+    movieGenres: [],
+    tvGenres: [10764],
+  },
+  {
+    id: "action",
+    label: "Action",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [28],
+    tvGenres: [10759],
+  },
+  {
+    id: "comedy",
+    label: "Comedy",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [35],
+    tvGenres: [35],
+  },
+  {
+    id: "drama",
+    label: "Drama",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [18],
+    tvGenres: [18],
+  },
+  {
+    id: "horror",
+    label: "Horror",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [27],
+    tvGenres: [9648],
+  },
+  {
+    id: "scifi",
+    label: "Sci-Fi & Fantasy",
+    fetchMovies: true,
+    fetchTv: true,
+    movieGenres: [878],
+    tvGenres: [10765],
+  },
+  {
+    id: "thriller",
+    label: "Thriller",
+    fetchMovies: true,
+    fetchTv: false,
+    movieGenres: [53],
+    tvGenres: [],
+  },
+  {
+    id: "romance",
+    label: "Romance",
+    fetchMovies: true,
+    fetchTv: false,
+    movieGenres: [10749],
+    tvGenres: [],
+  },
 ];
 
 const MAX_PER_BUCKET = 200;
@@ -73,9 +157,6 @@ export function ServiceView({ service }: { service: StreamingService }) {
           if (batch === 0) return { movies: b.movies, series: b.series };
           const movies = dedupe([...prev.movies, ...b.movies]);
           const series = dedupe([...prev.series, ...b.series]);
-          if (movies.length >= MAX_PER_BUCKET && series.length >= MAX_PER_BUCKET) {
-            setHasMore(false);
-          }
           return {
             movies: movies.slice(0, MAX_PER_BUCKET),
             series: series.slice(0, MAX_PER_BUCKET),
@@ -93,6 +174,12 @@ export function ServiceView({ service }: { service: StreamingService }) {
       cancelled = true;
     };
   }, [batch, service, category.id, settings.tmdbKey, settings.region, meta]);
+
+  useEffect(() => {
+    if (bucket.movies.length >= MAX_PER_BUCKET && bucket.series.length >= MAX_PER_BUCKET) {
+      setHasMore(false);
+    }
+  }, [bucket.movies.length, bucket.series.length]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -132,7 +219,10 @@ export function ServiceView({ service }: { service: StreamingService }) {
               <ServiceLogo service={service} height={56} />
             </div>
             <p className="max-w-xl text-[14.5px] leading-relaxed text-ink-muted">
-              {t("The most-watched movies and series on {name} right now in {region}.", { name: meta.name, region: settings.region })}
+              {t("The most-watched movies and series on {name} right now in {region}.", {
+                name: meta.name,
+                region: settings.region,
+              })}
             </p>
           </div>
         </div>
@@ -145,7 +235,10 @@ export function ServiceView({ service }: { service: StreamingService }) {
         {loading && (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-x-5 gap-y-9">
             {Array.from({ length: 18 }).map((_, i) => (
-              <div key={i} className="aspect-[2/3] animate-pulse rounded-xl border border-edge-soft bg-elevated/30" />
+              <div
+                key={i}
+                className="aspect-[2/3] animate-pulse rounded-xl border border-edge-soft bg-elevated/30"
+              />
             ))}
           </div>
         )}
@@ -158,7 +251,11 @@ export function ServiceView({ service }: { service: StreamingService }) {
               <>
                 {bucket.movies.length >= 10 ? (
                   <>
-                    <Row title={t("Top 10 Movies on {name}", { name: meta.name })} min={180} shape="rank">
+                    <Row
+                      title={t("Top 10 Movies on {name}", { name: meta.name })}
+                      min={180}
+                      shape="rank"
+                    >
                       {bucket.movies.slice(0, 10).map((m, i) => (
                         <TopRankCard key={m.id} meta={m} rank={i + 1} />
                       ))}
@@ -180,7 +277,11 @@ export function ServiceView({ service }: { service: StreamingService }) {
                 ) : null}
                 {bucket.series.length >= 10 ? (
                   <>
-                    <Row title={t("Top 10 Series on {name}", { name: meta.name })} min={180} shape="rank">
+                    <Row
+                      title={t("Top 10 Series on {name}", { name: meta.name })}
+                      min={180}
+                      shape="rank"
+                    >
                       {bucket.series.slice(0, 10).map((m, i) => (
                         <TopRankCard key={m.id} meta={m} rank={i + 1} />
                       ))}
@@ -334,7 +435,11 @@ function ScrollArrow({
           : "pointer-events-none opacity-0"
       }`}
     >
-      {side === "left" ? <ChevronLeft size={16} strokeWidth={2.4} /> : <ChevronRight size={16} strokeWidth={2.4} />}
+      {side === "left" ? (
+        <ChevronLeft size={16} strokeWidth={2.4} />
+      ) : (
+        <ChevronRight size={16} strokeWidth={2.4} />
+      )}
     </button>
   );
 }
@@ -352,13 +457,7 @@ function EdgeFade({ side, visible }: { side: "left" | "right"; visible: boolean 
   );
 }
 
-function CategoryFab({
-  active,
-  onChange,
-}: {
-  active: Category;
-  onChange: (c: Category) => void;
-}) {
+function CategoryFab({ active, onChange }: { active: Category; onChange: (c: Category) => void }) {
   const t = useT();
   const [open, setOpen] = useState(false);
 
@@ -468,7 +567,9 @@ async function fetchCategoryBatch(
   const startPage = batch * PAGE_BATCH + 1;
   const pages = Array.from({ length: PAGE_BATCH }, (_, i) => startPage + i);
   const moviePromise: Promise<any[][]> = cat.fetchMovies
-    ? Promise.all(pages.map((p) => fetchPage(key, "movie", providerIds, region, p, cat.movieGenres)))
+    ? Promise.all(
+        pages.map((p) => fetchPage(key, "movie", providerIds, region, p, cat.movieGenres)),
+      )
     : Promise.resolve([]);
   const tvPromise: Promise<any[][]> = cat.fetchTv
     ? Promise.all(pages.map((p) => fetchPage(key, "tv", providerIds, region, p, cat.tvGenres)))

--- a/src/views/settings/player-layout-panel/editor-chrome.tsx
+++ b/src/views/settings/player-layout-panel/editor-chrome.tsx
@@ -25,10 +25,22 @@ export function TopRow({
     return (
       <div className="absolute inset-x-0 top-0 z-30 flex h-[88px] items-center justify-between bg-gradient-to-b from-black/35 via-black/15 to-transparent px-6">
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <SlotZone slot="top-left" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+          <SlotZone
+            slot="top-left"
+            config={config}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            renderOne={renderOne}
+          />
         </div>
         <div className="flex items-center gap-1">
-          <SlotZone slot="top-right" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+          <SlotZone
+            slot="top-right"
+            config={config}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            renderOne={renderOne}
+          />
         </div>
       </div>
     );
@@ -36,10 +48,22 @@ export function TopRow({
   return (
     <div className="absolute inset-x-0 top-0 z-30 flex items-start justify-between bg-gradient-to-b from-black/55 via-black/15 to-transparent px-7 pt-4 pb-8">
       <div className="flex items-start gap-2">
-        <SlotZone slot="top-left" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+        <SlotZone
+          slot="top-left"
+          config={config}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          renderOne={renderOne}
+        />
       </div>
       <div className="flex items-start gap-2">
-        <SlotZone slot="top-right" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+        <SlotZone
+          slot="top-right"
+          config={config}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          renderOne={renderOne}
+        />
       </div>
     </div>
   );
@@ -89,9 +113,10 @@ function CyclingBackdrop({ bg }: { bg: string | null }) {
   const idRef = useRef(0);
   useEffect(() => {
     if (!bg) return;
+    const id = idRef.current++;
     setLayers((cur) => {
       if (cur.length && cur[cur.length - 1].url === bg) return cur;
-      return [...cur, { url: bg, id: idRef.current++ }].slice(-2);
+      return [...cur, { url: bg, id }].slice(-2);
     });
     const tid = setTimeout(() => setLayers((cur) => cur.slice(-1)), 2600);
     return () => clearTimeout(tid);
@@ -139,11 +164,23 @@ export function DefaultLayout({
           <LiveSeekRowMock />
         ) : (
           <>
-            <SlotZone slot="seek-leading" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+            <SlotZone
+              slot="seek-leading"
+              config={config}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              renderOne={renderOne}
+            />
             <div className="flex-1">
               <SeekBarPlaceholder />
             </div>
-            <SlotZone slot="seek-trailing" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+            <SlotZone
+              slot="seek-trailing"
+              config={config}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              renderOne={renderOne}
+            />
           </>
         )}
       </div>
@@ -153,13 +190,31 @@ export function DefaultLayout({
         }`}
       >
         <div className="flex min-w-0 items-center gap-2 justify-self-start">
-          <SlotZone slot="bottom-left" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+          <SlotZone
+            slot="bottom-left"
+            config={config}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            renderOne={renderOne}
+          />
         </div>
         <div className="flex items-center gap-1.5">
-          <SlotZone slot="bottom-center" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+          <SlotZone
+            slot="bottom-center"
+            config={config}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            renderOne={renderOne}
+          />
         </div>
         <div className="flex items-center gap-1.5 justify-self-end">
-          <SlotZone slot="bottom-right" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+          <SlotZone
+            slot="bottom-right"
+            config={config}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            renderOne={renderOne}
+          />
         </div>
       </div>
     </>
@@ -179,10 +234,28 @@ export function StremioLayout({ config, selectedId, onSelect, renderOne, isLive 
         )}
       </div>
       <div className="flex items-center gap-1">
-        <SlotZone slot="bottom-left" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
-        <SlotZone slot="bottom-center" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+        <SlotZone
+          slot="bottom-left"
+          config={config}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          renderOne={renderOne}
+        />
+        <SlotZone
+          slot="bottom-center"
+          config={config}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          renderOne={renderOne}
+        />
         <div className="flex-1" />
-        <SlotZone slot="bottom-right" config={config} selectedId={selectedId} onSelect={onSelect} renderOne={renderOne} />
+        <SlotZone
+          slot="bottom-right"
+          config={config}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          renderOne={renderOne}
+        />
       </div>
     </>
   );
@@ -227,7 +300,10 @@ function SlotZone({
     .sort((a, b) => a.order - b.order);
   const items = allInSlot
     .map((c) => ({ c, rendered: renderOne(c.id) }))
-    .filter((x): x is { c: typeof allInSlot[number]; rendered: NonNullable<React.ReactNode> } => x.rendered != null);
+    .filter(
+      (x): x is { c: (typeof allInSlot)[number]; rendered: NonNullable<React.ReactNode> } =>
+        x.rendered != null,
+    );
   if (items.length === 0) return null;
   return (
     <>


### PR DESCRIPTION
## Summary

Fix the high-confidence correctness issues reported by `react-doctor` while intentionally excluding heuristic refactors and project-specific false positives.

## Fixes

- Move `localStorage` writes out of functional state updaters.
- Allocate transition layer IDs before state updates instead of mutating refs inside updater callbacks.
- Remove nested state updates from pagination and category state updaters.
- Make profile creation synchronous and deterministic instead of assigning its return value from inside a React updater.
- Move profile-deletion storage cleanup outside the state updater.
- Add explicit `type="button"` to controls surfaced in the changed code.

## Findings intentionally excluded

- Latest-ref/event-handler patterns reported by `no-ref-current-in-render`: widespread intentional architecture, not safe for a bulk rewrite.
- `new Function` in Custom Code and Theme Studio: intentional user-authored code execution features, not remote code ingestion.
- Component-size, iteration-count, SVG-precision, and similar maintainability/performance heuristics.
- `royal-topbar` callback warning: false positive; the callback runs from an event handler, not from a state updater.

## Verification

- `bunx react-doctor@latest` on changed lines: **0 errors**, 5 non-blocking warnings.
- `vp check` on all 12 changed files: **0 errors**.
- `vp run typecheck`: passes.
- `git diff --check`: passes.