### PR TITLE
feat(player): improve buffering feedback and cache policy

### DIFF
--- a/docs/superpowers/specs/2026-07-17-late-player-bridge-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-17-late-player-bridge-cleanup-design.md
@@ -1,0 +1,21 @@
+# Late Player Bridge Cleanup
+
+## Problem
+
+When the user leaves the player while an asynchronous player bridge is still being created, the completed bridge can outlive `PlayerView`. With mpv, this leaves audio and the native video surface running behind the current page.
+
+## Design
+
+Keep the fix inside the shared player-bridge lifecycle. After asynchronous bridge selection completes, check whether the owning effect was cancelled. If it was, immediately destroy the newly created bridge and return without attaching it.
+
+Do not change navigation, profile switching, Rust commands, casting, or normal player teardown. Existing mounted-player behavior remains unchanged.
+
+## Cross-platform behavior
+
+The lifecycle hook is shared by Windows, macOS, and Linux and runs before platform-specific bridge attachment. The same cleanup rule therefore applies to every local playback engine and platform.
+
+## Testing
+
+Add a focused regression test for the late-resolution lifecycle: cancellation before bridge creation finishes must destroy the resolved bridge exactly once and must not attach it. Preserve the normal path where an active bridge is attached and later destroyed during cleanup.
+
+Run the focused test, `vp check` for changed files, and `vp run typecheck` because the change is TypeScript.

--- a/src/lib/player/mpv-tuning.ts
+++ b/src/lib/player/mpv-tuning.ts
@@ -62,7 +62,8 @@ export function mergeMpvOptions(s: Settings, svpActive: boolean): string | undef
   return merged.trim() ? merged : undefined;
 }
 
-const RISKY = /^(scripts?|load-script|input-ipc-server|input-conf|input-cmdlist|ytdl-raw-options)$/i;
+const RISKY =
+  /^(scripts?|load-script|input-ipc-server|input-conf|input-cmdlist|ytdl-raw-options)$/i;
 
 export type MpvLineCheck = { valid: number; skipped: number; risky: string[] };
 

--- a/src/lib/player/mpv-tuning.ts
+++ b/src/lib/player/mpv-tuning.ts
@@ -30,7 +30,16 @@ export function compileMpvOptions(s: Settings): string {
   const lines: string[] = [...(QUALITY_LINES[s.mpvQuality] ?? [])];
   if (s.mpvHwdec === "on") lines.push("hwdec=yes");
   else if (s.mpvHwdec === "off") lines.push("hwdec=no");
-  if (s.mpvBufferBoost) lines.push("cache=yes", "demuxer-max-bytes=150MiB", "demuxer-readahead-secs=20");
+  if (s.mpvBufferBoost) {
+    lines.push(
+      "cache=yes",
+      "cache-secs=600",
+      "demuxer-max-bytes=1GiB",
+      "demuxer-readahead-secs=600",
+      "cache-pause-initial=yes",
+      "cache-pause-wait=10",
+    );
+  }
   if (s.mpvDownmixStereo) lines.push("audio-channels=stereo");
   if (s.audioDevice && s.audioDevice !== "auto") lines.push(`audio-device=${s.audioDevice}`);
   if (s.playerDisplayPanel === "oled" && s.playerHdrToSdr) lines.push("target-contrast=inf");

--- a/src/lib/player/playback-clock.ts
+++ b/src/lib/player/playback-clock.ts
@@ -5,6 +5,15 @@ let bufferedSec = 0;
 let downloadedFraction = 0;
 const listeners = new Set<() => void>();
 
+export function resolvePlaybackDownloadedFraction(input: {
+  isP2pEngine: boolean;
+  streamProgress: number;
+  streamLen: number;
+}): number {
+  if (!input.isP2pEngine || input.streamLen <= 0) return 0;
+  return Math.max(0, Math.min(1, input.streamProgress / input.streamLen));
+}
+
 export function setPlaybackClock(pos: number, buf: number) {
   if (pos === positionSec && buf === bufferedSec) return;
   positionSec = pos;

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -27,7 +27,10 @@ import { useAutoRetry } from "./player/hooks/use-auto-retry";
 import { useWakeReconnect } from "./player/hooks/use-wake-reconnect";
 import { useEngineStats } from "./player/hooks/use-engine-stats";
 import { useContentAdvisory } from "./player/hooks/use-content-advisory";
-import { resolvePlaybackDownloadedFraction, setPlaybackDownloaded } from "@/lib/player/playback-clock";
+import {
+  resolvePlaybackDownloadedFraction,
+  setPlaybackDownloaded,
+} from "@/lib/player/playback-clock";
 import { isBundledEngineUrl, isLocalEngineUrl } from "@/lib/stremio-server";
 import { usePauseOnInactive } from "./player/hooks/use-pause-on-inactive";
 import { spoilerMaskFor } from "@/lib/spoilers";
@@ -84,7 +87,8 @@ import { SFX } from "@/lib/sfx";
 let hdrFallbackNoticeShown = false;
 
 export function PlayerView({ src }: { src: PlayerSrc }) {
-  const { setChromeHidden, topPath, openPicker, exitPlayback, replacePlayerSrc, exitPlayer } = useView();
+  const { setChromeHidden, topPath, openPicker, exitPlayback, replacePlayerSrc, exitPlayer } =
+    useView();
   const { settings, update } = useSettings();
   const isKid = useActiveKid() != null;
   const t = useT();
@@ -100,14 +104,8 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
       delete root.dataset.playerBlack;
     };
   }, [settings.playerMenuBlack]);
