### PR TITLE
fix(build): avoid stripped media asset imports

### DIFF
--- a/src/components/anime-awards-block.tsx
+++ b/src/components/anime-awards-block.tsx
@@ -41,7 +41,7 @@ function SourceGroup({ source, wins }: { source: AwardSourceId; wins: AwardWin[]
   const customLogo = resolveAwardIcon(`${source}_logo`) ?? resolveAwardIcon(source);
   const iconSrc = customLogo ?? meta.icon;
   const logoClass = `h-auto max-h-12 w-auto max-w-[180px] shrink-0 ${
-    source === "animation_kobe" ? (customLogo ? "max-h-14" : "brightness-0 invert max-h-14") : ""
+    source === "animation_kobe" ? "max-h-14" : ""
   }`;
   return (
     <section className="grid gap-7 lg:grid-cols-[240px_1fr] lg:gap-14">

--- a/src/lib/anime-awards.ts
+++ b/src/lib/anime-awards.ts
@@ -3,14 +3,6 @@ import taafData from "@/data/taaf-awards.json";
 import jmafData from "@/data/japan-media-arts-awards.json";
 import kobeData from "@/data/animation-kobe-awards.json";
 import rAnimeData from "@/data/r-anime-awards.json";
-import kobeIcon from "@/assets/awards/animation_kobe.svg";
-import rAnimeLogo from "@/assets/awards/r-anime-awards.png";
-import rAnimeIcon from "@/assets/awards/r-anime-icon.png";
-import jmafLogo from "@/assets/awards/japan-media-arts.webp";
-import jmafIcon from "@/assets/awards/jmaf-icon.png";
-import taafLogo from "@/assets/awards/taaf_logo.png";
-import taafIcon from "@/assets/awards/taaf-icon.png";
-import crunchyrollMark from "@/assets/awards/crunchyroll_mark.png";
 import animeAwardIds from "@/data/anime-award-ids.json";
 import { animeFranchiseKey, stripFranchiseSuffix } from "@/lib/providers/jikan";
 import { peekAwardWinsById } from "@/lib/anime-awards-source";
@@ -56,6 +48,19 @@ export type AwardWin = {
   isAOTY: boolean;
 };
 
+// The repository intentionally excludes third-party award artwork. Keep the
+// default marks self-contained; users can still override them with award packs.
+function defaultAwardMark(label: string, color: string): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 64"><rect width="160" height="64" rx="14" fill="${color}"/><text x="80" y="39" fill="white" font-family="system-ui,sans-serif" font-size="25" font-weight="700" text-anchor="middle">${label}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+const CRUNCHYROLL_MARK = defaultAwardMark("CR", "#f47521");
+const TAAF_MARK = defaultAwardMark("TAAF", "#ef8b27");
+const JMAF_MARK = defaultAwardMark("JMAF", "#6d5bd0");
+const R_ANIME_MARK = defaultAwardMark("r/anime", "#ff4500");
+const KOBE_MARK = defaultAwardMark("Kobe", "#0f766e");
+
 type Raw = {
   categories: Record<string, { name: string; winners: { year: number; title: string }[] }>;
 };
@@ -86,40 +91,40 @@ const SOURCE_META: Record<
     id: "crunchyroll",
     name: "Crunchyroll Anime Awards",
     shortName: "CR",
-    icon: crunchyrollMark,
-    iconSmall: crunchyrollMark,
+    icon: CRUNCHYROLL_MARK,
+    iconSmall: CRUNCHYROLL_MARK,
     prestige: 100,
   },
   taaf: {
     id: "taaf",
     name: "Tokyo Anime Award Festival",
     shortName: "TAAF",
-    icon: taafLogo,
-    iconSmall: taafIcon,
+    icon: TAAF_MARK,
+    iconSmall: TAAF_MARK,
     prestige: 95,
   },
   jmaf: {
     id: "jmaf",
     name: "Japan Media Arts Festival",
     shortName: "JMAF",
-    icon: jmafLogo,
-    iconSmall: jmafIcon,
+    icon: JMAF_MARK,
+    iconSmall: JMAF_MARK,
     prestige: 90,
   },
   r_anime: {
     id: "r_anime",
     name: "r/anime Awards",
     shortName: "r/anime",
-    icon: rAnimeLogo,
-    iconSmall: rAnimeIcon,
+    icon: R_ANIME_MARK,
+    iconSmall: R_ANIME_MARK,
     prestige: 70,
   },
   animation_kobe: {
     id: "animation_kobe",
     name: "Animation Kobe",
     shortName: "Kobe",
-    icon: kobeIcon,
-    iconSmall: kobeIcon,
+    icon: KOBE_MARK,
+    iconSmall: KOBE_MARK,
     prestige: 60,
   },
 };

--- a/src/views/manga/collection-badge.tsx
+++ b/src/views/manga/collection-badge.tsx
@@ -1,15 +1,22 @@
 import { useEffect, useState } from "react";
-import acclaimedArt from "@/assets/manga-badges/acclaimed.png";
-import expoArt from "@/assets/manga-badges/anime-expo.png";
-import eisnerArt from "@/assets/manga-badges/eisner.png";
-import harveyArt from "@/assets/manga-badges/harvey.png";
-import seiunArt from "@/assets/manga-badges/seiun.png";
-import popularArt from "@/assets/manga-badges/popular.png";
 import { HoverTooltip } from "@/components/hover-tooltip";
 import { useT } from "@/lib/i18n";
 import { collectionsForTitle } from "@/lib/manga/collections";
 import { hasAnyMangaSource } from "@/lib/manga/sources";
 import { useView } from "@/lib/view";
+
+function collectionBadge(label: string, color: string): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96"><circle cx="48" cy="48" r="46" fill="${color}"/><path d="m48 17 7 17 18 1-14 12 5 18-16-10-16 10 5-18-14-12 18-1z" fill="white"/><text x="48" y="84" fill="white" font-family="system-ui,sans-serif" font-size="11" font-weight="700" text-anchor="middle">${label}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+// Collection artwork is intentionally excluded from the public repository.
+const popularArt = collectionBadge("TOP", "#d97706");
+const acclaimedArt = collectionBadge("BEST", "#7c3aed");
+const expoArt = collectionBadge("EXPO", "#0f766e");
+const eisnerArt = collectionBadge("EISNER", "#1d4ed8");
+const harveyArt = collectionBadge("HARVEY", "#be123c");
+const seiunArt = collectionBadge("SEIUN", "#0369a1");
 
 const BADGE_ART: Record<string, string> = {
   popular: popularArt,

--- a/src/views/settings/ad-skip-showcase.tsx
+++ b/src/views/settings/ad-skip-showcase.tsx
@@ -1,18 +1,22 @@
-import adskipVideo from "@/assets/adskip.mp4";
+import { AdSkipIcon } from "@/components/icons/adskip-icon";
 import { useT } from "@/lib/i18n";
 
 export function AdSkipShowcase() {
   const t = useT();
   return (
     <div className="overflow-hidden rounded-2xl border border-edge-soft bg-black/50 shadow-[0_10px_34px_-14px_rgba(0,0,0,0.7)]">
-      <video
-        src={adskipVideo}
-        autoPlay
-        loop
-        muted
-        playsInline
-        className="block w-full"
-      />
+      <div className="relative flex aspect-video items-center justify-center overflow-hidden bg-gradient-to-br from-zinc-900 via-zinc-950 to-black">
+        <div className="absolute -right-10 -top-10 h-44 w-44 rounded-full bg-accent/20 blur-3xl" />
+        <div className="relative flex items-center gap-3 rounded-xl border border-white/15 bg-black/55 px-4 py-3 shadow-2xl">
+          <AdSkipIcon className="h-7 w-7 text-accent" />
+          <div className="flex flex-col">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/55">
+              {t("Ad detected")}
+            </span>
+            <span className="text-sm font-semibold text-white">{t("Skip ad")}</span>
+          </div>
+        </div>
+      </div>
       <div className="flex items-center gap-2 border-t border-edge-soft/60 px-4 py-2.5">
         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
         <span className="text-[11.5px] text-ink-muted">


### PR DESCRIPTION
## Summary
- replace ignored third-party award and manga artwork imports with built-in fallback marks
- retain installed award icon packs as overrides
- replace the ignored Ad Skip demo video with a static preview

## Validation
- `pnpm run check -- src/lib/anime-awards.ts src/components/anime-awards-block.tsx src/views/manga/collection-badge.tsx src/views/settings/ad-skip-showcase.tsx`
- `pnpm run typecheck`
- `pnpm run build`

This fixes clean beta-branch builds without restoring assets the repository intentionally strips. Needed this fix to start distributing Linux beta builds by making the beta-branch buildable