### PR TITLE
fix: make subtitle loading reliable

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2009,6 +2009,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-video",
  "discord-rich-presence",
+ "encoding_rs",
  "flate2",
  "futures-util",
  "gtk",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,8 +30,16 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 axum = { version = "0.8", features = ["ws"] }
-reqwest = { version = "0.12", default-features = false, features = ["native-tls", "stream", "multipart", "json", "gzip", "hickory-dns"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "native-tls",
+  "stream",
+  "multipart",
+  "json",
+  "gzip",
+  "hickory-dns",
+] }
 flate2 = "1"
+encoding_rs = "0.8"
 uuid = { version = "1", features = ["v4"] }
 futures-util = "0.3"
 libmpv2 = "4"
@@ -43,7 +51,12 @@ hound = "3.5"
 discord-rich-presence = "1.1"
 rust_cast = { path = "vendor/rust_cast", version = "0.20" }
 mdns-sd = "0.13"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "ring",
+  "std",
+  "tls12",
+  "logging",
+] }
 harbor-core = { path = "../harbor-core" }
 librqbit = { version = "=8.1.1", default-features = false, features = ["rust-tls"] }
 url = "2"
@@ -51,7 +64,19 @@ realfft = "3"
 hickory-resolver = "0.25"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell", "Win32_Graphics_Gdi", "Win32_Graphics_Dxgi", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_Diagnostics_ToolHelp", "Win32_System_SystemInformation", "Win32_System_LibraryLoader"] }
+windows = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_UI_WindowsAndMessaging",
+  "Win32_UI_Shell",
+  "Win32_Graphics_Gdi",
+  "Win32_Graphics_Dxgi",
+  "Win32_Graphics_Dxgi_Common",
+  "Win32_System_Threading",
+  "Win32_System_ProcessStatus",
+  "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_SystemInformation",
+  "Win32_System_LibraryLoader",
+] }
 window-vibrancy = "0.6"
 wasapi = "0.15"
 webview2-com = "0.37"
@@ -65,8 +90,20 @@ debug = "line-tables-only"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSGeometry", "NSThread", "NSValue", "NSDictionary", "NSString"] }
-objc2-app-kit = { version = "0.3", features = ["NSWindow", "NSView", "NSOpenGL", "NSOpenGLView", "NSResponder"] }
+objc2-foundation = { version = "0.3", features = [
+  "NSGeometry",
+  "NSThread",
+  "NSValue",
+  "NSDictionary",
+  "NSString",
+] }
+objc2-app-kit = { version = "0.3", features = [
+  "NSWindow",
+  "NSView",
+  "NSOpenGL",
+  "NSOpenGLView",
+  "NSResponder",
+] }
 objc2-web-kit = { version = "0.3", features = ["WKWebView"] }
 core-foundation = "0.10"
 core-video = "0.4"

--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -171,6 +171,7 @@ const OBSERVED_PROPS: &[(&str, u64, PropertyKind)] = &[
     ("dheight", 15, PropertyKind::Int64),
     ("video-params/gamma", 16, PropertyKind::String),
     ("demuxer-cache-duration", 17, PropertyKind::Double),
+    ("paused-for-cache", 18, PropertyKind::Flag),
 ];
 
 #[derive(Clone, Copy)]
@@ -1607,7 +1608,26 @@ fn sub_cache_dir() -> PathBuf {
     dir
 }
 
-fn sub_extension(url: &str, content_type: Option<&str>) -> &'static str {
+fn subtitle_extension(
+    url: &str,
+    content_type: Option<&str>,
+    format_hint: Option<&str>,
+    bytes: &[u8],
+) -> &'static str {
+    match format_hint.unwrap_or_default().trim().to_ascii_lowercase().as_str() {
+        "ass" | "ssa" => return "ass",
+        "vtt" | "webvtt" => return "vtt",
+        "srt" | "subrip" => return "srt",
+        _ => {}
+    }
+    let head_len = bytes.len().min(1024);
+    let head = String::from_utf8_lossy(&bytes[..head_len]).to_ascii_lowercase();
+    if head.contains("[script info]") || head.contains("[v4+ styles]") || head.contains("[v4 styles]") {
+        return "ass";
+    }
+    if head.trim_start_matches('\u{feff}').starts_with("webvtt") {
+        return "vtt";
+    }
     let lower = url.to_lowercase();
     if lower.ends_with(".vtt") || content_type.is_some_and(|c| c.contains("vtt")) {
         return "vtt";
@@ -1618,8 +1638,141 @@ fn sub_extension(url: &str, content_type: Option<&str>) -> &'static str {
     "srt"
 }
 
+fn normalize_subtitle_bytes(bytes: &[u8], encoding_hint: Option<&str>, lang: Option<&str>) -> Vec<u8> {
+    if let Ok(text) = std::str::from_utf8(bytes) {
+        return text.trim_start_matches('\u{feff}').as_bytes().to_vec();
+    }
+
+    let hinted = encoding_hint
+        .and_then(|label| encoding_rs::Encoding::for_label(label.trim().as_bytes()));
+    let language = lang.unwrap_or_default().trim().to_ascii_lowercase();
+    let encoding = hinted.or_else(|| {
+        if matches!(language.as_str(), "ar" | "ara" | "arabic") {
+            encoding_rs::Encoding::for_label(b"windows-1256")
+        } else {
+            encoding_rs::Encoding::for_label(b"windows-1252")
+        }
+    });
+    let Some(encoding) = encoding else {
+        return String::from_utf8_lossy(bytes).into_owned().into_bytes();
+    };
+    let (text, _, _) = encoding.decode(bytes);
+    text.trim_start_matches('\u{feff}').as_bytes().to_vec()
+}
+
+fn prepare_subtitle_download(
+    url: &str,
+    content_type: Option<&str>,
+    format_hint: Option<&str>,
+    encoding_hint: Option<&str>,
+    lang: Option<&str>,
+    bytes: &[u8],
+) -> (&'static str, Vec<u8>) {
+    let normalized = normalize_subtitle_bytes(bytes, encoding_hint, lang);
+    let extension = subtitle_extension(url, content_type, format_hint, &normalized);
+    (extension, normalized)
+}
+
+#[cfg(test)]
+mod subtitle_download_tests {
+    use super::{normalize_subtitle_bytes, prepare_subtitle_download, subtitle_extension};
+
+    #[test]
+    fn uses_explicit_ass_format_when_download_url_has_no_extension() {
+        let body = b"[Script Info]\nTitle: Styled\n[V4+ Styles]\n";
+        assert_eq!(
+            subtitle_extension(
+                "https://example.test/download?id=42",
+                Some("application/octet-stream"),
+                Some("ass"),
+                body,
+            ),
+            "ass",
+        );
+    }
+
+    #[test]
+    fn detects_ass_from_content_when_provider_omits_format() {
+        let body = b"[Script Info]\nTitle: Styled\n[V4+ Styles]\n";
+        assert_eq!(
+            subtitle_extension(
+                "https://example.test/download?id=42",
+                Some("text/plain"),
+                None,
+                body,
+            ),
+            "ass",
+        );
+    }
+
+    #[test]
+    fn converts_windows_1256_arabic_to_utf8() {
+        let windows_1256 = [
+            0xe3, 0xd1, 0xcd, 0xc8, 0xc7, 0x20, 0xc8, 0xc7, 0xe1, 0xda, 0xc7, 0xe1,
+            0xe3,
+        ];
+        let utf8 = normalize_subtitle_bytes(&windows_1256, Some("windows-1256"), Some("ar"));
+        assert_eq!(String::from_utf8(utf8).unwrap(), "مرحبا بالعالم");
+    }
+
+    #[test]
+    fn uses_arabic_language_as_legacy_encoding_fallback() {
+        let windows_1256 = [
+            0xe3, 0xd1, 0xcd, 0xc8, 0xc7, 0x20, 0xc8, 0xc7, 0xe1, 0xda, 0xc7, 0xe1,
+            0xe3,
+        ];
+        let utf8 = normalize_subtitle_bytes(&windows_1256, None, Some("ara"));
+        assert_eq!(String::from_utf8(utf8).unwrap(), "مرحبا بالعالم");
+    }
+
+    #[test]
+    fn converts_utf16_little_endian_bom_to_utf8() {
+        let utf16 = [0xff, 0xfe, b'H', 0x00, b'i', 0x00];
+        let utf8 = normalize_subtitle_bytes(&utf16, None, None);
+        assert_eq!(String::from_utf8(utf8).unwrap(), "Hi");
+    }
+
+    #[test]
+    fn detects_ass_after_utf16_normalization() {
+        let text = "[Script Info]\nTitle: Styled\n";
+        let mut utf16 = vec![0xff, 0xfe];
+        for unit in text.encode_utf16() {
+            utf16.extend_from_slice(&unit.to_le_bytes());
+        }
+        let normalized = normalize_subtitle_bytes(&utf16, None, None);
+        assert_eq!(
+            subtitle_extension("https://example.test/download", None, None, &normalized),
+            "ass",
+        );
+    }
+
+    #[test]
+    fn download_preparation_detects_utf16_ass_before_writing() {
+        let text = "[Script Info]\nTitle: Styled\n";
+        let mut utf16 = vec![0xff, 0xfe];
+        for unit in text.encode_utf16() {
+            utf16.extend_from_slice(&unit.to_le_bytes());
+        }
+        let (extension, normalized) = prepare_subtitle_download(
+            "https://example.test/download",
+            None,
+            None,
+            None,
+            None,
+            &utf16,
+        );
+        assert_eq!(extension, "ass");
+        assert_eq!(String::from_utf8(normalized).unwrap(), text);
+    }
+}
+
 #[tauri::command]