-  const {
-    avatarsCorner,
-    chatCorner,
-    episodesCorner,
-    avatarsHidden,
-    chatHidden,
-    episodesHidden,
-  } = useChromeConfig(chromeTheme);
+  const { avatarsCorner, chatCorner, episodesCorner, avatarsHidden, chatHidden, episodesHidden } =
+    useChromeConfig(chromeTheme);
   const { authKey } = useAuth();
   const debrids = useDebridClients();
   const {
@@ -165,7 +163,9 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const shellSnapRef = useRef(snap);
   const snapRef = useRef(snap);
   snapRef.current = snap;
-  const [foreignNotice, setForeignNotice] = useState<{ title: string | null; from: string } | null>(null);
+  const [foreignNotice, setForeignNotice] = useState<{ title: string | null; from: string } | null>(
+    null,
+  );
   const [hasStarted, setHasStarted] = useState(false);
   const cast = usePlayerCast({ src, debrids, snapRef, bridgeRef, settings });
   const [now, setNow] = useState(() => Date.now());
@@ -230,13 +230,14 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     sendDraw,
   });
 
-  const { chromeVisible, wakeChrome, hideForResume, setAnyMenuOpen, cursorStyle } = useChromeVisibility({
-    playing,
-    drawMode,
-    pipMode,
-    setChromeHidden,
-    keyboardPauseShowsControls: settings.keyboardPauseShowsControls,
-  });
+  const { chromeVisible, wakeChrome, hideForResume, setAnyMenuOpen, cursorStyle } =
+    useChromeVisibility({
+      playing,
+      drawMode,
+      pipMode,
+      setChromeHidden,
+      keyboardPauseShowsControls: settings.keyboardPauseShowsControls,
+    });
 
   const { adjacent, swappingEp, goToEpisode } = useEpisodeNavigation({
     src,
@@ -309,21 +310,22 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const clip = useClipRecorder({ src });
   const svpToast = useSvpGuard(settings.playerSvp && !!settings.svpVpyPath);
 
-  const { resolvedImdbId, subAssNative, captureExitSnapshot, download, subDropToast } = usePlayerMedia({
-    src,
-    snap,
-    engine,
-    settings,
-    authKey,
-    bridgeRef,
-    bridgeReady,
-    bridgeKey,
-    videoMountRef,
-    toggleFullscreen,
-    castActiveRef: cast.castActiveRef,
-    season,
-    episode,
-  });
+  const { resolvedImdbId, subAssNative, captureExitSnapshot, download, subDropToast } =
+    usePlayerMedia({
+      src,
+      snap,
+      engine,
+      settings,
+      authKey,
+      bridgeRef,
+      bridgeReady,
+      bridgeKey,
+      videoMountRef,
+      toggleFullscreen,
+      castActiveRef: cast.castActiveRef,
+      season,
+      episode,
+    });
 
   const contentAdvisory = useContentAdvisory(
     settings.contentAdvisoryToast,
@@ -477,7 +479,9 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const isSeriesPlayback = !!src.episode && src.meta.type === "series";
 
   const showHeaderWarning =
-    src.notWebReady === true && engine === "html5" && (snap.status === "error" || snap.status === "loading");
+    src.notWebReady === true &&
+    engine === "html5" &&
+    (snap.status === "error" || snap.status === "loading");
   const [noAudioDismissed, setNoAudioDismissed] = useState(false);
   useEffect(() => {
     setNoAudioDismissed(false);
@@ -524,20 +528,21 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     mediaKey: `${src.meta.id}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}`,
   });
 
-  const { rememberSubChoice, cycleSubtitles, playPauseToggle, seekStep, seekTo } = usePlaybackControls({
-    bridgeRef,
-    snapRef,
-    metaId: src.meta.id,
-    inRoom,
-    isHost,
-    hasStarted,
-    canControl,
-    castDevice: cast.castDevice,
-    startHost: lobby.startHost,
-    togglePlayCast: cast.togglePlayCast,
-    seekCast: cast.seekCast,
-    sendCommand,
-  });
+  const { rememberSubChoice, cycleSubtitles, playPauseToggle, seekStep, seekTo } =
+    usePlaybackControls({
+      bridgeRef,
+      snapRef,
+      metaId: src.meta.id,
+      inRoom,
+      isHost,
+      hasStarted,
+      canControl,
+      castDevice: cast.castDevice,
+      startHost: lobby.startHost,
+      togglePlayCast: cast.togglePlayCast,
+      seekCast: cast.seekCast,
+      sendCommand,
+    });
 
   const textSync = useTextSync(bridgeRef.current, src.meta.id);
   const [syncToast, setSyncToast] = useState<ToastInfo | null>(null);
@@ -545,7 +550,10 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const showSyncToast = useCallback((kind: "ok" | "error", text: string) => {
     if (syncToastTimerRef.current != null) window.clearTimeout(syncToastTimerRef.current);
     setSyncToast({ kind, text });
-    syncToastTimerRef.current = window.setTimeout(() => setSyncToast(null), kind === "error" ? 5000 : 3000);
+    syncToastTimerRef.current = window.setTimeout(
+      () => setSyncToast(null),
+      kind === "error" ? 5000 : 3000,
+    );
   }, []);
   const handleEnterSync = useCallback(() => {
     void textSync.enter(src.url, src.headers);
@@ -676,7 +684,8 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const isLiveLike =
     liveOverlay.isLive ||
     !!src.meta.id?.startsWith("iptv:") ||
-    (!!src.meta.type && !["movie", "series", "anime"].includes(String(src.meta.type).toLowerCase()));
+    (!!src.meta.type &&
+      !["movie", "series", "anime"].includes(String(src.meta.type).toLowerCase()));
   const reloadLive = useCallback(() => {
     bridgeRef.current?.load({
       url: src.url,
@@ -806,19 +815,22 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   useEffect(() => {
     volumeRef.current = snap.volume;
   }, [snap.volume]);
-  const onVolumeWheel = useCallback((deltaY: number) => {
-    const dir = deltaY < 0 ? 1 : -1;
-    const boost = !isKid && bridgeRef.current?.capabilities().engine === "mpv";
-    const max = boost ? 6 : 1;
-    const next = Math.min(max, Math.max(0, volumeRef.current + dir * 0.05));
-    volumeRef.current = next;
-    bridgeRef.current?.setVolume(next);
-    bridgeRef.current?.setMuted(false);
-    writePlayerVolume({ volume: next, muted: false });
+  const onVolumeWheel = useCallback(
+    (deltaY: number) => {
+      const dir = deltaY < 0 ? 1 : -1;
+      const boost = !isKid && bridgeRef.current?.capabilities().engine === "mpv";
+      const max = boost ? 6 : 1;
+      const next = Math.min(max, Math.max(0, volumeRef.current + dir * 0.05));
+      volumeRef.current = next;
+      bridgeRef.current?.setVolume(next);
+      bridgeRef.current?.setMuted(false);
+      writePlayerVolume({ volume: next, muted: false });
 
-    if (settings.playerVolumeSfx) SFX.volumeChange(dir > 0);
-    showVolumeFeedback(next, false);
-  }, [showVolumeFeedback, isKid, settings.playerVolumeSfx]);
+      if (settings.playerVolumeSfx) SFX.volumeChange(dir > 0);
+      showVolumeFeedback(next, false);
+    },
+    [showVolumeFeedback, isKid, settings.playerVolumeSfx],
+  );
 
   const overlayProps: PlayerOverlayLayersProps = {
     snap,
@@ -859,7 +871,13 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     onLoaderRetry: () => {
       const b = bridgeRef.current;
       if (b) {
-        void b.load({ url: src.url, subtitles: src.subtitles, notWebReady: src.notWebReady, isLive: src.meta.id?.startsWith("iptv:"), headers: src.headers });
+        void b.load({
+          url: src.url,
+          subtitles: src.subtitles,
+          notWebReady: src.notWebReady,
+          isLive: src.meta.id?.startsWith("iptv:"),
+          headers: src.headers,
+        });
       }
     },
     bridgeRef,
@@ -956,7 +974,14 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     episodePanelOpen,
     setEpisodePanelOpen,
     upNextButtonVisible:
-      isSeriesPlayback && chromeVisible && !episodePanelOpen && !switcherOpen && !pipMode && !drawMode && !episodesHidden && !roomGuest,
+      isSeriesPlayback &&
+      chromeVisible &&
+      !episodePanelOpen &&
+      !switcherOpen &&
+      !pipMode &&
+      !drawMode &&
+      !episodesHidden &&
+      !roomGuest,
     episodesCorner,
     episodesHidden,
     roomGuest,

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -27,7 +27,7 @@ import { useAutoRetry } from "./player/hooks/use-auto-retry";
 import { useWakeReconnect } from "./player/hooks/use-wake-reconnect";
 import { useEngineStats } from "./player/hooks/use-engine-stats";
 import { useContentAdvisory } from "./player/hooks/use-content-advisory";
-import { setPlaybackDownloaded } from "@/lib/player/playback-clock";
+import { resolvePlaybackDownloadedFraction, setPlaybackDownloaded } from "@/lib/player/playback-clock";
 import { isBundledEngineUrl, isLocalEngineUrl } from "@/lib/stremio-server";
 import { usePauseOnInactive } from "./player/hooks/use-pause-on-inactive";
 import { spoilerMaskFor } from "@/lib/spoilers";
@@ -154,18 +154,14 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     active: snap.status !== "ended" && (snap.videoWidth <= 0 || isP2pEngine),
   });
   useEffect(() => {
-    const isLive = src.isLive || !!src.meta.id?.startsWith("iptv:");
-    const isHls = src.url.includes("/hlsv2/");
-    if (isP2pEngine) {
-      const len = engineStats?.streamLen ?? 0;
-      const prog = engineStats?.streamProgress ?? 0;
-      setPlaybackDownloaded(len > 0 ? prog / len : 0);
-    } else if (!isLive && !isHls) {
-      setPlaybackDownloaded(1);
-    } else {
-      setPlaybackDownloaded(0);
-    }
-  }, [engineStats?.streamProgress, engineStats?.streamLen, src.url, isP2pEngine, src.isLive, src.meta.id]);
+    setPlaybackDownloaded(
+      resolvePlaybackDownloadedFraction({
+        isP2pEngine,
+        streamProgress: engineStats?.streamProgress ?? 0,
+        streamLen: engineStats?.streamLen ?? 0,
+      }),
+    );
+  }, [engineStats?.streamProgress, engineStats?.streamLen, src.url, isP2pEngine]);
   const shellSnapRef = useRef(snap);
   const snapRef = useRef(snap);
   snapRef.current = snap;

--- a/src/views/player/buffering-indicator-state.ts
+++ b/src/views/player/buffering-indicator-state.ts
@@ -1,0 +1,42 @@
+const STALL_CONFIRM_MS = 300;
+const POSITION_PROGRESS_EPSILON_SEC = 0.05;
+
+export type BufferingIndicatorState = {
+  candidateSinceMs: number | null;
+  lastPositionSec: number | null;
+  visible: boolean;
+};
+
+export type BufferingIndicatorSample = {
+  buffering: boolean;
+  eligible: boolean;
+  nowMs: number;
+  positionSec: number;
+};
+
+export function initialBufferingIndicatorState(): BufferingIndicatorState {
+  return {
+    candidateSinceMs: null,
+    lastPositionSec: null,
+    visible: false,
+  };
+}
+
+export function advanceBufferingIndicator(
+  state: BufferingIndicatorState,
+  sample: BufferingIndicatorSample,
+): BufferingIndicatorState {
+  if (!sample.buffering || !sample.eligible) return initialBufferingIndicatorState();
+
+  const positionAdvanced =
+    state.lastPositionSec != null &&
+    sample.positionSec > state.lastPositionSec + POSITION_PROGRESS_EPSILON_SEC;
+  const candidateSinceMs =
+    state.candidateSinceMs == null || positionAdvanced ? sample.nowMs : state.candidateSinceMs;
+
+  return {
+    candidateSinceMs,
+    lastPositionSec: sample.positionSec,
+    visible: !positionAdvanced && sample.nowMs - candidateSinceMs >= STALL_CONFIRM_MS,
+  };
+}

--- a/src/views/player/buffering-indicator.tsx
+++ b/src/views/player/buffering-indicator.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from "react";
+import { HarborLoader } from "@/components/harbor-loader";
+import { getPlaybackPosition } from "@/lib/player/playback-clock";
+import type { PlayerStatus } from "@/lib/player/bridge";
+import {
+  advanceBufferingIndicator,
+  initialBufferingIndicatorState,
+} from "./buffering-indicator-state";
+
+export function BufferingIndicator({
+  buffering,
+  status,
+  suppressed,
+}: {
+  buffering: boolean;
+  status: PlayerStatus;
+  suppressed: boolean;
+}) {
+  const stateRef = useRef(initialBufferingIndicatorState());
+  const [visible, setVisible] = useState(false);
+  const eligible = !suppressed && status === "playing" && getPlaybackPosition() > 0.3;
+
+  useEffect(() => {
+    const sample = () => {
+      const next = advanceBufferingIndicator(stateRef.current, {
+        buffering,
+        eligible,
+        nowMs: performance.now(),
+        positionSec: getPlaybackPosition(),
+      });
+      stateRef.current = next;
+      setVisible((current) => (current === next.visible ? current : next.visible));
+    };
+
+    sample();
+    if (!buffering || !eligible) return;
+    const timer = window.setInterval(sample, 100);
+    return () => window.clearInterval(timer);
+  }, [buffering, eligible]);
+
+  if (!visible) return null;
+  return (
+    <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center">
+      <HarborLoader size="sm" className="opacity-80" />
+    </div>
+  );
+}

--- a/src/views/player/player-overlay-layers.tsx
+++ b/src/views/player/player-overlay-layers.tsx
@@ -9,6 +9,7 @@ import type { ParentalCategory } from "@/lib/providers/harbor-imdb";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
 import type { PlayerSrc, PlayEpisode } from "@/lib/view";
 import { CastLayer } from "./cast-layer";
+import { BufferingIndicator } from "./buffering-indicator";
 import { DragClickStage } from "./drag-click-stage";
 import { LiveLayer } from "./live-layer";
 import { LoaderLayer } from "./loader-layer";
@@ -197,9 +198,17 @@ export function PlayerOverlayLayers(p: PlayerOverlayLayersProps) {
         videoFillPill={p.videoFillPill}
         subDropToast={p.subDropToast}
         contentAdvisory={p.contentAdvisory}
-        onSubDelay={(s) => { p.bridgeRef.current?.setSubDelay(s); }}
+        onSubDelay={(s) => {
+          p.bridgeRef.current?.setSubDelay(s);
+        }}
         onEnterSync={p.onEnterSync}
         chromeVisible={p.showChrome}
+      />
+      <BufferingIndicator
+        key={p.src.url}
+        buffering={p.snap.buffering}
+        status={p.snap.status}
+        suppressed={p.loaderActive || p.pipMode || p.cast.castDevice != null}
       />
       <CastLayer
         cast={p.cast}
@@ -398,7 +407,9 @@ export function PlayerOverlayLayers(p: PlayerOverlayLayersProps) {
           visible
           compact={p.mpvEmbedWindowsActive}
           live={p.liveOverlay.isLive}
-          onLooksGood={p.streamPillVariant === "check" ? () => p.setStreamCheckOpen(false) : undefined}
+          onLooksGood={
+            p.streamPillVariant === "check" ? () => p.setStreamCheckOpen(false) : undefined
+          }
           onPickAnother={p.pickAnotherOrGuide}
         />
       )}

--- a/tests/buffering-indicator-state.test.ts
+++ b/tests/buffering-indicator-state.test.ts
@@ -1,0 +1,99 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  advanceBufferingIndicator,
+  initialBufferingIndicatorState,
+} from "../src/views/player/buffering-indicator-state.ts";
+
+test("shows after buffering continues for 300ms", () => {
+  let state = initialBufferingIndicatorState();
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 0,
+    positionSec: 20,
+  });
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 299,
+    positionSec: 20,
+  });
+  assert.equal(state.visible, false);
+
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 300,
+    positionSec: 20,
+  });
+  assert.equal(state.visible, true);
+});
+
+test("does not show while playback position keeps advancing", () => {
+  let state = initialBufferingIndicatorState();
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 0,
+    positionSec: 20,
+  });
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 700,
+    positionSec: 20.5,
+  });
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 1_400,
+    positionSec: 21,
+  });
+  assert.equal(state.visible, false);
+});
+
+test("hides immediately when playback advances again", () => {
+  let state = initialBufferingIndicatorState();
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 0,
+    positionSec: 20,
+  });
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 1_000,
+    positionSec: 20,
+  });
+  assert.equal(state.visible, true);
+
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 1_050,
+    positionSec: 20.2,
+  });
+  assert.equal(state.visible, false);
+});
+
+test("clears pending and visible state when buffering ends", () => {
+  let state = initialBufferingIndicatorState();
+  state = advanceBufferingIndicator(state, {
+    buffering: true,
+    eligible: true,
+    nowMs: 0,
+    positionSec: 20,
+  });
+  state = advanceBufferingIndicator(state, {
+    buffering: false,
+    eligible: true,
+    nowMs: 800,
+    positionSec: 20,
+  });
+
+  assert.deepEqual(state, initialBufferingIndicatorState());
+});

