### PR TITLE
fix(search): prevent stale results and cache metadata

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -415,7 +415,11 @@ pub fn run() {
     let dvr_state = dvr::DvrState::new();
     let multiview_state = multiview::MultiviewState::new();
     let modal_overlay_state = modal_overlay::ModalOverlayState::new();
-    let app_builder = tauri::Builder::default()
+    let app_builder = tauri::Builder::default();
+    // Let a Linux development build run alongside the installed Harbor app.
+    // Packaged builds keep the normal single-instance behavior.
+    #[cfg(not(all(target_os = "linux", debug_assertions)))]
+    let app_builder = app_builder
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
             use tauri::{Emitter, Manager};
             if let Some(w) = app.get_webview_window("main") {
@@ -431,7 +435,8 @@ pub fn run() {
             if let Some(path) = media_file_from_args(&args) {
                 let _ = app.emit("harbor:open-file", path);
             }
-        }))
+        }));
+    let app_builder = app_builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_shell::init())

--- a/src/components/search/search-overlay.tsx
+++ b/src/components/search/search-overlay.tsx
@@ -22,6 +22,7 @@ import { AiModeButton } from "./ai-mode-button";
 import { AiExampleHint, SEARCH_EXAMPLES } from "@/components/ai-example-hint";
 import { useSettings } from "@/lib/settings";
 import { isMagnetInput, isDirectVideoUrl } from "@/lib/torrent/magnet";
