### PR TITLE
fix: prevent duplicate Trakt history entries

### DIFF
--- a/src/lib/trakt/provider.tsx
+++ b/src/lib/trakt/provider.tsx
@@ -15,17 +15,9 @@ import {
   type PollHandle,
   type PollResult,
 } from "./device-auth";
-import {
-  getSession,
-  setSession,
-  subscribeSession,
-} from "./session";
+import { getSession, setSession, subscribeSession } from "./session";
 import { stremioIdToTraktTarget, type TraktEpisodeRef } from "./ids";
-import {
-  scrobblePause,
-  scrobbleStart,
-  scrobbleStop,
-} from "./scrobble";
+import { scrobblePause, scrobbleStart, scrobbleStop } from "./scrobble";
 import { pushWatched } from "./history";
 import type { DeviceCode, TraktSession, TraktTarget } from "./types";
 
@@ -53,10 +45,7 @@ type Value = {
   cancelConnect: () => void;
   disconnect: () => void;
   scrobble: (action: "start" | "pause" | "stop", args: ScrobbleArgs) => Promise<void>;
-  resolveTarget: (
-    metaId: string,
-    episode?: TraktEpisodeRef,
-  ) => TraktTarget | null;
+  resolveTarget: (metaId: string, episode?: TraktEpisodeRef) => TraktTarget | null;
 };
 
 const Ctx = createContext<Value | null>(null);
@@ -119,13 +108,10 @@ export function TraktProvider({ children }: { children: ReactNode }) {
     setConnectState({ kind: "idle" });
   }, []);
 
