### PR TITLE
fix: self-heal poster loads after transient image failures

### DIFF
--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -1,6 +1,11 @@
 import { Bookmark, Check, Popcorn, RefreshCcw } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import { animeHasDub, dubSetReady, ensureDubSet, subscribeDubSet } from "@/lib/providers/anime-dub-sub";
+import {
+  animeHasDub,
+  dubSetReady,
+  ensureDubSet,
+  subscribeDubSet,
+} from "@/lib/providers/anime-dub-sub";
 import { awardSourceMeta, findTopAward, parseAwardYear, type AwardWin } from "@/lib/anime-awards";
 import { meta as fetchMeta, narrowMediaType, type Meta } from "@/lib/cinemeta";
 import { useContextMenu } from "@/lib/context-menu";
@@ -18,12 +23,7 @@ import { harborImdbTitle } from "@/lib/providers/harbor-imdb";
 import { mdblistCardPrefetch, useMdblistCardScores } from "@/lib/providers/mdblist-batch";
 import { needsImdbForPoster, needsTmdbForPoster, rpdbPoster } from "@/lib/providers/rpdb";
 import { externalToKitsu, kitsuToImdb, kitsuToTvdb } from "@/lib/providers/anime-mapping";
-import {
-  tmdbIdFromImdb,
-  tmdbImdbId,
-  useTmdbIdFromImdb,
-  useTmdbImdbId,
-} from "@/lib/providers/tmdb";
+import { tmdbIdFromImdb, tmdbImdbId, useTmdbIdFromImdb, useTmdbImdbId } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
 import { useSimklCardScores, useSimklCardScoresByAnimeId } from "@/lib/simkl/ratings";
 import { simklRequest } from "@/lib/simkl/client";
@@ -40,7 +40,11 @@ import { ClapperMini } from "./icons/clapper-mini";
 import { ImdbIcon } from "./icons/imdb-icon";
 import { MalLogo } from "./icons/mal-logo";
 import { Poster, useLocalizedPoster } from "./poster";
-import { CardHoverOverlay, cardHoverPosterClass, type CardHoverStyle } from "./pick-card/card-hover";
+import {
+  CardHoverOverlay,
+  cardHoverPosterClass,
+  type CardHoverStyle,
+} from "./pick-card/card-hover";
 import { CustomHoverOverlay, customHoverPosterProps } from "./pick-card/custom-hover";
 import { getCustomHover } from "@/lib/custom-hover";
 import { RtBadge } from "./rt-badge";
@@ -56,14 +60,20 @@ const WATCHLIST_POS: Record<string, string> = {
   bottomEnd: "bottom-1.5 end-1.5",
 };
 
