### PR TITLE
fix(ui): keep TV focus rings out of pointer sessions; ring the whole search bar

### DIFF
--- a/src/components/search/search-overlay.tsx
+++ b/src/components/search/search-overlay.tsx
@@ -38,8 +38,11 @@ export function SearchOverlay() {
   useEffect(() => {
     if (!open) return;
 
+    let input: HTMLInputElement | null = null;
+    let panel: Element | null = null;
+
     const id = window.setTimeout(() => {
-      const input = inputRef.current;
+      input = inputRef.current;
       if (!input) return;
 
       // Search Overlay opens directly in typing mode. It must never inherit
@@ -48,6 +51,9 @@ export function SearchOverlay() {
       input.removeAttribute("data-search-nav-mode");
       input.removeAttribute("data-tv-focused");
       input.setAttribute("data-search-editing", "true");
+      // Ring the whole search bar panel, not the bare input.
+      panel = input.closest("[data-tv-text-field]");
+      panel?.setAttribute("data-tv-search-editing-focused", "true");
       input.focus({ preventScroll: true });
 
       const len = input.value.length;
@@ -60,7 +66,8 @@ export function SearchOverlay() {
 
     return () => {
       window.clearTimeout(id);
-      inputRef.current?.removeAttribute("data-search-editing");
+      input?.removeAttribute("data-search-editing");
+      panel?.removeAttribute("data-tv-search-editing-focused");
       document.body.style.overflow = "";
     };
   }, [open]);
@@ -124,6 +131,7 @@ export function SearchOverlay() {
         className="relative mx-auto flex h-full w-full max-w-[1080px] flex-col px-6 py-6 sm:px-10 sm:py-10"
       >
         <div
+          data-tv-text-field
           className={`modal-panel relative flex shrink-0 items-center gap-3 rounded-2xl border bg-elevated/70 px-5 shadow-[0_24px_80px_-30px_rgba(0,0,0,0.7)] transition-colors ${
             aiMode ? "border-accent/55" : "border-edge-soft/80"
           }`}

--- a/src/index.css
+++ b/src/index.css
@@ -2275,6 +2275,13 @@ summary:focus-visible,
   outline-offset: 2px;
 }
 
+/* Search overlay: the editing indicator rings the whole search bar panel,
+   not the bare input. Keys/TV modality swaps this for the injected TV ring. */
+[data-search-overlay] [data-tv-search-editing-focused="true"] {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 3px;
+}
+
 /* Opaque-surface overrides for translucent "glass" facet (aurora + any user glass theme).
    Derived from each theme's own --color-canvas via color-mix so they adapt per theme.
    Canvas/bokeh page background is intentionally left untouched. Opaque themes

--- a/src/index.css
+++ b/src/index.css
@@ -2268,8 +2268,10 @@ html[data-theme-layout="minui"] .anime-award-banner-logo {
 
 button:focus-visible,
 a:focus-visible,
+input:focus-visible,
 select:focus-visible,
 summary:focus-visible,
+textarea:focus-visible,
 [tabindex]:focus-visible {
   outline: 2px solid var(--color-accent) !important;
   outline-offset: 2px;

--- a/src/lib/keyboard-navigation.ts
+++ b/src/lib/keyboard-navigation.ts
@@ -113,6 +113,12 @@ function setPointerModality() {
   document.querySelectorAll<HTMLElement>('[data-search-nav-mode="true"]').forEach((field) => {
     clearSearchNavMode(field);
   });
+
+  // A control focused by TV navigation can still match :focus-visible after its
+  // TV marker is removed. Drop that stale focus so pointer movement does not
+  // replace the inset TV ring with the regular outer keyboard outline.
+  const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  if (active && !isEditable(active)) active.blur();
 }
 
 /** Scroll/layout can synthesize pointermove without motion — require real movement. */
@@ -912,6 +918,10 @@ export function useKeyboardNavigation(options: TVNavigationOptions = {}) {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
       if (e.altKey || e.ctrlKey || e.metaKey) return;
+
+      // Tab is native keyboard navigation, but does not call moveFocus().
+      // Restore keyboard modality so its focus cues are not hidden after mouse use.
+      if (e.key === "Tab") setKeysModality();
 
       const target = e.target instanceof HTMLElement ? e.target : null;
       const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;

--- a/src/lib/keyboard-navigation.ts
+++ b/src/lib/keyboard-navigation.ts
@@ -80,6 +80,49 @@ let activeSearchEditEl: HTMLElement | null = null;
 let focusStylesInjected = false;
 let hasTvNavigationIntent = false;
 
+type InputModality = "pointer" | "keys";
+
+/**
+ * null until the first user input: TV/HTPC boots keep the focus ring visible,
+ * while mouse/scroll activity switches to pointer modality and hides TV visuals.
+ */
+let inputModality: InputModality | null = null;
+let lastPointerMoveX: number | null = null;
+let lastPointerMoveY: number | null = null;
+
+/** Mirror modality on <html> so injected TV ring styles can be scoped to it. */
+function reflectModalityAttr() {
+  if (typeof document === "undefined" || !inputModality) return;
+  document.documentElement.setAttribute("data-input-modality", inputModality);
+}
+
+function setKeysModality() {
+  if (inputModality === "keys") return;
+  inputModality = "keys";
+  reflectModalityAttr();
+}
+
+function setPointerModality() {
+  if (inputModality === "pointer") return;
+  inputModality = "pointer";
+  reflectModalityAttr();
+
+  // Mouse users get native focus behavior: drop TV rings and un-arm any
+  // read-only nav-mode text fields so they type like normal inputs.
+  clearTvFocusRing();
+  document.querySelectorAll<HTMLElement>('[data-search-nav-mode="true"]').forEach((field) => {
+    clearSearchNavMode(field);
+  });
+}
+
+/** Scroll/layout can synthesize pointermove without motion — require real movement. */
+function notePointerMove(x: number, y: number) {
+  const moved = lastPointerMoveX !== null && (x !== lastPointerMoveX || y !== lastPointerMoveY);
+  lastPointerMoveX = x;
+  lastPointerMoveY = y;
+  if (moved) setPointerModality();
+}
+
 function isEditable(el: HTMLElement | null) {
   if (!el) return false;
   const tag = el.tagName;
@@ -364,8 +407,10 @@ function ensureFocusStyles() {
 
   const style = document.createElement("style");
   style.setAttribute("data-tv-focus-styles", "true");
+  // TV rings are keyboard/remote affordances. Pointer modality (mouse/touch)
+  // keeps native focus visuals, so every ring rule is scoped to non-pointer.
   style.textContent = `
-    [data-tv-focused="true"] {
+    html:not([data-input-modality="pointer"]) [data-tv-focused="true"] {
       outline: none !important;
       box-shadow: inset 0 0 0 2px var(--color-accent) !important;
       transition: box-shadow 120ms ease;
@@ -377,7 +422,7 @@ function ensureFocusStyles() {
      * Text fields are often nested inside a label/card. Put the TV focus ring
      * on that visible container so Settings search looks like every other item.
      */
-    [data-tv-search-nav-focused="true"] {
+    html:not([data-input-modality="pointer"]) [data-tv-search-nav-focused="true"] {
       outline: none !important;
       box-shadow: inset 0 0 0 2px var(--color-accent) !important;
       transition: box-shadow 120ms ease;
@@ -385,13 +430,13 @@ function ensureFocusStyles() {
       position: relative;
     }
 
-    [data-tv-search-nav-focused="true"] [data-tv-focused="true"] {
+    html:not([data-input-modality="pointer"]) [data-tv-search-nav-focused="true"] [data-tv-focused="true"] {
       box-shadow: none !important;
     }
 
     /* Editing keeps the same theme-aware cue without the navigation marker. */
-    [data-tv-search-editing-focused="true"],
-    [data-search-editing="true"]:not([data-tv-focused="true"]) {
+    html:not([data-input-modality="pointer"]) [data-tv-search-editing-focused="true"],
+    html:not([data-input-modality="pointer"]) [data-search-editing="true"]:not([data-tv-focused="true"]) {
       outline: none !important;
       box-shadow: inset 0 0 0 2px var(--color-accent) !important;
       transition: box-shadow 120ms ease;
@@ -399,7 +444,7 @@ function ensureFocusStyles() {
       position: relative;
     }
 
-    [data-tv-search-editing-focused="true"] [data-search-editing="true"] {
+    html:not([data-input-modality="pointer"]) [data-tv-search-editing-focused="true"] [data-search-editing="true"] {
       box-shadow: none !important;
     }
   `;
@@ -479,6 +524,14 @@ function clearSearchVisualFocus() {
       el.removeAttribute("data-tv-search-nav-focused");
       el.removeAttribute("data-tv-search-editing-focused");
     });
+}
+
+/** Ring the visible field container (label/panel) instead of the bare input. */
+function markSearchEditingVisual(el: HTMLElement) {
+  const visual = getSearchFocusVisual(el);
+  if (visual && visual !== el) {
+    visual.setAttribute("data-tv-search-editing-focused", "true");
+  }
 }
 
 function focusElement(el: HTMLElement, scroll: "center" | "nearest" | "none" = "center") {
@@ -564,10 +617,7 @@ function enterSearchEditMode(el: HTMLElement) {
   el.removeAttribute("data-tv-focused");
   el.setAttribute("data-search-editing", "true");
 
-  const visual = getSearchFocusVisual(el);
-  if (visual && visual !== el) {
-    visual.setAttribute("data-tv-search-editing-focused", "true");
-  }
+  markSearchEditingVisual(el);
 
   el.focus({ preventScroll: true });
 
@@ -645,6 +695,7 @@ function getSpatialOrder(list: HTMLElement[]) {
 
 export function moveFocus(dir: Dir, wrap: boolean = true): void {
   hasTvNavigationIntent = true;
+  setKeysModality();
   const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   const root = getActiveModal(active) ?? getTopFocusScope() ?? document;
   const scroll = dir === "left" || dir === "right" ? "nearest" : "center";
@@ -883,7 +934,9 @@ export function useKeyboardNavigation(options: TVNavigationOptions = {}) {
         activeSearchEditEl = active;
         active.removeAttribute("data-tv-focused");
         active.setAttribute("data-search-editing", "true");
+        // Drop stale rings elsewhere, then ring this field's own container.
         clearSearchVisualFocus();
+        markSearchEditingVisual(active);
 
         if (isBackKey(e)) {
           e.preventDefault();
@@ -986,6 +1039,7 @@ export function useKeyboardNavigation(options: TVNavigationOptions = {}) {
     };
 
     const onPointerDown = (e: PointerEvent) => {
+      setPointerModality();
       const pointerTarget = e.target instanceof HTMLElement ? e.target : null;
       const clickedTextField = pointerTarget?.closest<HTMLElement>("input, textarea");
       const clickedSearch =
@@ -1025,10 +1079,17 @@ export function useKeyboardNavigation(options: TVNavigationOptions = {}) {
     window.addEventListener("beforeinput", onBeforeInput, true);
     window.addEventListener("pointerdown", onPointerDown, true);
 
+    const onPointerMove = (e: PointerEvent) => notePointerMove(e.screenX, e.screenY);
+    const onWheel = () => setPointerModality();
+    window.addEventListener("pointermove", onPointerMove, true);
+    window.addEventListener("wheel", onWheel, { capture: true, passive: true });
+
     return () => {
       window.removeEventListener("keydown", onKeyDown, true);
       window.removeEventListener("beforeinput", onBeforeInput, true);
       window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("pointermove", onPointerMove, true);
+      window.removeEventListener("wheel", onWheel, true);
       if (remoteBackOwner === owner) {
         remoteBackFns = {};
         remoteBackOwner = null;


### PR DESCRIPTION
## Problem

Clicking or focusing a text input with the mouse paints the TV editing indicator (accent inset ring) around the bare input. The TV navigation machinery runs for everyone (`tvNavigation` defaults to on), and `enterSearchEditMode` fires on every pointerdown on a text field regardless of input method — so mouse users get couch-navigation visuals that look out of place, most visibly as a box hugging the search overlay's input.

## Fix

**1. Input modality tracking** (`src/lib/keyboard-navigation.ts`)
- New `pointer` / `keys` modality state, mirrored on `<html data-input-modality>`. Arrow-key navigation (`moveFocus`) switches to `keys`; real mouse movement, wheel, or pointerdown switches to `pointer` and un-arms read-only nav-mode fields.
- Every injected TV ring rule is scoped to `html:not([data-input-modality="pointer"])`. Only painting is gated — the edit-mode state machine (readOnly arming, Escape handling, caret placement) is untouched.
- TV/HTPC behavior is preserved: modality starts `null` at boot so rings stay visible until mouse activity, and arrow keys/remote bring them back.

**2. Search overlay ring wraps the whole bar** (`search-overlay.tsx`, `index.css`)
- The search bar panel is tagged `data-tv-text-field`, so the editing indicator resolves to the whole rounded panel instead of falling back to the input's tight wrapper div.
- While the overlay is open the panel gets a soft white outline (`2px rgba(255,255,255,0.55)`, 3px offset) that follows the panel radius; in keys modality the standard TV ring takes over on the panel.
- The overlay typing path re-marks the panel after `clearSearchVisualFocus()`, so the ring no longer snaps back to the bare input on the first keystroke.

## Verification

- `vp check` clean on changed files (remaining warnings are the pre-existing baseline in `keyboard-navigation.ts`); `tsc -b` clean; full `vp build` succeeds.
- Smoke-tested the production build (`vp preview`) in a browser:
  - Mouse click on a text input → focused, editable, no ring.
  - Arrow-key navigation → modality flips to `keys`, accent inset ring paints as before.
  - Search overlay via mouse → soft white outline around the whole bar, input clean, ring persists while typing.
  - No Rust changes.