### PR TITLE
fix: prevent startup white flash

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -463,6 +463,14 @@ pub fn run() {
     });
 
     app_builder
+        .on_page_load(|webview, payload| {
+            if webview.label() == "main"
+                && matches!(payload.event(), tauri::webview::PageLoadEvent::Finished)
+            {
+                let _ = webview.window().show();
+                let _ = webview.window().set_focus();
+            }
+        })
         .setup(move |app| {
             #[cfg(windows)]
             {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
         "height": 800,
         "minWidth": 960,
         "minHeight": 600,
+        "visible": false,
         "decorations": false,
         "transparent": false,
         "backgroundColor": [0, 0, 0, 255],

--- a/src/index.css
+++ b/src/index.css
@@ -55,7 +55,7 @@ body,
 #root {
   height: 100%;
   margin: 0;
-  background: transparent;
+  background: var(--color-canvas);
   color: var(--color-ink);
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary

Prevent the intermittent white frame shown during Harbor startup in both the browser development URL and native Windows/macOS launches.

## Fixes

- Keep the normal `html`, `body`, and `#root` canvas opaque with the active canvas color instead of exposing the browser default background.
- Start the main Tauri window hidden.
- Reveal and focus the main window only after its WebView reports a finished page load.
- Preserve explicit transparency for modal and HDR overlay windows.

## Verification

- Verified `http://localhost:1420/` computes the same dark canvas color for `html`, `body`, and `#root`.
- Verified the modal overlay remains fully transparent.
- `vp check --no-error-on-unmatched-pattern src/index.css src-tauri/tauri.conf.json`: passes.
- `vp run typecheck`: passes.
- `cargo check --manifest-path src-tauri/Cargo.toml`: passes with 8 pre-existing warnings.
- `git diff --check`: passes.

Per request, no tests were added or run.