### PR TITLE
fix(ui): remove liquid glass chromatic separation

### DIFF
--- a/src/components/ThreeLiquidGlassSurface.tsx
+++ b/src/components/ThreeLiquidGlassSurface.tsx
@@ -50,11 +50,6 @@ export type LiquidGlassSurfaceProps = HTMLAttributes<HTMLDivElement> & {
   refractionStrength?: number;
 
   /**
-   * قوة الطيف اللوني والانفصال اللوني.
-   */
-  spectralStrength?: number;
-
-  /**
    * قوة إحساس العدسة المحدبة والحلقة الداخلية.
    * ملاحظة: هذا يحاكي العدسة بصريًا، لكنه لا يكبّر
    * بكسلات DOM الخلفية تكبيرًا حقيقيًا.
@@ -83,7 +78,6 @@ type AttachOptions = {
   radius: number;
   intensity: number;
   refractionStrength: number;
-  spectralStrength: number;
   lensStrength: number;
 };
 
@@ -187,7 +181,7 @@ class SharedLiquidGlassEngine {
       uRadius: { value: 1 },
       uIntensity: { value: 1.08 },
       uRefraction: { value: 1.42 },
-      uSpectrum: { value: 1.48 },
+      uSpectrum: { value: 0 },
       uLens: { value: 1.2 },
     };
 
@@ -705,8 +699,6 @@ class SharedLiquidGlassEngine {
 
     this.uniforms.uRefraction.value = clamp(options.refractionStrength, 0, 1.8);
 
-    this.uniforms.uSpectrum.value = clamp(options.spectralStrength, 0, 2.5);
-
     this.uniforms.uLens.value = clamp(options.lensStrength, 0, 2.5);
 
     this.resize(canvas);
@@ -878,7 +870,6 @@ export function LiquidGlassSurface({
   alwaysActive = false,
   intensity = 1.08,
   refractionStrength = 1.42,
-  spectralStrength = 1.48,
   lensStrength = 1.2,
   onPointerEnter,
   onPointerMove,
@@ -903,10 +894,9 @@ export function LiquidGlassSurface({
       radius: shaderRadius,
       intensity,
       refractionStrength,
-      spectralStrength,
       lensStrength,
     });
-  }, [intensity, lensStrength, refractionStrength, shaderRadius, spectralStrength]);
+  }, [intensity, lensStrength, refractionStrength, shaderRadius]);
 
   const deactivateWhenIdle = () => {
     const canvas = canvasRef.current;

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -319,7 +319,6 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
             shaderRadius={1}
             intensity={1.05}
             refractionStrength={1.18}
-            spectralStrength={0}
             className={`
               shrink-0 rounded-full
               border border-white/[0.10]

--- a/src/views/player/cinematic-player-loader.tsx
+++ b/src/views/player/cinematic-player-loader.tsx
@@ -182,7 +182,6 @@ export function CinematicPlayerLoader({
         shaderRadius={1}
         intensity={1.05}
         refractionStrength={1.18}
-        spectralStrength={1.08}
         contentClassName="h-full w-full"
         style={{
           background: "transparent",

--- a/tests/liquid-glass.test.ts
+++ b/tests/liquid-glass.test.ts
@@ -31,3 +31,11 @@ test("liquid glass uses portable WebGL 1 with lifecycle and CSS fallback guards"
   assert.match(source, /return null/);
   assert.match(source, /backdropFilter/);
 });
+
+test("liquid glass keeps refraction neutral without chromatic separation", () => {
+  assert.match(source, /uSpectrum:\s*\{\s*value:\s*0\s*\}/);
+  assert.doesNotMatch(source, /spectralStrength/);
+  assert.match(source, /refractionStrength/);
+  assert.match(source, /lensStrength/);
+  assert.match(source, /backdropFilter/);
+});

--- a/tests/player-loading-state.test.ts
+++ b/tests/player-loading-state.test.ts
@@ -53,6 +53,5 @@ test("playback stalls use a distinct quiet buffering indicator", () => {
   assert.match(bufferingIndicatorSource, /\[data-player-play-pause\]/);
   assert.match(bufferingIndicatorSource, /motion-safe:animate-spin/);
   assert.match(controlRendererSource, /data-player-play-pause/);
-  assert.match(controlRendererSource, /spectralStrength=\{0\}/);
   assert.match(stremioButtonSource, /data-player-play-pause/);
 });


### PR DESCRIPTION
## Summary

- remove the public `spectralStrength` option from `ThreeLiquidGlassSurface`
- keep the WebGL refraction, lens, blur, and CSS fallback behavior intact
- fix the spectrum uniform at zero so liquid-glass surfaces remain neutral across the app
- add a regression test that prevents chromatic separation from being reintroduced

## Context

This is a follow-up to the review discussion on #902 (`fix(player): tone down buffering indicator`). While reviewing that buffering change, the existing `ThreeLiquidGlassSurface` rainbow/chromatic effect was visible around the player and home-screen play controls and rendered inconsistently across macOS, Linux, and Windows.

This PR keeps that separate from the buffering indicator fix and addresses the shared liquid-glass implementation itself.

Related to #902.
Related to #901.

## Testing

- `pnpm test` (54/54 passing)
- `vp run typecheck`
- `vp check src/components/ThreeLiquidGlassSurface.tsx src/components/player/transport/control-renderer.tsx src/views/player/cinematic-player-loader.tsx tests/liquid-glass.test.ts tests/player-loading-state.test.ts`
- `git diff --check`