### PR TITLE
Feat/merge wayland perf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 ## Task Completion Requirements
 
-- Run `vp check` for files changed by the task before considering it complete.
-- Run `vp run typecheck` after TypeScript changes.
+- Run `pnpm run check` (`vp check`) for files changed by the task before considering it complete.
+- Run `pnpm run typecheck` (`tsc -b --pretty false`) after TypeScript changes.
 - Run `cargo check --manifest-path src-tauri/Cargo.toml` after Rust changes.
+- Run `pnpm tauri:build:linux-system` (`tauri build --config src-tauri/tauri.linux-system.conf.json`) to build the full Linux binary.
 - Test platform-specific changes on the affected platform when possible.
 - Do not leave warnings or errors introduced by the task unresolved.
 - If a repository-wide check fails on untouched files, record the baseline and do not reformat or refactor unrelated files.

--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -66,6 +66,7 @@ pub struct MpvGeometry {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(not(any(windows, test)), allow(dead_code))]
 pub(crate) struct NativeMpvRect {
     pub x: f64,
     pub y: f64,
@@ -73,6 +74,7 @@ pub(crate) struct NativeMpvRect {
     pub height: f64,
 }
 
+#[cfg_attr(not(any(windows, test)), allow(dead_code))]
 pub(crate) fn map_css_geometry(
     css: &MpvGeometry,
     native_width: f64,
@@ -1111,12 +1113,12 @@ pub async fn mpv_set_geometry(
             g.as_ref().map(|s| s.embedded).unwrap_or(false)
         };
         if embedded {
-            let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+            // GLArea fills the full window via GTK expand flags, so
+            // geometry tracking is redundant. We still dispatch to the
+            // main thread as a rendering tickle for the GLArea.
             let _ = app.run_on_main_thread(move || {
                 let _ = crate::mpv_render_linux::resize_to(geom);
-                let _ = tx.send(());
             });
-            let _ = rx.recv_timeout(std::time::Duration::from_millis(300));
             return Ok(());
         }
     }

--- a/src-tauri/src/mpv_render_linux.rs
+++ b/src-tauri/src/mpv_render_linux.rs
@@ -6,8 +6,6 @@ use std::os::raw::{c_char, c_int};
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
-use std::sync::Mutex;
-use std::time::Instant;
 
 use gtk::gdk;
 use gtk::glib;
@@ -67,8 +65,6 @@ static FBO_WIDTH: AtomicI32 = AtomicI32::new(-1);
 static FBO_HEIGHT: AtomicI32 = AtomicI32::new(-1);
 static LAST_SURFACE: AtomicU64 = AtomicU64::new(0);
 static FBO_ZERO_WARNED: AtomicBool = AtomicBool::new(false);
-static LAST_RENDER: Mutex<Option<Instant>> = Mutex::new(None);
-const RENDER_INTERVAL_US: u64 = 16_000; // cap at ~60 fps
 
 type GlProcLoader = unsafe extern "C" fn(*const c_char) -> *mut c_void;
 
@@ -437,16 +433,6 @@ fn restore_webview(embed: Embed) {
 }
 
 fn schedule_redraw() {
-    {
-        let mut last = LAST_RENDER.lock().unwrap();
-        let now = Instant::now();
-        if let Some(t) = last.as_ref() {
-            if now.duration_since(*t).as_micros() < RENDER_INTERVAL_US as u128 {
-                return;
-            }
-        }
-        *last = Some(now);
-    }
     if REDRAW_PENDING.swap(true, Ordering::AcqRel) {
         return;
     }

--- a/src-tauri/src/mpv_render_linux.rs
+++ b/src-tauri/src/mpv_render_linux.rs
@@ -6,6 +6,8 @@ use std::os::raw::{c_char, c_int};
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Instant;
 
 use gtk::gdk;
 use gtk::glib;
@@ -67,6 +69,8 @@ static REDRAW_PENDING: AtomicBool = AtomicBool::new(false);
 static LAST_SURFACE: AtomicU64 = AtomicU64::new(0);
 static PROC_WAYLAND: AtomicBool = AtomicBool::new(false);
 static FBO_ZERO_WARNED: AtomicBool = AtomicBool::new(false);
+static LAST_RENDER: Mutex<Option<Instant>> = Mutex::new(None);
+const RENDER_INTERVAL_US: u64 = 16_000; // cap at ~60 fps
 
 type GlProcLoader = unsafe extern "C" fn(*const c_char) -> *mut c_void;
 
@@ -428,6 +432,16 @@ fn restore_webview(embed: Embed) {
 }
 
 fn schedule_redraw() {
+    {
+        let mut last = LAST_RENDER.lock().unwrap();
+        let now = Instant::now();
+        if let Some(t) = last.as_ref() {
+            if now.duration_since(*t).as_micros() < RENDER_INTERVAL_US as u128 {
+                return;
+            }
+        }
+        *last = Some(now);
+    }
     if REDRAW_PENDING.swap(true, Ordering::AcqRel) {
         return;
     }

--- a/src-tauri/src/mpv_render_linux.rs
+++ b/src-tauri/src/mpv_render_linux.rs
@@ -5,7 +5,7 @@ use std::ffi::{c_void, CString};
 use std::os::raw::{c_char, c_int};
 use std::ptr::NonNull;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
 
 use gtk::gdk;
 use gtk::glib;
@@ -13,7 +13,6 @@ use gtk::glib::translate::{Stash, ToGlibPtr};
 use gtk::prelude::*;
 use libmpv2::render::{OpenGLInitParams, RenderContext, RenderParam, RenderParamApiType};
 use libmpv2_sys::mpv_handle;
-
 
 const GL_FRAMEBUFFER_BINDING: u32 = 0x8CA6;
 const GL_FRAMEBUFFER: u32 = 0x8D40;
@@ -61,8 +60,10 @@ thread_local! {
 }
 
 static REDRAW_PENDING: AtomicBool = AtomicBool::new(false);
-static LAST_SURFACE: AtomicU64 = AtomicU64::new(0);
 static PROC_WAYLAND: AtomicBool = AtomicBool::new(false);
+static FBO_WIDTH: AtomicI32 = AtomicI32::new(-1);
+static FBO_HEIGHT: AtomicI32 = AtomicI32::new(-1);
+static LAST_SURFACE: AtomicU64 = AtomicU64::new(0);
 static FBO_ZERO_WARNED: AtomicBool = AtomicBool::new(false);
 
 type GlProcLoader = unsafe extern "C" fn(*const c_char) -> *mut c_void;
@@ -131,7 +132,7 @@ fn current_fbo() -> i32 {
     }
 }
 
-fn fbo_color_size() -> Option<(i32, i32)> {
+fn query_fbo_dimensions() -> Option<(i32, i32)> {
     let get_attach: unsafe extern "C" fn(u32, u32, u32, *mut c_int) =
         resolve_gl(b"glGetFramebufferAttachmentParameteriv\0")?;
     let bind_rb: unsafe extern "C" fn(u32, u32) = resolve_gl(b"glBindRenderbuffer\0")?;
@@ -262,6 +263,9 @@ pub fn install(gtk_window: &gtk::ApplicationWindow, vbox: &gtk::Box) -> Result<(
     area.set_has_depth_buffer(false);
     area.set_has_stencil_buffer(false);
     area.set_app_paintable(true);
+    // GLArea fills the full overlay via GTK expand flags. This avoids
+    // set_size_request which on Wayland constrains the window's minimum
+    // size to the video resolution.
     area.set_hexpand(true);
     area.set_vexpand(true);
 
@@ -279,6 +283,17 @@ pub fn install(gtk_window: &gtk::ApplicationWindow, vbox: &gtk::Box) -> Result<(
     let mpv = pending.mpv;
     let backend = pending.backend;
     let display_native = pending.display_native;
+
+    // Invalidate cached FBO dimensions on GLArea resize so the next
+    // render call re-queries the physical GPU dimensions. This avoids
+    // synchronous GL queries on every frame.
+    let area_clone = area.clone();
+    area.connect_resize(move |_a, _w, _h| {
+        FBO_WIDTH.store(-1, Ordering::Relaxed);
+        FBO_HEIGHT.store(-1, Ordering::Relaxed);
+        area_clone.queue_render();
+    });
+
     area.connect_render(move |area, _ctx| {
         let mut slot = render_cell.borrow_mut();
         if slot.is_none() {
@@ -341,21 +356,29 @@ fn build_render_context(
 fn do_render(rc: &RenderContext, area: &gtk::GLArea) {
     area.attach_buffers();
     let fbo = current_fbo();
-    let (w, h, measured) = match fbo_color_size() {
-        Some((mw, mh)) => (mw, mh, true),
-        None => (
-            area.allocated_width().max(1),
-            area.allocated_height().max(1),
-            false,
-        ),
-    };
+
+    let mut w = FBO_WIDTH.load(Ordering::Relaxed);
+    let mut h = FBO_HEIGHT.load(Ordering::Relaxed);
+    if w <= 0 || h <= 0 {
+        // Query physical FBO dimensions on first render or after resize.
+        // This avoids synchronous GL queries on every frame; the result
+        // is cached and only invalidated by the GLArea::resize signal.
+        if let Some((mw, mh)) = query_fbo_dimensions() {
+            w = mw;
+            h = mh;
+        } else {
+            w = area.allocated_width().max(1);
+            h = area.allocated_height().max(1);
+        }
+        FBO_WIDTH.store(w, Ordering::Relaxed);
+        FBO_HEIGHT.store(h, Ordering::Relaxed);
+    }
+
     let packed = ((w as u64) << 32) | (h as u32 as u64);
     if LAST_SURFACE.swap(packed, Ordering::Relaxed) != packed {
         eprintln!(
-            "[harbor::mpv_linux] render surface {}x{} px ({})",
-            w,
-            h,
-            if measured { "measured fbo" } else { "computed scale" }
+            "[harbor::mpv_linux] render surface {}x{} px",
+            w, h,
         );
     }
     if fbo == 0 && !FBO_ZERO_WARNED.swap(true, Ordering::Relaxed) {
@@ -364,6 +387,9 @@ fn do_render(rc: &RenderContext, area: &gtk::GLArea) {
     let _ = rc.render::<()>(fbo, w, h, true);
 }
 
+// On Wayland, the GLArea fills the full window via GTK expand flags,
+// so geometry tracking is not needed. This function is kept for API
+// compatibility but is a no-op on Linux.
 pub fn resize_to(_css: crate::mpv::MpvGeometry) -> Result<(), String> {
     EMBED.with(|slot| {
         if let Some(embed) = slot.borrow().as_ref() {

--- a/src-tauri/src/mpv_render_linux.rs
+++ b/src-tauri/src/mpv_render_linux.rs
@@ -14,7 +14,6 @@ use gtk::prelude::*;
 use libmpv2::render::{OpenGLInitParams, RenderContext, RenderParam, RenderParamApiType};
 use libmpv2_sys::mpv_handle;
 
-use crate::mpv::{map_css_geometry, MpvGeometry};
 
 const GL_FRAMEBUFFER_BINDING: u32 = 0x8CA6;
 const GL_FRAMEBUFFER: u32 = 0x8D40;
@@ -57,8 +56,6 @@ struct Embed {
 }
 
 thread_local! {
-    // GTK objects are main-thread-only. Keeping them thread-local makes that
-    // invariant explicit and avoids unsound Send/Sync implementations.
     static EMBED: RefCell<Option<Embed>> = const { RefCell::new(None) };
     static PENDING: RefCell<Option<Pending>> = const { RefCell::new(None) };
 }
@@ -257,7 +254,6 @@ pub fn install(gtk_window: &gtk::ApplicationWindow, vbox: &gtk::Box) -> Result<(
         .ok_or_else(|| "no webview child in vbox".to_string())?;
 
     let overlay = gtk::Overlay::new();
-    let fixed = gtk::Fixed::new();
     let area = gtk::GLArea::new();
     // libmpv's update callback is the frame clock. Rendering on every GTK draw
     // as well would duplicate work whenever the transparent WebView repaints.
@@ -266,12 +262,12 @@ pub fn install(gtk_window: &gtk::ApplicationWindow, vbox: &gtk::Box) -> Result<(
     area.set_has_depth_buffer(false);
     area.set_has_stencil_buffer(false);
     area.set_app_paintable(true);
-    area.set_size_request(16, 16);
+    area.set_hexpand(true);
+    area.set_vexpand(true);
 
     gtk_window.remove(vbox);
     vbox.remove(&web_view);
-    fixed.put(&area, 0, 0);
-    overlay.add(&fixed);
+    overlay.add(&area);
     overlay.add_overlay(&web_view);
     overlay.set_overlay_pass_through(&web_view, false);
     gtk_window.add(&overlay);
@@ -368,28 +364,11 @@ fn do_render(rc: &RenderContext, area: &gtk::GLArea) {
     let _ = rc.render::<()>(fbo, w, h, true);
 }
 
-pub fn resize_to(css: MpvGeometry) -> Result<(), String> {
+pub fn resize_to(_css: crate::mpv::MpvGeometry) -> Result<(), String> {
     EMBED.with(|slot| {
-        let guard = slot.borrow();
-        let Some(embed) = guard.as_ref() else {
-            return;
-        };
-        let native = map_css_geometry(
-            &css,
-            embed.gtk_window.allocated_width().max(1) as f64,
-            embed.gtk_window.allocated_height().max(1) as f64,
-        );
-        let lw = native.width.round().max(1.0) as i32;
-        let lh = native.height.round().max(1.0) as i32;
-        embed.area.set_size_request(lw, lh);
-        if let Some(parent) = embed.area.parent() {
-            if let Some(fixed) = parent.downcast_ref::<gtk::Fixed>() {
-                let lx = native.x.round() as i32;
-                let ly = native.y.round() as i32;
-                fixed.move_(&embed.area, lx, ly);
-            }
+        if let Some(embed) = slot.borrow().as_ref() {
+            embed.area.queue_render();
         }
-        embed.area.queue_render();
     });
     Ok(())
 }

--- a/src/components/player/subtitle-overlay.tsx
+++ b/src/components/player/subtitle-overlay.tsx
@@ -22,7 +22,6 @@ export const SubtitleOverlay = memo(function SubtitleOverlay({ text, startSec, s
     window.addEventListener("resize", measure);
     return () => window.removeEventListener("resize", measure);
   }, [text]);
-  if (!text) return null;
 
   const responsive = useMemo(
     () => (boxH > 0 ? Math.max(0.3, Math.min(2.5, boxH / 1080)) : scale),
@@ -101,6 +100,8 @@ export const SubtitleOverlay = memo(function SubtitleOverlay({ text, startSec, s
   );
 
   const opacity = useMemo(() => clamp(settings.subOpacity ?? 1, 0.1, 1), [settings.subOpacity]);
+
+  if (!text) return null;
 
   return (
     <div

--- a/src/components/player/subtitle-overlay.tsx
+++ b/src/components/player/subtitle-overlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useActiveKid } from "@/lib/profiles";
 import { useSettings } from "@/lib/settings";
 
@@ -8,7 +8,7 @@ type Props = {
   scale?: number;
 };
 
-export function SubtitleOverlay({ text, startSec, scale = 1 }: Props) {
+export const SubtitleOverlay = memo(function SubtitleOverlay({ text, startSec, scale = 1 }: Props) {
   const { settings } = useSettings();
   const kid = useActiveKid();
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -24,51 +24,83 @@ export function SubtitleOverlay({ text, startSec, scale = 1 }: Props) {
   }, [text]);
   if (!text) return null;
 
-  const responsive = boxH > 0 ? Math.max(0.3, Math.min(2.5, boxH / 1080)) : scale;
-  const baseFont = kid ? Math.max(54, clamp(settings.subFontSize, 16, 120)) : clamp(settings.subFontSize, 16, 120);
-  const fontSize = Math.round(baseFont * responsive);
-  const marginY = clamp(settings.subMarginY, 0, 100);
+  const responsive = useMemo(
+    () => (boxH > 0 ? Math.max(0.3, Math.min(2.5, boxH / 1080)) : scale),
+    [boxH, scale],
+  );
+  const baseFont = useMemo(
+    () =>
+      kid
+        ? Math.max(54, clamp(settings.subFontSize, 16, 120))
+        : clamp(settings.subFontSize, 16, 120),
+    [kid, settings.subFontSize],
+  );
+  const fontSize = useMemo(() => Math.round(baseFont * responsive), [baseFont, responsive]);
+  const marginY = useMemo(() => clamp(settings.subMarginY, 0, 100), [settings.subMarginY]);
   const fontColor = settings.subFontColor || "#FFFFFF";
   const align = settings.subAlignX || "center";
-  const family = fontFamilyFor(settings.subFontFamily);
-  const style = kid ? "shadow" : settings.subStyle ?? "shadow";
-  const lines = text.split("\n");
+  const family = useMemo(() => fontFamilyFor(settings.subFontFamily), [settings.subFontFamily]);
+  const style = kid ? "shadow" : (settings.subStyle ?? "shadow");
+  const lines = useMemo(() => text.split("\n"), [text]);
 
-  const justify = align === "left" ? "justify-start" : align === "right" ? "justify-end" : "justify-center";
+  const justify =
+    align === "left" ? "justify-start" : align === "right" ? "justify-end" : "justify-center";
 
-  const baseTextStyle: React.CSSProperties = {
-    color: fontColor,
-    fontFamily: family,
-    fontWeight: kid || settings.subBold ? 700 : 400,
-    fontSize: `${fontSize}px`,
-    lineHeight: 1.2,
-    letterSpacing: `${(-0.005 + (settings.subLineSpacing ?? 0) * 0.06).toFixed(3)}em`,
-    whiteSpace: "pre-wrap",
-    textAlign: align as "left" | "center" | "right",
-  };
+  const borderSize = useMemo(
+    () => Math.max(1, Math.round((clamp(settings.subBorderSize, 1, 6) || 2) * responsive)),
+    [settings.subBorderSize, responsive],
+  );
+  const borderColor = settings.subBorderColor || "#000000";
 
-  if (style === "outline") {
-    const borderSize = Math.max(1, Math.round((clamp(settings.subBorderSize, 1, 6) || 2) * responsive));
-    const borderColor = settings.subBorderColor || "#000000";
-    baseTextStyle.textShadow = buildOutline(borderColor, borderSize);
-  } else if (style === "shadow") {
-    baseTextStyle.textShadow =
-      "0 1px 2px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55)";
-  }
+  const textShadow = useMemo(() => {
+    if (style === "outline") {
+      return buildOutline(borderColor, borderSize);
+    } else if (style === "shadow") {
+      return "0 1px 2px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55)";
+    }
+    return undefined;
+  }, [style, borderColor, borderSize]);
 
-  const boxOpacity = clamp(settings.subBoxOpacity, 0, 1);
-  const boxRgb = hexToRgb(settings.subBoxColor || "#000000");
-  const boxStyle: React.CSSProperties | undefined =
-    style === "box"
-      ? {
-          backgroundColor: `rgba(${boxRgb.r}, ${boxRgb.g}, ${boxRgb.b}, ${boxOpacity})`,
-          padding: `${Math.round(fontSize * 0.18)}px ${Math.round(fontSize * 0.5)}px`,
-          borderRadius: `${Math.round(fontSize * 0.25)}px`,
-          backdropFilter: "blur(2px)",
-        }
-      : undefined;
+  const baseTextStyle: React.CSSProperties = useMemo(
+    () => ({
+      color: fontColor,
+      fontFamily: family,
+      fontWeight: kid || settings.subBold ? 700 : 400,
+      fontSize: `${fontSize}px`,
+      lineHeight: 1.2,
+      letterSpacing: `${(-0.005 + (settings.subLineSpacing ?? 0) * 0.06).toFixed(3)}em`,
+      whiteSpace: "pre-wrap",
+      textAlign: align as "left" | "center" | "right",
+      ...(textShadow ? { textShadow } : {}),
+    }),
+    [
+      fontColor,
+      family,
+      kid,
+      settings.subBold,
+      fontSize,
+      settings.subLineSpacing,
+      align,
+      textShadow,
+    ],
+  );
 
-  const opacity = clamp(settings.subOpacity ?? 1, 0.1, 1);
+  const boxOpacity = useMemo(() => clamp(settings.subBoxOpacity, 0, 1), [settings.subBoxOpacity]);
+  const boxRgb = useMemo(() => hexToRgb(settings.subBoxColor || "#000000"), [settings.subBoxColor]);
+  const boxStyle: React.CSSProperties | undefined = useMemo(
+    () =>
+      style === "box"
+        ? {
+            backgroundColor: `rgba(${boxRgb.r}, ${boxRgb.g}, ${boxRgb.b}, ${boxOpacity})`,
+            padding: `${Math.round(fontSize * 0.18)}px ${Math.round(fontSize * 0.5)}px`,
+            borderRadius: `${Math.round(fontSize * 0.25)}px`,
+            backdropFilter: "blur(2px)",
+          }
+        : undefined,
+    [style, boxRgb, boxOpacity, fontSize],
+  );
+
+  const opacity = useMemo(() => clamp(settings.subOpacity ?? 1, 0.1, 1), [settings.subOpacity]);
 
   return (
     <div
@@ -86,7 +118,7 @@ export function SubtitleOverlay({ text, startSec, scale = 1 }: Props) {
       </div>
     </div>
   );
-}
+});
 
 function fontFamilyFor(family: string | undefined): string {
   if (family?.startsWith("custom:")) {

--- a/src/components/player/transport/seek-bar.tsx
+++ b/src/components/player/transport/seek-bar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSettings } from "@/lib/settings";
 import {
   usePlaybackPositionGated,
@@ -40,16 +40,23 @@ export function SeekBar({
   const pct = Math.max(0, Math.min(1, value / dur)) * 100;
   const cacheFill = Math.max(0, Math.min(1, (position + buffered) / dur));
   const fullyCached = downloaded >= 0.999;
-  const bufferedPct =
-    fullyCached || settings.seekBarFill === false ? 0 : Math.max(cacheFill, downloaded) * 100;
+  const bufferedPct = useMemo(
+    () =>
+      fullyCached || settings.seekBarFill === false ? 0 : Math.max(cacheFill, downloaded) * 100,
+    [fullyCached, settings.seekBarFill, cacheFill, downloaded],
+  );
   const skipSegments = useSkipSegmentsView();
-  const segmentSpans = skipSegments
-    .filter((s) => s.endSec > s.startSec && durationSec > 0)
-    .map((s) => ({
-      startPct: Math.max(0, Math.min(100, (s.startSec / dur) * 100)),
-      endPct: Math.max(0, Math.min(100, (s.endSec / dur) * 100)),
-      color: s.kind === "ad" ? "rgba(239,68,68,0.9)" : undefined,
-    }));
+  const segmentSpans = useMemo(
+    () =>
+      skipSegments
+        .filter((s) => s.endSec > s.startSec && durationSec > 0)
+        .map((s) => ({
+          startPct: Math.max(0, Math.min(100, (s.startSec / dur) * 100)),
+          endPct: Math.max(0, Math.min(100, (s.endSec / dur) * 100)),
+          color: s.kind === "ad" ? "rgba(239,68,68,0.9)" : undefined,
+        })),
+    [skipSegments, durationSec, dur],
+  );
 
   const clearInteraction = () => {
     setScrub(null);

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { subtitleDownloadArgs } from "./subtitle-load";
 import { mpvFailureSnapshot } from "./mpv-failure";
-import { isMacDesktop, isWindowsDesktop } from "@/lib/platform";
+import { isLinuxDesktop, isMacDesktop, isWindowsDesktop } from "@/lib/platform";
 import { makeSafeTauriUnlisten } from "@/lib/tauri-unlisten";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
@@ -393,8 +393,9 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
             () => {},
           );
         }
-        if (opts.embed && opts.getEmbedRect && geomTimer == null) {
+        if (opts.embed && opts.getEmbedRect && geomTimer == null && !isLinuxDesktop()) {
           let lastRect: MpvRect | null = null;
+          let geomDebounce: number | null = null;
           const tick = async () => {
             try {
               const r = await opts.getEmbedRect!();
@@ -415,16 +416,9 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
             } catch {}
           };
           tick();
-          geomTimer = window.setInterval(() => {
-            void tick();
-          }, 250);
           geomKickHandler = () => {
-            void tick();
-            window.setTimeout(() => void tick(), 60);
-            window.setTimeout(() => void tick(), 200);
-            window.setTimeout(() => void tick(), 500);
-            window.setTimeout(() => void tick(), 1000);
-            window.setTimeout(() => void tick(), 1800);
+            if (geomDebounce != null) window.clearTimeout(geomDebounce);
+            geomDebounce = window.setTimeout(() => void tick(), 40);
           };
           geomForceHandler = () => {
             lastRect = null;

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -133,6 +133,8 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const stageRef = useRef<HTMLDivElement>(null);
   const videoMountRef = useRef<HTMLDivElement>(null);
   const bridgeRef = useRef<PlayerBridge | null>(null);
+  const srcRef = useRef(src);
+  srcRef.current = src;
   const selfFrameReadyRef = useRef(false);
   const { fullscreen, toggleFullscreen } = useFullscreen();
   const { snap, engine, bridgeReady, bridgeKey, embedActive, svpActive } = usePlayerBridge({
@@ -834,6 +836,20 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     [showVolumeFeedback, isKid, settings.playerVolumeSfx],
   );
 
+  const onLoaderRetry = useCallback(() => {
+    const s = srcRef.current;
+    const b = bridgeRef.current;
+    if (b) {
+      void b.load({
+        url: s.url,
+        subtitles: s.subtitles,
+        notWebReady: s.notWebReady,
+        isLive: s.meta.id?.startsWith("iptv:"),
+        headers: s.headers,
+      });
+    }
+  }, []);
+
   const overlayProps: PlayerOverlayLayersProps = {
     snap,
     engine,
@@ -870,18 +886,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     engineStats,
     isP2pEngine,
     setLoaderShowing,
-    onLoaderRetry: () => {
-      const b = bridgeRef.current;
-      if (b) {
-        void b.load({
-          url: src.url,
-          subtitles: src.subtitles,
-          notWebReady: src.notWebReady,
-          isLive: src.meta.id?.startsWith("iptv:"),
-          headers: src.headers,
-        });
-      }
-    },
+    onLoaderRetry: onLoaderRetry,
     bridgeRef,
     strokes,
     hideOthersDrawings,

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -133,8 +133,6 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const stageRef = useRef<HTMLDivElement>(null);
   const videoMountRef = useRef<HTMLDivElement>(null);
   const bridgeRef = useRef<PlayerBridge | null>(null);
-  const srcRef = useRef(src);
-  srcRef.current = src;
   const selfFrameReadyRef = useRef(false);
   const { fullscreen, toggleFullscreen } = useFullscreen();
   const { snap, engine, bridgeReady, bridgeKey, embedActive, svpActive } = usePlayerBridge({
@@ -837,18 +835,17 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   );
 
   const onLoaderRetry = useCallback(() => {
-    const s = srcRef.current;
     const b = bridgeRef.current;
     if (b) {
       void b.load({
-        url: s.url,
-        subtitles: s.subtitles,
-        notWebReady: s.notWebReady,
-        isLive: s.meta.id?.startsWith("iptv:"),
-        headers: s.headers,
+        url: src.url,
+        subtitles: src.subtitles,
+        notWebReady: src.notWebReady,
+        isLive: src.meta.id?.startsWith("iptv:"),
+        headers: src.headers,
       });
     }
-  }, []);
+  }, [src]);
 
   const overlayProps: PlayerOverlayLayersProps = {
     snap,

--- a/src/views/player/buffering-indicator.tsx
+++ b/src/views/player/buffering-indicator.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { getPlaybackPosition } from "@/lib/player/playback-clock";
 import type { PlayerStatus } from "@/lib/player/bridge";
@@ -7,7 +7,7 @@ import {
   initialBufferingIndicatorState,
 } from "./buffering-indicator-state";
 
-export function BufferingIndicator({
+export const BufferingIndicator = memo(function BufferingIndicator({
   buffering,
   status,
   suppressed,
@@ -49,4 +49,4 @@ export function BufferingIndicator({
     />,
     playPauseButton,
   );
-}
+});

--- a/src/views/player/hooks/use-chrome-visibility.ts
+++ b/src/views/player/hooks/use-chrome-visibility.ts
@@ -1,6 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { getSeekHovering, subscribeSeekHovering } from "@/lib/player/playback-clock";
-import { CHROME_HIDE_MS_PAUSED, CHROME_HIDE_MS_PLAYING, CHROME_HIDE_MS_RESUME } from "../player-utils";
+import {
+  CHROME_HIDE_MS_PAUSED,
+  CHROME_HIDE_MS_PLAYING,
+  CHROME_HIDE_MS_RESUME,
+} from "../player-utils";
 import { getFocusable, isVisible } from "@/lib/keyboard-navigation";
 
 const UI_SCALE_ACTIVITY_EVENT = "harbor:ui-scale-activity";
@@ -177,11 +181,15 @@ export function useChromeVisibility(params: {
     }
   }, [anyMenuOpen]);
 
-  const cursorStyle: CSSProperties = drawMode
-    ? { cursor: "none" }
-    : !chromeVisible && playing
-      ? { cursor: "none" }
-      : { cursor: "default" };
+  const cursorStyle: CSSProperties = useMemo(
+    () =>
+      drawMode
+        ? { cursor: "none" }
+        : !chromeVisible && playing
+          ? { cursor: "none" }
+          : { cursor: "default" },
+    [drawMode, chromeVisible, playing],
+  );
 
   return {
     chromeVisible,

--- a/src/views/player/hooks/use-fullscreen.ts
+++ b/src/views/player/hooks/use-fullscreen.ts
@@ -38,6 +38,7 @@ export function useFullscreen() {
   useEffect(() => {
     if (!fullscreen) return;
     let cancelled = false;
+    let kickDebounce: number | null = null;
     const mpvKick = async () => {
       if (cancelled) return;
       window.dispatchEvent(new Event("resize"));
@@ -61,13 +62,15 @@ export function useFullscreen() {
     };
     void reassertOs();
     void mpvKick();
-    const delays = [60, 160, 320, 640, 1100, 1700, 2400, 3200, 4200];
-    const timers = delays.map((d) => window.setTimeout(() => void mpvKick(), d));
-    const sustain = window.setInterval(() => void mpvKick(), 2000);
+    const onResize = () => {
+      if (kickDebounce != null) window.clearTimeout(kickDebounce);
+      kickDebounce = window.setTimeout(() => void mpvKick(), 80);
+    };
+    window.addEventListener("resize", onResize);
     return () => {
       cancelled = true;
-      timers.forEach((t) => window.clearTimeout(t));
-      window.clearInterval(sustain);
+      if (kickDebounce != null) window.clearTimeout(kickDebounce);
+      window.removeEventListener("resize", onResize);
     };
   }, [fullscreen]);
 

--- a/src/views/player/loader-layer.tsx
+++ b/src/views/player/loader-layer.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { ComponentProps } from "react";
 import type { PlayerSnapshot } from "@/lib/player/bridge";
 import type { PlayerSrc } from "@/lib/view";
@@ -5,7 +6,7 @@ import { CinematicPlayerLoader } from "./cinematic-player-loader";
 import { LiveChannelError } from "./live-channel-error";
 import { LocalFileError } from "./local-file-error";
 
-export function LoaderLayer({
+export const LoaderLayer = memo(function LoaderLayer({
   src,
   snap,
   isLocalSrc,
@@ -59,4 +60,4 @@ export function LoaderLayer({
       )}
     </>
   );
-}
+});

--- a/src/views/player/panels-layer.tsx
+++ b/src/views/player/panels-layer.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { EpisodePanel } from "@/components/player/episode-panel";
 import { ResumePrompt } from "@/components/player/resume-prompt";
 import type { Meta } from "@/lib/cinemeta";
@@ -6,7 +7,7 @@ import type { PlayEpisode } from "@/lib/view";
 import { useT } from "@/lib/i18n";
 import { HeaderWarning, NoAudioWarning } from "./header-warning";
 
-export function PanelsLayer({
+export const PanelsLayer = memo(function PanelsLayer({
   isSeriesPlayback,
   meta,
   currentEpisode,
@@ -114,9 +115,7 @@ export function PanelsLayer({
       )}
 
       {showHeaderWarning && <HeaderWarning onPickAnother={onPickAnother} />}
-      {showNoAudioWarning && (
-        <NoAudioWarning onUseMpv={onUseMpv} onDismiss={onDismissNoAudio} />
-      )}
+      {showNoAudioWarning && <NoAudioWarning onUseMpv={onUseMpv} onDismiss={onDismissNoAudio} />}
     </>
   );
-}
+});

--- a/src/views/player/player-overlay-layers.tsx
+++ b/src/views/player/player-overlay-layers.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type RefObject } from "react";
+import { memo, type ComponentProps, type RefObject } from "react";
 import { DrawCanvas, StrokesLayer, type Stroke } from "@/components/player/draw-canvas";
 import { StreamSwitcher } from "@/components/player/stream-switcher";
 import { StreamCheckPill } from "@/components/player/stream-check-pill";
@@ -182,7 +182,7 @@ export type PlayerOverlayLayersProps = {
   onSyncPlayPause: () => void;
 };
 
-export function PlayerOverlayLayers(p: PlayerOverlayLayersProps) {
+export const PlayerOverlayLayers = memo(function PlayerOverlayLayers(p: PlayerOverlayLayersProps) {
   return (
     <>
       <StageOverlays
@@ -470,4 +470,4 @@ export function PlayerOverlayLayers(p: PlayerOverlayLayersProps) {
       />
     </>
   );
-}
+});

--- a/src/views/player/room-layer.tsx
+++ b/src/views/player/room-layer.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { AvatarDock } from "@/components/player/avatar-dock";
 import { ChatOverlay } from "@/components/player/chat-overlay";
 import type { PanelCorner } from "@/lib/player-chrome";
@@ -9,7 +9,7 @@ import { DurationMismatchChip } from "./duration-mismatch-chip";
 import { ForeignNoticeBox } from "./foreign-notice-box";
 import { WaitingForRoom } from "./waiting-for-room";
 
-export function RoomLayer({
+export const RoomLayer = memo(function RoomLayer({
   inRoom,
   pipMode,
   drawMode,
@@ -143,4 +143,4 @@ export function RoomLayer({
       )}
     </>
   );
-}
+});

--- a/src/views/player/shell-layer.tsx
+++ b/src/views/player/shell-layer.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from "react";
+import { memo, type RefObject } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
 import { getPlayerShell, type PlayerShellProps } from "@/lib/player-shells/registry";
@@ -6,7 +6,7 @@ import { writePlayerPrefs } from "@/lib/player-prefs";
 import { writePlayerVolume } from "@/lib/player-volume";
 import type { useVideoDownload } from "./hooks/use-video-download";
 
-export function ShellLayer({
+export const ShellLayer = memo(function ShellLayer({
   shellId,
   shellSnap,
   snapRef,
@@ -232,4 +232,4 @@ export function ShellLayer({
       sleep={sleep}
     />
   );
-}
+});

--- a/src/views/player/stage-overlays.tsx
+++ b/src/views/player/stage-overlays.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Anime4kIndicator } from "@/components/player/anime4k-indicator";
 import { SvpIndicator } from "@/components/player/svp-indicator";
 import { StatsOverlay } from "@/components/player/stats-overlay";
@@ -14,7 +15,7 @@ import type { ParentalCategory } from "@/lib/providers/harbor-imdb";
 import { ContentAdvisoryToast } from "@/components/player/content-advisory-toast";
 import { useT } from "@/lib/i18n";
 
-export function StageOverlays({
+export const StageOverlays = memo(function StageOverlays({
   snap,
   engine,
   pipMode,
@@ -53,15 +54,26 @@ export function StageOverlays({
   return (
     <>
       {(!pipMode || subShowInPip) && !subAssNative && (
-        <SubtitleOverlay text={snap.subText} startSec={snap.subStartSec} scale={pipMode ? 0.45 : 1} />
+        <SubtitleOverlay
+          text={snap.subText}
+          startSec={snap.subStartSec}
+          scale={pipMode ? 0.45 : 1}
+        />
       )}
       {showStats && !pipMode && <StatsOverlay snap={snap} engine={engine} />}
-      {!pipMode && <Anime4kIndicator engine={engine} chromeVisible={chromeVisible} suppressed={topVolumeShowing} />}
-      {!pipMode && <SvpIndicator engine={engine} chromeVisible={chromeVisible} suppressed={topVolumeShowing} />}
+      {!pipMode && (
+        <Anime4kIndicator
+          engine={engine}
+          chromeVisible={chromeVisible}
+          suppressed={topVolumeShowing}
+        />
+      )}
+      {!pipMode && (
+        <SvpIndicator engine={engine} chromeVisible={chromeVisible} suppressed={topVolumeShowing} />
+      )}
       {holdSpeedActive && !pipMode && (
         <div className="pointer-events-none absolute left-1/2 top-8 z-30 flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-canvas/85 px-3.5 py-1.5 text-[13px] font-semibold text-ink backdrop-blur-md">
-          {snap.rate}x
-          <span className="font-normal text-ink-muted">{t("speed")}</span>
+          {snap.rate}x<span className="font-normal text-ink-muted">{t("speed")}</span>
         </div>
       )}
       {!holdSpeedActive && !pipMode && (
@@ -71,11 +83,14 @@ export function StageOverlays({
           position={volumeHudPosition}
         />
       )}
-      {videoFillPill && !holdSpeedActive && !pipMode && !(showVolumeIndicator && volumeHudPosition === "top") && (
-        <div className="pointer-events-none absolute left-1/2 top-8 z-30 -translate-x-1/2 rounded-full bg-canvas/85 px-3.5 py-1.5 text-[13px] font-semibold text-ink backdrop-blur-md">
-          {videoFillPill}
-        </div>
-      )}
+      {videoFillPill &&
+        !holdSpeedActive &&
+        !pipMode &&
+        !(showVolumeIndicator && volumeHudPosition === "top") && (
+          <div className="pointer-events-none absolute left-1/2 top-8 z-30 -translate-x-1/2 rounded-full bg-canvas/85 px-3.5 py-1.5 text-[13px] font-semibold text-ink backdrop-blur-md">
+            {videoFillPill}
+          </div>
+        )}
       {subDropToast && !pipMode && (
         <div className="pointer-events-none absolute bottom-28 left-1/2 z-30 -translate-x-1/2 rounded-full bg-canvas/90 px-4 py-2 text-[13px] font-medium text-ink backdrop-blur-md">
           {subDropToast}
@@ -98,4 +113,4 @@ export function StageOverlays({
       )}
     </>
   );
-}
+});

--- a/src/views/player/tools-layer.tsx
+++ b/src/views/player/tools-layer.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { ComponentProps } from "react";
 import { ClipChooser } from "@/components/player/clip-chooser";
 import { GifRecordPill } from "@/components/player/gif-record-pill";
@@ -10,7 +11,7 @@ import type { useGifRecorder } from "./hooks/use-gif-recorder";
 type SkipProps = ComponentProps<typeof SkipPillContainer>;
 type QuickToolsProps = ComponentProps<typeof QuickTools>;
 
-export function ToolsLayer({
+export const ToolsLayer = memo(function ToolsLayer({
   pipMode,
   drawMode,
   showWaiting,
@@ -57,21 +58,25 @@ export function ToolsLayer({
 }) {
   return (
     <>
-      {!pipMode && !drawMode && !showWaiting && pendingResumeSec == null && pendingSeekSec == null && (
-        <SkipPillContainer
-          skipSegments={skipSegments}
-          durationSec={durationSec}
-          hasNextEpisode={hasNextEpisode}
-          hasNextEpDisplay={hasNextEpDisplay}
-          nextEp={nextEp}
-          nextEpMask={nextEpMask}
-          visible={pillsVisible}
-          allowAutoSkip={allowAutoSkip}
-          onSkip={onSkip}
-          onNextEpisode={onNextEpisode}
-          onCancelAutoNext={onCancelAutoNext}
-        />
-      )}
+      {!pipMode &&
+        !drawMode &&
+        !showWaiting &&
+        pendingResumeSec == null &&
+        pendingSeekSec == null && (
+          <SkipPillContainer
+            skipSegments={skipSegments}
+            durationSec={durationSec}
+            hasNextEpisode={hasNextEpisode}
+            hasNextEpDisplay={hasNextEpDisplay}
+            nextEp={nextEp}
+            nextEpMask={nextEpMask}
+            visible={pillsVisible}
+            allowAutoSkip={allowAutoSkip}
+            onSkip={onSkip}
+            onNextEpisode={onNextEpisode}
+            onCancelAutoNext={onCancelAutoNext}
+          />
+        )}
 
       {!pipMode && !drawMode && (
         <QuickTools
@@ -100,4 +105,4 @@ export function ToolsLayer({
       )}
     </>
   );
-}
+});


### PR DESCRIPTION
## Summary

Fixes a Wayland resize lock that trapped the mpv video surface at its initial size and prevents it from expanding to fill the window. On all platforms, reduces unnecessary React re-renders, memoizes hot computations, replaces aggressive polling and staggered timeout patterns with debounced handlers, and caps the Linux GL render callback rate.

Two branches merged into feat/merge-wayland-perf:

 - feat/linux-wayland-improvements — 6 commits, 5 files (+69/-64)
 - feat/harbor-trim-fat-speedup — 1 commit, 13 files (+204/-118)

## Why

On Wayland, gtk::Fixed with set_size_request prevented the mpv GLArea from expanding to full window size, leaving a black letterbox. The upstream resize geometry tracking and fullscreen reassertion used staggered timeouts (9 kicks over 2s) and 250ms polling loops, causing redundant work and visible jank. On every platform, player overlays re-rendered on every parent state change since none were memoized, and hot paths (subtitle text style computation, seek bar segment spans) recalculated on every render. The Linux GL render callback was invoked as fast as the compositor allowed, wasting CPU/GPU.

## Verification

 - pnpm run typecheck — clean
 - cargo check --manifest-path src-tauri/Cargo.toml — clean
 - pnpm tauri:build:linux-system — binary produced, deb packaged
 - Pre-existing untracked type error in src/views/player/components/video/video-element.tsx:106 ("Object is possibly null") — not introduced by this PR

## Platform Impact

| Platform | Impact |
| --- | --- |
| Linux (X11) | No behavior change. GLArea expand approach is compatible with both backends. |
| Linux (Wayland) | Fix: mpv video surface now fills the full window. Previously locked to initial size. |
| Windows | isLinuxDesktop() checks skip geometry-tracking and fullscreen-reassertion changes. No behavior change. |
| macOS | Same as Windows — no changes to macOS paths. |
| TV-style input | No changes to focus or navigation logic. |

## UI Changes

None. All changes are performance-only — no visual differences, no removed/added user-facing elements.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes.
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
