### PR TITLE
fix(detail): move season picker beside episodes

### DIFF
--- a/src/views/detail/anime-episodes.tsx
+++ b/src/views/detail/anime-episodes.tsx
@@ -135,7 +135,10 @@ export function AnimeEpisodes({
     [currentId, franchise, franchiseEpisodes, openMeta],
   );
   const entryEpisodes = useMemo(
-    () => (activeIsAnchor ? episodes : franchiseEpisodes.filter((ep) => ep.sourceMetaId === activeEntryId)),
+    () =>
+      activeIsAnchor
+        ? episodes
+        : franchiseEpisodes.filter((ep) => ep.sourceMetaId === activeEntryId),
     [activeIsAnchor, franchiseEpisodes, activeEntryId, episodes],
   );
   const tvdbPanel = useAnimeTvdbPanel(
@@ -235,7 +238,12 @@ export function AnimeEpisodes({
   const [searchOpen, setSearchOpen] = useState(false);
   const [aiMode, setAiMode] = useState(false);
   const aiProvider = providerForModel(settings.aiSearchModel);
-  const ai = useAnimeAiSearch(meta.name, displayEpisodes, settings.aiSearchKey, settings.aiSearchModel);
+  const ai = useAnimeAiSearch(
+    meta.name,
+    displayEpisodes,
+    settings.aiSearchKey,
+    settings.aiSearchModel,
+  );
   const filteredEpisodes = useMemo(() => {
     if (aiMode && ai.matched) return displayEpisodes.filter((e) => ai.matched!.has(e.number));
     const q = query.trim().toLowerCase();
@@ -281,94 +289,102 @@ export function AnimeEpisodes({
   return (
     <div data-anime-episodes className="flex flex-col gap-6 scroll-mt-24">
       <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-6">
-        <h3 className="text-[22px] font-medium tracking-tight text-ink">
-          {isOneOff ? t("Movie") : t("Episodes")}
-        </h3>
-        <div className="flex items-center gap-4">
-          {!isOneOff && (
-            <p className="text-[13px] text-ink-subtle">
-              {displayEpisodes.length === 1
-                ? t("{n} episode", { n: displayEpisodes.length })
-                : t("{n} episodes", { n: displayEpisodes.length })}
-            </p>
-          )}
-          {!isOneOff && <AnimeRandomButton episodes={displayEpisodes} metaForEp={routing.metaForEp} />}
-          {!isOneOff && (
-            <EpisodeLayoutToggle
-              value={settings.episodeLayout}
-              onChange={(v) => update({ episodeLayout: v })}
-            />
-          )}
-          {!isOneOff && (
-            <EpisodeGridControls
-              sort={settings.episodeSort}
-              onSort={(s) => update({ episodeSort: s })}
-              allWatched={allWatched}
-              onMarkSeason={markSeason}
-            />
-          )}
-          {!isOneOff && (
-            <EpisodeSearchToggle
-              searchActive={searchOpen || query.trim().length > 0}
-              aiMode={aiMode}
-              aiEnabled={!!settings.aiSearchKey.trim()}
-              aiProvider={aiProvider}
-              onSearch={() => {
-                setSearchOpen((v) => !v);
-                setAiMode(false);
-                ai.reset();
-              }}
-              onAskAi={() => {
-                setAiMode(true);
-                setSearchOpen(false);
-                setQuery("");
-              }}
-            />
-          )}
-          {isOneOff ? null : panelExtras ? (
-            <TvdbOrderPanel
-              items={panelExtras.items}
-              activeKey={panelExtras.activeKey}
-              onSelect={panelExtras.onSelect}
-              orderTypes={panelExtras.orderTypes}
-              activeType={panelExtras.activeType}
-              onSelectType={(v) => update({ tvdbSeasonType: v })}
-            />
-          ) : tvdbPanel.active ? (
-            <div
-              aria-hidden
-              className="h-10 w-44 animate-pulse rounded-full border border-edge-soft/50 bg-elevated/40"
-            />
-          ) : order ? (
-            <SeasonArcPicker
-              items={pickerItems}
-              activeKey={franchiseActiveKey ?? order.activeKey}
-              onSelect={selectPickerItem}
-            />
-          ) : franchise.length > 1 ? (
-            <AnimeSeasonPicker
-              franchise={franchise}
-              activeEntryId={activeEntryId}
-              onSelectEntry={onSelectEntry}
-            />
-          ) : null}
+        <div className="flex items-center justify-between gap-6">
+          <div className="flex min-w-0 items-center gap-3">
+            <h3 className="shrink-0 text-[22px] font-medium tracking-tight text-ink">
+              {isOneOff ? t("Movie") : t("Episodes")}
+            </h3>
+            {isOneOff ? null : panelExtras ? (
+              <TvdbOrderPanel
+                items={panelExtras.items}
+                activeKey={panelExtras.activeKey}
+                onSelect={panelExtras.onSelect}
+                orderTypes={panelExtras.orderTypes}
+                activeType={panelExtras.activeType}
+                onSelectType={(v) => update({ tvdbSeasonType: v })}
+              />
+            ) : tvdbPanel.active ? (
+              <div
+                aria-hidden
+                className="h-10 w-44 animate-pulse rounded-full border border-edge-soft/50 bg-elevated/40"
+              />
+            ) : order ? (
+              <SeasonArcPicker
+                items={pickerItems}
+                activeKey={franchiseActiveKey ?? order.activeKey}
+                onSelect={selectPickerItem}
+              />
+            ) : franchise.length > 1 ? (
+              <AnimeSeasonPicker
+                franchise={franchise}
+                activeEntryId={activeEntryId}
+                onSelectEntry={onSelectEntry}
+              />
+            ) : null}
+          </div>
+          <div className="flex items-center gap-4">
+            {!isOneOff && (
+              <p className="text-[13px] text-ink-subtle">
+                {displayEpisodes.length === 1
+                  ? t("{n} episode", { n: displayEpisodes.length })
+                  : t("{n} episodes", { n: displayEpisodes.length })}
+              </p>
+            )}
+            {!isOneOff && (
+              <AnimeRandomButton episodes={displayEpisodes} metaForEp={routing.metaForEp} />
+            )}
+            {!isOneOff && (
+              <EpisodeLayoutToggle
+                value={settings.episodeLayout}
+                onChange={(v) => update({ episodeLayout: v })}
+              />
+            )}
+            {!isOneOff && (
+              <EpisodeGridControls
+                sort={settings.episodeSort}
+                onSort={(s) => update({ episodeSort: s })}
+                allWatched={allWatched}
+                onMarkSeason={markSeason}
+              />
+            )}
+            {!isOneOff && (
+              <EpisodeSearchToggle
+                searchActive={searchOpen || query.trim().length > 0}
+                aiMode={aiMode}
+                aiEnabled={!!settings.aiSearchKey.trim()}
+                aiProvider={aiProvider}
+                onSearch={() => {
+                  setSearchOpen((v) => !v);
+                  setAiMode(false);
+                  ai.reset();
+                }}
+                onAskAi={() => {
+                  setAiMode(true);
+                  setSearchOpen(false);
+                  setQuery("");
+                }}
+              />
+            )}
+          </div>
         </div>
-      </div>
-      {!isOneOff && aiMode && (
-        <AnimeAiBar
-          provider={aiProvider}
-          loading={ai.status === "loading"}
-          onSubmit={ai.run}
-          onExit={() => {
-            setAiMode(false);
-            ai.reset();
-          }}
-        />
-      )}
-      {!isOneOff && !aiMode && searchOpen && (
-        <EpisodeSearch query={query} onQuery={setQuery} matched={filteredEpisodes?.length ?? null} />
-      )}
+        {!isOneOff && aiMode && (
+          <AnimeAiBar
+            provider={aiProvider}
+            loading={ai.status === "loading"}
+            onSubmit={ai.run}
+            onExit={() => {
+              setAiMode(false);
+              ai.reset();
+            }}
+          />
+        )}
+        {!isOneOff && !aiMode && searchOpen && (
+          <EpisodeSearch
+            query={query}
+            onQuery={setQuery}
+            matched={filteredEpisodes?.length ?? null}
+          />
+        )}
       </div>
       {isOneOff ? (
         <MovieEntryCard meta={meta} ep={episodes[0]} watched={anilistCompleted || malCompleted} />
@@ -423,7 +439,12 @@ export function AnimeEpisodes({
           meta={
             watchedMenu.metaId
               ? routing.manualMetaFor(watchedMenu.metaId)
-              : { type: "series", name: meta.name, poster: meta.poster, background: meta.background }
+              : {
+                  type: "series",
+                  name: meta.name,
+                  poster: meta.poster,
+                  background: meta.background,
+                }
           }
           target={watchedMenu}
           onClose={() => setWatchedMenu(null)}

--- a/src/views/detail/cinemeta-episodes.tsx
+++ b/src/views/detail/cinemeta-episodes.tsx
@@ -114,7 +114,7 @@ export function CinemetaEpisodes({
 
   return (
     <div data-episodes className="flex scroll-mt-24 flex-col gap-6">
-      <div className="flex items-end justify-between gap-6">
+      <div className="flex items-center gap-6">
         <div className="flex min-w-0 items-center gap-3">
           <h3 className="shrink-0 text-[22px] font-medium tracking-tight text-ink">
             {t("Episodes")}

--- a/src/views/detail/cinemeta-episodes.tsx
+++ b/src/views/detail/cinemeta-episodes.tsx
@@ -3,7 +3,11 @@ import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "reac
 import { createPortal } from "react-dom";
 import type { Meta } from "@/lib/cinemeta";
 import { EpisodeWatchedMenu, type WatchedMenuTarget } from "@/components/episode-watched-menu";
-import { manualWatchedState, manualWatchedVersion, subscribeManualWatched } from "@/lib/manual-watched";
+import {
+  manualWatchedState,
+  manualWatchedVersion,
+  subscribeManualWatched,
+} from "@/lib/manual-watched";
 import { getLastSeason, setLastSeason } from "@/lib/last-season";
 import { lastPlayedEpisode } from "@/lib/resume";
 import { Poster } from "@/components/poster";
@@ -36,7 +40,12 @@ export function CinemetaEpisodes({
   const t = useT();
   useSyncExternalStore(subscribeManualWatched, manualWatchedVersion);
   const [watchedMenu, setWatchedMenu] = useState<WatchedMenuTarget | null>(null);
-  const openWatchedMenu = (e: React.MouseEvent, season: number, episode: number, watched: boolean) => {
+  const openWatchedMenu = (
+    e: React.MouseEvent,
+    season: number,
+    episode: number,
+    watched: boolean,
+  ) => {
     e.preventDefault();
     setWatchedMenu({ x: e.clientX, y: e.clientY, season, episode, watched });
   };
@@ -56,7 +65,9 @@ export function CinemetaEpisodes({
       .sort(([a], [b]) => a - b)
       .map(([s, eps]) => ({
         seasonNumber: s,
-        episodes: eps.slice().sort((a, b) => ((a.episode ?? a.number) ?? 0) - ((b.episode ?? b.number) ?? 0)),
+        episodes: eps
+          .slice()
+          .sort((a, b) => (a.episode ?? a.number ?? 0) - (b.episode ?? b.number ?? 0)),
       }));
     if (flat.length > 0 && numbered.length === 0) {
       flat.sort((a, b) => (a.released ?? "").localeCompare(b.released ?? ""));
@@ -77,7 +88,10 @@ export function CinemetaEpisodes({
   );
 
   const [active, setActive] = useState<number>(() =>
-    pickDefaultSeason(meta.id, grouped.map((g) => g.seasonNumber)),
+    pickDefaultSeason(
+      meta.id,
+      grouped.map((g) => g.seasonNumber),
+    ),
   );
   const userPickedRef = useRef(false);
 
@@ -87,7 +101,12 @@ export function CinemetaEpisodes({
 
   useEffect(() => {
     if (userPickedRef.current) return;
-    setActive(pickDefaultSeason(meta.id, grouped.map((g) => g.seasonNumber)));
+    setActive(
+      pickDefaultSeason(
+        meta.id,
+        grouped.map((g) => g.seasonNumber),
+      ),
+    );
   }, [meta.id, grouped.length]);
 
   if (grouped.length === 0) return null;
@@ -96,18 +115,22 @@ export function CinemetaEpisodes({
   return (
     <div data-episodes className="flex scroll-mt-24 flex-col gap-6">
       <div className="flex items-end justify-between gap-6">
-        <h3 className="text-[22px] font-medium tracking-tight text-ink">{t("Episodes")}</h3>
-        {grouped.length > 1 && (
-          <SeasonDropdown
-            seasons={grouped.map((g) => g.seasonNumber)}
-            active={active}
-            onChange={(n) => {
-              userPickedRef.current = true;
-              setLastSeason(meta.id, n);
-              setActive(n);
-            }}
-          />
-        )}
+        <div className="flex min-w-0 items-center gap-3">
+          <h3 className="shrink-0 text-[22px] font-medium tracking-tight text-ink">
+            {t("Episodes")}
+          </h3>
+          {grouped.length > 1 && (
+            <SeasonDropdown
+              seasons={grouped.map((g) => g.seasonNumber)}
+              active={active}
+              onChange={(n) => {
+                userPickedRef.current = true;
+                setLastSeason(meta.id, n);
+                setActive(n);
+              }}
+            />
+          )}
+        </div>
       </div>
       <p className="text-[13px] text-ink-subtle">
         {activeEps.length === 1
@@ -133,7 +156,12 @@ export function CinemetaEpisodes({
       {watchedMenu && (
         <EpisodeWatchedMenu
           metaId={meta.id}
-          meta={{ type: "series", name: meta.name, poster: meta.poster, background: meta.background }}
+          meta={{
+            type: "series",
+            name: meta.name,
+            poster: meta.poster,
+            background: meta.background,
+          }}
           target={watchedMenu}
           allEpisodes={allEpisodesOrdered}
           onClose={() => setWatchedMenu(null)}
@@ -235,7 +263,12 @@ function SeasonDropdown({
   onChange: (n: number) => void;
 }) {
   const t = useT();
-  const [menu, setMenu] = useState<{ right: number; top?: number; bottom?: number; maxH: number } | null>(null);
+  const [menu, setMenu] = useState<{
+    right: number;
+    top?: number;
+    bottom?: number;
+    maxH: number;
+  } | null>(null);
   const btnRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const open = menu != null;

--- a/src/views/detail/series-episodes.tsx
+++ b/src/views/detail/series-episodes.tsx
@@ -120,7 +120,9 @@ export function SeriesEpisodes({
           for (const k of combinedWatched) if (k.startsWith(`${s.seasonNumber}:`)) n += 1;
           return `S${s.seasonNumber} ${n}/${s.episodeCount}`;
         });
-      console.debug(`[season-default] ${meta.id} pick=${def} hint=${resumeSeason} [${counts.join(", ")}]`);
+      console.debug(
+        `[season-default] ${meta.id} pick=${def} hint=${resumeSeason} [${counts.join(", ")}]`,
+      );
     }
     setActive(def);
   }, [meta.id, seasons, combinedWatched, resumeSeason]);
@@ -166,7 +168,9 @@ export function SeriesEpisodes({
     if (Object.keys(tvdbStills).length === 0) return enrichedBase;
     return enrichedBase.map((ep) => {
       if (ep.stillPath || ep.stillUrl) return ep;
-      const img = tvdbStills[`s${ep.seasonNumber}e${ep.episodeNumber}`] ?? tvdbStills[`abs${ep.episodeNumber}`];
+      const img =
+        tvdbStills[`s${ep.seasonNumber}e${ep.episodeNumber}`] ??
+        tvdbStills[`abs${ep.episodeNumber}`];
       return img ? { ...ep, stillUrl: img } : ep;
     });
   }, [enrichedBase, tvdbStills]);
@@ -217,7 +221,7 @@ export function SeriesEpisodes({
   const orderedEps = arcActive
     ? arc.episodes
     : ordering
-      ? ordering.bySeason.get(orderSeasonEff) ?? []
+      ? (ordering.bySeason.get(orderSeasonEff) ?? [])
       : [];
   const orderedLoading = arcActive && arc.loading;
 
@@ -246,7 +250,31 @@ export function SeriesEpisodes({
   return (
     <div data-episodes className="flex scroll-mt-24 flex-col gap-6">
       <div className="flex items-end justify-between gap-6">
-        <h3 className="text-[22px] font-medium tracking-tight text-ink">{t("Episodes")}</h3>
+        <div className="flex min-w-0 items-center gap-3">
+          <h3 className="shrink-0 text-[22px] font-medium tracking-tight text-ink">
+            {t("Episodes")}
+          </h3>
+          {panelActive ? (
+            <TvdbOrderPanel
+              items={picker.items}
+              activeKey={picker.activeKey}
+              onSelect={picker.onSelect}
+              orderTypes={orderTypes}
+              activeType={settings.tvdbSeasonType}
+              onSelectType={(v) => update({ tvdbSeasonType: v })}
+            />
+          ) : (
+            (picker.items.length > 1 || arcAvailable) && (
+              <SeasonArcPicker
+                items={picker.items}
+                activeKey={picker.activeKey}
+                onSelect={picker.onSelect}
+                mode={arcAvailable ? mode : undefined}
+                onModeChange={arcAvailable ? setMode : undefined}
+              />
+            )
+          )}
+        </div>
         <div className="flex items-center gap-2.5">
           <RandomEpisodeButton meta={meta} seasons={seasons} />
           <EpisodeLayoutToggle
@@ -275,130 +303,121 @@ export function SeriesEpisodes({
               setSearchOpen(false);
             }}
           />
-          {panelActive ? (
-            <TvdbOrderPanel
-              items={picker.items}
-              activeKey={picker.activeKey}
-              onSelect={picker.onSelect}
-              orderTypes={orderTypes}
-              activeType={settings.tvdbSeasonType}
-              onSelectType={(v) => update({ tvdbSeasonType: v })}
-            />
-          ) : (
-            (picker.items.length > 1 || arcAvailable) && (
-              <SeasonArcPicker
-                items={picker.items}
-                activeKey={picker.activeKey}
-                onSelect={picker.onSelect}
-                mode={arcAvailable ? mode : undefined}
-                onModeChange={arcAvailable ? setMode : undefined}
-              />
-            )
-          )}
         </div>
       </div>
 
       {!aiMode && searchOpen && <EpisodeSearchBar value={epSearch} onChange={setEpSearch} />}
 
       {aiMode ? (
-        <EpisodeAiMode meta={meta} videos={cinemetaVideos} imdbId={imdbId} onExit={() => setAiMode(false)} />
+        <EpisodeAiMode
+          meta={meta}
+          videos={cinemetaVideos}
+          imdbId={imdbId}
+          onExit={() => setAiMode(false)}
+        />
       ) : searching ? (
         <CrossSeasonResults meta={meta} videos={cinemetaVideos} query={epSearch} imdbId={imdbId} />
       ) : (
-      <>
-
-      {altActive && (
-        <OrderedEpisodes
-          meta={meta}
-          episodes={orderedEps}
-          loading={orderedLoading}
-          traktKey={traktKey}
-          traktWatched={traktWatched}
-          stremioWatched={stremioWatched}
-          simklWatched={simklWatched}
-          cinemetaVideos={cinemetaVideos}
-          seriesImdbId={imdbId}
-          onContextMenu={openWatchedMenu}
-        />
-      )}
-
-      {!altActive && activeSeason && (activeSeason.airDate || activeSeason.episodeCount > 0) && (
-        <p className="text-[13px] text-ink-subtle">
-          {activeSeason.episodeCount === 1
-            ? t("{n} episode", { n: activeSeason.episodeCount })
-            : t("{n} episodes", { n: activeSeason.episodeCount })}
-          {activeSeason.airDate && ` · ${activeSeason.airDate.slice(0, 4)}`}
-        </p>
-      )}
-
-      {!altActive && loading && <EpisodeGridSkeleton />}
-
-      {!altActive && !loading && enrichedEpisodes.length === 0 && (
-        <CinemetaFallback meta={meta} videos={cinemetaVideos} season={active} />
-      )}
-
-      {!altActive && !loading && enrichedEpisodes.length > 0 && (
-        <div key={settings.episodeLayout} className="animate-fade-in">
-          {settings.episodeLayout !== "list" ? (
-            <EpisodeStrip
-              layout={settings.episodeLayout === "grid" ? "grid" : "strip"}
+        <>
+          {altActive && (
+            <OrderedEpisodes
               meta={meta}
-              seriesImdbId={imdbId}
+              episodes={orderedEps}
+              loading={orderedLoading}
+              traktKey={traktKey}
+              traktWatched={traktWatched}
+              stremioWatched={stremioWatched}
+              simklWatched={simklWatched}
               cinemetaVideos={cinemetaVideos}
-              episodes={enrichedEpisodes}
-              progressFor={(ep) =>
-                getEpisodeProgress(
-                  meta.id,
-                  ep.seasonNumber,
-                  ep.episodeNumber,
-                  ep.runtime,
-                  traktKey,
-                  traktWatched,
-                  stremioWatched,
-                  undefined,
-                  simklWatched,
-                )
-              }
-              thumbnailFor={(ep) =>
-                cinemetaVideos?.find(
-                  (v) => v.season === ep.seasonNumber && v.episode === ep.episodeNumber,
-                )?.thumbnail
-              }
-              spoilerFor={(ep) => spoilerFor(ep.episodeNumber)}
+              seriesImdbId={imdbId}
               onContextMenu={openWatchedMenu}
             />
-          ) : (
-            <div className="flex flex-col gap-1">
-              {enrichedEpisodes.map((ep) => (
-                <EpisodeRow
-                  key={ep.id}
+          )}
+
+          {!altActive &&
+            activeSeason &&
+            (activeSeason.airDate || activeSeason.episodeCount > 0) && (
+              <p className="text-[13px] text-ink-subtle">
+                {activeSeason.episodeCount === 1
+                  ? t("{n} episode", { n: activeSeason.episodeCount })
+                  : t("{n} episodes", { n: activeSeason.episodeCount })}
+                {activeSeason.airDate && ` · ${activeSeason.airDate.slice(0, 4)}`}
+              </p>
+            )}
+
+          {!altActive && loading && <EpisodeGridSkeleton />}
+
+          {!altActive && !loading && enrichedEpisodes.length === 0 && (
+            <CinemetaFallback meta={meta} videos={cinemetaVideos} season={active} />
+          )}
+
+          {!altActive && !loading && enrichedEpisodes.length > 0 && (
+            <div key={settings.episodeLayout} className="animate-fade-in">
+              {settings.episodeLayout !== "list" ? (
+                <EpisodeStrip
+                  layout={settings.episodeLayout === "grid" ? "grid" : "strip"}
                   meta={meta}
-                  ep={ep}
-                  cinemetaThumbnail={
+                  seriesImdbId={imdbId}
+                  cinemetaVideos={cinemetaVideos}
+                  episodes={enrichedEpisodes}
+                  progressFor={(ep) =>
+                    getEpisodeProgress(
+                      meta.id,
+                      ep.seasonNumber,
+                      ep.episodeNumber,
+                      ep.runtime,
+                      traktKey,
+                      traktWatched,
+                      stremioWatched,
+                      undefined,
+                      simklWatched,
+                    )
+                  }
+                  thumbnailFor={(ep) =>
                     cinemetaVideos?.find(
                       (v) => v.season === ep.seasonNumber && v.episode === ep.episodeNumber,
                     )?.thumbnail
                   }
-                  cinemetaVideos={cinemetaVideos}
-                  seriesImdbId={imdbId}
-                  progress={progressByEp.get(ep.episodeNumber)!}
-                  spoiler={spoilerFor(ep.episodeNumber)}
+                  spoilerFor={(ep) => spoilerFor(ep.episodeNumber)}
                   onContextMenu={openWatchedMenu}
                 />
-              ))}
+              ) : (
+                <div className="flex flex-col gap-1">
+                  {enrichedEpisodes.map((ep) => (
+                    <EpisodeRow
+                      key={ep.id}
+                      meta={meta}
+                      ep={ep}
+                      cinemetaThumbnail={
+                        cinemetaVideos?.find(
+                          (v) => v.season === ep.seasonNumber && v.episode === ep.episodeNumber,
+                        )?.thumbnail
+                      }
+                      cinemetaVideos={cinemetaVideos}
+                      seriesImdbId={imdbId}
+                      progress={progressByEp.get(ep.episodeNumber)!}
+                      spoiler={spoilerFor(ep.episodeNumber)}
+                      onContextMenu={openWatchedMenu}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           )}
-        </div>
-      )}
-      {!altActive && settings.episodeLayout === "list" && (
-        <EpisodeJumper scrollRef={scrollRef} totalEpisodes={enrichedEpisodes.length} />
-      )}
-      </>
+          {!altActive && settings.episodeLayout === "list" && (
+            <EpisodeJumper scrollRef={scrollRef} totalEpisodes={enrichedEpisodes.length} />
+          )}
+        </>
       )}
       {watchedMenu && (
         <EpisodeWatchedMenu
           metaId={meta.id}
-          meta={{ type: "series", name: meta.name, poster: meta.poster, background: meta.background }}
+          meta={{
+            type: "series",
+            name: meta.name,
+            poster: meta.poster,
+            background: meta.background,
+          }}
           target={watchedMenu}
           onClose={() => setWatchedMenu(null)}
         />
@@ -406,4 +425,3 @@ export function SeriesEpisodes({
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary

Moves the season, arc, franchise, and TVDB order selectors beside the Episodes heading instead of placing them at the far right of the episode header.

This applies to the TMDB series, anime, and Cinemeta fallback episode views.


Before:
<img width="1128" height="560" alt="Screenshot 2026-07-23 at 12 49 06 PM" src="https://github.com/user-attachments/assets/dcf377b3-c2ad-479c-a513-7d9faa6f16d3" />
After:
<img width="1139" height="532" alt="Screenshot 2026-07-23 at 12 48 43 PM" src="https://github.com/user-attachments/assets/c514f52d-ada3-4f39-9158-503a672e580d" />


This gives a cleaner look and makes the episode bar feel less cluttered 
## Verification

- `pnpm run check`
- `pnpm run typecheck`