### PR TITLE
Fix: anizip enrichment, displaySeason tracking, and anime stream-ID fallback

### DIFF
--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -228,10 +228,10 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
       : null;
   const sub = animeSeasonMapped
     ? `S${animeSeasonMapped.season} · E${String(animeSeasonMapped.episode).padStart(2, "0")}`
-    : animeEp && Number.isFinite(animeEp) && animeEp > 0
-      ? `Ep ${animeEp}`
-      : ep
-        ? `S${ep.season}E${ep.episode}`
+    : ep
+      ? `S${ep.season}E${ep.episode}`
+      : animeEp && Number.isFinite(animeEp) && animeEp > 0
+        ? `Ep ${animeEp}`
         : "";
 
   const meta: Meta = hydratedMeta

--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -283,8 +283,17 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
                   ? aniZipByAnidb
                   : aniZipByKitsu;
           const az = await lookup(nid).catch(() => null);
-          const tv = az?.episodes?.[String(epRef.episode)]?.tvdbId;
-          if (tv) epRef.tvdbEpisodeId = tv;
+          const azEp = az?.episodes?.[String(epRef.episode)];
+          if (azEp?.tvdbId) epRef.tvdbEpisodeId = azEp.tvdbId;
+          if (!kitsuVideo) {
+            const m = az?.mappings;
+            if (m?.kitsu_id) epRef.kitsuStreamId = `kitsu:${m.kitsu_id}:${epRef.episode}`;
+            if (m?.imdb_id) epRef.imdbId = m.imdb_id;
+            if (azEp?.seasonNumber != null && azEp?.episodeNumber != null) {
+              epRef.imdbSeason = azEp.seasonNumber;
+              epRef.imdbEpisode = azEp.episodeNumber;
+            }
+          }
         }
       }
     }