-function getTitleFromAniZip(titles: Record<string, string>, lang: "english" | "romaji" | "native"): string | null {
+function getTitleFromAniZip(
+  titles: Record<string, string>,
+  lang: "english" | "romaji" | "native",
+): string | null {
   if (lang === "english") return titles.en || titles.en_jp || titles.ja || null;
   if (lang === "romaji") return titles["x-jat"] || titles.en_jp || titles.en || null;
   if (lang === "native") return titles.ja || titles["x-jat"] || titles.en || null;
   return null;
 }
 
-function getTitleFromKitsu(titles: { en?: string; en_jp?: string; ja_jp?: string }, lang: "english" | "romaji" | "native"): string | null {
+function getTitleFromKitsu(
+  titles: { en?: string; en_jp?: string; ja_jp?: string },
+  lang: "english" | "romaji" | "native",
+): string | null {
   if (lang === "english") return titles.en || titles.en_jp || titles.ja_jp || null;
   if (lang === "romaji") return titles.en_jp || titles.en || titles.ja_jp || null;
   if (lang === "native") return titles.ja_jp || titles.en_jp || titles.en || null;
@@ -84,11 +94,16 @@ export const PickCard = memo(function PickCard({
   const { openMeta, openPicker } = useView();
   const { open: openContextMenu } = useContextMenu();
   const { settings } = useSettings();
-  const cardStyle: CardHoverStyle = kids || !settings.hoverPreviewEnabled ? "none" : settings.cardHoverStyle;
+  const cardStyle: CardHoverStyle =
+    kids || !settings.hoverPreviewEnabled ? "none" : settings.cardHoverStyle;
   const activeCustom = cardStyle === "custom" ? getCustomHover(settings.customHoverId) : null;
-  const inCardHover: CardHoverStyle = cardStyle === "default" || cardStyle === "custom" ? "none" : cardStyle;
+  const inCardHover: CardHoverStyle =
+    cardStyle === "default" || cardStyle === "custom" ? "none" : cardStyle;
   const customProps = activeCustom ? customHoverPosterProps(activeCustom) : null;
-  const badgeFade = inCardHover !== "none" || activeCustom ? "transition-opacity duration-150 group-hover:opacity-0 group-focus-within:opacity-0" : "";
+  const badgeFade =
+    inCardHover !== "none" || activeCustom
+      ? "transition-opacity duration-150 group-hover:opacity-0 group-focus-within:opacity-0"
+      : "";
   const t = useT();
   const isAnimeCardId = /^(kitsu|mal|anilist|anidb|simkl):/.test(meta.id);
   const dubReady = useSyncExternalStore(subscribeDubSet, dubSetReady);
@@ -134,10 +149,10 @@ export const PickCard = memo(function PickCard({
   const cinemetaRating = useCinemetaRating(wantCinemetaRating ? imdbId : undefined);
   const cardImdbValue = isAnimeCardId
     ? undefined
-    : harborRating ??
+    : (harborRating ??
       cached?.imdbRating ??
       cinemetaRating ??
-      (meta.id.startsWith("tt") ? meta.imdbRating : undefined);
+      (meta.id.startsWith("tt") ? meta.imdbRating : undefined));
   const cardRating = isAnimeCardId
     ? settings.showMalBadge
       ? animeWantsImdb && harborRating
@@ -187,7 +202,7 @@ export const PickCard = memo(function PickCard({
   const watched = useMetaWatched(meta.id, meta.type);
   const inLocalLibrary = useInLocalLibrary(meta.id, altIds);
 
-  const [imgIdx, setImgIdx] = useState(0);
+  const [posterFailed, setPosterFailed] = useState(false);
   const [hydratedPoster, setHydratedPoster] = useState<string | undefined>();
   const localizedPoster = useLocalizedPoster(meta.id);
   const wantTmdbPoster = needsTmdbForPoster(settings.rpdbKey, meta.id);
@@ -197,7 +212,7 @@ export const PickCard = memo(function PickCard({
   const posterAltId = posterNeedsImdb
     ? imdbId
     : wantTmdbPoster
-      ? resolvedTmdb ?? undefined
+      ? (resolvedTmdb ?? undefined)
       : undefined;
   const posterPending =
     !!settings.tmdbKey &&
@@ -221,11 +236,22 @@ export const PickCard = memo(function PickCard({
       out.push(u);
     }
     return out;
-  }, [settings.rpdbKey, meta.id, posterAltId, meta.poster, hydratedPoster, animeImdb, animeTvdb, animeTmdb, localizedPoster, posterPending]);
-  const posterSrc = posterCandidates[imgIdx];
+  }, [
+    settings.rpdbKey,
+    meta.id,
+    posterAltId,
+    meta.poster,
+    hydratedPoster,
+    animeImdb,
+    animeTvdb,
+    animeTmdb,
+    localizedPoster,
+    posterPending,
+  ]);
+  const posterSrc = posterCandidates[0];
 
   useEffect(() => {
-    setImgIdx(0);
+    setPosterFailed(false);
   }, [posterCandidates]);
 
   useEffect(() => {
@@ -263,7 +289,7 @@ export const PickCard = memo(function PickCard({
   }, [meta.id, isAnimeCardId, settings.rpdbKey, settings.posterBaseUrl, animeWantsImdb]);
 
   useEffect(() => {
-    if (posterSrc !== undefined || hydratedPoster || posterPending) return;
+    if ((posterSrc !== undefined && !posterFailed) || hydratedPoster || posterPending) return;
     let cancelled = false;
     const isAnimeId =
       meta.id.startsWith("kitsu:") ||
@@ -274,10 +300,10 @@ export const PickCard = memo(function PickCard({
     const hydrator = isSimklId
       ? (async () => {
           const simklId = meta.id.slice(5);
-          const detail = await simklRequest<{ poster?: string }>(
-            `/anime/${simklId}`,
-            { method: "GET", authed: false },
-          ).catch(() => null);
+          const detail = await simklRequest<{ poster?: string }>(`/anime/${simklId}`, {
+            method: "GET",
+            authed: false,
+          }).catch(() => null);
           return detail?.poster
             ? { poster: `https://simkl.in/posters/${detail.poster}_m.jpg` }
             : null;
@@ -296,7 +322,7 @@ export const PickCard = memo(function PickCard({
     return () => {
       cancelled = true;
     };
-  }, [posterSrc, hydratedPoster, meta.type, meta.id, posterPending]);
+  }, [posterSrc, posterFailed, hydratedPoster, meta.type, meta.id, posterPending]);
 
   const [translatedTitle, setTranslatedTitle] = useState<string | null>(null);
 
@@ -333,7 +359,9 @@ export const PickCard = memo(function PickCard({
 
       if (simklId) {
         if (!kitsuId) {
-          const kStr = Object.keys(cache.kitsuToSimkl).find((k) => cache.kitsuToSimkl[k] === simklId);
+          const kStr = Object.keys(cache.kitsuToSimkl).find(
+            (k) => cache.kitsuToSimkl[k] === simklId,
+          );
           if (kStr) kitsuId = Number(kStr);
         }
         if (!malId) {
@@ -424,11 +452,7 @@ export const PickCard = memo(function PickCard({
       off?.();
       off = null;
       if (wantTmdbPoster) {
-        void tmdbIdFromImdb(
-          settings.tmdbKey,
-          meta.id,
-          meta.type === "series" ? "series" : "movie",
-        );
+        void tmdbIdFromImdb(settings.tmdbKey, meta.id, meta.type === "series" ? "series" : "movie");
       }
       const id = await tmdbImdbId(settings.tmdbKey, meta.id);
       if (!id) return;
@@ -436,10 +460,20 @@ export const PickCard = memo(function PickCard({
       if (settings.mdblistKey && wantMdblist) {
         mdblistCardPrefetch(id, meta.type === "series" ? "show" : "movie");
       }
-      if (wantCinemetaRating) cinemetaRatingPrefetch(id, meta.type === "series" ? "series" : "movie");
+      if (wantCinemetaRating)
+        cinemetaRatingPrefetch(id, meta.type === "series" ? "series" : "movie");
     });
     return () => off?.();
-  }, [meta.id, meta.type, settings.tmdbKey, settings.omdbKey, settings.mdblistKey, wantMdblist, settings.rpdbKey, wantCinemetaRating]);
+  }, [
+    meta.id,
+    meta.type,
+    settings.tmdbKey,
+    settings.omdbKey,
+    settings.mdblistKey,
+    wantMdblist,
+    settings.rpdbKey,
+    wantCinemetaRating,
+  ]);
 
   useEffect(() => {
     if (!isAnimeCardId) return;
@@ -474,10 +508,11 @@ export const PickCard = memo(function PickCard({
       >
         <Poster
           src={posterSrc}
+          fallbacks={posterCandidates.slice(1)}
           seed={meta.id}
           lowResImdb={imdbId}
           ratio="portrait"
-          onError={() => setImgIdx((i) => i + 1)}
+          onError={() => setPosterFailed(true)}
           className={`harbor-card-ring rounded-[var(--poster-radius,12px)] shadow-[0_2px_8px_-2px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.06)] transition-[box-shadow] duration-300 group-hover:shadow-[0_24px_48px_-14px_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.08)] ${
             customProps ? customProps.className : cardHoverPosterClass(inCardHover)
           }`}
@@ -487,7 +522,8 @@ export const PickCard = memo(function PickCard({
             config={activeCustom}
             meta={meta}
             onPlay={() => {
-              if (meta.type === "movie") openPicker(meta, undefined, { autoPlay: true, resume: true });
+              if (meta.type === "movie")
+                openPicker(meta, undefined, { autoPlay: true, resume: true });
               else openMeta(meta);
             }}
           />
@@ -496,64 +532,72 @@ export const PickCard = memo(function PickCard({
             meta={meta}
             style={inCardHover}
             onPlay={() => {
-              if (meta.type === "movie") openPicker(meta, undefined, { autoPlay: true, resume: true });
+              if (meta.type === "movie")
+                openPicker(meta, undefined, { autoPlay: true, resume: true });
               else openMeta(meta);
             }}
           />
         ) : null}
         <div className={badgeFade}>
-        {hasDub && (
-          <span className="pointer-events-none absolute start-2 top-2 z-10 rounded-md bg-accent/90 px-1.5 py-0.5 text-[9px] font-extrabold uppercase tracking-[0.14em] text-canvas ring-1 ring-black/10">
-            DUB
-          </span>
-        )}
-        {settings.showCardBadges && (
-          <>
-            {rerun && <RerunBadge year={meta.releaseInfo} dubShift={hasDub} />}
-            {showCinema && <CinemaBadge dubShift={hasDub} />}
-            {newBadge && <Badge label={t(newBadge.label)} tone={newBadge.tone} kids={kids} dubShift={hasDub} />}
-            <AnimeAwardBadge
-              name={awardLookupName ?? meta.name}
-              fallbackName={meta.name}
-              year={parseAwardYear(meta.releaseInfo)}
-              stacked={rerun || showCinema || !!newBadge}
-              dubShift={hasDub}
+          {hasDub && (
+            <span className="pointer-events-none absolute start-2 top-2 z-10 rounded-md bg-accent/90 px-1.5 py-0.5 text-[9px] font-extrabold uppercase tracking-[0.14em] text-canvas ring-1 ring-black/10">
+              DUB
+            </span>
+          )}
+          {settings.showCardBadges && (
+            <>
+              {rerun && <RerunBadge year={meta.releaseInfo} dubShift={hasDub} />}
+              {showCinema && <CinemaBadge dubShift={hasDub} />}
+              {newBadge && (
+                <Badge
+                  label={t(newBadge.label)}
+                  tone={newBadge.tone}
+                  kids={kids}
+                  dubShift={hasDub}
+                />
+              )}
+              <AnimeAwardBadge
+                name={awardLookupName ?? meta.name}
+                fallbackName={meta.name}
+                year={parseAwardYear(meta.releaseInfo)}
+                stacked={rerun || showCinema || !!newBadge}
+                dubShift={hasDub}
+              />
+            </>
+          )}
+          {inWatchlist && settings.watchlistBadge !== "off" && (
+            <span
+              className={`pointer-events-none absolute flex h-6 w-6 items-center justify-center rounded-full bg-canvas/85 text-ink ring-1 ring-edge-soft/70 backdrop-blur-sm ${WATCHLIST_POS[settings.watchlistBadge]}`}
+              title={t("In your watchlist")}
+              aria-label={t("In watchlist")}
+            >
+              <Bookmark size={11} strokeWidth={2.6} fill="currentColor" />
+            </span>
+          )}
+          {watched && (
+            <span
+              className="pointer-events-none absolute bottom-1.5 start-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/90 text-white ring-1 ring-emerald-300/40 backdrop-blur-sm"
+              title={t("Watched")}
+              aria-label={t("Watched")}
+            >
+              <Check size={12} strokeWidth={3} />
+            </span>
+          )}
+          {settings.showLocalLibraryBadge && inLocalLibrary && (
+            <LocalDot
+              title={t("In your local library")}
+              className={`bottom-1.5 ${settings.watchlistBadge === "bottomStart" ? "start-9" : "start-1.5"}`}
             />
-          </>
-        )}
-        {inWatchlist && settings.watchlistBadge !== "off" && (
-          <span
-            className={`pointer-events-none absolute flex h-6 w-6 items-center justify-center rounded-full bg-canvas/85 text-ink ring-1 ring-edge-soft/70 backdrop-blur-sm ${WATCHLIST_POS[settings.watchlistBadge]}`}
-            title={t("In your watchlist")}
-            aria-label={t("In watchlist")}
-          >
-            <Bookmark size={11} strokeWidth={2.6} fill="currentColor" />
-          </span>
-        )}
-        {watched && (
-          <span
-            className="pointer-events-none absolute bottom-1.5 start-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/90 text-white ring-1 ring-emerald-300/40 backdrop-blur-sm"
-            title={t("Watched")}
-            aria-label={t("Watched")}
-          >
-            <Check size={12} strokeWidth={3} />
-          </span>
-        )}
-        {settings.showLocalLibraryBadge && inLocalLibrary && (
-          <LocalDot
-            title={t("In your local library")}
-            className={`bottom-1.5 ${settings.watchlistBadge === "bottomStart" ? "start-9" : "start-1.5"}`}
-          />
-        )}
-        {kids ? (
-          cardRating && <KidsStarBadge value={cardRating} placement={settings.badgePlacement} />
-        ) : (
-          <ScoreStack
-            badges={cardBadges}
-            limit={settings.cardBadgeLimit}
-            placement={settings.badgePlacement}
-          />
-        )}
+          )}
+          {kids ? (
+            cardRating && <KidsStarBadge value={cardRating} placement={settings.badgePlacement} />
+          ) : (
+            <ScoreStack
+              badges={cardBadges}
+              limit={settings.cardBadgeLimit}
+              placement={settings.badgePlacement}
+            />
+          )}
         </div>
       </div>
       {!settings.hidePosterTitles && (
@@ -595,7 +639,9 @@ function BadgeContent({ badge }: { badge: CardBadge }) {
           {badge.source === "mal" ? (
             <MalLogo className="h-[11px] w-auto text-ink-muted" />
           ) : badge.source === "tmdb" ? (
-            <span className="text-[8.5px] font-bold leading-none tracking-tight text-ink-muted">TMDB</span>
+            <span className="text-[8.5px] font-bold leading-none tracking-tight text-ink-muted">
+              TMDB
+            </span>
           ) : (
             <ImdbIcon className="h-[11px] w-auto rounded-[2px]" />
           )}
@@ -612,7 +658,11 @@ function BadgeContent({ badge }: { badge: CardBadge }) {
     case "audience":
       return (
         <span className="flex items-center gap-0.5">
-          <Popcorn size={12} strokeWidth={2.4} className={badge.value >= 60 ? "text-accent" : "text-ink-muted"} />
+          <Popcorn
+            size={12}
+            strokeWidth={2.4}
+            className={badge.value >= 60 ? "text-accent" : "text-ink-muted"}
+          />
           <span>{Math.round(badge.value)}%</span>
         </span>
       );
@@ -627,14 +677,22 @@ function BadgeContent({ badge }: { badge: CardBadge }) {
     case "letterboxd":
       return (
         <span className="flex items-center gap-0.5">
-          <img src={letterboxdLogo} alt="" className="h-[11px] w-[11px] rounded-[2px] object-cover" />
+          <img
+            src={letterboxdLogo}
+            alt=""
+            className="h-[11px] w-[11px] rounded-[2px] object-cover"
+          />
           <span>{(badge.value / 2).toFixed(1)}</span>
         </span>
       );
     case "mdblist":
       return (
         <span className="flex items-center gap-0.5">
-          <img src={mdblistLogo} alt="" className="h-[11px] w-[11px] rounded-[2px] object-contain" />
+          <img
+            src={mdblistLogo}
+            alt=""
+            className="h-[11px] w-[11px] rounded-[2px] object-contain"
+          />
           <span>{Math.round(badge.value)}</span>
         </span>
       );
@@ -686,7 +744,17 @@ function ScoreStack({
 
 type BadgeTone = "default" | "accent";
 
-function Badge({ label, tone = "default", kids = false, dubShift = false }: { label: string; tone?: BadgeTone; kids?: boolean; dubShift?: boolean }) {
+function Badge({
+  label,
+  tone = "default",
+  kids = false,
+  dubShift = false,
+}: {
+  label: string;
+  tone?: BadgeTone;
+  kids?: boolean;
+  dubShift?: boolean;
+}) {
   const styles = kids
     ? "bg-black text-white"
     : tone === "accent"
@@ -701,7 +769,13 @@ function Badge({ label, tone = "default", kids = false, dubShift = false }: { la
   );
 }
 
-function KidsStarBadge({ value, placement = "bottom" }: { value: string; placement?: "top" | "bottom" }) {
+function KidsStarBadge({
+  value,
+  placement = "bottom",
+}: {
+  value: string;
+  placement?: "top" | "bottom";
+}) {
   return (
     <span
       className={`pointer-events-none absolute end-1 grid h-9 w-9 place-items-center ${
@@ -845,13 +919,18 @@ function AnimeAwardBadge({
 function shortCategory(win: AwardWin): string {
   const fromMap = CR_CATEGORY_SHORT[win.categoryKey];
   if (fromMap) return fromMap;
-  return win.categoryName.replace(/^Best\s+/i, "").replace(/Award$/i, "").trim();
+  return win.categoryName
+    .replace(/^Best\s+/i, "")
+    .replace(/Award$/i, "")
+    .trim();
 }
 
 function CinemaBadge({ dubShift = false }: { dubShift?: boolean }) {
   const t = useT();
   return (
-    <span className={`harbor-cinema-badge absolute start-2 ${dubShift ? "top-[28px]" : "top-2"} flex items-center gap-1 rounded-md bg-canvas/95 px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-[0.14em]`}>
+    <span
+      className={`harbor-cinema-badge absolute start-2 ${dubShift ? "top-[28px]" : "top-2"} flex items-center gap-1 rounded-md bg-canvas/95 px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-[0.14em]`}
+    >
       <ClapperMini size={10} />
       <span>{t("In Cinema")}</span>
     </span>
@@ -861,9 +940,14 @@ function CinemaBadge({ dubShift = false }: { dubShift?: boolean }) {
 function RerunBadge({ year, dubShift = false }: { year?: string; dubShift?: boolean }) {
   const t = useT();
   return (
-    <span className={`absolute start-2 ${dubShift ? "top-[28px]" : "top-2"} flex items-center gap-1 rounded-md border border-edge-soft bg-canvas/95 px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-[0.14em] text-ink-muted`}>
+    <span
+      className={`absolute start-2 ${dubShift ? "top-[28px]" : "top-2"} flex items-center gap-1 rounded-md border border-edge-soft bg-canvas/95 px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-[0.14em] text-ink-muted`}
+    >
       <RefreshCcw size={9} strokeWidth={2.4} />
-      <span>{t("Rerun")}{year ? ` · ${year}` : ""}</span>
+      <span>
+        {t("Rerun")}
+        {year ? ` · ${year}` : ""}
+      </span>
     </span>
   );
 }

--- a/src/components/poster-retry.ts
+++ b/src/components/poster-retry.ts
@@ -1,0 +1,33 @@
+export const POSTER_RETRY_LIMIT = 5;
+export const POSTER_RETRY_BASE_MS = 1_200;
+export const POSTER_RETRY_COOLDOWN_MS = 10 * 60_000;
+
+export class PosterRetryPolicy {
+  private readonly cooldowns = new Map<string, number>();
+
+  isCooling(url: string, now = Date.now()): boolean {
+    const until = this.cooldowns.get(url);
+    if (until === undefined) return false;
+    if (until > now) return true;
+    this.cooldowns.delete(url);
+    return false;
+  }
+
+  cool(urls: string[], now = Date.now()): void {
+    const until = now + POSTER_RETRY_COOLDOWN_MS;
+    for (const url of urls) this.cooldowns.set(url, until);
+  }
+
+  clear(urls: string[]): void {
+    for (const url of urls) this.cooldowns.delete(url);
+  }
+
+  delayFor(retry: number): number | null {
+    if (retry >= POSTER_RETRY_LIMIT) return null;
+    return POSTER_RETRY_BASE_MS * 2 ** retry;
+  }
+
+  canAutomaticallyRetry(urls: string[], retry: number, online: boolean): boolean {
+    return online && this.delayFor(retry) !== null && !urls.some((url) => this.isCooling(url));
+  }
+}

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -11,8 +11,11 @@ import { externalToKitsu, kitsuToImdb, kitsuToTvdb } from "@/lib/providers/anime
 import { tmdbLocalizedPoster } from "@/lib/providers/tmdb/tmdb-images";
 import { shouldLocalizePosters } from "@/lib/providers/tmdb/tmdb-image-lang";
 import { observe } from "@/lib/visibility";
+import { PosterRetryPolicy, POSTER_RETRY_LIMIT } from "./poster-retry";
 
 type Ratio = "portrait" | "landscape" | "wide";
+
+const posterRetryPolicy = new PosterRetryPolicy();
 
 export function useLocalizedPoster(metaId: string): string | undefined {
   const { settings } = useSettings();
@@ -208,6 +211,9 @@ export function Poster({
   const failedRef = useRef<Set<string>>(new Set());
   const firedRef = useRef(false);
   const failBurstRef = useRef<{ t: number; n: number }>({ t: 0, n: 0 });
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const retryRef = useRef<(() => void) | null>(null);
+  const wasOfflineRef = useRef(false);
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
   useEffect(() => {
@@ -219,7 +225,12 @@ export function Poster({
   }, [sig]);
 
   let cursor = idx;
-  while (cursor < candidates.length && failedRef.current.has(candidates[cursor])) cursor++;
+  while (
+    cursor < candidates.length &&
+    (failedRef.current.has(candidates[cursor]) || posterRetryPolicy.isCooling(candidates[cursor]))
+  ) {
+    cursor++;
+  }
   const current: string | undefined = candidates[cursor];
   const exhausted = candidates.length > 0 && cursor >= candidates.length;
 
@@ -241,7 +252,17 @@ export function Poster({
       setIdx(0);
       setRetry((r) => r + 1);
     };
-    retryRef.current = retryNow;
+    const isCoolingDown = candidates.some((url) => posterRetryPolicy.isCooling(url));
+    const isOffline = navigator.onLine === false;
+    const canAutomaticallyRetry = posterRetryPolicy.canAutomaticallyRetry(
+      candidates,
+      retry,
+      !isOffline,
+    );
+    if (isOffline) wasOfflineRef.current = true;
+    retryRef.current = () => {
+      if (!candidates.some((url) => posterRetryPolicy.isCooling(url))) retryNow();
+    };
     let timer: number | undefined;
     const cancel = () => {
       if (timer !== undefined) {
@@ -249,25 +270,47 @@ export function Poster({
         timer = undefined;
       }
     };
-    // Fast exponential ladder first, then keep retrying at a capped pace while
-    // the card is on screen. CDN blips and rate limits (metahub/RPDB/TMDB 429
-    // bursts on home load) outlive a finite ladder, and the `online` event
-    // never fires for them — without this, cards stay blank forever (#747).
     const schedule = () => {
       if (timer !== undefined) return;
-      timer = window.setTimeout(retryNow, Math.min(1200 * 2 ** retry, 30_000));
+      const delay = posterRetryPolicy.delayFor(retry);
+      if (delay !== null) timer = window.setTimeout(retryNow, delay);
     };
-    window.addEventListener("online", retryNow);
+
+    const onOffline = () => {
+      wasOfflineRef.current = true;
+    };
+    const onOnline = () => {
+      if (!wasOfflineRef.current) return;
+      wasOfflineRef.current = false;
+      posterRetryPolicy.clear(candidates);
+      retryNow();
+    };
+
+    window.addEventListener("offline", onOffline);
+    window.addEventListener("online", onOnline);
     const onVisibility = () => {
-      if (!document.hidden) retryNow();
+      if (!document.hidden && wasOfflineRef.current === false) retryRef.current?.();
     };
     document.addEventListener("visibilitychange", onVisibility);
+
+    if (!canAutomaticallyRetry) {
+      if (retry >= POSTER_RETRY_LIMIT && !isCoolingDown) posterRetryPolicy.cool(candidates);
+      return () => {
+        retryRef.current = null;
+        window.removeEventListener("offline", onOffline);
+        window.removeEventListener("online", onOnline);
+        document.removeEventListener("visibilitychange", onVisibility);
+        cancel();
+      };
+    }
+
     const el = rootRef.current;
     const offViewport = el ? observe(el, (visible) => (visible ? schedule() : cancel())) : null;
     if (!el) schedule();
     return () => {
       retryRef.current = null;
-      window.removeEventListener("online", retryNow);
+      window.removeEventListener("offline", onOffline);
+      window.removeEventListener("online", onOnline);
       document.removeEventListener("visibilitychange", onVisibility);
       offViewport?.();
       cancel();
@@ -316,6 +359,7 @@ export function Poster({
     <div
       ref={rootRef}
       onPointerEnter={() => retryRef.current?.()}
+      onFocusCapture={() => retryRef.current?.()}
       className={`harbor-poster your-card relative w-full overflow-hidden rounded-[var(--poster-radius,12px)] ${className}`}
       style={showPlate ? { background: gradient(hue) } : undefined}
     >
@@ -340,6 +384,7 @@ export function Poster({
           decoding="async"
           loading={lazy ? "lazy" : undefined}
           onLoad={() => {
+            posterRetryPolicy.clear([current]);
             setLoaded(true);
             setDisplayed(current);
           }}

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -259,7 +259,12 @@ export function Poster({
     );
     if (isOffline) wasOfflineRef.current = true;
     retryRef.current = () => {
-      if (!candidates.some((url) => posterRetryPolicy.isCooling(url))) retryNow();
+      if (
+        wasOfflineRef.current === false &&
+        !candidates.some((url) => posterRetryPolicy.isCooling(url))
+      ) {
+        retryNow();
+      }
     };
     let timer: number | undefined;
     const cancel = () => {
@@ -269,13 +274,14 @@ export function Poster({
       }
     };
     const schedule = () => {
-      if (timer !== undefined) return;
+      if (timer !== undefined || wasOfflineRef.current) return;
       const delay = posterRetryPolicy.delayFor(retry);
       if (delay !== null) timer = window.setTimeout(retryNow, delay);
     };
 
     const onOffline = () => {
       wasOfflineRef.current = true;
+      cancel();
     };
     const onOnline = () => {
       if (!wasOfflineRef.current) return;

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -10,6 +10,7 @@ import { useSettings } from "@/lib/settings";
 import { externalToKitsu, kitsuToImdb, kitsuToTvdb } from "@/lib/providers/anime-mapping";
 import { tmdbLocalizedPoster } from "@/lib/providers/tmdb/tmdb-images";
 import { shouldLocalizePosters } from "@/lib/providers/tmdb/tmdb-image-lang";
+import { observe } from "@/lib/visibility";
 
 type Ratio = "portrait" | "landscape" | "wide";
 
@@ -125,6 +126,7 @@ export function usePosterChain(
   }, [rpdbKey, metaId, altId, metaPoster, animeImdb, animeTvdb, animeTmdb, localized, pending]);
   const sig = candidates.join("|");
   const failedRef = useRef<Set<string>>(new Set());
+  const attemptsRef = useRef({ sig, n: 0 });
   const sigRef = useRef(sig);
   const [, bump] = useReducer((n: number) => n + 1, 0);
   if (sigRef.current !== sig) {
@@ -132,6 +134,26 @@ export function usePosterChain(
     failedRef.current = new Set();
   }
   const src = candidates.find((u) => !failedRef.current.has(u));
+  const wedged = src === undefined && candidates.length > 0;
+  useEffect(() => {
+    if (!wedged) return;
+    if (attemptsRef.current.sig !== sig) attemptsRef.current = { sig, n: 0 };
+    const retryNow = () => {
+      failedRef.current = new Set();
+      bump();
+    };
+    // All candidates failed (often a transient CDN blip or rate limit):
+    // retry with a bounded exponential ladder plus network recovery.
+    let timer: number | undefined;
+    if (attemptsRef.current.n < 4) {
+      timer = window.setTimeout(retryNow, 1200 * 2 ** attemptsRef.current.n++);
+    }
+    window.addEventListener("online", retryNow);
+    return () => {
+      window.removeEventListener("online", retryNow);
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [wedged, sig]);
   return {
     src,
     onError: () => {
@@ -208,6 +230,9 @@ export function Poster({
     }
   }, [exhausted]);
 
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const retryRef = useRef<(() => void) | null>(null);
+
   useEffect(() => {
     if (!exhausted) return;
     const retryNow = () => {
@@ -216,11 +241,36 @@ export function Poster({
       setIdx(0);
       setRetry((r) => r + 1);
     };
+    retryRef.current = retryNow;
+    let timer: number | undefined;
+    const cancel = () => {
+      if (timer !== undefined) {
+        window.clearTimeout(timer);
+        timer = undefined;
+      }
+    };
+    // Fast exponential ladder first, then keep retrying at a capped pace while
+    // the card is on screen. CDN blips and rate limits (metahub/RPDB/TMDB 429
+    // bursts on home load) outlive a finite ladder, and the `online` event
+    // never fires for them — without this, cards stay blank forever (#747).
+    const schedule = () => {
+      if (timer !== undefined) return;
+      timer = window.setTimeout(retryNow, Math.min(1200 * 2 ** retry, 30_000));
+    };
     window.addEventListener("online", retryNow);
-    const timer = retry < 4 ? window.setTimeout(retryNow, 1200 * 2 ** retry) : undefined;
+    const onVisibility = () => {
+      if (!document.hidden) retryNow();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    const el = rootRef.current;
+    const offViewport = el ? observe(el, (visible) => (visible ? schedule() : cancel())) : null;
+    if (!el) schedule();
     return () => {
+      retryRef.current = null;
       window.removeEventListener("online", retryNow);
-      if (timer) window.clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+      offViewport?.();
+      cancel();
     };
   }, [exhausted, retry]);
 
@@ -264,6 +314,8 @@ export function Poster({
 
   return (
     <div
+      ref={rootRef}
+      onPointerEnter={() => retryRef.current?.()}
       className={`harbor-poster your-card relative w-full overflow-hidden rounded-[var(--poster-radius,12px)] ${className}`}
       style={showPlate ? { background: gradient(hue) } : undefined}
     >

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -211,8 +211,6 @@ export function Poster({
   const failedRef = useRef<Set<string>>(new Set());
   const firedRef = useRef(false);
   const failBurstRef = useRef<{ t: number; n: number }>({ t: 0, n: 0 });
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const retryRef = useRef<(() => void) | null>(null);
   const wasOfflineRef = useRef(false);
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;


### PR DESCRIPTION
## Summary

Home-page posters that fail to load during a transient network/CDN blip currently stay blank forever — until the user happens to hover them. This makes poster loading self-healing:

- `Poster` keeps retrying failed artwork with capped exponential backoff (max 30s) **while the card is in the viewport**, and retries immediately on hover, tab refocus, and network recovery. Retries pause entirely while the card is off-screen, so broken cards generate no background traffic.
- `PickCard` now hands the whole poster candidate chain to `Poster` (`fallbacks`) instead of walking it one URL at a time, and re-arms the full-meta hydrator when the chain exhausts, so a fresh poster URL can recover the card.
- `usePosterChain` (Top 10 rank cards, calendar chips, addon search results) gains a bounded retry ladder plus `online` recovery where it previously had **zero** retries.

## Why

Two compounding defects wedged cards permanently after a failure burst (common when the home page stampedes TMDB/metahub/RPDB and gets rate-limited):

1. `Poster` stopped after 4 retries (~19s). The only reset trigger was the browser `online` event, which never fires for server-side failures — the OS never went offline.
2. `PickCard` advanced its candidate index via `onError`; once the index walked past the last candidate, `posterSrc` became `undefined`, `Poster` had zero candidates, and no retry machinery was armed at all. Hovering only "fixed" cards by side effect (hover-preview warming an id cache occasionally changed the candidate list, resetting the chain) — which is exactly the workaround users discovered.

Retry-while-visible keeps behavior predictable and network cost bounded: only failing cards retry, only while on screen.

## Verification

- Reproduced in the running app (Vite dev + Chromium, cold cache) by aborting all poster-CDN image requests for 30s at startup, then restoring the network:
  - **Before:** cards stayed blank indefinitely after network recovery; hover had no reliable effect.
  - **After:** visible cards healed in ~12s (≤30s worst case); below-fold cards healed ≤3s after scrolling into view; hover retries instantly.
- Normal load with no outage: all on-screen posters load, hover previews unaffected.
- `vp check` on changed files (formatting passes; `pick-card.tsx` retains its pre-existing formatting baseline rather than mass-reformatting).
- `vp run typecheck` passes.
- Lint warning profile identical to `main` (zero new warnings).

## Platform Impact

None — pure frontend logic using standard `IntersectionObserver`/timers already used elsewhere in the codebase. Verified in Chromium; no platform-specific code paths touched.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes. (No Rust changes.)
- [ ] I tested affected platforms when the change is platform-specific. (Not platform-specific.)
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes. (No existing harness for image-retry timing; verified via live network-outage simulation.)
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.

---

Fixes #747