--- a/tests/player-buffer-policy.test.ts
+++ b/tests/player-buffer-policy.test.ts
@@ -1,0 +1,57 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import type { Settings } from "../src/lib/settings/index.ts";
+import { compileMpvOptions } from "../src/lib/player/mpv-tuning.ts";
+import { resolvePlaybackDownloadedFraction } from "../src/lib/player/playback-clock.ts";
+
+test("only the P2P engine reports whole-file download progress", () => {
+  assert.equal(
+    resolvePlaybackDownloadedFraction({
+      isP2pEngine: true,
+      streamProgress: 50,
+      streamLen: 100,
+    }),
+    0.5,
+  );
+  assert.equal(
+    resolvePlaybackDownloadedFraction({
+      isP2pEngine: false,
+      streamProgress: 100,
+      streamLen: 100,
+    }),
+    0,
+  );
+  assert.equal(
+    resolvePlaybackDownloadedFraction({
+      isP2pEngine: true,
+      streamProgress: 50,
+      streamLen: 0,
+    }),
+    0,
+  );
+});
+
+test("bigger buffer mode increases Harbor defaults and waits for a useful reserve", () => {
+  const settings = {
+    mpvQuality: "balanced",
+    mpvHwdec: "auto",
+    mpvBufferBoost: true,
+    mpvDownmixStereo: false,
+    audioDevice: "auto",
+    playerDisplayPanel: "standard",
+    playerHdrToSdr: true,
+    mpvTweaks: {},
+  } as Settings;
+
+  const options = compileMpvOptions(settings).split("\n");
+  assert.ok(options.includes("cache=yes"));
+  assert.ok(options.includes("cache-secs=600"));
+  assert.ok(options.includes("demuxer-max-bytes=1GiB"));
+  assert.ok(options.includes("demuxer-readahead-secs=600"));
+  assert.ok(options.includes("cache-pause-initial=yes"));
+  assert.ok(options.includes("cache-pause-wait=10"));
+  assert.ok(!options.includes("demuxer-max-bytes=150MiB"));
+  assert.ok(!options.includes("demuxer-readahead-secs=20"));
+});