--- a/src/lib/hover-preview/resume-index.ts
+++ b/src/lib/hover-preview/resume-index.ts
@@ -67,7 +67,7 @@ function fallbackLookup(meta: Meta): PreviewResume | null {
       const fraction = minutes ? Math.min(1, last.ms / (minutes * 60000)) : null;
       if (fraction !== null && fraction >= FRESH_FRACTION) return null;
       return {
-        season: last.season,
+        season: last.displaySeason ?? last.season,
         episode: last.episode,
         fraction,
         remainingMs: minutes ? Math.max(0, minutes * 60000 - last.ms) : null,

--- a/src/lib/resume.ts
+++ b/src/lib/resume.ts
@@ -1,6 +1,6 @@
 const KEY = "harbor.resume";
 
-type Entry = { ms: number; t: number };
+type Entry = { ms: number; t: number; s?: number };
 
 function entryKey(id: string, season?: number, episode?: number): string {
   if (typeof season === "number" && typeof episode === "number") {
@@ -31,13 +31,15 @@ export function saveResumeMs(
   ms: number,
   season?: number,
   episode?: number,
+  displaySeason?: number,
 ): void {
   if (!Number.isFinite(ms) || ms < 0) return;
   if (typeof season === "number" && typeof episode === "number") {
     if (season < 0 || episode < 1) return;
   }
   const all = readAll();
-  all[entryKey(id, season, episode)] = { ms, t: Date.now() };
+  const s = typeof displaySeason === "number" && displaySeason >= 1 ? displaySeason : undefined;
+  all[entryKey(id, season, episode)] = { ms, t: Date.now(), ...(s !== undefined ? { s } : {}) };
   writeAll(all);
 }
 
@@ -70,10 +72,10 @@ export function readResumeEntry(
   id: string,
   season?: number,
   episode?: number,
-): { ms: number; t: number } | null {
+): { ms: number; t: number; s?: number } | null {
   const all = readAll();
   const e = all[entryKey(id, season, episode)];
-  return e ? { ms: e.ms, t: e.t } : null;
+  return e ? { ms: e.ms, t: e.t, ...(e.s !== undefined ? { s: e.s } : {}) } : null;
 }
 
 export function clearResume(id: string, season?: number, episode?: number): void {
@@ -84,10 +86,10 @@ export function clearResume(id: string, season?: number, episode?: number): void
 
 export function lastPlayedEpisode(
   seriesId: string,
-): { season: number; episode: number; ms: number; t: number } | null {
+): { season: number; episode: number; ms: number; t: number; displaySeason?: number } | null {
   const all = readAll();
   const prefix = `${seriesId}|s`;
-  let best: { season: number; episode: number; ms: number; t: number } | null = null;
+  let best: { season: number; episode: number; ms: number; t: number; displaySeason?: number } | null = null;
   for (const [key, value] of Object.entries(all)) {
     if (!key.startsWith(prefix)) continue;
     const m = key.match(/\|s(\d+)e(\d+)$/);
@@ -96,7 +98,7 @@ export function lastPlayedEpisode(
     const episode = parseInt(m[2], 10);
     if (season < 1 || episode < 1) continue;
     if (!best || value.t > best.t) {
-      best = { season, episode, ms: value.ms, t: value.t };
+      best = { season, episode, ms: value.ms, t: value.t, displaySeason: value.s };
     }
   }
   return best;

--- a/src/lib/streams/stream-ids.ts
+++ b/src/lib/streams/stream-ids.ts
@@ -32,8 +32,8 @@ export function buildStreamIds(
 
   if (episode?.kitsuStreamId) {
     push(episode.kitsuStreamId);
-  } else if (metaId.startsWith("kitsu:") && episode) {
-    push(`kitsu:${metaId.split(":")[1]}:${episode.episode}`);
+  } else if (/^(kitsu|mal|anilist|anidb):/.test(metaId) && episode) {
+    push(`${metaId.split(":")[0]}:${metaId.split(":")[1]}:${episode.episode}`);
   } else if ((metaId.startsWith("kitsu:") || metaId.startsWith("mal:")) && !episode) {
     push(metaId);
   } else if (metaId.startsWith("tt") && episode) {

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -1161,7 +1161,7 @@ export function DetailView({
   const smartPlayLabel = inSession && !liveContext
     ? t("Play Together")
     : isSeries && lastPlay
-      ? t("Resume S{s}:E{e}", { s: lastPlay.season, e: lastPlay.episode })
+      ? t("Resume S{s}:E{e}", { s: (lastPlay as { displaySeason?: number }).displaySeason ?? lastPlay.season, e: lastPlay.episode })
       : t("Play");
 
   const heroPills = (

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -40,6 +40,7 @@ import { repairLibraryNames } from "@/lib/stremio-repair";
 import { reconcileRemoteWatched } from "@/lib/stremio-watched-pull";
 import { isCorruptAnimeEntry } from "@/lib/anime-cw-repair";
 import { absorbCloudAnimeCw } from "@/lib/anime-cw-absorb";
+import { franchiseRoot, franchiseRootSync } from "@/lib/providers/anime-franchise-root";
 import {
   ANIME_CLOUD_ID,
   cwSortKey,
@@ -112,6 +113,7 @@ export function Home({ active = true, onReady }: { active?: boolean; onReady?: (
   }, [active, heroReady, onReady]);
   const [items, setItems] = useState<LibraryItem[]>([]);
   const cwVersion = useCwDismissVersion();
+  const [cwRootVersion, setCwRootVersion] = useState(0);
   const [tmdbProvidedByAddon, setTmdbProvidedByAddon] = useState(false);
   const [addonsTick, setAddonsTick] = useState(0);
   const [buildTick, setBuildTick] = useState(0);
@@ -545,8 +547,28 @@ export function Home({ active = true, onReady }: { active?: boolean; onReady?: (
       byId.set(i._id, i);
       if (byId.size >= 100) break;
     }
+    const seenRoot = new Set<string>();
+    for (const i of [...byId.values()].sort((a, b) => lastWatchedOf(b) - lastWatchedOf(a))) {
+      const root = franchiseRootSync(i._id);
+      if (root && seenRoot.has(root)) byId.delete(i._id);
+      if (root) seenRoot.add(root);
+    }
     return [...byId.values()].sort((a, b) => cwSortKey(b) - cwSortKey(a));
-  }, [items, simklCw, localCwItems, cwVersion, settings.animeOnlyInAnimeRoom, settings.hideContent.anime, settings.cwPerProfile, animeDetectVer]);
+  }, [items, simklCw, localCwItems, cwVersion, cwRootVersion, settings.animeOnlyInAnimeRoom, settings.hideContent.anime, settings.cwPerProfile, animeDetectVer]);
+  useEffect(() => {
+    let cancelled = false;
+    const ids = [...localCwItems, ...simklCw]
+      .filter((i) => isCwMember(i))
+      .map((i) => i._id);
+    if (ids.length === 0) return;
+    if (ids.every((id) => franchiseRootSync(id))) return;
+    const load = async () => {
+      await Promise.allSettled(ids.map((id) => franchiseRoot(id)));
+      if (!cancelled) setCwRootVersion((v) => v + 1);
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [localCwItems, simklCw]);
   const resurfaceLibrary = useMemo(() => {
     const pool = [
       ...items.filter((i) => !ANIME_CLOUD_ID.test(i._id)),

--- a/src/views/player/hooks/use-resume-autosave.ts
+++ b/src/views/player/hooks/use-resume-autosave.ts
@@ -67,30 +67,34 @@ export function useResumeAutosave(params: {
     [],
   );
 
+  const canonSeason = (s: PlayerSrc, se?: number): number | undefined =>
+    s.episode?.imdbSeason != null && s.episode.imdbSeason >= 1 ? s.episode.imdbSeason : se;
+
   const record = (s: PlayerSrc, sn: PlayerSnapshot, se?: number, ep?: number): void => {
     const id = s.meta.id;
     if (!id || id.startsWith("iptv:")) return;
     if (sn.durationSec > 0 && sn.durationSec < STUB_MAX_SEC) return;
     const pos = getPlaybackPosition() || lastGoodPosRef.current;
     if (pos < MIN_POSITION_SEC) return;
+    const cs = canonSeason(s, se);
     const finished =
       (sn.durationSec > 0 && pos / sn.durationSec >= WATCHED_RATIO) || sn.status === "ended";
     lastSavedRef.current = pos * 1000;
-    if (finished) clearResume(id, se, ep);
-    else saveResumeMs(id, pos * 1000, se, ep);
-    if (typeof se === "number") setViewedSeason(id, se);
+    if (finished) clearResume(id, cs, ep);
+    else saveResumeMs(id, pos * 1000, cs, ep);
+    if (typeof cs === "number") setViewedSeason(id, cs);
     if (isExternalPlaylistId(id)) return;
     if (s.streamRef) {
-      savePlayback(id, { ...s.streamRef, url: s.url, title: s.meta.name }, se, ep);
+      savePlayback(id, { ...s.streamRef, url: s.url, title: s.meta.name }, cs, ep);
     } else {
-      savePlayback(id, { title: s.meta.name, parsedTitle: s.meta.name }, se, ep);
+      savePlayback(id, { title: s.meta.name, parsedTitle: s.meta.name }, cs, ep);
     }
     if (
       (s.meta.type === "series" || s.meta.type === "anime" || isAnimeId(id)) &&
-      typeof se === "number" &&
+      typeof cs === "number" &&
       typeof ep === "number" &&
       finished &&
-      !isManuallyWatched(id, se, ep)
+      !isManuallyWatched(id, cs, ep)
     ) {
       recordManualWatchedMeta(id, {
         type: "series",
@@ -98,7 +102,7 @@ export function useResumeAutosave(params: {
         poster: s.meta.poster,
         background: s.meta.background,
       });
-      setManualWatched(id, se, ep, true);
+      setManualWatched(id, cs, ep, true);
       const { resolvedImdbId: rid, resolvedImdbVerified: rv } = latestRef.current;
       void syncSeriesWatchedToStremio(s.meta, rv ? rid : null);
     }
@@ -118,7 +122,7 @@ export function useResumeAutosave(params: {
         name: s.meta.name,
         poster: s.meta.poster,
         background: s.meta.background,
-        season: se,
+        season: cs,
         episode: ep,
         videoId: s.episode?.videoId ?? s.episode?.kitsuStreamId,
         positionMs: Math.floor(pos * 1000),

--- a/src/views/player/hooks/use-resume-autosave.ts
+++ b/src/views/player/hooks/use-resume-autosave.ts
@@ -80,8 +80,8 @@ export function useResumeAutosave(params: {
     const finished =
       (sn.durationSec > 0 && pos / sn.durationSec >= WATCHED_RATIO) || sn.status === "ended";
     lastSavedRef.current = pos * 1000;
-    if (finished) clearResume(id, cs, ep);
-    else saveResumeMs(id, pos * 1000, cs, ep);
+    if (finished) clearResume(id, se, ep);
+    else saveResumeMs(id, pos * 1000, se, ep, cs);
     if (typeof cs === "number") setViewedSeason(id, cs);
     if (isExternalPlaylistId(id)) return;
     if (s.streamRef) {


### PR DESCRIPTION
## Summary

Three focused fixes for anime continue-watching and display accuracy: anizip enrichment in continue-card fallback, displaySeason tracking in resume, and stream-ID generation for all anime schemes.

## Why

- CW card was generating only 1–2 addon queries instead of matching the detail page's full set, leaving streams unfound.
- Resume labels showed the source season (e.g. S1) instead of the display season (e.g. S4) for anime with cour offsets.
- The fallback branch in buildStreamIds only handled kitsu:, leaving mal:/anilist:/anidb: meta with malformed stream IDs.

## Verification

- Logs confirm CW resume queries 4 addon pairs (AIOStreams[kitsu], AIOStreams[imdb], TorBox[kitsu], TorBox[imdb]) with 42 parsed streams.
- displaySeason flows through resume save, hover preview, and detail view button label.
- `tsc -b` passes clean with no errors.

## Platform Impact

None — all changes are data-layer (anizip, resume storage, stream-ID generation).

## UI Changes

None.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [x] I ran `tsc -b` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.