### PR TITLE
fix(security): prevent injection via addon-controlled stream URLs

### DIFF
--- a/src-tauri/src/cast_hls.rs
+++ b/src-tauri/src/cast_hls.rs
@@ -371,6 +371,9 @@ async fn probe_source(url: &str, headers: &HashMap<String, String>) -> Result<Pr
         .arg("stream=codec_name,codec_type,width,height,r_frame_rate,bit_rate:format=duration,bit_rate")
         .arg("-of")
         .arg("default=noprint_wrappers=1:nokey=0")
+        // Pass the input via `-i` so an addon-controlled URL beginning with
+        // `-` is treated as ffprobe's input value, not parsed as a flag.
+        .arg("-i")
         .arg(url);
     #[cfg(windows)]
     {

--- a/src-tauri/src/multiview.rs
+++ b/src-tauri/src/multiview.rs
@@ -551,8 +551,11 @@ fn spawn_mpv(
 }
 
 fn ipc_loadfile_msg(url: &str) -> String {
-    let escaped = url.replace('\\', "\\\\").replace('"', "\\\"");
-    format!("{{\"command\":[\"loadfile\",\"{escaped}\",\"replace\"]}}")
+    // Serialize via serde_json so control characters (notably `\n`/`\r`) are
+    // correctly escaped. Hand-building this JSON let a newline in an
+    // addon-controlled stream URL inject a second mpv IPC command line
+    // (the protocol is newline-delimited), reaching commands such as `run`.
+    serde_json::json!({ "command": ["loadfile", url, "replace"] }).to_string()
 }
 
 const IPC_WAKE_REDRAW: &str = "{\"command\":[\"set_property\",\"video-zoom\",0]}";

--- a/src-tauri/src/thumbs.rs
+++ b/src-tauri/src/thumbs.rs
@@ -583,6 +583,10 @@ async fn spawn_shadow(url: &str, session: &str, pending: Pending) -> Result<Shad
         format!("--screenshot-jpeg-quality={}", SCREENSHOT_QUALITY),
         "--screenshot-tag-colorspace=no".into(),
         "--hr-seek=no".into(),
+        // End-of-options terminator: without it, an addon-controlled stream
+        // URL beginning with `-`/`--` (e.g. `--log-file=<path>`) would be
+        // parsed by mpv as an option, allowing arbitrary file writes.
+        "--".into(),
         url.to_string(),
     ];
 

--- a/src-tauri/src/transcode.rs
+++ b/src-tauri/src/transcode.rs
@@ -256,6 +256,9 @@ pub async fn probe_codecs(url: &str, headers: &HashMap<String, String>) -> Probe
         .arg("stream=codec_name,codec_type")
         .arg("-of")
         .arg("default=noprint_wrappers=1:nokey=0")
+        // Pass the input via `-i` so an addon-controlled URL beginning with
+        // `-` is treated as ffprobe's input value, not parsed as a flag.
+        .arg("-i")
         .arg(url);
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary

Several native subprocess/IPC call sites received **untrusted media URLs** — taken from Stremio addon stream objects, which are fully attacker-controlled — without validation or argument-boundary handling. This PR closes those injection paths. All fixes are minimal and preserve existing behavior for legitimate `http(s)`/`file` URLs.

## Vulnerabilities fixed

### 1. mpv IPC command injection → arbitrary command execution (`multiview.rs`)
`ipc_loadfile_msg` hand-built the mpv JSON IPC command and escaped only `\` and `"`, not `\n`/`\r`. The mpv IPC channel is newline-delimited, so a stream URL containing a newline could inject a **second** IPC command line (e.g. mpv's `run`), yielding arbitrary command execution on the host.
**Fix:** serialize the command with `serde_json`, which escapes control characters.

### 2. mpv argument injection → arbitrary file write (`thumbs.rs`)
The shadow-mpv (thumbnail) process appended the stream URL as the final positional argument with no `--` end-of-options terminator. A URL beginning with `-`/`--` (e.g. `--log-file=<path>`, `--dump-stats=<path>`) was parsed by mpv as an option, allowing arbitrary file create/overwrite.
**Fix:** insert a `--` terminator before the URL.

### 3. ffprobe argument injection (`transcode.rs`, `cast_hls.rs`)
Two ffprobe invocations passed the stream URL as a bare trailing positional, so a leading-`-` URL was parsed as a flag.
**Fix:** pass the input via `-i <url>` (consistent with the existing transcode path).

## Threat model
A malicious or compromised Stremio addon can return arbitrary strings in a stream's `url` field. These reach the sinks above during ordinary playback actions (opening a stream in Multiview, hovering the seek bar for thumbnails, starting a cast/transcode), so no unusual user interaction is required.

## Changes
- `src-tauri/src/multiview.rs` — serialize mpv IPC `loadfile` via `serde_json`
- `src-tauri/src/thumbs.rs` — add `--` end-of-options terminator before the URL
- `src-tauri/src/transcode.rs` — ffprobe input via `-i`
- `src-tauri/src/cast_hls.rs` — ffprobe input via `-i`

## Testing
Please run the standard backend check on a machine with the Rust toolchain:

```
cargo check --manifest-path src-tauri/Cargo.toml
```

(The `serde_json` serialization pattern is already used elsewhere in `multiview.rs`, and the `-i` form matches the existing `handle_transcode` invocation.)
