### PR TITLE
perf(ui): lazily activate thumbnail glass

### DIFF
--- a/src/components/ThreeLiquidGlassSurface.tsx
+++ b/src/components/ThreeLiquidGlassSurface.tsx
@@ -10,12 +10,16 @@ export type LiquidGlassSurfaceProps = HTMLAttributes<HTMLDivElement> & {
   refractionStrength?: number;
   lensStrength?: number;
   contentClassName?: string;
+  surfaceClassName?: string;
+  variant?: "default" | "overlay";
+  backdropBlur?: boolean;
 };
 
 export function LiquidGlassSurface({
   children,
   className = "",
   contentClassName = "",
+  surfaceClassName = "",
   style,
   radius = "999999px",
   shaderRadius: _shaderRadius,
@@ -24,27 +28,50 @@ export function LiquidGlassSurface({
   intensity = 1,
   refractionStrength: _refractionStrength,
   lensStrength: _lensStrength,
+  variant = "default",
+  backdropBlur = false,
   ...wrapperProps
 }: LiquidGlassSurfaceProps) {
   const strength = Math.min(1, Math.max(0, intensity));
-  const glassStyle: CSSProperties = {
+  const wrapperStyle: CSSProperties = {
     position: "relative",
     isolation: "isolate",
     overflow: "hidden",
     borderRadius: radius,
-    background: `linear-gradient(145deg, rgba(255,255,255,${0.025 + strength * 0.015}), rgba(255,255,255,0.006))`,
-    boxShadow: "inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -1px 0 rgba(0,0,0,0.05)",
     ...style,
   };
+  const surfaceStyle: CSSProperties = {
+    background:
+      variant === "overlay"
+        ? `linear-gradient(145deg, rgba(255,255,255,${0.09 + strength * 0.04}), rgba(255,255,255,0.028)), rgba(8,12,20,0.28)`
+        : `linear-gradient(145deg, rgba(255,255,255,${0.045 + strength * 0.025}), rgba(255,255,255,0.012))`,
+    boxShadow:
+      variant === "overlay"
+        ? "inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.18), 0 8px 22px rgba(0,0,0,0.28)"
+        : "inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -1px 0 rgba(0,0,0,0.05)",
+    backdropFilter:
+      variant === "overlay" && backdropBlur ? "blur(2.5px) saturate(1.08)" : undefined,
+  };
+  const contentStyle: CSSProperties = backdropBlur ? { transform: "translateZ(0)" } : {};
 
   return (
     <div
       {...wrapperProps}
-      style={glassStyle}
+      style={wrapperStyle}
       data-liquid-glass={interactive ? "interactive" : "static"}
       className={className}
     >
-      <div className={`relative z-10 h-full w-full ${contentClassName}`}>{children}</div>
+      <div
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-0 z-0 rounded-[inherit] ${surfaceClassName}`}
+        style={surfaceStyle}
+      />
+      <div
+        className={`relative z-10 isolate h-full w-full ${contentClassName}`}
+        style={contentStyle}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -32,6 +32,8 @@ type Props = {
   onDismiss?: (item: LibraryItem) => void;
 };
 
+let backdropBlurHasWarmed = false;
+
 export const ContinueCard = memo(function ContinueCard({
   item,
   watched = false,
@@ -41,6 +43,10 @@ export const ContinueCard = memo(function ContinueCard({
   const t = useT();
   const { settings, update } = useSettings();
   const { profiles, activeProfile } = useProfiles();
+  const [hasActivatedGlass, setHasActivatedGlass] = useState(false);
+  const [shouldRevealGlass, setShouldRevealGlass] = useState(false);
+  const hasActivatedGlassRef = useRef(false);
+  const revealFrameRef = useRef<number | null>(null);
   const watcherId = getWatchedBy(item._id);
   const watcher = watcherId ? profiles.find((p) => p.id === watcherId) : null;
   const showWatcher = !!watcher && watcher.id !== activeProfile?.id;
@@ -70,6 +76,42 @@ export const ContinueCard = memo(function ContinueCard({
     : isAnimeCwItem(item) && ep
       ? ep.episode
       : null;
+
+  useEffect(
+    () => () => {
+      if (revealFrameRef.current !== null) {
+        cancelAnimationFrame(revealFrameRef.current);
+      }
+    },
+    [],
+  );
+
+  const activateGlass = () => {
+    if (hasActivatedGlassRef.current) return;
+
+    hasActivatedGlassRef.current = true;
+    setHasActivatedGlass(true);
+
+    if (backdropBlurHasWarmed) {
+      setShouldRevealGlass(true);
+      return;
+    }
+
+    backdropBlurHasWarmed = true;
+    revealFrameRef.current = requestAnimationFrame(() => {
+      revealFrameRef.current = requestAnimationFrame(() => {
+        revealFrameRef.current = null;
+        setShouldRevealGlass(true);
+      });
+    });
+  };
+
+  const glassSurfaceRevealClass = shouldRevealGlass
+    ? "opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+    : "opacity-0";
+  const glassContentRevealClass = shouldRevealGlass
+    ? "scale-95 opacity-0 transition-[opacity,transform] duration-[120ms] group-hover:scale-100 group-hover:opacity-100 focus-within:scale-100 focus-within:opacity-100"
+    : "scale-95 opacity-0";
   const sub =
     animeEp && Number.isFinite(animeEp) && animeEp > 0
       ? `Ep ${animeEp}`
@@ -288,7 +330,11 @@ export const ContinueCard = memo(function ContinueCard({
   };
 
   return (
-    <div className="group relative w-full min-w-0">
+    <div
+      className="group relative w-full min-w-0"
+      onPointerEnter={activateGlass}
+      onFocusCapture={activateGlass}
+    >
       <button
         ref={cardRef}
         onClick={onClick}
@@ -413,10 +459,10 @@ export const ContinueCard = memo(function ContinueCard({
           shaderRadius={1}
           intensity={0.86}
           variant="overlay"
-          backdropBlur
+          backdropBlur={hasActivatedGlass}
           className="pointer-events-none h-14 w-14 group-hover:pointer-events-auto focus-within:pointer-events-auto"
-          surfaceClassName="border border-white/[0.10] opacity-0 group-hover:opacity-100 focus-within:opacity-100"
-          contentClassName="h-full w-full scale-95 opacity-0 transition-[opacity,transform] duration-[120ms] group-hover:scale-100 group-hover:opacity-100 focus-within:scale-100 focus-within:opacity-100"
+          surfaceClassName={`border border-white/[0.10] ${glassSurfaceRevealClass}`}
+          contentClassName={`h-full w-full ${glassContentRevealClass}`}
           style={{
             background: "transparent",
             boxShadow: "none",
@@ -453,10 +499,10 @@ export const ContinueCard = memo(function ContinueCard({
             shaderRadius={1}
             intensity={0.74}
             variant="overlay"
-            backdropBlur
+            backdropBlur={hasActivatedGlass}
             className="pointer-events-none h-9 w-9 group-hover:pointer-events-auto focus-within:pointer-events-auto"
-            surfaceClassName="border border-white/[0.09] opacity-0 group-hover:opacity-100 focus-within:opacity-100"
-            contentClassName="h-full w-full scale-95 opacity-0 transition-[opacity,transform] duration-[120ms] group-hover:scale-100 group-hover:opacity-100 focus-within:scale-100 focus-within:opacity-100"
+            surfaceClassName={`border border-white/[0.09] ${glassSurfaceRevealClass}`}
+            contentClassName={`h-full w-full ${glassContentRevealClass}`}
             style={{
               background: "transparent",
               boxShadow: "none",

--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -407,13 +407,16 @@ export const ContinueCard = memo(function ContinueCard({
           {translatedTitle || hydratedMeta?.name?.trim() || item.name}
         </p>
       </button>
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex aspect-[16/9] items-center justify-center opacity-0 transition-opacity duration-[220ms] group-hover:opacity-100 group-focus-within:opacity-100">
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex aspect-[16/9] items-center justify-center">
         <ThreeLiquidGlassSurface
           radius="9999px"
           shaderRadius={1}
           intensity={0.86}
-          className="pointer-events-auto h-14 w-14 border border-white/[0.10]"
-          contentClassName="h-full w-full"
+          variant="overlay"
+          backdropBlur
+          className="pointer-events-none h-14 w-14 group-hover:pointer-events-auto focus-within:pointer-events-auto"
+          surfaceClassName="border border-white/[0.10] opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+          contentClassName="h-full w-full scale-95 opacity-0 transition-[opacity,transform] duration-[120ms] group-hover:scale-100 group-hover:opacity-100 focus-within:scale-100 focus-within:opacity-100"
           style={{
             background: "transparent",
             boxShadow: "none",
@@ -443,18 +446,17 @@ export const ContinueCard = memo(function ContinueCard({
             absolute end-0.5 top-0.5 z-10
             flex h-11 w-11
             items-center justify-center
-            opacity-0
-            transition-opacity duration-200
-            group-hover:opacity-100
-            focus-within:opacity-100
           "
         >
           <ThreeLiquidGlassSurface
             radius="9999px"
             shaderRadius={1}
             intensity={0.74}
-            className="h-9 w-9 border border-white/[0.09]"
-            contentClassName="h-full w-full"
+            variant="overlay"
+            backdropBlur
+            className="pointer-events-none h-9 w-9 group-hover:pointer-events-auto focus-within:pointer-events-auto"
+            surfaceClassName="border border-white/[0.09] opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+            contentClassName="h-full w-full scale-95 opacity-0 transition-[opacity,transform] duration-[120ms] group-hover:scale-100 group-hover:opacity-100 focus-within:scale-100 focus-within:opacity-100"
             style={{
               background: "transparent",
               boxShadow: "none",

--- a/src/components/row.tsx
+++ b/src/components/row.tsx
@@ -539,6 +539,8 @@ function EdgeArrow({
           radius="9999px"
           shaderRadius={1}
           intensity={1}
+          variant="overlay"
+          backdropBlur
           className={`h-11 w-11 pointer-events-auto ${
             visible
               ? "opacity-0 group-hover/row:opacity-100 focus-within:opacity-100"
@@ -579,6 +581,8 @@ function EdgeArrow({
         radius="9999px"
         shaderRadius={1}
         intensity={1}
+        variant="overlay"
+        backdropBlur
         className={`h-11 w-11 pointer-events-auto ${
           visible
             ? "opacity-0 group-hover/row:opacity-100 focus-within:opacity-100"

--- a/tests/liquid-glass.test.ts
+++ b/tests/liquid-glass.test.ts
@@ -27,7 +27,7 @@ test("liquid glass does not keep a GPU render loop alive", () => {
   assert.doesNotMatch(source, /requestAnimationFrame/);
   assert.doesNotMatch(source, /<canvas/);
   assert.match(source, /linear-gradient/);
-  assert.doesNotMatch(source, /backdropFilter/);
+  assert.match(source, /backdropFilter: variant === "overlay" && backdropBlur/);
   assert.doesNotMatch(source, /WebkitBackdropFilter/);
 });
 
@@ -36,4 +36,7 @@ test("liquid glass keeps its public compatibility props", () => {
   assert.match(source, /refractionStrength/);
   assert.match(source, /lensStrength/);
   assert.match(source, /alwaysActive/);
+  assert.match(source, /surfaceClassName/);
+  assert.match(source, /variant/);
+  assert.match(source, /backdropBlur/);
 });

--- a/tests/liquid-glass.test.ts
+++ b/tests/liquid-glass.test.ts
@@ -27,7 +27,7 @@ test("liquid glass does not keep a GPU render loop alive", () => {
   assert.doesNotMatch(source, /requestAnimationFrame/);
   assert.doesNotMatch(source, /<canvas/);
   assert.match(source, /linear-gradient/);
-  assert.match(source, /backdropFilter: variant === "overlay" && backdropBlur/);
+  assert.match(source, /backdropFilter:\s+variant === "overlay" && backdropBlur/);
   assert.doesNotMatch(source, /WebkitBackdropFilter/);
 });
 


### PR DESCRIPTION
## Summary

- activate thumbnail backdrop blur only after a card is first hovered or focused
- prewarm the first blur layer invisibly for one compositor frame, avoiding the initial frosted-surface pop
- retain instant reveals after the compositor is warm and keep carousel arrows unchanged

## Windows validation

@aajsa, could you please check the Home thumbnail play/remove controls on a Windows device? In particular, verify the first hover has no delayed blur, icons stay sharp, and there are no black-screen regressions.