+import { getSearchDisplayState } from "@/lib/search-display-state";
 
 export function SearchOverlay() {
   const { open, setOpen, query, setQuery, results, status, clear, recordRecent } = useSearch();
@@ -91,35 +92,14 @@ export function SearchOverlay() {
   };
 
   const trimmed = query.trim();
-  const currentResults = results?.query === trimmed ? results : null;
+  const { currentResults, hasResults, noResults, tmdbUnavailable } = getSearchDisplayState(
+    results,
+    query,
+    status,
+  );
   const magnetInput = !!trimmed && isMagnetInput(trimmed);
   const urlInput = !!trimmed && !magnetInput && isDirectVideoUrl(trimmed);
   const directInput = magnetInput || urlInput;
-  const hasResults = !!(
-    currentResults &&
-    trimmed &&
-    (currentResults.topMatch ||
-      currentResults.people.length ||
-      currentResults.movies.length ||
-      currentResults.series.length ||
-      currentResults.liveTv.length ||
-      currentResults.anime.length ||
-      currentResults.addons.length ||
-      currentResults.addonGroups.length)
-  );
-  const noResults = !!(
-    currentResults &&
-    trimmed &&
-    status === "done" &&
-    !currentResults.topMatch &&
-    currentResults.people.length === 0 &&
-    currentResults.movies.length === 0 &&
-    currentResults.series.length === 0 &&
-    currentResults.liveTv.length === 0 &&
-    currentResults.anime.length === 0 &&
-    currentResults.addons.length === 0 &&
-    currentResults.addonGroups.length === 0
-  );
 
   return createPortal(
     <div
@@ -274,13 +254,16 @@ export function SearchOverlay() {
             />
           )}
 
+          {tmdbUnavailable && !directInput && !aiActive && (
+            <div className="mb-5 rounded-2xl border border-edge-soft bg-elevated/60 px-5 py-4 text-[13px] text-ink-muted">
+              {hasResults
+                ? t("TMDB is temporarily unavailable. These results may be incomplete.")
+                : t("TMDB is temporarily unavailable. Try your search again shortly.")}
+            </div>
+          )}
+
           {trimmed && !directInput && hasResults && !aiActive && currentResults && (
             <div className="flex flex-col gap-8 pb-12">
-              {currentResults.tmdbUnavailable && (
-                <p className="-mb-3 text-[13px] text-ink-muted">
-                  {t("TMDB is temporarily unavailable. These results may be incomplete.")}
-                </p>
-              )}
               {currentResults.topMatch && (
                 <TopMatch match={currentResults.topMatch} onClose={close} />
               )}

--- a/src/components/search/search-overlay.tsx
+++ b/src/components/search/search-overlay.tsx
@@ -72,7 +72,7 @@ export function SearchOverlay() {
   };
 
   const onIntent = () => {
-    const intent = results?.intent;
+    const intent = currentResults?.intent;
     if (!intent) return;
     if (intent.kind === "genre") {
       const id = (intent.mediaType === "movie" ? MOVIE_GENRES : TV_GENRES)[intent.genre];
@@ -91,33 +91,34 @@ export function SearchOverlay() {
   };
 
   const trimmed = query.trim();
+  const currentResults = results?.query === trimmed ? results : null;
   const magnetInput = !!trimmed && isMagnetInput(trimmed);
   const urlInput = !!trimmed && !magnetInput && isDirectVideoUrl(trimmed);
   const directInput = magnetInput || urlInput;
   const hasResults = !!(
-    results &&
+    currentResults &&
     trimmed &&
-    (results.topMatch ||
-      results.people.length ||
-      results.movies.length ||
-      results.series.length ||
-      results.liveTv.length ||
-      results.anime.length ||
-      results.addons.length ||
-      results.addonGroups.length)
+    (currentResults.topMatch ||
+      currentResults.people.length ||
+      currentResults.movies.length ||
+      currentResults.series.length ||
+      currentResults.liveTv.length ||
+      currentResults.anime.length ||
+      currentResults.addons.length ||
+      currentResults.addonGroups.length)
   );
   const noResults = !!(
-    results &&
+    currentResults &&
     trimmed &&
     status === "done" &&
-    !results.topMatch &&
-    results.people.length === 0 &&
-    results.movies.length === 0 &&
-    results.series.length === 0 &&
-    results.liveTv.length === 0 &&
-    results.anime.length === 0 &&
-    results.addons.length === 0 &&
-    results.addonGroups.length === 0
+    !currentResults.topMatch &&
+    currentResults.people.length === 0 &&
+    currentResults.movies.length === 0 &&
+    currentResults.series.length === 0 &&
+    currentResults.liveTv.length === 0 &&
+    currentResults.anime.length === 0 &&
+    currentResults.addons.length === 0 &&
+    currentResults.addonGroups.length === 0
   );
 
   return createPortal(
@@ -176,10 +177,10 @@ export function SearchOverlay() {
                   }
                   return;
                 }
-                if (results?.topMatch) {
+                if (currentResults?.topMatch) {
                   e.preventDefault();
                   recordRecent(query);
-                  const meta = results.topMatch.meta;
+                  const meta = currentResults.topMatch.meta;
                   setOpen(false);
                   openMeta(meta);
                 }
@@ -240,13 +241,13 @@ export function SearchOverlay() {
             </div>
           )}
 
-          {trimmed && !directInput && results?.intent && (
+          {trimmed && !directInput && currentResults?.intent && (
             <button
               onClick={onIntent}
               className="mb-5 flex h-14 w-full items-center gap-3 rounded-2xl border border-accent/40 bg-accent/10 px-5 text-start transition-colors hover:bg-accent/15"
             >
               <span className="flex h-9 w-9 items-center justify-center rounded-full bg-accent/20 text-accent">
-                {results.intent.kind === "year" ? (
+                {currentResults.intent.kind === "year" ? (
                   <CalendarRange size={16} strokeWidth={2.1} />
                 ) : (
                   <Tag size={16} strokeWidth={2.1} />
@@ -256,7 +257,9 @@ export function SearchOverlay() {
                 <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-accent">
                   {t("Browse")}
                 </span>
-                <span className="text-[15px] font-semibold text-ink">{results.intent.label}</span>
+                <span className="text-[15px] font-semibold text-ink">
+                  {currentResults.intent.label}
+                </span>
               </span>
               <CornerDownLeft size={15} className="ms-auto text-ink-subtle" />
             </button>
@@ -271,18 +274,25 @@ export function SearchOverlay() {
             />
           )}
 
-          {trimmed && !directInput && hasResults && !aiActive && results && (
+          {trimmed && !directInput && hasResults && !aiActive && currentResults && (
             <div className="flex flex-col gap-8 pb-12">
-              {results.topMatch && <TopMatch match={results.topMatch} onClose={close} />}
-              <LiveTvRow items={results.liveTv} onClose={close} />
-              <AddonHits hits={results.addons} onClose={close} />
-              <PeopleRow people={results.people} onClose={close} />
+              {currentResults.tmdbUnavailable && (
+                <p className="-mb-3 text-[13px] text-ink-muted">
+                  {t("TMDB is temporarily unavailable. These results may be incomplete.")}
+                </p>
+              )}
+              {currentResults.topMatch && (
+                <TopMatch match={currentResults.topMatch} onClose={close} />
+              )}
+              <LiveTvRow items={currentResults.liveTv} onClose={close} />
+              <AddonHits hits={currentResults.addons} onClose={close} />
+              <PeopleRow people={currentResults.people} onClose={close} />
               <div className="grid gap-8 lg:grid-cols-2">
-                <MetaList title={t("Movies")} items={results.movies} onClose={close} />
-                <MetaList title={t("Series")} items={results.series} onClose={close} />
+                <MetaList title={t("Movies")} items={currentResults.movies} onClose={close} />
+                <MetaList title={t("Series")} items={currentResults.series} onClose={close} />
               </div>
-              <AnimeRow items={results.anime} onClose={close} />
-              <AddonResults groups={results.addonGroups} onClose={close} />
+              <AnimeRow items={currentResults.anime} onClose={close} />
+              <AddonResults groups={currentResults.addonGroups} onClose={close} />
             </div>
           )}
 
@@ -299,7 +309,7 @@ export function SearchOverlay() {
             </div>
           )}
 
-          {trimmed && !directInput && !results && status !== "done" && (
+          {trimmed && !directInput && !currentResults && status !== "done" && (
             <div className="flex flex-col items-center gap-3 pt-16 text-ink-muted">
               <Loader2 size={22} className="animate-spin" />
               <span className="text-[13.5px]">{t("Looking…")}</span>

--- a/src/lib/search-context.tsx
+++ b/src/lib/search-context.tsx
@@ -1,9 +1,26 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { MOVIE_GENRES } from "@/lib/feed/tags";
 import { useParental } from "@/lib/parental";
-import { searchAll, searchAnime, searchCinemeta, searchLiveTvChannels, type SearchResults } from "@/lib/search";
+import {
+  detectIntent,
+  searchAll,
+  searchAnime,
+  searchCinemeta,
+  searchLiveTvChannels,
+  type SearchResults,
+} from "@/lib/search";
 import { searchAddonCatalogs, searchAddonGroups, mergeMetas } from "@/lib/search-addons";
 import { searchAddonIndex } from "@/lib/search-addon-index";
+import { createSearchRequestGuard } from "@/lib/search-request-guard";
 import { gatherCatalogAddons, type Addon } from "@/lib/addons";
 import { useAuth } from "@/lib/auth";
 import { useSettings } from "@/lib/settings";
@@ -28,6 +45,33 @@ type SearchValue = SearchState & {
 const Ctx = createContext<SearchValue | null>(null);
 const RECENT_KEY = "harbor.search.recent";
 const MAX_RECENT = 8;
+const TMDB_CACHE_TTL_MS = 60_000;
+const SECONDARY_CACHE_TTL_MS = 60_000;
+const MAX_CACHE_ENTRIES = 16;
+
+type SearchCache<T> = Map<string, { expiresAt: number; result: T }>;
+
+function cachedSearch<T>(
+  cache: SearchCache<T>,
+  key: string,
+  ttlMs: number,
+  load: () => Promise<T>,
+): Promise<T> {
+  const now = Date.now();
+  for (const [cacheKey, value] of cache) {
+    if (value.expiresAt <= now) cache.delete(cacheKey);
+  }
+  const cached = cache.get(key);
+  if (cached) return Promise.resolve(cached.result);
+  return load().then((result) => {
+    if (cache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = cache.keys().next().value;
+      if (oldest) cache.delete(oldest);
+    }
+    cache.set(key, { expiresAt: Date.now() + ttlMs, result });
+    return result;
+  });
+}
 
 function loadRecent(): string[] {
   try {
@@ -58,7 +102,14 @@ export function SearchProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<SearchState["status"]>("idle");
   const [recent, setRecent] = useState<string[]>(() => loadRecent());
   const debounceRef = useRef<number | null>(null);
-  const reqIdRef = useRef(0);
+  const requestGuardRef = useRef(createSearchRequestGuard());
+  const tmdbCacheRef = useRef(new Map<string, { expiresAt: number; result: SearchResults }>());
+  const animeCacheRef = useRef(
+    new Map<string, { expiresAt: number; result: Awaited<ReturnType<typeof searchAnime>> }>(),
+  );
+  const cinemetaCacheRef = useRef(
+    new Map<string, { expiresAt: number; result: Awaited<ReturnType<typeof searchCinemeta>> }>(),
+  );
   const addonsRef = useRef<{ key: string | null; addons: Addon[] } | null>(null);
   const ensureAddons = useCallback(async (): Promise<Addon[]> => {
     if (addonsRef.current && addonsRef.current.key === authKey) return addonsRef.current.addons;
@@ -82,6 +133,9 @@ export function SearchProvider({ children }: { children: ReactNode }) {
   }, [hiddenTabs.anime]);
 
   useEffect(() => {
+    // Invalidate an already-running request before the debounce starts. Without
+    // this, an older search can publish while the user is typing a new query.
+    const id = requestGuardRef.current.begin();
     const trimmed = query.trim();
     if (debounceRef.current) window.clearTimeout(debounceRef.current);
     if (!trimmed) {
@@ -89,23 +143,40 @@ export function SearchProvider({ children }: { children: ReactNode }) {
       setStatus("idle");
       return;
     }
+    setResults(null);
     setStatus("typing");
     const animeAllowed = !hiddenTabs.anime;
     const liveTvAllowed = !hiddenTabs.liveTv && settings.iptvPlaylists.length > 0;
     debounceRef.current = window.setTimeout(() => {
-      const id = ++reqIdRef.current;
+      if (!requestGuardRef.current.isCurrent(id)) return;
       setStatus("loading");
       const liveTv = liveTvAllowed ? searchLiveTvChannels(trimmed, settings.iptvPlaylists) : [];
-      const tmdbPromise = searchAll(settings.tmdbKey, trimmed, { excludeGenres });
-      const animePromise = animeAllowed ? searchAnime(trimmed) : Promise.resolve([]);
+      const normalizedQuery = trimmed.toLocaleLowerCase().replace(/\s+/g, " ");
+      const tmdbCacheKey = [
+        settings.tmdbKey,
+        settings.tmdbLanguage,
+        excludeGenres.join(","),
+        normalizedQuery,
+      ].join("\0");
+      const tmdbPromise = cachedSearch(tmdbCacheRef.current, tmdbCacheKey, TMDB_CACHE_TTL_MS, () =>
+        searchAll(settings.tmdbKey, trimmed, { excludeGenres }),
+      );
+      const animePromise = animeAllowed
+        ? cachedSearch(animeCacheRef.current, normalizedQuery, SECONDARY_CACHE_TTL_MS, () =>
+            searchAnime(trimmed),
+          )
+        : Promise.resolve([]);
       const addonsP = ensureAddons();
       const addonPromise = addonsP
         .then((a) => searchAddonCatalogs(a, trimmed))
         .catch(() => ({ movies: [], series: [] }));
-      const addonGroupsPromise = addonsP
-        .then((a) => searchAddonGroups(a, trimmed))
-        .catch(() => []);
-      const cinemetaPromise = searchCinemeta(trimmed).catch(() => ({ movies: [], series: [] }));
+      const addonGroupsPromise = addonsP.then((a) => searchAddonGroups(a, trimmed)).catch(() => []);
+      const cinemetaPromise = cachedSearch(
+        cinemetaCacheRef.current,
+        normalizedQuery,
+        SECONDARY_CACHE_TTL_MS,
+        () => searchCinemeta(trimmed),
+      ).catch(() => ({ movies: [], series: [] }));
       let tmdbResult: Awaited<typeof tmdbPromise> | null = null;
       const acc = {
         anime: [] as Awaited<typeof animePromise>,
@@ -114,9 +185,15 @@ export function SearchProvider({ children }: { children: ReactNode }) {
         groups: [] as Awaited<typeof addonGroupsPromise>,
       };
       const publish = () => {
-        if (id !== reqIdRef.current || !tmdbResult) return;
-        const mergedMovies = mergeMetas(mergeMetas(tmdbResult.movies, acc.addon.movies), acc.cine.movies);
-        const mergedSeries = mergeMetas(mergeMetas(tmdbResult.series, acc.addon.series), acc.cine.series);
+        if (!requestGuardRef.current.isCurrent(id) || !tmdbResult) return;
+        const mergedMovies = mergeMetas(
+          mergeMetas(tmdbResult.movies, acc.addon.movies),
+          acc.cine.movies,
+        );
+        const mergedSeries = mergeMetas(
+          mergeMetas(tmdbResult.series, acc.addon.series),
+          acc.cine.series,
+        );
         const shown = new Set<string>([...mergedMovies, ...mergedSeries].map((m) => m.id));
         const dedupedGroups = acc.groups
           .map((g) => ({ ...g, metas: g.metas.filter((m) => !shown.has(m.id)) }))
@@ -138,7 +215,22 @@ export function SearchProvider({ children }: { children: ReactNode }) {
           publish();
         })
         .catch(() => {
-          if (id === reqIdRef.current) setStatus("done");
+          // Other search providers remain useful when TMDB is temporarily
+          // unavailable, so use an empty TMDB result as the publish baseline.
+          tmdbResult = {
+            query: trimmed,
+            topMatch: null,
+            people: [],
+            movies: [],
+            series: [],
+            liveTv: [],
+            anime: [],
+            addonGroups: [],
+            addons: [],
+            intent: detectIntent(trimmed),
+            tmdbUnavailable: true,
+          };
+          publish();
         });
       void animePromise.then((a) => {
         acc.anime = a;
@@ -157,7 +249,23 @@ export function SearchProvider({ children }: { children: ReactNode }) {
         publish();
       });
     }, 180);
-  }, [query, settings.tmdbKey, settings.iptvPlaylists, excludeGenres, hiddenTabs.anime, hiddenTabs.liveTv, authKey]);
+
+    return () => {
+      if (debounceRef.current) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, [
+    query,
+    settings.tmdbKey,
+    settings.tmdbLanguage,
+    settings.iptvPlaylists,
+    excludeGenres,
+    hiddenTabs.anime,
+    hiddenTabs.liveTv,
+    ensureAddons,
+  ]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -188,7 +296,10 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     const trimmed = q.trim();
     if (!trimmed) return;
     setRecent((prev) => {
-      const next = [trimmed, ...prev.filter((p) => p.toLowerCase() !== trimmed.toLowerCase())].slice(0, MAX_RECENT);
+      const next = [
+        trimmed,
+        ...prev.filter((p) => p.toLowerCase() !== trimmed.toLowerCase()),
+      ].slice(0, MAX_RECENT);
       saveRecent(next);
       return next;
     });
@@ -208,8 +319,31 @@ export function SearchProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const value = useMemo(
-    () => ({ open, setOpen, query, setQuery, results, status, recent, clear, recordRecent, removeRecent, clearRecent }),
-    [open, query, results, status, recent, setQuery, clear, recordRecent, removeRecent, clearRecent],
+    () => ({
+      open,
+      setOpen,
+      query,
+      setQuery,
+      results,
+      status,
+      recent,
+      clear,
+      recordRecent,
+      removeRecent,
+      clearRecent,
+    }),
+    [
+      open,
+      query,
+      results,
+      status,
+      recent,
+      setQuery,
+      clear,
+      recordRecent,
+      removeRecent,
+      clearRecent,
+    ],
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/src/lib/search-context.tsx
+++ b/src/lib/search-context.tsx
@@ -21,6 +21,7 @@ import {
 import { searchAddonCatalogs, searchAddonGroups, mergeMetas } from "@/lib/search-addons";
 import { searchAddonIndex } from "@/lib/search-addon-index";
 import { createSearchRequestGuard } from "@/lib/search-request-guard";
+import { normalizeSearchQuery } from "@/lib/search-query";
 import { gatherCatalogAddons, type Addon } from "@/lib/addons";
 import { useAuth } from "@/lib/auth";
 import { useSettings } from "@/lib/settings";
@@ -151,7 +152,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
       if (!requestGuardRef.current.isCurrent(id)) return;
       setStatus("loading");
       const liveTv = liveTvAllowed ? searchLiveTvChannels(trimmed, settings.iptvPlaylists) : [];
-      const normalizedQuery = trimmed.toLocaleLowerCase().replace(/\s+/g, " ");
+      const normalizedQuery = normalizeSearchQuery(trimmed);
       const tmdbCacheKey = [
         settings.tmdbKey,
         settings.tmdbLanguage,

--- a/src/lib/search-display-state.ts
+++ b/src/lib/search-display-state.ts
@@ -1,0 +1,40 @@
+import type { SearchResults } from "./search.ts";
+import { normalizeSearchQuery } from "./search-query.ts";
+
+export type SearchDisplayState = {
+  currentResults: SearchResults | null;
+  hasResults: boolean;
+  noResults: boolean;
+  tmdbUnavailable: boolean;
+};
+
+export function getSearchDisplayState(
+  results: SearchResults | null,
+  query: string,
+  status: "idle" | "typing" | "loading" | "done",
+): SearchDisplayState {
+  const normalizedQuery = normalizeSearchQuery(query);
+  const currentResults =
+    normalizedQuery && results && normalizeSearchQuery(results.query) === normalizedQuery
+      ? results
+      : null;
+  const hasResults = !!(
+    currentResults &&
+    (currentResults.topMatch ||
+      currentResults.people.length ||
+      currentResults.movies.length ||
+      currentResults.series.length ||
+      currentResults.liveTv.length ||
+      currentResults.anime.length ||
+      currentResults.addons.length ||
+      currentResults.addonGroups.length)
+  );
+  const tmdbUnavailable = !!currentResults?.tmdbUnavailable;
+
+  return {
+    currentResults,
+    hasResults,
+    noResults: !!currentResults && status === "done" && !hasResults && !tmdbUnavailable,
+    tmdbUnavailable,
+  };
+}

--- a/src/lib/search-query.ts
+++ b/src/lib/search-query.ts
@@ -1,0 +1,3 @@
+export function normalizeSearchQuery(query: string): string {
+  return query.normalize("NFKC").trim().toLowerCase().replace(/\s+/gu, " ");
+}

--- a/src/lib/search-request-guard.ts
+++ b/src/lib/search-request-guard.ts
@@ -1,0 +1,13 @@
+export type SearchRequestGuard = {
+  begin: () => number;
+  isCurrent: (id: number) => boolean;
+};
+
+export function createSearchRequestGuard(): SearchRequestGuard {
+  let current = 0;
+
+  return {
+    begin: () => ++current,
+    isCurrent: (id) => id === current,
+  };
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,5 +1,11 @@
 import { get } from "@/lib/providers/tmdb/tmdb-client";
-import { movieMeta, seriesMeta, type Page, type RawMovie, type RawSeries } from "@/lib/providers/tmdb/tmdb-meta-mappers";
+import {
+  movieMeta,
+  seriesMeta,
+  type Page,
+  type RawMovie,
+  type RawSeries,
+} from "@/lib/providers/tmdb/tmdb-meta-mappers";
 import { MOVIE_GENRES, TV_GENRES } from "@/lib/feed/tags";
 import type { Meta } from "@/lib/cinemeta";
 import type { AddonResultGroup } from "@/lib/search-addons";
@@ -56,7 +62,14 @@ export type AnimeHit = {
 
 export type SearchResults = {
   query: string;
-  topMatch: { kind: "movie" | "series"; meta: Meta; popularity: number; backdrop?: string; overview?: string; voteAverage?: number } | null;
+  topMatch: {
+    kind: "movie" | "series";
+    meta: Meta;
+    popularity: number;
+    backdrop?: string;
+    overview?: string;
+    voteAverage?: number;
+  } | null;
   people: SearchPerson[];
   movies: Meta[];
   series: Meta[];
@@ -65,6 +78,7 @@ export type SearchResults = {
   addonGroups: AddonResultGroup[];
   addons: AddonHit[];
   intent: SearchIntent;
+  tmdbUnavailable?: boolean;
 };
 
 export type SearchIntent =
@@ -198,10 +212,32 @@ export async function searchAll(
 ): Promise<SearchResults> {
   const trimmed = query.trim();
   if (!trimmed) {
-    return { query: "", topMatch: null, people: [], movies: [], series: [], liveTv: [], anime: [], addonGroups: [], addons: [], intent: null };
+    return {
+      query: "",
+      topMatch: null,
+      people: [],
+      movies: [],
+      series: [],
+      liveTv: [],
+      anime: [],
+      addonGroups: [],
+      addons: [],
+      intent: null,
+    };
   }
   if (!key) {
-    return { query: trimmed, topMatch: null, people: [], movies: [], series: [], liveTv: [], anime: [], addonGroups: [], addons: [], intent: detectIntent(trimmed) };
+    return {
+      query: trimmed,
+      topMatch: null,
+      people: [],
+      movies: [],
+      series: [],
+      liveTv: [],
+      anime: [],
+      addonGroups: [],
+      addons: [],
+      intent: detectIntent(trimmed),
+    };
   }
 
   const data = await get<Page<MultiItem>>(key, "search/multi", {
@@ -242,7 +278,10 @@ export async function searchAll(
       }
     } else if (r.media_type === "person") {
       const known = (r.known_for ?? [])
-        .map((k) => (k as { title?: string; name?: string }).title ?? (k as { name?: string }).name ?? "")
+        .map(
+          (k) =>
+            (k as { title?: string; name?: string }).title ?? (k as { name?: string }).name ?? "",
+        )
         .filter(Boolean)
         .slice(0, 2)
         .join(", ");
@@ -273,7 +312,9 @@ export async function searchAll(
       kind: isMovie ? "movie" : "series",
       meta: isMovie ? movieMeta(winner as RawMovie) : seriesMeta(winner as RawSeries),
       popularity: winner.popularity ?? 0,
-      backdrop: winner.backdrop_path ? `https://image.tmdb.org/t/p/w1280${winner.backdrop_path}` : undefined,
+      backdrop: winner.backdrop_path
+        ? `https://image.tmdb.org/t/p/w1280${winner.backdrop_path}`
+        : undefined,
       overview: winner.overview,
       voteAverage: winner.vote_average,
     };
@@ -340,7 +381,10 @@ async function fuzzyPeopleFallback(
     if (seen.has(r.id) || !nameCloseTo(r.name, query)) continue;
     seen.add(r.id);
     const known = (r.known_for ?? [])
-      .map((k) => (k as { title?: string; name?: string }).title ?? (k as { name?: string }).name ?? "")
+      .map(
+        (k) =>
+          (k as { title?: string; name?: string }).title ?? (k as { name?: string }).name ?? "",
+      )
       .filter(Boolean)
       .slice(0, 2)
       .join(", ");

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -244,6 +244,21 @@ export async function searchAll(
     query: trimmed,
     include_adult: "false",
   });
+  if (!data) {
+    return {
+      query: trimmed,
+      topMatch: null,
+      people: [],
+      movies: [],
+      series: [],
+      liveTv: [],
+      anime: [],
+      addonGroups: [],
+      addons: [],
+      intent: detectIntent(trimmed),
+      tmdbUnavailable: true,
+    };
+  }
   const exclude = new Set(opts.excludeGenres ?? []);
   const hasExcludedGenre = (gs?: number[]) => (gs ?? []).some((id) => exclude.has(id));
   const results = (data?.results ?? []).filter((r) => {

--- a/tests/search-display-state.test.ts
+++ b/tests/search-display-state.test.ts
@@ -1,0 +1,46 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { getSearchDisplayState } from "../src/lib/search-display-state.ts";
+import { normalizeSearchQuery } from "../src/lib/search-query.ts";
+import type { SearchResults } from "../src/lib/search.ts";
+
+function results(query: string, tmdbUnavailable = false): SearchResults {
+  return {
+    query,
+    topMatch: null,
+    people: [],
+    movies: [],
+    series: [],
+    liveTv: [],
+    anime: [],
+    addonGroups: [],
+    addons: [],
+    intent: null,
+    tmdbUnavailable,
+  };
+}
+
+test("normalizes cache and result comparisons consistently", () => {
+  assert.equal(normalizeSearchQuery("  Ｂａｔｍａｎ   "), "batman");
+  assert.equal(normalizeSearchQuery("Batman"), normalizeSearchQuery("batman"));
+
+  const state = getSearchDisplayState(results("Batman"), "  batman  ", "done");
+  assert.equal(state.currentResults?.query, "Batman");
+});
+
+test("does not present a TMDB outage as no matches", () => {
+  const state = getSearchDisplayState(results("Batman", true), "batman", "done");
+
+  assert.equal(state.tmdbUnavailable, true);
+  assert.equal(state.hasResults, false);
+  assert.equal(state.noResults, false);
+});
+
+test("shows no matches only after a complete successful search", () => {
+  const state = getSearchDisplayState(results("Batman"), "batman", "done");
+
+  assert.equal(state.tmdbUnavailable, false);
+  assert.equal(state.noResults, true);
+});

--- a/tests/search-request-guard.test.ts
+++ b/tests/search-request-guard.test.ts
@@ -1,0 +1,14 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { createSearchRequestGuard } from "../src/lib/search-request-guard.ts";
+
+test("rejects a late response from a superseded query", () => {
+  const guard = createSearchRequestGuard();
+  const first = guard.begin();
+  const second = guard.begin();
+
+  assert.equal(guard.isCurrent(first), false);
+  assert.equal(guard.isCurrent(second), true);
+});


### PR DESCRIPTION
## Summary
- prevent stale search responses from replacing the active query and render only results that match it
- cache TMDB, Cinemeta, and anime metadata searches for 60 seconds with a bounded 16-entry cache per provider
- keep addon results uncached; show a partial-results notice when TMDB fails
- allow Linux debug builds to run alongside the installed Harbor app while release builds retain single-instance behavior

## Advantages
- avoids incorrect or missing Top Match/results after rapid query changes
- reduces repeated metadata API calls for backspacing, reopening, and refining searches
- bounds memory to 48 cached result sets and keeps variable addon results fresh
- preserves release single-instance behavior and adds a stale-response regression test




## Review notes
- reviewed the complete diff against ; no search behavior regressions found
- addon catalog searches are intentionally not cached
- the cache key scopes TMDB data by API key, language, genre filtering, and normalized query