### PR TITLE
fix(player): tone down buffering indicator

### DIFF
--- a/src/components/player/shells/minimal-shell.tsx
+++ b/src/components/player/shells/minimal-shell.tsx
@@ -36,7 +36,8 @@ export function MinimalShell({
         </button>
         <button
           onClick={onPlayPause}
-          className="flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white backdrop-blur-md transition-colors hover:bg-white/25"
+          data-player-play-pause
+          className="relative flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white backdrop-blur-md transition-colors hover:bg-white/25"
           aria-label={playing ? t("Pause") : t("Play")}
         >
           {playing ? (
@@ -56,7 +57,11 @@ export function MinimalShell({
           className="flex h-10 w-10 items-center justify-center rounded-full bg-black/55 text-white backdrop-blur-md transition-colors hover:bg-black/85"
           aria-label={fullscreen ? t("Exit fullscreen") : t("Fullscreen")}
         >
-          {fullscreen ? <Minimize size={16} strokeWidth={2.2} /> : <Maximize size={16} strokeWidth={2.2} />}
+          {fullscreen ? (
+            <Minimize size={16} strokeWidth={2.2} />
+          ) : (
+            <Maximize size={16} strokeWidth={2.2} />
+          )}
         </button>
       </div>
       <MinimalTrack durationSec={snap.durationSec} visible={visible} onSeek={onSeek} />

--- a/src/components/player/transport-kids.tsx
+++ b/src/components/player/transport-kids.tsx
@@ -95,7 +95,12 @@ export function TransportKids({
           <span className="w-[68px] shrink-0 font-mono text-[17px] font-bold tabular-nums text-white">
             {fmtTime(snap.positionSec)}
           </span>
-          <KidsSeekBar position={snap.positionSec} duration={snap.durationSec} buffered={snap.bufferedSec} onSeek={onSeek} />
+          <KidsSeekBar
+            position={snap.positionSec}
+            duration={snap.durationSec}
+            buffered={snap.bufferedSec}
+            onSeek={onSeek}
+          />
           <span className="w-[68px] shrink-0 text-end font-mono text-[17px] font-bold tabular-nums text-white">
             {fmtTime(snap.durationSec)}
           </span>
@@ -103,15 +108,21 @@ export function TransportKids({
 
         <div className="pointer-events-auto grid grid-cols-[1fr_auto_1fr] items-center gap-4">
           <div className="flex items-center justify-self-start">
-            <KidsVolume volume={snap.volume} muted={snap.muted} onMute={onMute} onVolume={onVolume} />
+            <KidsVolume
+              volume={snap.volume}
+              muted={snap.muted}
+              onMute={onMute}
+              onVolume={onVolume}
+            />
           </div>
 
           <div className="flex items-center gap-6 justify-self-center">
             <SeekBtn dir={-1} onClick={() => onSeekStep(-10)} label={t("Back 10s")} />
             <button
               onClick={onPlayPause}
+              data-player-play-pause
               aria-label={playing ? t("Pause") : t("Play")}
-              className="flex h-24 w-24 shrink-0 items-center justify-center rounded-full bg-white text-[#1f8f88] shadow-[0_14px_36px_-10px_rgba(0,0,0,0.7)] transition-transform hover:scale-105 active:scale-95"
+              className="relative flex h-24 w-24 shrink-0 items-center justify-center rounded-full bg-white text-[#1f8f88] shadow-[0_14px_36px_-10px_rgba(0,0,0,0.7)] transition-transform hover:scale-105 active:scale-95"
             >
               {playing ? (
                 <Pause size={46} strokeWidth={0} fill="currentColor" />
@@ -138,7 +149,11 @@ export function TransportKids({
               </button>
             )}
             <RoundBtn onClick={onFullscreen} label={t("Fullscreen")}>
-              {fullscreen ? <Minimize size={28} strokeWidth={2.2} /> : <Maximize size={28} strokeWidth={2.2} />}
+              {fullscreen ? (
+                <Minimize size={28} strokeWidth={2.2} />
+              ) : (
+                <Maximize size={28} strokeWidth={2.2} />
+              )}
             </RoundBtn>
           </div>
         </div>
@@ -228,7 +243,11 @@ function KidsVolume({
         aria-label={v === 0 ? "Unmute" : "Mute"}
         className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-white/15 text-white transition hover:bg-white/25 active:scale-95"
       >
-        {v === 0 ? <VolumeX size={28} strokeWidth={2.2} /> : <Volume2 size={28} strokeWidth={2.2} />}
+        {v === 0 ? (
+          <VolumeX size={28} strokeWidth={2.2} />
+        ) : (
+          <Volume2 size={28} strokeWidth={2.2} />
+        )}
       </button>
       <div
         ref={ref}

--- a/src/components/player/transport/control-renderer-stremio.tsx
+++ b/src/components/player/transport/control-renderer-stremio.tsx
@@ -243,7 +243,11 @@ export function RenderedStremioControl({
     case "play-pause":
       return (
         <Tooltip label={ctx.playing ? tr("Pause") : tr("Play")}>
-          <StremioBtn onClick={ctx.onPlayPause} ariaLabel={ctx.playing ? tr("Pause") : tr("Play")}>
+          <StremioBtn
+            onClick={ctx.onPlayPause}
+            ariaLabel={ctx.playing ? tr("Pause") : tr("Play")}
+            playPause
+          >
             {ctx.playing ? (
               <Pause size={32} strokeWidth={2} fill="currentColor" />
             ) : (

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -334,10 +334,11 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
             <button
               type="button"
               onClick={ctx.onPlayPause}
+              data-player-play-pause
               data-tv-initial-focus
               aria-label={ctx.playing ? t("Pause") : t("Play")}
               className="
-                flex h-full w-full
+                relative flex h-full w-full
                 items-center justify-center
                 rounded-full
                 bg-transparent

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -319,7 +319,7 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
             shaderRadius={1}
             intensity={1.05}
             refractionStrength={1.18}
-            spectralStrength={1.08}
+            spectralStrength={0}
             className={`
               shrink-0 rounded-full
               border border-white/[0.10]

--- a/src/components/player/transport/custom-icon-renderer.tsx
+++ b/src/components/player/transport/custom-icon-renderer.tsx
@@ -64,8 +64,9 @@ export function renderCustomIconControl(
         <Tooltip label={ctx.playing ? t("Pause") : t("Play")}>
           <button
             onClick={ctx.onPlayPause}
+            data-player-play-pause
             aria-label={ctx.playing ? t("Pause") : t("Play")}
-            className={`flex items-center justify-center rounded-full bg-white/12 text-white backdrop-blur-md transition-[background-color,transform] hover:bg-white/22 active:scale-95 ${boxSize}`}
+            className={`relative flex items-center justify-center rounded-full bg-white/12 text-white backdrop-blur-md transition-[background-color,transform] hover:bg-white/22 active:scale-95 ${boxSize}`}
           >
             <CustomIcon url={iconUrl} size={iconSize} />
           </button>
@@ -113,7 +114,9 @@ export function renderCustomIconControl(
             disabled={!ctx.hasPrevEp}
             aria-label={t("Previous Episode")}
             className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-[background-color,color] ${
-              ctx.hasPrevEp ? "text-white/90 hover:bg-white/10 hover:text-white" : "cursor-not-allowed text-white/25"
+              ctx.hasPrevEp
+                ? "text-white/90 hover:bg-white/10 hover:text-white"
+                : "cursor-not-allowed text-white/25"
             }`}
           >
             <CustomIcon url={iconUrl} size={22} />
@@ -130,7 +133,9 @@ export function renderCustomIconControl(
             disabled={!ctx.hasNextEp}
             aria-label={t("Next Episode")}
             className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-[background-color,color] ${
-              ctx.hasNextEp ? "text-white/90 hover:bg-white/10 hover:text-white" : "cursor-not-allowed text-white/25"
+              ctx.hasNextEp
+                ? "text-white/90 hover:bg-white/10 hover:text-white"
+                : "cursor-not-allowed text-white/25"
             }`}
           >
             <CustomIcon url={iconUrl} size={22} />
@@ -166,7 +171,12 @@ export function renderCustomIconControl(
     case "draw-toggle": {
       if (ctx.compact || !ctx.showDraw) return null;
       return (
-        <BigButton onClick={ctx.onToggleDraw} active={ctx.drawMode} ariaLabel={t("Draw on video")} tooltip={t("Draw on video")}>
+        <BigButton
+          onClick={ctx.onToggleDraw}
+          active={ctx.drawMode}
+          ariaLabel={t("Draw on video")}
+          tooltip={t("Draw on video")}
+        >
           <CustomIcon url={iconUrl} size={22} />
         </BigButton>
       );
@@ -174,7 +184,11 @@ export function renderCustomIconControl(
     case "pip": {
       if (!ctx.capabilities.pictureInPicture) return null;
       return (
-        <BigButton onClick={ctx.onPiP} ariaLabel={t("Picture in Picture")} tooltip={t("Picture in Picture")}>
+        <BigButton
+          onClick={ctx.onPiP}
+          ariaLabel={t("Picture in Picture")}
+          tooltip={t("Picture in Picture")}
+        >
           <CustomIcon url={iconUrl} size={22} />
         </BigButton>
       );
@@ -221,7 +235,11 @@ export function renderCustomIconControlStremio(
     case "play-pause":
       return (
         <Tooltip label={ctx.playing ? t("Pause") : t("Play")}>
-          <StremioBtn onClick={ctx.onPlayPause} ariaLabel={ctx.playing ? t("Pause") : t("Play")}>
+          <StremioBtn
+            onClick={ctx.onPlayPause}
+            ariaLabel={ctx.playing ? t("Pause") : t("Play")}
+            playPause
+          >
             <CustomIcon url={iconUrl} size={32} />
           </StremioBtn>
         </Tooltip>
@@ -230,7 +248,11 @@ export function renderCustomIconControlStremio(
       if (!ctx.showEpisodeNav) return null;
       return (
         <Tooltip label={t("Previous episode")}>
-          <StremioBtn onClick={ctx.onPrevEp} ariaLabel={t("Previous episode")} disabled={!ctx.hasPrevEp}>
+          <StremioBtn
+            onClick={ctx.onPrevEp}
+            ariaLabel={t("Previous episode")}
+            disabled={!ctx.hasPrevEp}
+          >
             <CustomIcon url={iconUrl} size={26} />
           </StremioBtn>
         </Tooltip>
@@ -239,7 +261,11 @@ export function renderCustomIconControlStremio(
       if (!ctx.showEpisodeNav) return null;
       return (
         <Tooltip label={t("Next episode")}>
-          <StremioBtn onClick={ctx.onNextEp} ariaLabel={t("Next episode")} disabled={!ctx.hasNextEp}>
+          <StremioBtn
+            onClick={ctx.onNextEp}
+            ariaLabel={t("Next episode")}
+            disabled={!ctx.hasNextEp}
+          >
             <CustomIcon url={iconUrl} size={26} />
           </StremioBtn>
         </Tooltip>

--- a/src/components/player/transport/stremio-btn.tsx
+++ b/src/components/player/transport/stremio-btn.tsx
@@ -4,20 +4,23 @@ export function StremioBtn({
   ariaLabel,
   active,
   disabled,
+  playPause,
 }: {
   children: React.ReactNode;
   onClick?: () => void;
   ariaLabel: string;
   active?: boolean;
   disabled?: boolean;
+  playPause?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
+      data-player-play-pause={playPause ? "" : undefined}
       aria-label={ariaLabel}
-      className={`pointer-events-auto flex h-16 w-16 items-center justify-center rounded-xl transition-colors duration-150 ${
+      className={`pointer-events-auto relative flex h-16 w-16 items-center justify-center rounded-xl transition-colors duration-150 ${
         disabled
           ? "cursor-not-allowed text-white/30"
           : active

--- a/src/views/player/buffering-indicator.tsx
+++ b/src/views/player/buffering-indicator.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { getPlaybackPosition } from "@/lib/player/playback-clock";
 import type { PlayerStatus } from "@/lib/player/bridge";
 import {
@@ -37,13 +38,15 @@ export function BufferingIndicator({
     return () => window.clearInterval(timer);
   }, [buffering, eligible]);
 
-  if (!visible) return null;
-  return (
-    <div
+  const playPauseButton = visible
+    ? document.querySelector<HTMLElement>("[data-player-play-pause]")
+    : null;
+  if (!playPauseButton) return null;
+  return createPortal(
+    <span
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center"
-    >
-      <div className="h-[4.5rem] w-[4.5rem] rounded-full border-2 border-white/15 border-r-white/35 border-t-white/70 motion-safe:animate-spin" />
-    </div>
+      className="pointer-events-none absolute -inset-1 rounded-full border-2 border-white/15 border-r-white/35 border-t-white/70 motion-safe:animate-spin"
+    />,
+    playPauseButton,
   );
 }

--- a/src/views/player/buffering-indicator.tsx
+++ b/src/views/player/buffering-indicator.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { HarborLoader } from "@/components/harbor-loader";
 import { getPlaybackPosition } from "@/lib/player/playback-clock";
 import type { PlayerStatus } from "@/lib/player/bridge";
 import {
@@ -40,8 +39,11 @@ export function BufferingIndicator({
 
   if (!visible) return null;
   return (
-    <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center">
-      <HarborLoader size="sm" className="opacity-80" />
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center"
+    >
+      <div className="h-[4.5rem] w-[4.5rem] rounded-full border-2 border-white/15 border-r-white/35 border-t-white/70 motion-safe:animate-spin" />
     </div>
   );
 }

--- a/tests/player-loading-state.test.ts
+++ b/tests/player-loading-state.test.ts
@@ -53,5 +53,6 @@ test("playback stalls use a distinct quiet buffering indicator", () => {
   assert.match(bufferingIndicatorSource, /\[data-player-play-pause\]/);
   assert.match(bufferingIndicatorSource, /motion-safe:animate-spin/);
   assert.match(controlRendererSource, /data-player-play-pause/);
+  assert.match(controlRendererSource, /spectralStrength=\{0\}/);
   assert.match(stremioButtonSource, /data-player-play-pause/);
 });

--- a/tests/player-loading-state.test.ts
+++ b/tests/player-loading-state.test.ts
@@ -23,6 +23,14 @@ const bufferingIndicatorSource = readFileSync(
   new URL("../src/views/player/buffering-indicator.tsx", import.meta.url),
   "utf8",
 );
+const controlRendererSource = readFileSync(
+  new URL("../src/components/player/transport/control-renderer.tsx", import.meta.url),
+  "utf8",
+);
+const stremioButtonSource = readFileSync(
+  new URL("../src/components/player/transport/stremio-btn.tsx", import.meta.url),
+  "utf8",
+);
 
 test("native mpv buffering is published through the player snapshot", () => {
   assert.match(nativeMpvSource, /\("paused-for-cache",\s*\d+,\s*PropertyKind::Flag\)/);
@@ -41,6 +49,9 @@ test("playback stalls use a distinct quiet buffering indicator", () => {
   assert.match(playerOverlayLayersSource, /buffering=\{p\.snap\.buffering\}/);
   assert.match(playerOverlayLayersSource, /suppressed=\{p\.loaderActive/);
   assert.doesNotMatch(bufferingIndicatorSource, /HarborLoader/);
+  assert.match(bufferingIndicatorSource, /createPortal/);
+  assert.match(bufferingIndicatorSource, /\[data-player-play-pause\]/);
   assert.match(bufferingIndicatorSource, /motion-safe:animate-spin/);
-  assert.match(bufferingIndicatorSource, /border-t-white\/70/);
+  assert.match(controlRendererSource, /data-player-play-pause/);
+  assert.match(stremioButtonSource, /data-player-play-pause/);
 });

--- a/tests/player-loading-state.test.ts
+++ b/tests/player-loading-state.test.ts
@@ -19,6 +19,10 @@ const playerOverlayLayersSource = readFileSync(
   new URL("../src/views/player/player-overlay-layers.tsx", import.meta.url),
   "utf8",
 );
+const bufferingIndicatorSource = readFileSync(
+  new URL("../src/views/player/buffering-indicator.tsx", import.meta.url),
+  "utf8",
+);
 
 test("native mpv buffering is published through the player snapshot", () => {
   assert.match(nativeMpvSource, /\("paused-for-cache",\s*\d+,\s*PropertyKind::Flag\)/);
@@ -36,4 +40,7 @@ test("playback stalls use a distinct quiet buffering indicator", () => {
   assert.match(playerOverlayLayersSource, /BufferingIndicator/);
   assert.match(playerOverlayLayersSource, /buffering=\{p\.snap\.buffering\}/);
   assert.match(playerOverlayLayersSource, /suppressed=\{p\.loaderActive/);
+  assert.doesNotMatch(bufferingIndicatorSource, /HarborLoader/);
+  assert.match(bufferingIndicatorSource, /motion-safe:animate-spin/);
+  assert.match(bufferingIndicatorSource, /border-t-white\/70/);
 });


### PR DESCRIPTION
## Summary

- replace the animated multicolor Harbor loader with a subtle neutral progress ring
- keep the center of the control clear so the play/pause icon remains visible
- preserve the existing 300 ms confirmed-stall behavior
- respect reduced-motion preferences

## Verification

- `pnpm test` (41 passed)
- `vp run typecheck`
- `vp check src/views/player/buffering-indicator.tsx tests/player-loading-state.test.ts`
- `git diff --check`

Refs #901

The issue should remain open pending reporter verification.