-pub async fn sub_download(url: String) -> Result<String, String> {
+pub async fn sub_download(
+    url: String,
+    format: Option<String>,
+    encoding: Option<String>,
+    lang: Option<String>,
+) -> Result<String, String> {
     use std::io::Read;
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
@@ -1644,9 +1797,8 @@ pub async fn sub_download(url: String) -> Result<String, String> {
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_lowercase());
-    let ext = sub_extension(&url, ct.as_deref());
     let raw = res.bytes().await.map_err(|e| format!("read: {}", e))?;
-    let bytes: Vec<u8> = if raw.len() >= 2 && raw[0] == 0x1f && raw[1] == 0x8b {
+    let unpacked: Vec<u8> = if raw.len() >= 2 && raw[0] == 0x1f && raw[1] == 0x8b {
         let mut decoder = flate2::read::GzDecoder::new(&raw[..]);
         let mut decoded = Vec::with_capacity(raw.len() * 4);
         decoder
@@ -1656,6 +1808,14 @@ pub async fn sub_download(url: String) -> Result<String, String> {
     } else {
         raw.to_vec()
     };
+    let (ext, bytes) = prepare_subtitle_download(
+        &url,
+        ct.as_deref(),
+        format.as_deref(),
+        encoding.as_deref(),
+        lang.as_deref(),
+        &unpacked,
+    );
     let id = Uuid::new_v4();
     let path = sub_cache_dir().join(format!("{}.{}", id, ext));
     std::fs::write(&path, &bytes).map_err(|e| format!("write: {}", e))?;

--- a/src/components/player/subtitle-menu.tsx
+++ b/src/components/player/subtitle-menu.tsx
@@ -52,8 +52,17 @@ export function SubtitleMenu(props: Props) {
       }),
     );
     offs.push(
-      listen<{ url: string; lang?: string; title?: string }>("modal://subtitle/add", (e) => {
-        propsRef.current.onAddSubtitle(e.payload.url, e.payload.lang, e.payload.title);
+      listen<{
+        url: string;
+        lang?: string;
+        title?: string;
+        format?: "srt" | "vtt" | "ass" | "ssa" | "sub";
+        encoding?: string;
+      }>("modal://subtitle/add", (e) => {
+        propsRef.current.onAddSubtitle(e.payload.url, e.payload.lang, e.payload.title, {
+          format: e.payload.format,
+          encoding: e.payload.encoding,
+        });
       }),
     );
     offs.push(listen("modal://closed", () => setOpen(false)));

--- a/src/components/player/subtitle-menu/search-section.tsx
+++ b/src/components/player/subtitle-menu/search-section.tsx
@@ -83,7 +83,7 @@ export function SearchSection(props: SubtitleMenuProps) {
       };
 
       // Log search attempt for debugging (will appear in terminal)
-      console.log('[SUBTITLES SEARCH] Starting with:', {
+      console.log("[SUBTITLES SEARCH] Starting with:", {
         hasImdbId: !!metaImdbId,
         addonsCount: addons?.length ?? 0,
         providers: searchOpts.providers,
@@ -93,11 +93,14 @@ export function SearchSection(props: SubtitleMenuProps) {
       const r = await searchSubtitles(searchQuery, searchOpts);
 
       // Log results by source (will appear in terminal)
-      const bySource = r.reduce((acc, sub) => {
-        acc[sub.source] = (acc[sub.source] || 0) + 1;
-        return acc;
-      }, {} as Record<string, number>);
-      console.log('[SUBTITLES SEARCH] Complete:', {
+      const bySource = r.reduce(
+        (acc, sub) => {
+          acc[sub.source] = (acc[sub.source] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>,
+      );
+      console.log("[SUBTITLES SEARCH] Complete:", {
         total: r.length,
         bySource,
         addonResults: bySource.addon || 0,
@@ -195,7 +198,12 @@ export function SearchSection(props: SubtitleMenuProps) {
             lang={lang}
             items={items}
             defaultOpen={i === 0}
-            onAdd={(r) => onAddSubtitle(r.url, r.lang, r.title)}
+            onAdd={(r) =>
+              onAddSubtitle(r.url, r.lang, r.title, {
+                format: r.format,
+                encoding: r.encoding,
+              })
+            }
           />
         ))}
       </div>
@@ -212,7 +220,7 @@ function LangGroup({
   lang: string;
   items: SubResult[];
   defaultOpen: boolean;
-  onAdd: (r: SubResult) => void | Promise<boolean>;
+  onAdd: (r: SubResult) => void | Promise<boolean | void>;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   return (
@@ -234,9 +242,9 @@ function LangGroup({
         />
       </button>
       {open &&
-        items.slice(0, 30).map((r) => (
-          <ResultRow key={r.id} result={r} lang={lang} onAdd={() => onAdd(r)} />
-        ))}
+        items
+          .slice(0, 30)
+          .map((r) => <ResultRow key={r.id} result={r} lang={lang} onAdd={() => onAdd(r)} />)}
     </div>
   );
 }
@@ -248,7 +256,7 @@ function ResultRow({
 }: {
   result: SubResult;
   lang: string;
-  onAdd: () => void | Promise<boolean>;
+  onAdd: () => void | Promise<boolean | void>;
 }) {
   const t = useT();
   const { open } = useContextMenu();
@@ -305,18 +313,17 @@ function ResultRow({
   };
 
   // Enhanced source display with color coding
-  const sourceColor = {
-    addon: "text-blue-400",
-    opensubtitles: "text-emerald-400",
-    wyzie: "text-purple-400",
-    jimaku: "text-amber-400",
-  }[result.source] || "text-ink-subtle";
+  const sourceColor =
+    {
+      addon: "text-blue-400",
+      opensubtitles: "text-emerald-400",
+      wyzie: "text-purple-400",
+      jimaku: "text-amber-400",
+    }[result.source] || "text-ink-subtle";
 
   return (
     <div
-      onContextMenu={(e) =>
-        open(e, { kind: "subtitle", label: result.title || lang, download })
-      }
+      onContextMenu={(e) => open(e, { kind: "subtitle", label: result.title || lang, download })}
       className={`group flex w-full items-start gap-3 px-4 py-2.5 transition-colors duration-300 ${
         added ? "bg-emerald-400/12" : "hover:bg-canvas/60"
       }`}
@@ -391,8 +398,9 @@ function ResultRow({
             void download();
           }
         }}
-        className={`mt-0.5 inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors ${saved ? "text-accent" : "text-ink-subtle hover:bg-elevated hover:text-ink"
-          }`}
+        className={`mt-0.5 inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors ${
+          saved ? "text-accent" : "text-ink-subtle hover:bg-elevated hover:text-ink"
+        }`}
       >
         {busy ? (
           <Loader2 size={13} className="animate-spin" />
@@ -418,10 +426,11 @@ function FilterChip({
   return (
     <button
       onClick={onClick}
-      className={`flex h-7 items-center rounded-full px-2.5 text-[11.5px] font-semibold transition-colors ${active
+      className={`flex h-7 items-center rounded-full px-2.5 text-[11.5px] font-semibold transition-colors ${
+        active
           ? "bg-elevated text-ink ring-1 ring-edge"
           : "bg-raised text-ink-muted hover:bg-elevated/80"
-        }`}
+      }`}
     >
       {children}
     </button>

--- a/src/components/player/subtitle-menu/types.ts
+++ b/src/components/player/subtitle-menu/types.ts
@@ -1,4 +1,5 @@
 import type { TrackInfo } from "@/lib/player/bridge";
+import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 
 export type SubtitleMenuProps = {
   tracks: TrackInfo[];
@@ -7,7 +8,7 @@ export type SubtitleMenuProps = {
   onSelect: (id: string | null) => void;
   onDelay: (sec: number) => void;
   onEnterSync?: () => void;
-  onAddSubtitle: (url: string, lang?: string, title?: string) => void | Promise<boolean>;
+  onAddSubtitle: SubtitleAddHandler;
   metaImdbId?: string | null;
   metaTitle?: string | null;
   metaReleaseDate?: string | null;

--- a/src/components/player/subtitle-menu/utils.ts
+++ b/src/components/player/subtitle-menu/utils.ts
@@ -1,5 +1,5 @@
 import type { TrackInfo } from "@/lib/player/bridge";
-import { languageName } from "@/lib/subtitles/language";
+import { subtitleTrackLanguageLabel, subtitleTrackTitle } from "@/lib/subtitles/track-label";
 import type { Group, SubtitleMenuProps } from "./types";
 
 export function buildOverlayState(props: SubtitleMenuProps) {
@@ -18,8 +18,7 @@ export function buildOverlayState(props: SubtitleMenuProps) {
 export function groupByLang(tracks: TrackInfo[]): Group[] {
   const map = new Map<string, Group>();
   for (const t of tracks) {
-    const code = (t.lang || "").trim();
-    const display = code ? languageName(code) : "Unknown";
+    const display = subtitleTrackLanguageLabel(t);
     const key = display.toLowerCase();
     let g = map.get(key);
     if (!g) {
@@ -32,9 +31,7 @@ export function groupByLang(tracks: TrackInfo[]): Group[] {
 }
 
 export function variantTitle(t: TrackInfo): string {
-  if (t.title && t.title.trim() && t.title !== t.lang) return t.title;
-  if (t.external) return "External";
-  return "Embedded";
+  return subtitleTrackTitle(t);
 }
 
 export function variantSubtitle(t: TrackInfo): string {

--- a/src/components/player/subtitle-menu/variant-row.tsx
+++ b/src/components/player/subtitle-menu/variant-row.tsx
@@ -2,7 +2,7 @@ import { Check, Sparkles } from "lucide-react";
 import type { TrackInfo } from "@/lib/player/bridge";
 import { useContextMenu } from "@/lib/context-menu";
 import { isImageSubTrack } from "@/lib/player/sub-format";
-import { languageName } from "@/lib/subtitles/language";
+import { subtitleTrackLanguageLabel, subtitleTrackTitle } from "@/lib/subtitles/track-label";
 import { saveSubtitleToDisk } from "@/lib/subtitles/save-to-disk";
 import { useImportedSubs } from "@/lib/player/imported-subs";
 import { useT } from "@/lib/i18n";
@@ -34,12 +34,15 @@ export function VariantRow({
   if (track.hearingImpaired) tags.push({ label: tr("HI/SDH"), tone: "warn" });
   if (track.default) tags.push({ label: tr("Default"), tone: "default" });
   if (isImageSubTrack(track)) tags.push({ label: tr("Position and size only"), tone: "warn" });
-  const sourceLabel = isImported ? tr("Imported") : track.external ? tr("External") : tr("Embedded");
+  const sourceLabel = isImported
+    ? tr("Imported")
+    : track.external
+      ? tr("External")
+      : tr("Embedded");
   const codec = track.codec?.toUpperCase();
   const release = pickReleaseHint(track);
-  const titleText =
-    track.title?.trim() || (track.external ? tr("External subtitle") : tr("Embedded track"));
-  const langName = track.lang ? languageName(track.lang) : tr("Unknown");
+  const titleText = subtitleTrackTitle(track);
+  const langName = subtitleTrackLanguageLabel(track);
 
   return (
     <button

--- a/src/components/player/transport-stremio.tsx
+++ b/src/components/player/transport-stremio.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { PlayerCapabilities, PlayerSnapshot } from "@/lib/player/bridge";
+import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 import type { Meta } from "@/lib/cinemeta";
 import {
   controlsInSlot,
@@ -40,7 +41,7 @@ export type TransportStremioProps = {
   onSubDelay: (sec: number) => void;
   onAudioDelay: (sec: number) => void;
   onEnterSync?: () => void;
-  onAddSubtitle: (url: string, lang?: string, title?: string) => void;
+  onAddSubtitle: SubtitleAddHandler;
   onRate: (r: number) => void;
   cropMode?: string;
   onCropMode?: (id: string) => void;
@@ -162,8 +163,17 @@ export function TransportStremio(p: TransportStremioProps) {
   const controlsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    onMenuOpenChange?.(audioMenuOpen || subtitleMenuOpen || speedMenuOpen || aspectMenuOpen || anime4kMenuOpen);
-  }, [audioMenuOpen, subtitleMenuOpen, speedMenuOpen, aspectMenuOpen, anime4kMenuOpen, onMenuOpenChange]);
+    onMenuOpenChange?.(
+      audioMenuOpen || subtitleMenuOpen || speedMenuOpen || aspectMenuOpen || anime4kMenuOpen,
+    );
+  }, [
+    audioMenuOpen,
+    subtitleMenuOpen,
+    speedMenuOpen,
+    aspectMenuOpen,
+    anime4kMenuOpen,
+    onMenuOpenChange,
+  ]);
 
   useEffect(() => {
     const refresh = () => setConfig(readPlayerChromeConfig("stremio"));
@@ -330,9 +340,7 @@ export function TransportStremio(p: TransportStremioProps) {
             setCastModalOpen(false);
             castModalPlay(m, ep);
           }}
-          currentEpisode={
-            season != null && episode != null ? { season, episode } : null
-          }
+          currentEpisode={season != null && episode != null ? { season, episode } : null}
         />
       )}
     </>

--- a/src/components/player/transport.tsx
+++ b/src/components/player/transport.tsx
@@ -1,6 +1,7 @@
 import { Settings2 } from "lucide-react";
 import { Fragment, useEffect, useRef, useState } from "react";
 import type { PlayerCapabilities, PlayerSnapshot } from "@/lib/player/bridge";
+import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 import type { Meta } from "@/lib/cinemeta";
 import { CastModal } from "./cast-modal";
 import type { DownloadStatus } from "@/views/player/hooks/use-video-download";
@@ -110,7 +111,7 @@ export function Transport({
   onSubDelay: (sec: number) => void;
   onAudioDelay: (sec: number) => void;
   onEnterSync?: () => void;
-  onAddSubtitle: (url: string, lang?: string, title?: string) => void;
+  onAddSubtitle: SubtitleAddHandler;
   onRate: (r: number) => void;
   cropMode?: string;
   onCropMode?: (id: string) => void;
@@ -157,7 +158,8 @@ export function Transport({
   const t = useT();
   const { settings } = useSettings();
   const kid = useActiveKid();
-  const isStremioLayout = resolveChromeTheme(settings.theme, settings.playerChromeTheme) === "stremio";
+  const isStremioLayout =
+    resolveChromeTheme(settings.theme, settings.playerChromeTheme) === "stremio";
   const playing = snap.status === "playing";
   const showEpisodeNav = hasPrevEp || hasNextEp;
   const [audioMenuOpen, setAudioMenuOpen] = useState(false);
@@ -178,8 +180,17 @@ export function Transport({
   const [compact, setCompact] = useState(false);
   const [tight, setTight] = useState(false);
   useEffect(() => {
-    onMenuOpenChange?.(audioMenuOpen || subtitleMenuOpen || speedMenuOpen || aspectMenuOpen || anime4kMenuOpen);
-  }, [audioMenuOpen, subtitleMenuOpen, speedMenuOpen, aspectMenuOpen, anime4kMenuOpen, onMenuOpenChange]);
+    onMenuOpenChange?.(
+      audioMenuOpen || subtitleMenuOpen || speedMenuOpen || aspectMenuOpen || anime4kMenuOpen,
+    );
+  }, [
+    audioMenuOpen,
+    subtitleMenuOpen,
+    speedMenuOpen,
+    aspectMenuOpen,
+    anime4kMenuOpen,
+    onMenuOpenChange,
+  ]);
   useEffect(() => {
     const refresh = () => setChromeConfig(readPlayerChromeConfig("default"));
     const onStorage = (e: StorageEvent) => {
@@ -456,9 +467,11 @@ export function Transport({
             </>
           )}
         </div>
-        <div className={`pointer-events-auto grid items-center ${
-          compact ? "grid-cols-[auto_1fr_auto] gap-2" : "grid-cols-[1fr_auto_1fr] gap-4"
-        }`}>
+        <div
+          className={`pointer-events-auto grid items-center ${
+            compact ? "grid-cols-[auto_1fr_auto] gap-2" : "grid-cols-[1fr_auto_1fr] gap-4"
+          }`}
+        >
           <div className="flex min-w-0 items-center gap-2 justify-self-start">
             {controlsInSlot(chromeConfig, "bottom-left").map((c) => (
               <Fragment key={c.id}>{renderControl(c.id, ctx)}</Fragment>
@@ -492,9 +505,7 @@ export function Transport({
             setCastModalOpen(false);
             castModalPlay(m, ep);
           }}
-          currentEpisode={
-            season != null && episode != null ? { season, episode } : null
-          }
+          currentEpisode={season != null && episode != null ? { season, episode } : null}
         />
       )}
     </>

--- a/src/components/player/transport/control-renderer-stremio.tsx
+++ b/src/components/player/transport/control-renderer-stremio.tsx
@@ -14,8 +14,15 @@ import {
 } from "lucide-react";
 import { realQualityLabel } from "@/lib/player/resolution-label";
 import type { PlayerCapabilities, PlayerSnapshot } from "@/lib/player/bridge";
+import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 import type { Meta } from "@/lib/cinemeta";
-import { getCustomIcon, type CustomIconMap, type PlayerControlId, type TimeFormat, type VolumeStyle } from "@/lib/player-chrome";
+import {
+  getCustomIcon,
+  type CustomIconMap,
+  type PlayerControlId,
+  type TimeFormat,
+  type VolumeStyle,
+} from "@/lib/player-chrome";
 import type { DownloadStatus } from "@/views/player/hooks/use-video-download";
 import { useT } from "@/lib/i18n";
 import { SubtitleMenu } from "../subtitle-menu";
@@ -39,8 +46,10 @@ import { IdentifySongButton } from "@/components/identify-song-button";
 
 function qualityInfoOn(): boolean {
   try {
-    return (JSON.parse(localStorage.getItem("harbor.settings") ?? "{}") as { showQualityInfo?: boolean })
-      .showQualityInfo === true;
+    return (
+      (JSON.parse(localStorage.getItem("harbor.settings") ?? "{}") as { showQualityInfo?: boolean })
+        .showQualityInfo === true
+    );
   } catch {
     return false;
   }
@@ -105,7 +114,7 @@ export type StremioRenderCtx = {
   onSubDelay: (sec: number) => void;
   onAudioDelay: (sec: number) => void;
   onEnterSync?: () => void;
-  onAddSubtitle: (url: string, lang?: string, title?: string) => void;
+  onAddSubtitle: SubtitleAddHandler;
   onRate: (r: number) => void;
   onPiP: () => void;
   onCast: () => void;
@@ -184,7 +193,9 @@ export function RenderedStremioControl({
               <span className="flex min-w-0 items-center gap-2 truncate">
                 <h1 className="truncate text-[19px] font-medium leading-tight">{ctx.title}</h1>
                 {ctx.subtitle && (
-                  <span className="shrink-0 text-[13px] font-normal text-white/55">{ctx.subtitle}</span>
+                  <span className="shrink-0 text-[13px] font-normal text-white/55">
+                    {ctx.subtitle}
+                  </span>
                 )}
                 {!showQuality && res && (
                   <span className="shrink-0 rounded-md bg-white/15 px-1.5 py-0.5 text-[10.5px] font-bold uppercase tracking-wide text-white/80">
@@ -193,10 +204,16 @@ export function RenderedStremioControl({
                 )}
               </span>
               {showQuality && (
-                <span className="truncate text-[12px] font-normal tabular-nums text-white/55">{ctx.quality}</span>
+                <span className="truncate text-[12px] font-normal tabular-nums text-white/55">
+                  {ctx.quality}
+                </span>
               )}
             </span>
-            <Info size={13} strokeWidth={2.1} className="shrink-0 opacity-40 transition-opacity group-hover:opacity-90" />
+            <Info
+              size={13}
+              strokeWidth={2.1}
+              className="shrink-0 opacity-40 transition-opacity group-hover:opacity-90"
+            />
           </button>
         );
       }
@@ -239,7 +256,11 @@ export function RenderedStremioControl({
       if (!ctx.showEpisodeNav) return null;
       return (
         <Tooltip label={tr("Previous episode")}>
-          <StremioBtn onClick={ctx.onPrevEp} ariaLabel={tr("Previous episode")} disabled={!ctx.hasPrevEp}>
+          <StremioBtn
+            onClick={ctx.onPrevEp}
+            ariaLabel={tr("Previous episode")}
+            disabled={!ctx.hasPrevEp}
+          >
             <SkipBack size={26} strokeWidth={2} fill="currentColor" />
           </StremioBtn>
         </Tooltip>
@@ -248,7 +269,11 @@ export function RenderedStremioControl({
       if (!ctx.showEpisodeNav) return null;
       return (
         <Tooltip label={tr("Next episode")}>
-          <StremioBtn onClick={ctx.onNextEp} ariaLabel={tr("Next episode")} disabled={!ctx.hasNextEp}>
+          <StremioBtn
+            onClick={ctx.onNextEp}
+            ariaLabel={tr("Next episode")}
+            disabled={!ctx.hasNextEp}
+          >
             <SkipForward size={26} strokeWidth={2} fill="currentColor" />
           </StremioBtn>
         </Tooltip>
@@ -288,7 +313,11 @@ export function RenderedStremioControl({
             onClick={ctx.onPickAnother}
             ariaLabel={ctx.isLiveChannel ? tr("TV Guide") : tr("Switch stream")}
           >
-            {ctx.isLiveChannel ? <Tv size={26} strokeWidth={1.9} /> : <Replace size={26} strokeWidth={1.9} />}
+            {ctx.isLiveChannel ? (
+              <Tv size={26} strokeWidth={1.9} />
+            ) : (
+              <Replace size={26} strokeWidth={1.9} />
+            )}
           </StremioBtn>
         </Tooltip>
       );
@@ -297,7 +326,14 @@ export function RenderedStremioControl({
       return <DvrButton channelName={ctx.meta?.name ?? tr("Live")} onClick={ctx.onOpenDvr} />;
     case "download":
       if (ctx.isLiveChannel) return null;
-      if (!ctx.download || !ctx.onDownloadStart || !ctx.onDownloadCancel || !ctx.onDownloadReveal || !ctx.onDownloadReset) return null;
+      if (
+        !ctx.download ||
+        !ctx.onDownloadStart ||
+        !ctx.onDownloadCancel ||
+        !ctx.onDownloadReveal ||
+        !ctx.onDownloadReset
+      )
+        return null;
       return (
         <DownloadButton
           status={ctx.download}
@@ -409,7 +445,11 @@ export function RenderedStremioControl({
       return (
         <Tooltip label={ctx.fullscreen ? tr("Exit fullscreen") : tr("Fullscreen")} side="bottom">
           <StremioBtn onClick={ctx.onFullscreen} ariaLabel={tr("Fullscreen")}>
-            {ctx.fullscreen ? <Minimize size={28} strokeWidth={2} /> : <Maximize size={28} strokeWidth={2} />}
+            {ctx.fullscreen ? (
+              <Minimize size={28} strokeWidth={2} />
+            ) : (
+              <Maximize size={28} strokeWidth={2} />
+            )}
           </StremioBtn>
         </Tooltip>
       );

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import type { PlayerCapabilities, PlayerSnapshot } from "@/lib/player/bridge";
+import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 import type { Meta } from "@/lib/cinemeta";
 import {
   getCustomIcon,
@@ -122,7 +123,7 @@ export type ControlContext = {
   onSubDelay: (sec: number) => void;
   onAudioDelay: (sec: number) => void;
   onEnterSync?: () => void;
-  onAddSubtitle: (url: string, lang?: string, title?: string) => void;
+  onAddSubtitle: SubtitleAddHandler;
   onRate: (r: number) => void;
   onPiP: () => void;
   onFullscreen: () => void;

--- a/src/components/popups/subtitle-modal.tsx
+++ b/src/components/popups/subtitle-modal.tsx
@@ -1,5 +1,6 @@
 import { SubtitleMenuBody } from "@/components/player/subtitle-menu";
 import type { TrackInfo } from "@/lib/player/bridge";
+import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 
 export type SubtitleModalState = {
   tracks: TrackInfo[];
@@ -16,7 +17,7 @@ type Props = {
   state: SubtitleModalState;
   onSelect: (id: string | null) => void;
   onDelay: (sec: number) => void;
-  onAddSubtitle: (url: string, lang?: string, title?: string) => void;
+  onAddSubtitle: SubtitleAddHandler;
   onClose: () => void;
 };
 

--- a/src/lib/player-shells/types.ts
+++ b/src/lib/player-shells/types.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import type { PlayerCapabilities, PlayerSnapshot } from "@/lib/player/bridge";
+import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 
 export type PlayerShellProps = {
   snap: PlayerSnapshot;
@@ -22,7 +23,7 @@ export type PlayerShellProps = {
   onSubDelay: (sec: number) => void;
   onAudioDelay: (sec: number) => void;
   onEnterSync?: () => void;
-  onAddSubtitle: (url: string, lang?: string, title?: string) => void;
+  onAddSubtitle: SubtitleAddHandler;
   onRate: (r: number) => void;
   cropMode?: string;
   onCropMode?: (id: string) => void;

--- a/src/lib/player/bridge.ts
+++ b/src/lib/player/bridge.ts
@@ -1,4 +1,5 @@
 import type { SubCue } from "@/lib/subtitles/parser";
+import type { SubtitleLoadMetadata } from "./subtitle-load";
 
 export type TrackInfo = {
   id: string;
@@ -24,6 +25,18 @@ export type Chapter = {
 };
 
 export type PlayerStatus = "idle" | "loading" | "ready" | "playing" | "paused" | "ended" | "error";
+
+export function loadingSurfaceFor(input: {
+  forceShow: boolean;
+  everPlayed: boolean;
+  buffering: boolean;
+  status: PlayerStatus;
+  errorCode: PlayerSnapshot["errorCode"];
+}): "startup" | "buffering" | null {
+  if (input.errorCode != null || input.status === "ended") return null;
+  if (input.forceShow || !input.everPlayed) return "startup";
+  return input.buffering ? "buffering" : null;
+}
 
 export type PlayerSnapshot = {
   status: PlayerStatus;
@@ -81,7 +94,13 @@ export type PlayerBridge = {
   setStretch: (on: boolean) => void;
   setVideoEq: (name: string, value: number) => void;
   setAnime4kShaders: (shaders: string[]) => void;
-  addSubtitle: (url: string, lang?: string, title?: string, select?: boolean) => Promise<boolean>;
+  addSubtitle: (
+    url: string,
+    lang?: string,
+    title?: string,
+    select?: boolean,
+    metadata?: SubtitleLoadMetadata,
+  ) => Promise<boolean>;
   getSelectedTrackCues: () => SubCue[] | null;
   getSelectedTrackUrl: () => string | null;
   setAudioNormalize: (on: boolean) => void;

--- a/src/lib/player/html5/bridge.ts
+++ b/src/lib/player/html5/bridge.ts
@@ -71,6 +71,8 @@ export function createHtml5Bridge(): PlayerBridge {
     snap.positionSec = Number.isFinite(video.currentTime) ? video.currentTime : 0;
     snap.durationSec = Number.isFinite(video.duration) ? video.duration : 0;
     snap.bufferedSec = bufferedAhead(video);
+    snap.buffering =
+      !video.paused && !video.ended && video.readyState < HTMLMediaElement.HAVE_FUTURE_DATA;
     snap.volume = pendingVolume;
     snap.muted = video.muted;
     snap.rate = video.playbackRate;
@@ -181,7 +183,7 @@ export function createHtml5Bridge(): PlayerBridge {
     if (track.cues || track.loading) return;
     track.loading = true;
     try {
-      track.cues = await fetchAndParse(track.url);
+      track.cues = await fetchAndParse(track.url, { ...track.metadata, lang: track.lang });
     } catch (e) {
       console.warn(`[subtitles] failed to load ${track.url}`, e);
       track.cues = [];
@@ -259,7 +261,9 @@ export function createHtml5Bridge(): PlayerBridge {
       ms.setActionHandler("seekforward", (details) => {
         if (!video) return;
         const offset = details && details.seekOffset != null ? details.seekOffset : 30;
-        const max = Number.isFinite(video.duration) ? video.duration - 0.25 : video.currentTime + offset;
+        const max = Number.isFinite(video.duration)
+          ? video.duration - 0.25
+          : video.currentTime + offset;
         video.currentTime = Math.min(max, video.currentTime + offset);
       });
       ms.setActionHandler("seekto", (details) => {
@@ -276,7 +280,11 @@ export function createHtml5Bridge(): PlayerBridge {
     if (!mediaSessionBound || !video) return;
     if (!("mediaSession" in navigator)) return;
     const ms = navigator.mediaSession as MediaSession & {
-      setPositionState?: (state: { duration: number; position: number; playbackRate: number }) => void;
+      setPositionState?: (state: {
+        duration: number;
+        position: number;
+        playbackRate: number;
+      }) => void;
     };
     if (!ms.setPositionState) return;
     if (!Number.isFinite(video.duration) || video.duration <= 0) return;
@@ -328,7 +336,9 @@ export function createHtml5Bridge(): PlayerBridge {
       unbind();
       stopCueTicker();
       if (hls) {
-        try { hls.destroy(); } catch {}
+        try {
+          hls.destroy();
+        } catch {}
         hls = null;
       }
       teardownTs();
@@ -349,7 +359,9 @@ export function createHtml5Bridge(): PlayerBridge {
       isLiveSrc = src.notWebReady === true;
       pendingStart = src.startAtSec ?? null;
       if (hls) {
-        try { hls.destroy(); } catch {}
+        try {
+          hls.destroy();
+        } catch {}
         hls = null;
       }
       teardownTs();
@@ -366,12 +378,20 @@ export function createHtml5Bridge(): PlayerBridge {
 
       const bare = src.url.toLowerCase().split("?")[0];
       const lowerUrl = src.url.toLowerCase();
-      const isHls = /\.m3u8$/.test(bare) || lowerUrl.includes("m3u8") || lowerUrl.includes("/playlist/");
-      const isTs = bare.endsWith(".ts") || (src.notWebReady === true && !isHls && !/\.(mp4|webm|mov|mkv|mpd)$/.test(bare));
+      const isHls =
+        /\.m3u8$/.test(bare) || lowerUrl.includes("m3u8") || lowerUrl.includes("/playlist/");
+      const isTs =
+        bare.endsWith(".ts") ||
+        (src.notWebReady === true && !isHls && !/\.(mp4|webm|mov|mkv|mpd)$/.test(bare));
       if (isHls && Hls.isSupported()) {
         hls = new Hls(
           src.notWebReady === true || src.isLive === true
-            ? { enableWorker: true, lowLatencyMode: false, liveDurationInfinity: true, backBufferLength: 30 }
+            ? {
+                enableWorker: true,
+                lowLatencyMode: false,
+                liveDurationInfinity: true,
+                backBufferLength: 30,
+              }
             : { enableWorker: true },
         );
         hls.loadSource(src.url);
@@ -419,6 +439,7 @@ export function createHtml5Bridge(): PlayerBridge {
       snap.positionSec = 0;
       snap.durationSec = 0;
       snap.bufferedSec = 0;
+      snap.buffering = false;
       startCueTicker();
       emit();
     },
@@ -546,7 +567,7 @@ export function createHtml5Bridge(): PlayerBridge {
     },
     setVideoEq() {},
     setAnime4kShaders() {},
-    async addSubtitle(url, lang, title, select): Promise<boolean> {
+    async addSubtitle(url, lang, title, select, metadata): Promise<boolean> {
       let resolvedUrl = url;
       if (
         !/^(https?|blob|data):/i.test(url) &&
@@ -559,7 +580,16 @@ export function createHtml5Bridge(): PlayerBridge {
         } catch {}
       }
       const id = `ext-${subTracks.length}-${Date.now()}`;
-      const track: SubTrack = { id, url: resolvedUrl, lang, title, external: true, cues: null, loading: false };
+      const track: SubTrack = {
+        id,
+        url: resolvedUrl,
+        lang,
+        title,
+        external: true,
+        cues: null,
+        loading: false,
+        metadata,
+      };
       subTracks.push(track);
       if (select === true) {
         activeSubId = id;
@@ -597,7 +627,9 @@ export function createHtml5Bridge(): PlayerBridge {
         const ctx = canvas.getContext("2d");
         if (!ctx) return { ok: false, error: "no 2d context" };
         ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-        const blob: Blob | null = await new Promise((res) => canvas.toBlob((b) => res(b), "image/png"));
+        const blob: Blob | null = await new Promise((res) =>
+          canvas.toBlob((b) => res(b), "image/png"),
+        );
         if (!blob) return { ok: false, error: "encode failed" };
         if (typeof window !== "undefined" && "__TAURI_INTERNALS__" in window) {
           const fs = await import("@tauri-apps/plugin-fs");
@@ -626,7 +658,13 @@ export function createHtml5Bridge(): PlayerBridge {
       if (!video || !host) return;
       if (pipWindow) return;
       bindMediaSession();
-      const dpip = (window as Window & { documentPictureInPicture?: { requestWindow: (o: { width: number; height: number }) => Promise<Window> } }).documentPictureInPicture;
+      const dpip = (
+        window as Window & {
+          documentPictureInPicture?: {
+            requestWindow: (o: { width: number; height: number }) => Promise<Window>;
+          };
+        }
+      ).documentPictureInPicture;
       const tryDocumentPip = async (): Promise<boolean> => {
         if (DOCUMENT_PIP_KNOWN_BROKEN) return false;
         if (!dpip || typeof dpip.requestWindow !== "function") return false;
@@ -639,7 +677,13 @@ export function createHtml5Bridge(): PlayerBridge {
             ),
           );
           const w = await dpip.requestWindow({ width: aspectW, height: 280 });
-          mountCustomPip(w, video!, host!, () => emit(), () => snap);
+          mountCustomPip(
+            w,
+            video!,
+            host!,
+            () => emit(),
+            () => snap,
+          );
           pipWindow = w;
           pipCleanup = () => {
             if (!host || !video) {
@@ -718,12 +762,15 @@ export function createHtml5Bridge(): PlayerBridge {
       }
     },
     capabilities(): PlayerCapabilities {
-      const nativePiP = "pictureInPictureEnabled" in document ? document.pictureInPictureEnabled : false;
+      const nativePiP =
+        "pictureInPictureEnabled" in document ? document.pictureInPictureEnabled : false;
       const docPiP = "documentPictureInPicture" in window;
       return {
         engine: "html5",
         pictureInPicture: !!nativePiP || docPiP,
-        airplay: typeof (window as { WebKitPlaybackTargetAvailabilityEvent?: unknown }).WebKitPlaybackTargetAvailabilityEvent !== "undefined",
+        airplay:
+          typeof (window as { WebKitPlaybackTargetAvailabilityEvent?: unknown })
+            .WebKitPlaybackTargetAvailabilityEvent !== "undefined",
         chromecast: false,
         hdrPassthrough: false,
         hardwareDecode: true,
@@ -741,7 +788,9 @@ export function createHtml5Bridge(): PlayerBridge {
       subTracks.length = 0;
       activeSubId = null;
       if (hls) {
-        try { hls.destroy(); } catch {}
+        try {
+          hls.destroy();
+        } catch {}
         hls = null;
       }
       teardownTs();

--- a/src/lib/player/html5/types.ts
+++ b/src/lib/player/html5/types.ts
@@ -1,4 +1,5 @@
 import type { SubCue } from "@/lib/subtitles/parser";
+import type { SubtitleLoadMetadata } from "../subtitle-load";
 
 export type SubTrack = {
   id: string;
@@ -8,6 +9,7 @@ export type SubTrack = {
   external: boolean;
   cues: SubCue[] | null;
   loading: boolean;
+  metadata?: SubtitleLoadMetadata;
 };
 
 export type AudioTrackList = {

--- a/src/lib/player/mpv-forward.ts
+++ b/src/lib/player/mpv-forward.ts
@@ -1,6 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
-import { emptySnapshot, type PlayerBridge, type PlayerCapabilities, type PlayerSnapshot } from "./bridge";
+import {
+  emptySnapshot,
+  type PlayerBridge,
+  type PlayerCapabilities,
+  type PlayerSnapshot,
+} from "./bridge";
 import { isWindowsDesktop } from "@/lib/platform";
+import { subtitleDownloadArgs } from "./subtitle-load";
 
 export type ForwardingBridge = PlayerBridge & {
   pushSnapshot: (snap: PlayerSnapshot) => void;
@@ -77,9 +83,17 @@ export function createForwardingMpvBridge(): ForwardingBridge {
       const sep = isWindowsDesktop() ? ";" : ":";
       void set("glsl-shaders", shaders.filter(Boolean).join(sep));
     },
-    async addSubtitle(url, lang, title, select) {
+    async addSubtitle(url, lang, title, select, metadata) {
       try {
-        await invoke("mpv_sub_add", { url, lang: lang ?? null, title: title ?? null, select: select ?? true });
+        const resolvedUrl = /^https?:/i.test(url)
+          ? await invoke<string>("sub_download", subtitleDownloadArgs(url, { ...metadata, lang }))
+          : url;
+        await invoke("mpv_sub_add", {
+          url: resolvedUrl,
+          lang: lang ?? null,
+          title: title ?? null,
+          select: select ?? true,
+        });
         return true;
       } catch {
         return false;
@@ -90,8 +104,12 @@ export function createForwardingMpvBridge(): ForwardingBridge {
     setAudioDevice(name) {
       void set("audio-device", name && name !== "auto" ? name : "auto");
     },
-    getSelectedTrackCues() { return null; },
-    getSelectedTrackUrl() { return null; },
+    getSelectedTrackCues() {
+      return null;
+    },
+    getSelectedTrackUrl() {
+      return null;
+    },
     setMediaInfo() {},
     async screenshot(path) {
       try {

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { subtitleDownloadArgs } from "./subtitle-load";
 import { isMacDesktop, isWindowsDesktop } from "@/lib/platform";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
@@ -225,6 +226,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       if (name === "dheight" && typeof data === "number") snap.videoHeight = data;
       if (name === "video-params/gamma" && typeof data === "string" && data) snap.hdrGamma = data;
       if (name === "demuxer-cache-duration" && typeof data === "number") snap.bufferedSec = data;
+      if (name === "paused-for-cache" && typeof data === "boolean") snap.buffering = data;
       if (name === "af") {
         const repr = typeof data === "string" ? data : JSON.stringify(data ?? "");
         snap.audioNormalize = repr.includes("dynaudnorm");
@@ -299,6 +301,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       snap.positionSec = 0;
       snap.durationSec = 0;
       snap.bufferedSec = 0;
+      snap.buffering = false;
       snap.hdrGamma = "";
       pendingTracks = {};
       urlByExternalFilename.clear();
@@ -331,7 +334,10 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
                 let url = s.url;
                 if (/^https?:/i.test(url)) {
                   try {
-                    url = await invoke<string>("sub_download", { url: s.url });
+                    url = await invoke<string>(
+                      "sub_download",
+                      subtitleDownloadArgs(s.url, { lang: s.lang }),
+                    );
                   } catch {
                     /* fall back to remote URL */
                   }
@@ -514,11 +520,14 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
         value: shaders.filter(Boolean).join(sep),
       }).catch(() => {});
     },
-    async addSubtitle(url, lang, title, select): Promise<boolean> {
+    async addSubtitle(url, lang, title, select, metadata): Promise<boolean> {
       let mpvUrl = url;
       if (/^https?:/i.test(url)) {
         try {
-          mpvUrl = await invoke<string>("sub_download", { url });
+          mpvUrl = await invoke<string>(
+            "sub_download",
+            subtitleDownloadArgs(url, { ...metadata, lang }),
+          );
         } catch (e) {
           console.warn("[mpv] sub_download failed, falling back to URL", e);
         }

--- a/src/lib/player/sub-format.ts
+++ b/src/lib/player/sub-format.ts
@@ -1,8 +1,12 @@
-import type { TrackInfo } from "./bridge";
+type SubtitleFormatTrack = {
+  codec?: string;
+  title?: string;
+  label?: string;
+};
 
-export function isAssTrack(track: TrackInfo | null | undefined): boolean {
+export function isAssTrack(track: SubtitleFormatTrack | null | undefined): boolean {
   if (!track) return false;
-  const codec = (track.codec ?? "").toUpperCase();
+  const codec = `${track.codec ?? ""} ${track.title ?? ""} ${track.label ?? ""}`.toUpperCase();
   if (
     codec.includes("ASS") ||
     codec.includes("SSA") ||
@@ -11,18 +15,19 @@ export function isAssTrack(track: TrackInfo | null | undefined): boolean {
   ) {
     return true;
   }
-  const title = (track.title ?? "").toLowerCase();
-  return /\.(ass|ssa)$/.test(title);
+  return /\.(ass|ssa)\b/i.test(`${track.title ?? ""} ${track.label ?? ""}`);
 }
 
-export function isImageSubTrack(track: TrackInfo | null | undefined): boolean {
+export function isImageSubTrack(track: SubtitleFormatTrack | null | undefined): boolean {
   if (!track) return false;
-  const codec = (track.codec ?? "").toUpperCase();
+  const codec = `${track.codec ?? ""} ${track.title ?? ""} ${track.label ?? ""}`
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "");
   return (
     codec.includes("PGS") ||
     codec.includes("HDMV") ||
-    codec.includes("DVD_SUB") ||
-    codec.includes("DVD SUBTITLES") ||
+    codec.includes("DVDSUB") ||
+    codec.includes("DVDSUBTITLE") ||
     codec.includes("DVB") ||
     codec.includes("VOBSUB") ||
     codec.includes("XSUB")

--- a/src/lib/player/subtitle-load.ts
+++ b/src/lib/player/subtitle-load.ts
@@ -1,0 +1,23 @@
+export type SubtitleLoadMetadata = {
+  format?: "srt" | "vtt" | "ass" | "ssa" | "sub";
+  encoding?: string;
+};
+
+export type SubtitleAddHandler = (
+  url: string,
+  lang?: string,
+  title?: string,
+  metadata?: SubtitleLoadMetadata,
+) => void | Promise<boolean | void>;
+
+export function subtitleDownloadArgs(
+  url: string,
+  metadata: SubtitleLoadMetadata & { lang?: string } = {},
+) {
+  return {
+    url,
+    lang: metadata.lang ?? null,
+    format: metadata.format ?? null,
+    encoding: metadata.encoding ?? null,
+  };
+}

--- a/src/lib/subtitles/addon-source.ts
+++ b/src/lib/subtitles/addon-source.ts
@@ -1,60 +1,75 @@
 import { userAddons, type Addon } from "@/lib/addons";
 import { fetchManifestAt, loadInstalled } from "@/lib/addon-store";
 import { dlog } from "@/lib/debug";
+import { SUBTITLE_PROVIDER_TIMEOUT_MS, withSubtitleTimeout } from "./autoload";
 
 function hasSubtitleResource(a: Addon): boolean {
   const resources = a.manifest?.resources ?? [];
   const hasSubtitles = resources.some((r) =>
     typeof r === "string" ? r === "subtitles" : r.name === "subtitles",
   );
-  
+
   if (!hasSubtitles) {
-    dlog(`[addon-source] ${a.manifest.name} does NOT have subtitle resource. Resources: ${JSON.stringify(resources.map(r => typeof r === 'string' ? r : r.name))}`);
+    dlog(
+      `[addon-source] ${a.manifest.name} does NOT have subtitle resource. Resources: ${JSON.stringify(resources.map((r) => (typeof r === "string" ? r : r.name)))}`,
+    );
   }
-  
+
   return hasSubtitles;
 }
 
 export async function gatherSubtitleAddons(authKey: string | null): Promise<Addon[]> {
   dlog(`[addon-source] === GATHERING SUBTITLE ADDONS ===`);
   dlog(`[addon-source] Auth key present: ${!!authKey}`);
-  
-  const cloud = authKey ? await userAddons(authKey).catch((e) => {
-    dlog(`[addon-source] Failed to fetch cloud addons: ${e}`);
-    return [] as Addon[];
-  }) : [];
+
+  const cloud = authKey
+    ? await withSubtitleTimeout(userAddons(authKey), SUBTITLE_PROVIDER_TIMEOUT_MS, []).catch(
+        (e) => {
+          dlog(`[addon-source] Failed to fetch cloud addons: ${e}`);
+          return [] as Addon[];
+        },
+      )
+    : [];
   dlog(`[addon-source] Cloud addons: ${cloud.length}`);
   if (cloud.length > 0) {
-    dlog(`[addon-source] Cloud addon names: ${cloud.map(a => a.manifest.name).join(', ')}`);
+    dlog(`[addon-source] Cloud addon names: ${cloud.map((a) => a.manifest.name).join(", ")}`);
   }
-  
+
   const localInstalled = loadInstalled();
   dlog(`[addon-source] Total local installed addons: ${localInstalled.length}`);
   if (localInstalled.length > 0) {
-    dlog(`[addon-source] Local installed names: ${localInstalled.map(l => l.manifest?.name || 'no-name').join(', ')}`);
+    dlog(
+      `[addon-source] Local installed names: ${localInstalled.map((l) => l.manifest?.name || "no-name").join(", ")}`,
+    );
   }
-  
+
   const seen = new Set(cloud.map((a) => a.transportUrl));
   const localOnly = localInstalled.filter((l) => !seen.has(l.transportUrl));
   dlog(`[addon-source] Local addons (not in cloud): ${localOnly.length}`);
-  
-  const localFull = await Promise.all(
-    localOnly.map(async (l): Promise<Addon | null> => {
-      if (l.manifest) return { manifest: l.manifest, transportUrl: l.transportUrl };
-      const manifest = await fetchManifestAt(l.transportUrl).catch(() => null);
-      return manifest ? { manifest, transportUrl: l.transportUrl } : null;
-    }),
+
+  const localFull = await withSubtitleTimeout(
+    Promise.all(
+      localOnly.map(async (l): Promise<Addon | null> => {
+        if (l.manifest) return { manifest: l.manifest, transportUrl: l.transportUrl };
+        const manifest = await fetchManifestAt(l.transportUrl).catch(() => null);
+        return manifest ? { manifest, transportUrl: l.transportUrl } : null;
+      }),
+    ),
+    SUBTITLE_PROVIDER_TIMEOUT_MS,
+    [] as Array<Addon | null>,
   );
-  
+
   const merged = [...cloud, ...localFull.filter((a): a is Addon => a != null)];
   dlog(`[addon-source] Total merged addons (before subtitle filter): ${merged.length}`);
-  
+
   // Check each addon for subtitle resource
   const withSubtitles = merged.filter(hasSubtitleResource);
   dlog(`[addon-source] === RESULT: ${withSubtitles.length} addons with subtitle resource ===`);
   if (withSubtitles.length > 0) {
-    dlog(`[addon-source] Subtitle addon names: ${withSubtitles.map(a => a.manifest.name).join(', ')}`);
+    dlog(
+      `[addon-source] Subtitle addon names: ${withSubtitles.map((a) => a.manifest.name).join(", ")}`,
+    );
   }
-  
+
   return withSubtitles;
 }

--- a/src/lib/subtitles/autoload.ts
+++ b/src/lib/subtitles/autoload.ts
@@ -1,0 +1,43 @@
+export const SUBTITLE_PROVIDER_TIMEOUT_MS = 6_000;
+
+export function subtitleSearchImdbId(
+  imdbId: string | null | undefined,
+  verified: boolean,
+): string | undefined {
+  return verified && imdbId ? imdbId : undefined;
+}
+
+export function canStartSubtitleAutoload(input: {
+  imdbId: string | null | undefined;
+  mediaReady: boolean;
+  addons: unknown[] | null;
+}): boolean {
+  return !!input.imdbId && input.mediaReady && input.addons !== null;
+}
+
+export function withSubtitleTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return new Promise<T>((resolve) => {
+    const timer = setTimeout(() => resolve(fallback), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(fallback);
+      },
+    );
+  });
+}
+
+export async function loadFirstWorkingSubtitle<T>(
+  candidates: T[],
+  load: (candidate: T) => Promise<boolean>,
+  limit = 5,
+): Promise<T | null> {
+  for (const candidate of candidates.slice(0, Math.max(0, limit))) {
+    if (await load(candidate)) return candidate;
+  }
+  return null;
+}

--- a/src/lib/subtitles/encoding.ts
+++ b/src/lib/subtitles/encoding.ts
@@ -1,0 +1,29 @@
+export type SubtitleEncodingOptions = {
+  encoding?: string;
+  lang?: string;
+};
+
+export function decodeSubtitleBytes(
+  bytes: Uint8Array,
+  options: SubtitleEncodingOptions = {},
+): string {
+  if (bytes[0] === 0xff && bytes[1] === 0xfe)
+    return new TextDecoder("utf-16le").decode(bytes.slice(2));
+  if (bytes[0] === 0xfe && bytes[1] === 0xff)
+    return new TextDecoder("utf-16be").decode(bytes.slice(2));
+  if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf)
+    return new TextDecoder("utf-8").decode(bytes.slice(3));
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    const lang = (options.lang ?? "").trim().toLowerCase();
+    const fallback =
+      lang === "ar" || lang === "ara" || lang === "arabic" ? "windows-1256" : "windows-1252";
+    const encoding = options.encoding?.trim() || fallback;
+    try {
+      return new TextDecoder(encoding).decode(bytes);
+    } catch {
+      return new TextDecoder(fallback).decode(bytes);
+    }
+  }
+}

--- a/src/lib/subtitles/parser.ts
+++ b/src/lib/subtitles/parser.ts
@@ -1,4 +1,5 @@
 import { safeFetch as fetch } from "@/lib/safe-fetch";
+import { decodeSubtitleBytes } from "./encoding";
 
 export type SubCue = {
   start: number;
@@ -8,12 +9,21 @@ export type SubCue = {
 
 export type SubFormat = "srt" | "vtt" | "ass" | "ssa" | "sub";
 
-export async function fetchAndParse(url: string): Promise<SubCue[]> {
+export type SubtitleDecodeOptions = {
+  encoding?: string;
+  lang?: string;
+  format?: SubFormat;
+};
+
+export async function fetchAndParse(
+  url: string,
+  options: SubtitleDecodeOptions = {},
+): Promise<SubCue[]> {
   const res = await fetch(url, { method: "GET" });
   if (!res.ok) throw new Error(`subtitle fetch ${res.status}`);
   const buf = await res.arrayBuffer();
-  const text = decodeText(new Uint8Array(buf));
-  return parseSubtitle(text);
+  const text = decodeSubtitleBytes(new Uint8Array(buf), options);
+  return parseSubtitle(text, options.format);
 }
 
 export function parseSubtitle(raw: string, format?: SubFormat): SubCue[] {
@@ -164,19 +174,9 @@ function cleanInline(s: string): string {
 
 function toSec(h: string, m: string, s: string, ms: string): number {
   const padded = (ms + "000").slice(0, 3);
-  return parseInt(h, 10) * 3600 + parseInt(m, 10) * 60 + parseInt(s, 10) + parseInt(padded, 10) / 1000;
-}
-
-function decodeText(bytes: Uint8Array): string {
-  if (bytes[0] === 0xff && bytes[1] === 0xfe) return new TextDecoder("utf-16le").decode(bytes.slice(2));
-  if (bytes[0] === 0xfe && bytes[1] === 0xff) return new TextDecoder("utf-16be").decode(bytes.slice(2));
-  if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) return new TextDecoder("utf-8").decode(bytes.slice(3));
-  try {
-    const out = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    return out;
-  } catch {
-    return new TextDecoder("windows-1252").decode(bytes);
-  }
+  return (
+    parseInt(h, 10) * 3600 + parseInt(m, 10) * 60 + parseInt(s, 10) + parseInt(padded, 10) / 1000
+  );
 }
 
 export function findActiveCue(cues: SubCue[], timeSec: number): SubCue | null {

--- a/src/lib/subtitles/search.ts
+++ b/src/lib/subtitles/search.ts
@@ -5,6 +5,7 @@ import { searchWyzie } from "./providers/wyzie";
 import { searchAddons } from "./providers/addons";
 import { searchOpenSubtitlesV3 } from "./providers/opensubtitles-v3";
 import { langScore, normalizeLang } from "./language";
+import { SUBTITLE_PROVIDER_TIMEOUT_MS, withSubtitleTimeout } from "./autoload";
 
 export type SearchOptions = {
   providers?: { wyzie?: boolean; addons?: boolean; opensubtitles?: boolean };
@@ -28,12 +29,27 @@ export async function searchSubtitles(
   const wyzieOn = want.wyzie === true;
   const addonsOn = want.addons ?? true;
   const osOn = want.opensubtitles ?? true;
-  dinfo("[subs] search", { q, providers: { osOn, addonsOn, wyzieOn }, addons: opts.addons?.length ?? 0 });
+  dinfo("[subs] search", {
+    q,
+    providers: { osOn, addonsOn, wyzieOn },
+    addons: opts.addons?.length ?? 0,
+  });
   const tasks: Array<{ name: string; p: Promise<SubResult[]> }> = [];
-  if (osOn) tasks.push({ name: "opensubtitles-v3", p: searchOpenSubtitlesV3(q) });
-  if (wyzieOn) tasks.push({ name: "wyzie", p: searchWyzie(q) });
+  if (osOn)
+    tasks.push({
+      name: "opensubtitles-v3",
+      p: withSubtitleTimeout(searchOpenSubtitlesV3(q), SUBTITLE_PROVIDER_TIMEOUT_MS, []),
+    });
+  if (wyzieOn)
+    tasks.push({
+      name: "wyzie",
+      p: withSubtitleTimeout(searchWyzie(q), SUBTITLE_PROVIDER_TIMEOUT_MS, []),
+    });
   if (addonsOn && opts.addons && opts.addons.length > 0)
-    tasks.push({ name: "addons", p: searchAddons(opts.addons, q) });
+    tasks.push({
+      name: "addons",
+      p: withSubtitleTimeout(searchAddons(opts.addons, q), SUBTITLE_PROVIDER_TIMEOUT_MS, []),
+    });
   const settled = await Promise.allSettled(tasks.map((t) => t.p));
   const all: SubResult[] = [];
   settled.forEach((r, i) => {
@@ -49,7 +65,8 @@ export async function searchSubtitles(
   return ranked;
 }
 
-const RELEASE_GROUP_RX = /[-.][A-Z0-9]{2,}$|\b(EVO|RARBG|YTS|YIFY|FGT|PSA|TBS|GalaxyRG|GalaxyTV|MeGusta|ION10|EZTV|NTb|FLUX|TEPES|KOGi|SMURF|RZeroX|d3g|TGx)\b/gi;
+const RELEASE_GROUP_RX =
+  /[-.][A-Z0-9]{2,}$|\b(EVO|RARBG|YTS|YIFY|FGT|PSA|TBS|GalaxyRG|GalaxyTV|MeGusta|ION10|EZTV|NTb|FLUX|TEPES|KOGi|SMURF|RZeroX|d3g|TGx)\b/gi;
 
 function extractReleaseGroup(text: string | null | undefined): string | null {
   if (!text) return null;
@@ -62,8 +79,10 @@ function extractReleaseGroup(text: string | null | undefined): string | null {
 function sourceTokens(source: string | null | undefined): string[] {
   if (!source) return [];
   const s = source.toLowerCase();
-  if (s.includes("bluray") || s === "remux" || s.includes("bdrip")) return ["bluray", "bdrip", "remux"];
-  if (s.includes("web-dl") || s === "webdl" || s.includes("webrip")) return ["web-dl", "webdl", "webrip", "web"];
+  if (s.includes("bluray") || s === "remux" || s.includes("bdrip"))
+    return ["bluray", "bdrip", "remux"];
+  if (s.includes("web-dl") || s === "webdl" || s.includes("webrip"))
+    return ["web-dl", "webdl", "webrip", "web"];
   if (s.includes("hdtv")) return ["hdtv"];
   if (s.includes("dvd")) return ["dvd", "dvdrip"];
   return [s];
@@ -105,11 +124,7 @@ function sourcePriority(source: SubResult["source"]): number {
   }
 }
 
-function dedupAndRank(
-  results: SubResult[],
-  preferred: string[],
-  hints?: StreamHints,
-): SubResult[] {
+function dedupAndRank(results: SubResult[], preferred: string[], hints?: StreamHints): SubResult[] {
   const seen = new Set<string>();
   const filtered: SubResult[] = [];
   for (const r of results) {

--- a/src/lib/subtitles/track-label.ts
+++ b/src/lib/subtitles/track-label.ts
@@ -1,0 +1,28 @@
+import { languageName } from "./language.ts";
+
+type SubtitleTrackLabelInput = {
+  id?: string;
+  lang?: string;
+  title?: string;
+  codec?: string;
+  external?: boolean;
+};
+
+function hasUnknownLanguage(lang: string | undefined): boolean {
+  const value = (lang ?? "").trim().toLowerCase();
+  return value === "" || value === "und" || value === "unknown" || value === "undetermined";
+}
+
+export function subtitleTrackLanguageLabel(track: SubtitleTrackLabelInput): string {
+  if (hasUnknownLanguage(track.lang)) return track.external ? "Unknown" : "Embedded";
+  return languageName(track.lang!);
+}
+
+export function subtitleTrackTitle(track: SubtitleTrackLabelInput): string {
+  const title = track.title?.trim();
+  if (title && title !== track.lang) return title;
+  if (track.external) return "External subtitle";
+  const id = track.id?.trim();
+  const codec = track.codec?.trim().toUpperCase();
+  return [id ? `Embedded ${id}` : "Embedded track", codec].filter(Boolean).join(" · ");
+}

--- a/src/lib/subtitles/track-selection.ts
+++ b/src/lib/subtitles/track-selection.ts
@@ -1,0 +1,40 @@
+import { langScore } from "./language.ts";
+
+type SelectableSubtitleTrack = {
+  id: string;
+  lang?: string;
+  default?: boolean;
+  external?: boolean;
+  title?: string;
+  label?: string;
+};
+
+function isForcedTrack(track: SelectableSubtitleTrack): boolean {
+  return /\bforced\b/i.test(`${track.title ?? ""} ${track.label ?? ""}`);
+}
+
+function sourceRank(track: SelectableSubtitleTrack, preferEmbedded: boolean): number {
+  if (!track.external) return preferEmbedded ? 3 : 0;
+  const text = `${track.title ?? ""} ${track.label ?? ""}`.toLowerCase();
+  return text.includes("opensubtitles") ? 1 : 2;
+}
+
+export function pickDesiredSubtitleTrack<T extends SelectableSubtitleTrack>(
+  tracks: T[],
+  preferredLanguages: string[],
+  preferEmbedded: boolean,
+): T | null {
+  const matching = tracks.filter(
+    (track) => !isForcedTrack(track) && langScore(track.lang ?? "", preferredLanguages) >= 0,
+  );
+  if (matching.length === 0) return null;
+  matching.sort((a, b) => {
+    const languageDelta =
+      langScore(b.lang ?? "", preferredLanguages) - langScore(a.lang ?? "", preferredLanguages);
+    if (languageDelta !== 0) return languageDelta;
+    const sourceDelta = sourceRank(b, preferEmbedded) - sourceRank(a, preferEmbedded);
+    if (sourceDelta !== 0) return sourceDelta;
+    return Number(b.default === true) - Number(a.default === true);
+  });
+  return matching[0];
+}

--- a/src/views/modal-overlay-app.tsx
+++ b/src/views/modal-overlay-app.tsx
@@ -70,8 +70,8 @@ function ModalRouter() {
         state={payload.state as SubtitleModalState}
         onSelect={(id) => modalOverlayEmitAction("modal://subtitle/select", { id })}
         onDelay={(sec) => modalOverlayEmitAction("modal://subtitle/delay", { sec })}
-        onAddSubtitle={(url, lang, title) =>
-          modalOverlayEmitAction("modal://subtitle/add", { url, lang, title })
+        onAddSubtitle={(url, lang, title, metadata) =>
+          modalOverlayEmitAction("modal://subtitle/add", { url, lang, title, ...metadata })
         }
         onClose={close}
       />

--- a/src/views/player/hooks/use-player-media.ts
+++ b/src/views/player/hooks/use-player-media.ts
@@ -13,7 +13,11 @@ import { useSettings } from "@/lib/settings";
 import { isLocalEngineUrl } from "@/lib/stremio-server";
 import { useSimklScrobble } from "@/lib/simkl/scrobble-hook";
 import { useTraktScrobble } from "@/lib/trakt/scrobble-hook";
-import { cancelTorrentRemoval, scheduleTorrentRemoval, torrentEngineRemove } from "@/lib/torrent/local-engine";
+import {
+  cancelTorrentRemoval,
+  scheduleTorrentRemoval,
+  torrentEngineRemove,
+} from "@/lib/torrent/local-engine";
 import type { PlayerSrc } from "@/lib/view";
 import { useExitSnapshot } from "./use-exit-snapshot";
 import { usePowerInhibit } from "./use-power-inhibit";
@@ -67,7 +71,7 @@ export function usePlayerMedia(params: {
 
   const prevEngineHashRef = useRef<string | null>(null);
   useEffect(() => {
-    const hash = isLocalEngineUrl(src.url) ? src.streamRef?.infoHash ?? null : null;
+    const hash = isLocalEngineUrl(src.url) ? (src.streamRef?.infoHash ?? null) : null;
     const prev = prevEngineHashRef.current;
     const purge = () =>
       settings.streamCacheRetentionHours === 0 ||
@@ -116,15 +120,15 @@ export function usePlayerMedia(params: {
     isWindowsDesktop() &&
     !settings.playerHdrToSdr &&
     HDR_NATIVE_GAMMAS.has(snap.hdrGamma) &&
-    (settings.playerHdrOpaqueWindow || (settings.playerMpvEmbed && settings.playerHdrStage !== "off"));
+    (settings.playerHdrOpaqueWindow ||
+      (settings.playerMpvEmbed && settings.playerHdrStage !== "off"));
   const selectedSubTrack = snap.subtitleTracks.find((t) => t.selected) ?? null;
   const subAssOverridden = settings.subAssOverride !== "no" && settings.subAssOverride !== "scale";
   const selectedAssSub = isAssTrack(selectedSubTrack);
   const selectedImageSub = isImageSubTrack(selectedSubTrack);
   const subAssNative =
     subEmbed && selectedAssSub && (!subAssOverridden || !selectedSubTrack?.external);
-  const subNativeRender =
-    hdrNativeSurface || subAssNative || (subEmbed && selectedImageSub);
+  const subNativeRender = hdrNativeSurface || subAssNative || (subEmbed && selectedImageSub);
   const assNativeActive = selectedAssSub && (subNativeRender || !subEmbed);
   const imageNativeActive = selectedImageSub && (subNativeRender || !subEmbed);
   const mpvMediaReadyForStyle =
@@ -134,7 +138,7 @@ export function usePlayerMedia(params: {
       snap.videoWidth > 0 ||
       snap.audioTracks.length > 0 ||
       snap.subtitleTracks.length > 0);
-  const suppressHtmlSubs = subAssNative || hdrNativeSurface;
+  const suppressHtmlSubs = subAssNative || (subEmbed && selectedImageSub) || hdrNativeSurface;
   useSubStyleApply({
     engine,
     settings,
@@ -173,7 +177,7 @@ export function usePlayerMedia(params: {
     if (!b) return;
     const base = src.episode
       ? `${src.meta.name ?? "Subtitle"} S${src.episode.season}E${src.episode.episode}`
-      : src.meta.name ?? "Subtitle";
+      : (src.meta.name ?? "Subtitle");
     const fileName = `${base.replace(/[\\/:*?"<>|]+/g, " ").trim() || "Subtitle"}.srt`;
     const res = await getCuesAnySource(b, src.url, src.headers);
     if (res.ok && res.source.cues.length > 0) {
@@ -194,7 +198,15 @@ export function usePlayerMedia(params: {
   }, [download.start, toggleFullscreen, src.url, doDownloadSubtitle, canDownloadSub]);
 
   useResumeAutosave({ src, snap, season, episode });
-  useStremioSync({ src, snap, authKey, resolvedImdbId, resolvedImdbVerified, resolutionSettled, castActiveRef });
+  useStremioSync({
+    src,
+    snap,
+    authKey,
+    resolvedImdbId,
+    resolvedImdbVerified,
+    resolutionSettled,
+    castActiveRef,
+  });
   usePowerInhibit(snap);
   const subDropToast = useSubDrop(bridgeRef, src.meta.id);
 
@@ -210,5 +222,11 @@ export function usePlayerMedia(params: {
     });
   }, [engine, src.url, src.meta.name, src.meta.poster, src.episode, snap.durationSec]);
 
-  return { resolvedImdbId, subAssNative: suppressHtmlSubs, captureExitSnapshot, download, subDropToast };
+  return {
+    resolvedImdbId,
+    subAssNative: suppressHtmlSubs,
+    captureExitSnapshot,
+    download,
+    subDropToast,
+  };
 }

--- a/src/views/player/hooks/use-track-autoload.ts
+++ b/src/views/player/hooks/use-track-autoload.ts
@@ -9,6 +9,12 @@ import type { Addon } from "@/lib/addons";
 import { gatherSubtitleAddons } from "@/lib/subtitles/addon-source";
 import type { PlayerSrc } from "@/lib/view";
 import type { Settings } from "@/lib/settings";
+import {
+  canStartSubtitleAutoload,
+  loadFirstWorkingSubtitle,
+  subtitleSearchImdbId,
+} from "@/lib/subtitles/autoload";
+import { pickDesiredSubtitleTrack } from "@/lib/subtitles/track-selection";
 
 export function useTrackAutoload(params: {
   bridgeRef: RefObject<PlayerBridge | null>;
@@ -62,15 +68,19 @@ export function useTrackAutoload(params: {
     };
   }, [src.imdbId, src.imdbIdVerified, src.meta.id, settings.tmdbKey]);
 
-  const userAddonsRef = useRef<Addon[] | null>(null);
+  const [userAddonsState, setUserAddonsState] = useState<{
+    authKey: string | null;
+    addons: Addon[] | null;
+  }>({ authKey, addons: null });
+  const userAddons = userAddonsState.authKey === authKey ? userAddonsState.addons : null;
   useEffect(() => {
     let cancelled = false;
     gatherSubtitleAddons(authKey)
       .then((a) => {
-        if (!cancelled) userAddonsRef.current = a;
+        if (!cancelled) setUserAddonsState({ authKey, addons: a });
       })
       .catch(() => {
-        if (!cancelled) userAddonsRef.current = [];
+        if (!cancelled) setUserAddonsState({ authKey, addons: [] });
       });
     return () => {
       cancelled = true;
@@ -79,35 +89,34 @@ export function useTrackAutoload(params: {
 
   const autoSubLoadKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!resolvedImdbId) return;
-    if (snap.audioTracks.length === 0 && snap.durationSec === 0) return;
-    const key = `${resolvedImdbId}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}|${src.url}`;
+    if (!resolutionSettled) return;
+    const mediaReady = snap.audioTracks.length > 0 || snap.durationSec > 0;
+    const enabled = settings.subProvidersEnabled ?? {};
+    const readyAddons = enabled.addons === false ? [] : userAddons;
+    const searchImdbId = subtitleSearchImdbId(resolvedImdbId, resolvedImdbVerified);
+    const contentId = searchImdbId ?? src.meta.id;
+    if (!canStartSubtitleAutoload({ imdbId: contentId, mediaReady, addons: readyAddons })) return;
+    const key = `${contentId}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}|${src.url}`;
     if (autoSubLoadKeyRef.current === key) return;
     const subIsAnime =
       !!src.meta.id?.startsWith("kitsu:") ||
       !!src.meta.id?.startsWith("mal:") ||
       (src.meta.genres ?? []).some((g) => g.toLowerCase() === "anime");
-    const rawLangs = resolveLangPreference(
-      settings.preferredSubLangs,
-      settings.preferredLanguages,
-    );
+    const rawLangs = resolveLangPreference(settings.preferredSubLangs, settings.preferredLanguages);
     const langs = subIsAnime ? rawLangs : rawLangs.filter((l) => !isJapanese(l));
     autoSubLoadKeyRef.current = key;
-    const enabled = settings.subProvidersEnabled ?? {};
     void (async () => {
       console.info("[subs/autoload] starting", {
-        imdbId: resolvedImdbId,
+        imdbId: searchImdbId,
         season: src.episode?.season,
         episode: src.episode?.episode,
         langs,
       });
-      const { videoHash, videoSize } = settings.subtitleAutoSync
-        ? await resolveVideoHash(src)
-        : {};
+      const { videoHash, videoSize } = settings.subtitleAutoSync ? await resolveVideoHash(src) : {};
       if (videoHash) console.info(`[subs/autoload] moviehash ${videoHash} (${videoSize})`);
       const results = await searchSubtitles(
         {
-          imdbId: resolvedImdbId,
+          imdbId: searchImdbId,
           stremioId: src.meta.id,
           type: src.meta.type === "series" ? "series" : "movie",
           season: src.episode?.season,
@@ -123,7 +132,7 @@ export function useTrackAutoload(params: {
             addons: enabled.addons ?? true,
             opensubtitles: enabled.opensubtitles ?? true,
           },
-          addons: userAddonsRef.current ?? [],
+          addons: readyAddons ?? [],
           preferredLangs: langs,
           streamHints: {
             release: src.streamRef?.title ?? src.streamRef?.parsedTitle ?? null,
@@ -134,39 +143,33 @@ export function useTrackAutoload(params: {
       );
       console.info(`[subs/autoload] search returned ${results.length} subs`);
       const b = bridgeRef.current;
-      if (!b) {
+      if (!b || autoSubLoadKeyRef.current !== key) {
         console.warn("[subs/autoload] no bridge ready, skipping");
         return;
       }
       const matches = results.filter((r) => langScore(r.lang ?? "", langs) >= 0);
       console.info(`[subs/autoload] ${matches.length} match preferred langs`);
-      const perLang = new Map<string, number>();
-      const maxForLang = (lang: string) => (langScore(lang, langs) > 0 ? 25 : 6);
-      let attempted = 0;
-      let added = 0;
-      for (const r of matches) {
-        const k = (r.lang ?? "und").toLowerCase();
-        const n = perLang.get(k) ?? 0;
-        if (n >= maxForLang(r.lang ?? "")) continue;
-        perLang.set(k, n + 1);
-        attempted++;
-        const ok = await b.addSubtitle(r.url, r.lang, labelForTrack(r), false);
-        if (ok) added++;
-      }
+      const loaded = await loadFirstWorkingSubtitle(matches, async (r) => {
+        if (autoSubLoadKeyRef.current !== key) return false;
+        return b.addSubtitle(r.url, r.lang, labelForTrack(r), false, {
+          format: r.format,
+          encoding: r.encoding,
+        });
+      });
       console.info(
-        `[subs/autoload] ${added}/${attempted} subs added (selection handled by priority effect)`,
+        `[subs/autoload] ${loaded ? "loaded best available subtitle" : "no subtitle loaded"}`,
       );
     })();
   }, [
-    engine,
     resolvedImdbId,
-    src.episode?.season,
-    src.episode?.episode,
-    src.url,
+    resolvedImdbVerified,
+    resolutionSettled,
+    src,
     snap.audioTracks.length,
     snap.durationSec,
-    snap.subtitleTracks,
+    userAddons,
     settings,
+    bridgeRef,
   ]);
 
   const autoTrackKeyRef = useRef<string | null>(null);
@@ -180,7 +183,8 @@ export function useTrackAutoload(params: {
   useEffect(() => {
     const choice = src.subtitlePreselect;
     if (!choice) return;
-    if (snap.audioTracks.length === 0 && snap.subtitleTracks.length === 0 && snap.durationSec === 0) return;
+    if (snap.audioTracks.length === 0 && snap.subtitleTracks.length === 0 && snap.durationSec === 0)
+      return;
     if (preselectAppliedRef.current === src.url) return;
     preselectAppliedRef.current = src.url;
     if (choice.off) {
@@ -190,7 +194,14 @@ export function useTrackAutoload(params: {
     if (choice.url) {
       void bridgeRef.current?.addSubtitle(choice.url, choice.lang, choice.title, true);
     }
-  }, [src.url, src.subtitlePreselect, snap.audioTracks.length, snap.subtitleTracks, snap.durationSec, bridgeRef]);
+  }, [
+    src.url,
+    src.subtitlePreselect,
+    snap.audioTracks.length,
+    snap.subtitleTracks,
+    snap.durationSec,
+    bridgeRef,
+  ]);
   useEffect(() => {
     if (engine !== "mpv") return;
     bridgeRef.current?.setAudioDevice?.(settings.audioDevice);
@@ -256,11 +267,15 @@ export function useTrackAutoload(params: {
           langScore(effAudio.lang ?? "", subLangs) >= 0;
         const want = nativeAudio
           ? (snap.subtitleTracks
-            .filter(isForcedTrack)
-            .sort(
-              (a, b) => langScore(b.lang ?? "", subLangs) - langScore(a.lang ?? "", subLangs),
-            )[0] ?? null)
-          : pickDesiredSub(allow(snap.subtitleTracks), subLangs, settings.preferEmbeddedSubs);
+              .filter(isForcedTrack)
+              .sort(
+                (a, b) => langScore(b.lang ?? "", subLangs) - langScore(a.lang ?? "", subLangs),
+              )[0] ?? null)
+          : pickDesiredSubtitleTrack(
+              allow(snap.subtitleTracks),
+              subLangs,
+              settings.preferEmbeddedSubs,
+            );
         if (want) {
           if (want.id !== current?.id) bridgeRef.current?.setSubtitleTrack(want.id);
           autoSubIdRef.current = want.id;
@@ -277,7 +292,16 @@ export function useTrackAutoload(params: {
         bridgeRef.current?.setSubDelay(prefs.subDelaySec);
       }
     }
-  }, [engine, src.url, src.meta.id, snap.audioTracks, snap.subtitleTracks, snap.rate, snap.subDelaySec, settings]);
+  }, [
+    engine,
+    src.url,
+    src.meta.id,
+    snap.audioTracks,
+    snap.subtitleTracks,
+    snap.rate,
+    snap.subDelaySec,
+    settings,
+  ]);
 
   useEffect(() => {
     if (!subsOffFor(readPlayerPrefs(src.meta.id), settings)) return;
@@ -308,44 +332,6 @@ function subsOffFor(prefs: PerShowPrefs | null, s: Settings): boolean {
   return false;
 }
 
-function sourceRank(t: { external?: boolean; title?: string; label?: string }, preferEmbedded: boolean): number {
-  if (!t.external) return preferEmbedded ? 3 : 0;
-  const text = `${t.title ?? ""} ${t.label ?? ""}`.toLowerCase();
-  if (text.includes("opensubtitles")) return 1;
-  return 2;
-}
-
-function pickDesiredSub<
-  T extends { id: string; lang?: string; default?: boolean; external?: boolean; title?: string; label?: string },
->(tracks: T[], subLangs: string[], preferEmbedded: boolean): T | null {
-  const matching = tracks.filter((t) => !isForcedTrack(t) && langScore(t.lang ?? "", subLangs) >= 0);
-  if (matching.length > 0) {
-    matching.sort((a, b) => {
-      const la = langScore(a.lang ?? "", subLangs);
-      const lb = langScore(b.lang ?? "", subLangs);
-      if (la !== lb) return lb - la;
-      const ra = sourceRank(a, preferEmbedded);
-      const rb = sourceRank(b, preferEmbedded);
-      if (ra !== rb) return rb - ra;
-      return (b.default ? 1 : 0) - (a.default ? 1 : 0);
-    });
-    return matching[0];
-  }
-  if (preferEmbedded) {
-    const embedded = tracks.filter(
-      (t) => !t.external && !isForcedTrack(t) && !isNonPreferredLang(t.lang, subLangs),
-    );
-    return embedded.find((t) => t.default) ?? embedded[0] ?? null;
-  }
-  return null;
-}
-
-function isNonPreferredLang(lang: string | undefined, subLangs: string[]): boolean {
-  const l = (lang ?? "").trim().toLowerCase();
-  if (l === "" || l === "und" || l === "unknown" || l === "undetermined") return false;
-  return langScore(lang ?? "", subLangs) < 0;
-}
-
 function resolveLangPreference(
   primary: string[] | undefined,
   fallback: string[] | undefined,
@@ -365,10 +351,7 @@ function isLoopback(url: string): boolean {
 }
 
 function raceTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
-  return Promise.race([
-    p,
-    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
-  ]);
+  return Promise.race([p, new Promise<null>((resolve) => setTimeout(() => resolve(null), ms))]);
 }
 
 async function resolveVideoHash(

--- a/src/views/player/shell-layer.tsx
+++ b/src/views/player/shell-layer.tsx
@@ -124,7 +124,16 @@ export function ShellLayer({
       engine={engine}
       useOverlayPopups={false}
       onMenuOpenChange={onMenuOpenChange}
-      capabilities={bridgeRef.current?.capabilities() ?? { engine: "html5", pictureInPicture: false, airplay: false, chromecast: false, hdrPassthrough: false, hardwareDecode: true }}
+      capabilities={
+        bridgeRef.current?.capabilities() ?? {
+          engine: "html5",
+          pictureInPicture: false,
+          airplay: false,
+          chromecast: false,
+          hdrPassthrough: false,
+          hardwareDecode: true,
+        }
+      }
       visible={visible}
       fullscreen={fullscreen}
       drawMode={drawMode}
@@ -162,8 +171,10 @@ export function ShellLayer({
       }}
       onEnterSync={onEnterSync}
       onAudioDelay={(s) => bridgeRef.current?.setAudioDelay(s)}
-      onAddSubtitle={(url, lang, title2) => {
-        const p = bridgeRef.current?.addSubtitle(url, lang, title2) ?? Promise.resolve(false);
+      onAddSubtitle={(url, lang, title2, metadata) => {
+        const p =
+          bridgeRef.current?.addSubtitle(url, lang, title2, true, metadata) ??
+          Promise.resolve(false);
         void p.then((ok) => {
           if (ok) rememberSubChoice({ lang });
         });
@@ -181,9 +192,7 @@ export function ShellLayer({
       onPiP={onPiP}
       onFullscreen={onFullscreen}
       onCast={() => {
-        const btn = (document.querySelector(
-          '[aria-label="Cast"]',
-        ) as HTMLElement | null);
+        const btn = document.querySelector('[aria-label="Cast"]') as HTMLElement | null;
         if (btn) {
           const r = btn.getBoundingClientRect();
           openCastMenu({ right: r.right, bottom: r.top });

--- a/tests/subtitle-autoload.test.ts
+++ b/tests/subtitle-autoload.test.ts
@@ -1,0 +1,58 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  canStartSubtitleAutoload,
+  loadFirstWorkingSubtitle,
+  subtitleSearchImdbId,
+  withSubtitleTimeout,
+} from "../src/lib/subtitles/autoload.ts";
+
+test("autoload waits until subtitle addons have settled", () => {
+  assert.equal(
+    canStartSubtitleAutoload({ imdbId: "tt123", mediaReady: true, addons: null }),
+    false,
+  );
+  assert.equal(canStartSubtitleAutoload({ imdbId: "tt123", mediaReady: true, addons: [] }), true);
+});
+
+test("automatic search never sends an unverified IMDb fallback", () => {
+  assert.equal(subtitleSearchImdbId("tt123", false), undefined);
+  assert.equal(subtitleSearchImdbId("tt456", true), "tt456");
+});
+
+test("a stalled subtitle provider resolves to its fallback at the deadline", async () => {
+  const never = new Promise<string[]>(() => {});
+  const started = Date.now();
+  const result = await withSubtitleTimeout(never, 15, []);
+  assert.deepEqual(result, []);
+  assert.ok(Date.now() - started < 250);
+});
+
+test("autoload stops after the first subtitle that loads", async () => {
+  const attempts: string[] = [];
+  const selected = await loadFirstWorkingSubtitle(
+    ["broken-1", "broken-2", "working", "unused"],
+    async (candidate) => {
+      attempts.push(candidate);
+      return candidate === "working";
+    },
+  );
+  assert.equal(selected, "working");
+  assert.deepEqual(attempts, ["broken-1", "broken-2", "working"]);
+});
+
+test("autoload caps fallback downloads", async () => {
+  const attempts: string[] = [];
+  const selected = await loadFirstWorkingSubtitle(
+    ["one", "two", "three", "four"],
+    async (candidate) => {
+      attempts.push(candidate);
+      return false;
+    },
+    3,
+  );
+  assert.equal(selected, null);
+  assert.deepEqual(attempts, ["one", "two", "three"]);
+});

--- a/tests/subtitle-embedded.test.ts
+++ b/tests/subtitle-embedded.test.ts
@@ -1,0 +1,44 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { isAssTrack, isImageSubTrack } from "../src/lib/player/sub-format.ts";
+import {
+  subtitleTrackLanguageLabel,
+  subtitleTrackTitle,
+} from "../src/lib/subtitles/track-label.ts";
+import { pickDesiredSubtitleTrack } from "../src/lib/subtitles/track-selection.ts";
+
+test("does not automatically select an embedded track with unknown language", () => {
+  const selected = pickDesiredSubtitleTrack(
+    [{ id: "3", external: false, default: true, codec: "PGS" }],
+    ["Arabic"],
+    true,
+  );
+  assert.equal(selected, null);
+});
+
+test("known preferred embedded language still wins", () => {
+  const arabic = { id: "4", external: false, lang: "ara", codec: "ASS" };
+  const selected = pickDesiredSubtitleTrack(
+    [{ id: "3", external: false, default: true, codec: "PGS" }, arabic],
+    ["Arabic"],
+    true,
+  );
+  assert.equal(selected, arabic);
+});
+
+test("unknown embedded tracks get distinct useful labels", () => {
+  const track = { id: "3", external: false, codec: "HDMV_PGS_SUBTITLE" };
+  assert.equal(subtitleTrackLanguageLabel(track), "Embedded");
+  assert.equal(subtitleTrackTitle(track), "Embedded 3 · HDMV_PGS_SUBTITLE");
+});
+
+test("image subtitle detection accepts compact codecs and descriptive titles", () => {
+  assert.equal(isImageSubTrack({ codec: "dvdsub" }), true);
+  assert.equal(isImageSubTrack({ title: "English PGS" }), true);
+});
+
+test("ASS detection accepts descriptive labels", () => {
+  assert.equal(isAssTrack({ label: "Embedded 2 · ASS" }), true);
+});

--- a/tests/subtitle-load.test.ts
+++ b/tests/subtitle-load.test.ts
@@ -1,0 +1,38 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { subtitleDownloadArgs } from "../src/lib/player/subtitle-load.ts";
+import { decodeSubtitleBytes } from "../src/lib/subtitles/encoding.ts";
+
+test("passes provider format and encoding to the native subtitle downloader", () => {
+  assert.deepEqual(
+    subtitleDownloadArgs("https://example.test/subtitle?id=1", {
+      lang: "ar",
+      format: "ass",
+      encoding: "windows-1256",
+    }),
+    {
+      url: "https://example.test/subtitle?id=1",
+      lang: "ar",
+      format: "ass",
+      encoding: "windows-1256",
+    },
+  );
+});
+
+test("uses nulls for subtitle metadata that is not available", () => {
+  assert.deepEqual(subtitleDownloadArgs("https://example.test/subtitle", {}), {
+    url: "https://example.test/subtitle",
+    lang: null,
+    format: null,
+    encoding: null,
+  });
+});
+
+test("decodes legacy Arabic subtitle bytes as Windows-1256", () => {
+  const bytes = Uint8Array.from([
+    0xe3, 0xd1, 0xcd, 0xc8, 0xc7, 0x20, 0xc8, 0xc7, 0xe1, 0xda, 0xc7, 0xe1, 0xe3,
+  ]);
+  assert.equal(decodeSubtitleBytes(bytes, { lang: "ar" }), "مرحبا بالعالم");
+});


### PR DESCRIPTION
## What was wrong

Subtitle loading was not reliable:

- sometimes subtitle addons finished after autoload already ran, so the result changed depending on timing
- one slow provider could delay every other provider
- autoload could try up to 25 subtitle files per language one by one
- Arabic Windows-1256 and UTF-16 subtitles could show broken characters
- ASS format information was lost, so colors and styles did not always render
- embedded subtitles without language metadata showed as Unknown and could be selected automatically even when they were not usable
- embedded ASS, PGS, VobSub, DVD, and DVB tracks were not detected consistently

## What changed

- wait for subtitle addons before automatic search starts
- give every provider a 6-second limit and continue when one stalls
- try only the best 5 results and stop at the first subtitle that loads
- do not send an unverified IMDb fallback to automatic subtitle search
- carry subtitle format and encoding through the full UI, player, and native path
- normalize Windows-1256 and UTF-16 subtitle text to UTF-8
- preserve ASS and VTT extensions so mpv/libass keeps colors and styles
- improve embedded subtitle detection and labels
- do not auto-select unknown-language embedded tracks
- use native mpv rendering for image subtitles such as PGS and VobSub

## How to test

- play an Arabic Windows-1256 SRT and confirm the text is readable
- play a colored ASS subtitle and confirm colors/styles are preserved
- open a movie with nameless embedded subtitles and confirm every track has a useful label
- select embedded PGS or VobSub and confirm it renders
- make one subtitle provider slow/offline and confirm the others still return
- confirm autoload stops after the first working subtitle

## Verification

- `pnpm test` — 28 passed
- `vp run typecheck` — passed
- `vp check <changed files>` — 0 errors
- `cargo check --manifest-path src-tauri/Cargo.toml` — passed
- `cargo test --manifest-path src-tauri/Cargo.toml subtitle_download_tests` — 7 passed
- no docs or media fixtures included
