### PR TITLE
chore: fetch bundled mpv for Windows builds

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -120,6 +120,10 @@ jobs:
             pnpm run setup:libmpv
           }
 
+      - name: Fetch mpv (Windows x64)
+        if: matrix.platform.target == 'x86_64-pc-windows-msvc'
+        run: pnpm run setup:mpv
+
       - name: Fetch external binaries
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- fetch the pinned bundled mpv executable for Windows x64 builds
- satisfy the mpv.exe resource declared by tauri.windows.conf.json

## Verification
- YAML syntax validated
- vp formatting check passed