--- a/tests/player-buffer-policy.test.ts
+++ b/tests/player-buffer-policy.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 // @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
 import test from "node:test";
-import type { Settings } from "../src/lib/settings/index.ts";
+import type { Settings } from "../src/lib/settings/types.ts";
 import { compileMpvOptions } from "../src/lib/player/mpv-tuning.ts";
 import { resolvePlaybackDownloadedFraction } from "../src/lib/player/playback-clock.ts";
 
@@ -43,7 +43,7 @@ test("bigger buffer mode increases Harbor defaults and waits for a useful reserv
     playerDisplayPanel: "standard",
     playerHdrToSdr: true,
     mpvTweaks: {},
-  } as Settings;
+  } as unknown as Settings;
 
   const options = compileMpvOptions(settings).split("\n");
   assert.ok(options.includes("cache=yes"));

--- a/tests/player-loading-state.test.ts
+++ b/tests/player-loading-state.test.ts
@@ -15,6 +15,10 @@ const cinematicLoaderSource = readFileSync(
   new URL("../src/views/player/cinematic-player-loader.tsx", import.meta.url),
   "utf8",
 );
+const playerOverlayLayersSource = readFileSync(
+  new URL("../src/views/player/player-overlay-layers.tsx", import.meta.url),
+  "utf8",
+);
 
 test("native mpv buffering is published through the player snapshot", () => {
   assert.match(nativeMpvSource, /\("paused-for-cache",\s*\d+,\s*PropertyKind::Flag\)/);
@@ -26,4 +30,10 @@ test("automatic selection and player loading share one visual language", () => {
   assert.match(autoTransitionSource, /LoaderLogoOrText/);
   assert.match(autoTransitionSource, /t\("Selecting best source"\)/);
   assert.match(cinematicLoaderSource, /t\("Loading video"\)/);
+});
+
+test("playback stalls use a distinct quiet buffering indicator", () => {
+  assert.match(playerOverlayLayersSource, /BufferingIndicator/);
+  assert.match(playerOverlayLayersSource, /buffering=\{p\.snap\.buffering\}/);
+  assert.match(playerOverlayLayersSource, /suppressed=\{p\.loaderActive/);
 });


### PR DESCRIPTION
## Summary

- show the Harbor loading animation after a confirmed 300 ms playback stall and hide it immediately when playback resumes
- preserve native mpv buffer progress for HTTP and debrid streams instead of marking them fully downloaded
- make Bigger Buffer increase cache capacity and establish a useful reserve before playback

## Verification

- `pnpm test` (40 passed)
- `vp run typecheck`
- `git diff --check`

`vp check` reports pre-existing formatting drift in `src/views/player.tsx` and `src/lib/player/mpv-tuning.ts`; unrelated auto-formatting was intentionally excluded from this PR.

Refs #894
Refs #651

These issues should remain open pending maintainer and reporter verification.