-  const resolveTarget = useCallback(
-    (metaId: string, episode?: TraktEpisodeRef) => {
-      const r = stremioIdToTraktTarget(metaId, episode);
-      return r.ok ? r.target : null;
-    },
-    [],
-  );
+  const resolveTarget = useCallback((metaId: string, episode?: TraktEpisodeRef) => {
+    const r = stremioIdToTraktTarget(metaId, episode);
+    return r.ok ? r.target : null;
+  }, []);
 
   const scrobble = useCallback(
     async (action: "start" | "pause" | "stop", args: ScrobbleArgs) => {
@@ -136,8 +122,8 @@ export function TraktProvider({ children }: { children: ReactNode }) {
       if (action === "start") await scrobbleStart(target, progress);
       else if (action === "pause") await scrobblePause(target, progress);
       else {
-        const res = await scrobbleStop(target, progress);
-        if (!res) await pushWatched(target);
+        const outcome = await scrobbleStop(target, progress);
+        if (outcome === "failed") await pushWatched(target);
       }
     },
     [resolveTarget],

--- a/src/lib/trakt/scrobble.ts
+++ b/src/lib/trakt/scrobble.ts
@@ -1,5 +1,7 @@
-import { traktRequest } from "./client";
-import type { ScrobbleAction, ScrobbleResponse, TraktTarget } from "./types";
+import { traktRequest, TraktApiError } from "./client";
+import type { ScrobbleAction, TraktTarget } from "./types";
+
+export type ScrobbleOutcome = "recorded" | "already-recorded" | "failed";
 
 function scrobbleBody(target: TraktTarget, progress: number) {
   const clamped = Math.max(0, Math.min(100, Number(progress.toFixed(2))));
@@ -20,23 +22,27 @@ async function send(
   action: ScrobbleAction,
   target: TraktTarget,
   progress: number,
-): Promise<ScrobbleResponse | null> {
-  if (target.kind === "show") return null;
+): Promise<ScrobbleOutcome> {
+  if (target.kind === "show") return "failed";
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      return await traktRequest<ScrobbleResponse>(`/scrobble/${action}`, {
+      await traktRequest(`/scrobble/${action}`, {
         method: "POST",
         body: scrobbleBody(target, progress),
       });
-    } catch {
+      return "recorded";
+    } catch (error) {
+      if (action === "stop" && error instanceof TraktApiError && error.status === 409) {
+        return "already-recorded";
+      }
       if (attempt === 0 && action === "stop") {
         await new Promise((r) => setTimeout(r, 800));
         continue;
       }
-      return null;
+      return "failed";
     }
   }
-  return null;
+  return "failed";
 }
 
 export function scrobbleStart(target: TraktTarget, progress: number) {

--- a/src/views/home/home-rows.ts
+++ b/src/views/home/home-rows.ts
@@ -236,6 +236,13 @@ export function mergeRows(
   opts: { dedup?: boolean } = {},
 ): HomeRow[] {
   const dedup = opts.dedup ?? true;
+  const addonTypesByName = new Map<string, Set<string>>();
+  for (const addon of addons) {
+    const name = addon.name.trim().toLowerCase();
+    const types = addonTypesByName.get(name) ?? new Set<string>();
+    types.add(addon.type);
+    addonTypesByName.set(name, types);
+  }
   const seen = new Set<string>();
   const out: HomeRow[] = [];
   for (const r of built) {
@@ -252,10 +259,15 @@ export function mergeRows(
     const more = a.more;
     const origin = a.metas[0]?.addonOrigin;
     const canPage = !!more && step > 0;
+    const sameNameTypes = addonTypesByName.get(a.name.trim().toLowerCase());
+    const name =
+      sameNameTypes && sameNameTypes.size > 1
+        ? `${a.name}: ${a.type === "movie" ? "Movies" : a.type === "series" ? "Series" : a.type}`
+        : a.name;
     out.push({
       key: a.key,
       type: a.type as "movie" | "series",
-      name: a.name,
+      name,
       metas: a.metas,
       page: 1,
       hasMore: canPage,

--- a/src/views/home/home-rows.ts
+++ b/src/views/home/home-rows.ts
@@ -17,22 +17,62 @@ export function buildTmdbSpecs(settings: Settings): RowSpec[] {
   const key = settings.tmdbKey;
   const region = settings.region;
   return [
-    { key: "tmdb-trending-movies", type: "movie", name: "Trending This Week", fetcher: (p) => tmdbTrending(key, "movie", "week", p) },
-    { key: "tmdb-now-playing", type: "movie", name: "In Theaters Now", noDedup: true, fetcher: (p) => tmdbMovieRow(key, "now_playing", region, p) },
-    { key: "tmdb-popular-movies", type: "movie", name: "Popular Movies", fetcher: (p) => tmdbMovieRow(key, "popular", region, p) },
-    { key: "tmdb-trending-tv", type: "series", name: "Trending Series", fetcher: (p) => tmdbTrending(key, "tv", "week", p) },
-    { key: "tmdb-on-the-air", type: "series", name: "On The Air", noDedup: true, fetcher: (p) => tmdbSeriesRow(key, "on_the_air", p) },
-    { key: "tmdb-popular-tv", type: "series", name: "Popular Series", fetcher: (p) => tmdbSeriesRow(key, "popular", p) },
-    { key: "tmdb-top-rated-tv", type: "series", name: "Top Rated Series", fetcher: (p) => tmdbSeriesRow(key, "top_rated", p) },
-    { key: "tmdb-top-rated-movies", type: "movie", name: "Top Rated Movies", fetcher: (p) => tmdbMovieRow(key, "top_rated", region, p) },
+    {
+      key: "tmdb-trending-movies",
+      type: "movie",
+      name: "Trending This Week",
+      fetcher: (p) => tmdbTrending(key, "movie", "week", p),
+    },
+    {
+      key: "tmdb-now-playing",
+      type: "movie",
+      name: "In Theaters Now",
+      noDedup: true,
+      fetcher: (p) => tmdbMovieRow(key, "now_playing", region, p),
+    },
+    {
+      key: "tmdb-popular-movies",
+      type: "movie",
+      name: "Popular Movies",
+      fetcher: (p) => tmdbMovieRow(key, "popular", region, p),
+    },
+    {
+      key: "tmdb-trending-tv",
+      type: "series",
+      name: "Trending Series",
+      fetcher: (p) => tmdbTrending(key, "tv", "week", p),
+    },
+    {
+      key: "tmdb-on-the-air",
+      type: "series",
+      name: "On The Air",
+      noDedup: true,
+      fetcher: (p) => tmdbSeriesRow(key, "on_the_air", p),
+    },
+    {
+      key: "tmdb-popular-tv",
+      type: "series",
+      name: "Popular Series",
+      fetcher: (p) => tmdbSeriesRow(key, "popular", p),
+    },
+    {
+      key: "tmdb-top-rated-tv",
+      type: "series",
+      name: "Top Rated Series",
+      fetcher: (p) => tmdbSeriesRow(key, "top_rated", p),
+    },
+    {
+      key: "tmdb-top-rated-movies",
+      type: "movie",
+      name: "Top Rated Movies",
+      fetcher: (p) => tmdbMovieRow(key, "top_rated", region, p),
+    },
   ];
 }
 
 export async function buildTmdbRows(settings: Settings) {
   const specs = buildTmdbSpecs(settings);
-  const firstPages = await Promise.all(
-    specs.map((s) => s.fetcher(1).catch(() => [] as Meta[])),
-  );
+  const firstPages = await Promise.all(specs.map((s) => s.fetcher(1).catch(() => [] as Meta[])));
   const rows: HomeRow[] = specs
     .map((spec, i) => ({
       key: spec.key,
@@ -94,12 +134,14 @@ export async function buildCinemetaRows() {
     topSeries("Comedy").catch(() => [] as Meta[]),
     topSeries("Crime").catch(() => [] as Meta[]),
   ]);
-  const make = (
-    key: string,
-    type: "movie" | "series",
-    name: string,
-    metas: Meta[],
-  ): HomeRow => ({ key, type, name, metas, page: 1, hasMore: false });
+  const make = (key: string, type: "movie" | "series", name: string, metas: Meta[]): HomeRow => ({
+    key,
+    type,
+    name,
+    metas,
+    page: 1,
+    hasMore: false,
+  });
   const rows: HomeRow[] = [
     make("cm-top-movies", "movie", "Top 10 on Stremio", movies.slice(0, 10)),
     make("cm-popular", "movie", "Popular Movies", movies.slice(10, 40)),
@@ -120,8 +162,9 @@ export async function buildCinemetaRows() {
     make("cm-comedy-tv", "series", "Comedy Series", sComedy.slice(0, 30)),
     make("cm-crime-tv", "series", "Crime Series", sCrime.slice(0, 30)),
   ].filter((r) => r.metas.length > 0);
-  const hero = [movies[0], series[0], mDrama[0], mComedy[0], mAction[0], mScifi[0]]
-    .filter(Boolean) as Meta[];
+  const hero = [movies[0], series[0], mDrama[0], mComedy[0], mAction[0], mScifi[0]].filter(
+    Boolean,
+  ) as Meta[];
   return { rows, hero };
 }
 


### PR DESCRIPTION
## Summary

Prevent duplicate Trakt history writes and make same-named Trakt addon rows clearly distinguish movies from series.

## Fixes

- Distinguish recorded, already-recorded, and failed scrobble outcomes.
- Treat the Trakt HTTP 409 response as already recorded instead of retrying it as a generic failure.
- Use the direct sync/history fallback only when scrobbling actually fails.
- Label same-named addon catalogs by media type, so Trakt History and Trakt Recommendations appear as separate Movies and Series rows instead of looking duplicated.
- Format home-rows.ts with the current project formatter because CI checks the complete contents of every changed file; the formatting commit contains no additional behavior changes.

## Verification

- vp check src/lib/trakt/provider.tsx src/lib/trakt/scrobble.ts src/views/home/home-rows.ts: passes.
- vp run typecheck: passes.
- git diff --check upstream/main...HEAD: passes.

Per request, no tests or documentation files were added, and no tests were run.