### PR TITLE
Fix NVIDIA WebKit rendering on Wayland

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -416,7 +416,7 @@ pub fn run() {
     #[cfg(windows)]
     svp::prime_svp_env();
     #[cfg(target_os = "linux")]
-    mpv_render_linux::enforce_nvidia_x11();
+    mpv_render_linux::configure_nvidia_graphics();
     let _ = rustls::crypto::ring::default_provider().install_default();
     trailer::sweep_cache();
     let proxy_state = tauri::async_runtime::block_on(stream_proxy::ProxyState::start())

--- a/src-tauri/src/mpv_render_linux.rs
+++ b/src-tauri/src/mpv_render_linux.rs
@@ -206,23 +206,29 @@ fn native_display(backend: Backend) -> u64 {
     native as u64
 }
 
-pub fn enforce_nvidia_x11() {
+pub fn configure_nvidia_graphics() {
     if !std::path::Path::new("/proc/driver/nvidia/version").exists() {
         return;
-    }
-    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
-        eprintln!("[harbor::mpv_linux] NVIDIA detected; setting WEBKIT_DISABLE_DMABUF_RENDERER=1 (WebKitGTK DMABUF renderer blanks on NVIDIA)");
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
     let wayland = std::env::var("XDG_SESSION_TYPE")
         .map(|v| v.eq_ignore_ascii_case("wayland"))
         .unwrap_or(false)
-        || std::env::var("WAYLAND_DISPLAY").map(|v| !v.is_empty()).unwrap_or(false);
-    if !wayland {
+        || std::env::var("WAYLAND_DISPLAY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+    if wayland {
+        if std::env::var("__NV_DISABLE_EXPLICIT_SYNC").is_err() {
+            eprintln!("[harbor::mpv_linux] NVIDIA + Wayland detected; setting __NV_DISABLE_EXPLICIT_SYNC=1");
+            std::env::set_var("__NV_DISABLE_EXPLICIT_SYNC", "1");
+        }
         return;
     }
-    eprintln!("[harbor::mpv_linux] NVIDIA + Wayland detected; forcing GDK_BACKEND=x11 (EGL on NVIDIA-Wayland crashes the GL context)");
-    std::env::set_var("GDK_BACKEND", "x11");
+    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+        eprintln!(
+            "[harbor::mpv_linux] NVIDIA + X11 detected; setting WEBKIT_DISABLE_DMABUF_RENDERER=1"
+        );
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
 }
 
 pub fn prepare(mpv_ctx: NonNull<mpv_handle>) -> Result<(), String> {


### PR DESCRIPTION
## What changed

I was running into three different rendering problems with the existing NVIDIA workaround on Wayland:

- forcing X11 made the embedded mpv video blank
- using native Wayland with WebKitGTK's DMA-BUF renderer disabled left stale transparent UI pixels over the video
- enabling DMA-BUF without an NVIDIA workaround crashed with a Wayland protocol error 71

This keeps the existing DMA-BUF fallback for NVIDIA on X11, but changes the Wayland path to stay native and set `__NV_DISABLE_EXPLICIT_SYNC=1`. That allows WebKitGTK's DMA-BUF renderer to remain enabled, so transparent overlays composite and clear correctly, while avoiding the protocol error.

Environment variables explicitly provided by the user are still respected.

## Test setup

- CachyOS rolling
- KDE Plasma / KWin 6.7.3 on Wayland
- Linux 7.1.4-1-cachyos-bore
- NVIDIA GeForce RTX 5080 Laptop GPU
- NVIDIA driver 610.43.03
- WebKitGTK 2.52.5
- GTK 3.24.52

## Testing

- Built the Linux system package successfully
- Launched Harbor through NVIDIA PRIME render offload
- Confirmed embedded mpv video renders instead of staying blank
- Confirmed subtitles, timeline, tooltips, and menus clear without stale pixels
- Confirmed the Wayland protocol error no longer occurs