### PR TITLE
Fixed Liquid Glass styling in the Player Controls HUD for HTML5, with a darker fallback for MPV.

### DIFF
--- a/src/components/player/episode-panel/index.tsx
+++ b/src/components/player/episode-panel/index.tsx
@@ -29,6 +29,7 @@ function sameEpisode(a: PlayEpisode, b: PlayEpisode): boolean {
 }
 
 export function EpisodePanel({
+  engine,
   open,
   onClose,
   meta,
@@ -40,6 +41,7 @@ export function EpisodePanel({
   nextEp,
   onRestart,
 }: {
+  engine: "html5" | "mpv";
   open: boolean;
   onClose: () => void;
   meta: Meta;
@@ -52,6 +54,7 @@ export function EpisodePanel({
   onRestart?: () => void;
 }) {
   const t = useT();
+  const isMpv = engine === "mpv";
   const { settings, update } = useSettings();
   const { openPicker, replacePlayerSrc } = useView();
   const debrids = useDebridClients();
@@ -213,20 +216,36 @@ export function EpisodePanel({
           motionSpeed={0.5}
           interactive={false}
           alwaysActive
-          style={{
-            background:
-              "linear-gradient(145deg, rgba(8,12,18,0.36), rgba(8,12,18,0.30) 48%, rgba(8,12,18,0.34))",
-            boxShadow:
-              corner === "top-left" || corner === "bottom-left"
-                ? "inset -1px 0 0 rgba(255,255,255,0.13), inset 0 1px 0 rgba(255,255,255,0.07), inset 0 -1px 0 rgba(0,0,0,0.08)"
-                : "inset 1px 0 0 rgba(255,255,255,0.13), inset 0 1px 0 rgba(255,255,255,0.07), inset 0 -1px 0 rgba(0,0,0,0.08)",
-          }}
+          style={
+            isMpv
+              ? {
+                  background:
+                    "linear-gradient(145deg, rgba(8,12,18,0.36), rgba(8,12,18,0.30) 48%, rgba(8,12,18,0.34))",
+                  boxShadow:
+                    corner === "top-left" || corner === "bottom-left"
+                      ? "inset -1px 0 0 rgba(255,255,255,0.13), inset 0 1px 0 rgba(255,255,255,0.07), inset 0 -1px 0 rgba(0,0,0,0.08)"
+                      : "inset 1px 0 0 rgba(255,255,255,0.13), inset 0 1px 0 rgba(255,255,255,0.07), inset 0 -1px 0 rgba(0,0,0,0.08)",
+                }
+              : {
+                  background:
+                    "linear-gradient(145deg, rgba(255,255,255,0.055), rgba(10,12,18,0.16) 48%, rgba(255,255,255,0.018))",
+                  WebkitBackdropFilter:
+                    "blur(18px) saturate(1.38) brightness(1.025) contrast(1.025)",
+                  backdropFilter: "blur(18px) saturate(1.38) brightness(1.025) contrast(1.025)",
+                  boxShadow:
+                    corner === "top-left" || corner === "bottom-left"
+                      ? "inset -1px 0 0 rgba(255,255,255,0.13), inset 0 1px 0 rgba(255,255,255,0.07), inset 0 -1px 0 rgba(0,0,0,0.08)"
+                      : "inset 1px 0 0 rgba(255,255,255,0.13), inset 0 1px 0 rgba(255,255,255,0.07), inset 0 -1px 0 rgba(0,0,0,0.08)",
+                }
+          }
           className={`h-full w-full ${
             corner === "top-left" || corner === "bottom-left" ? "border-r" : "border-l"
           } border-white/[0.10]`}
           contentClassName="relative h-full w-full overflow-hidden"
         >
-          <div aria-hidden className="pointer-events-none absolute inset-0 z-0 bg-[#080c12]/55" />
+          {isMpv && (
+            <div aria-hidden className="pointer-events-none absolute inset-0 z-0 bg-[#080c12]/55" />
+          )}
           <div className="relative z-10 flex h-full w-full flex-col">
             {pickingFor ? (
               <StreamsView
@@ -257,12 +276,23 @@ export function EpisodePanel({
                     motionSpeed={0.5}
                     interactive={false}
                     alwaysActive
-                    style={{
-                      background:
-                        "linear-gradient(145deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018))",
-                      boxShadow:
-                        "inset 0 1px 0 rgba(255,255,255,0.16), inset 0 -1px 0 rgba(0,0,0,0.08)",
-                    }}
+                    style={
+                      isMpv
+                        ? {
+                            background:
+                              "linear-gradient(145deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018))",
+                            boxShadow:
+                              "inset 0 1px 0 rgba(255,255,255,0.16), inset 0 -1px 0 rgba(0,0,0,0.08)",
+                          }
+                        : {
+                            background:
+                              "linear-gradient(145deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018))",
+                            WebkitBackdropFilter: "blur(12px) saturate(1.42) brightness(1.035)",
+                            backdropFilter: "blur(12px) saturate(1.42) brightness(1.035)",
+                            boxShadow:
+                              "inset 0 1px 0 rgba(255,255,255,0.16), inset 0 -1px 0 rgba(0,0,0,0.08)",
+                          }
+                    }
                     className="h-11 w-11 shrink-0 border border-white/[0.12]"
                     contentClassName="flex h-full w-full"
                   >

--- a/src/components/player/skip-pill.tsx
+++ b/src/components/player/skip-pill.tsx
@@ -9,6 +9,7 @@ import { useSettings } from "@/lib/settings";
 import { ThreeLiquidGlassSurface } from "@/components/ThreeLiquidGlassSurface";
 
 export function SkipPill({
+  engine,
   segment,
   hasNextEp,
   nextEp,
@@ -21,6 +22,7 @@ export function SkipPill({
   onCancelAutoNext,
   onDismiss,
 }: {
+  engine: "html5" | "mpv";
   segment: SkipSegment | null;
   hasNextEp: boolean;
   nextEp: PlayEpisode | null;
@@ -80,7 +82,7 @@ export function SkipPill({
           : t("Skip Credits");
   const action = isOutroNext ? onNextEpisode : onSkip;
   const Icon = isOutroNext ? ChevronsRight : FastForward;
-
+  const isMpv = engine === "mpv";
   return (
     <div
       className={`pointer-events-none absolute end-7 z-30 flex items-center gap-2 transition-all duration-200 ease-out ${
@@ -91,10 +93,16 @@ export function SkipPill({
     >
       <ThreeLiquidGlassSurface
         radius="9999px"
-        shaderRadius={0.28}
-        intensity={0.9}
-        refractionStrength={0.8}
+        shaderRadius={0.48}
+        intensity={0.3}
+        refractionStrength={0.08}
         interactive={false}
+        alwaysActive
+        experimentalStyle={{
+          background: isMpv ? "rgba(8,12,18,0.35)" : "transparent",
+          backdropFilter: "blur(18px) saturate(1.25)",
+          WebkitBackdropFilter: "blur(18px) saturate(1.25)",
+        }}
         style={{
           boxShadow: "inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -1px 0 rgba(0,0,0,0.05)",
         }}
@@ -134,10 +142,16 @@ export function SkipPill({
       {onDismiss && !isOutroNext && (
         <ThreeLiquidGlassSurface
           radius="9999px"
-          shaderRadius={0.28}
-          intensity={0.9}
-          refractionStrength={0.8}
+          shaderRadius={0.48}
+          intensity={0.3}
+          refractionStrength={0.08}
           interactive={false}
+          alwaysActive
+          experimentalStyle={{
+            background: isMpv ? "rgba(8,12,18,0.35)" : "transparent",
+            backdropFilter: "blur(18px) saturate(1.25)",
+            WebkitBackdropFilter: "blur(18px) saturate(1.25)",
+          }}
           style={{
             boxShadow: "inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -1px 0 rgba(0,0,0,0.05)",
           }}

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -164,18 +164,22 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
   switch (id) {
     case "back": {
       if (!ctx.onBack) return null;
+
+      const isMpv = ctx.engine === "mpv";
+
       return (
         <Tooltip label={t("Back")} side="bottom">
           <ThreeLiquidGlassSurface
             radius="9999px"
-            shaderRadius={0.28}
-            intensity={0.1}
-            causticsStrength={0.8}
+            shaderRadius={0.48}
+            intensity={0.3}
+            refractionStrength={0.08}
             interactive={false}
             alwaysActive
             experimentalStyle={{
-              background:
-                "linear-gradient(145deg, rgba(8,12,18,0.36), rgba(8,12,18,0.30) 48%, rgba(8,12,18,0.34))",
+              background: isMpv ? "rgba(8,12,18,0.35)" : "transparent",
+              backdropFilter: "blur(18px) saturate(1.25)",
+              WebkitBackdropFilter: "blur(18px) saturate(1.25)",
             }}
             style={{
               transition: "opacity 300ms ease-out",
@@ -338,17 +342,23 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
       const sizeClass = ctx.tight ? "h-12 w-12" : ctx.compact ? "h-14 w-14" : "h-16 w-16";
 
       const iconSize = ctx.tight ? 28 : ctx.compact ? 32 : 36;
+      const isMpv = ctx.engine === "mpv";
 
       return (
         <Tooltip label={ctx.playing ? t("Pause") : t("Play")}>
           <ThreeLiquidGlassSurface
             radius="9999px"
-            shaderRadius={0.28}
-            intensity={0.9}
+            shaderRadius={0.48}
+            intensity={0.3}
             refractionStrength={0.08}
+            interactive={false}
+            alwaysActive
             experimentalStyle={{
-              background:
-                "linear-gradient(145deg, rgba(8,12,18,0.36), rgba(8,12,18,0.30) 48%, rgba(8,12,18,0.34))",
+              background: isMpv
+                ? "linear-gradient(145deg, rgba(4,6,10,0.68), rgba(4,6,10,0.60) 48%, rgba(4,6,10,0.66))"
+                : "transparent",
+              backdropFilter: isMpv ? undefined : "blur(18px) saturate(1.25)",
+              WebkitBackdropFilter: isMpv ? undefined : "blur(18px) saturate(1.25)",
             }}
             className={`
               shrink-0 rounded-full
@@ -357,7 +367,7 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
               transition-opacity duration-300
               ${ctx.active ? "opacity-100" : "opacity-0"}
             `}
-            contentClassName="h-full w-full"
+            contentClassName="h-full w-full bg-transparent"
             style={{
               transition: "opacity 300ms ease-out",
               boxShadow: "inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -1px 0 rgba(0,0,0,0.05)",

--- a/src/views/player/panels-layer.tsx
+++ b/src/views/player/panels-layer.tsx
@@ -9,6 +9,7 @@ import { HeaderWarning, NoAudioWarning } from "./header-warning";
 import { ThreeLiquidGlassSurface } from "@/components/ThreeLiquidGlassSurface";
 
 export const PanelsLayer = memo(function PanelsLayer({
+  engine,
   isSeriesPlayback,
   meta,
   currentEpisode,
@@ -34,6 +35,7 @@ export const PanelsLayer = memo(function PanelsLayer({
   onDismissNoAudio,
   onPickAnother,
 }: {
+  engine: "html5" | "mpv";
   isSeriesPlayback: boolean;
   meta: Meta;
   currentEpisode: PlayEpisode | undefined;
@@ -60,7 +62,10 @@ export const PanelsLayer = memo(function PanelsLayer({
   onPickAnother: () => void;
 }) {
   const t = useT();
+
   const episodesOnLeft = episodesCorner === "top-left" || episodesCorner === "bottom-left";
+
+  const isMpv = engine === "mpv";
 
   return (
     <>
@@ -72,12 +77,16 @@ export const PanelsLayer = memo(function PanelsLayer({
         >
           <ThreeLiquidGlassSurface
             radius={episodesOnLeft ? "0 16px 16px 0" : "16px 0 0 16px"}
-            shaderRadius={0.28}
-            intensity={0.1}
+            shaderRadius={0.48}
+            intensity={0.3}
             refractionStrength={0.08}
             interactive={false}
             alwaysActive
-            experimentalStyle={{ background: "rgba(8,12,18,0.35)" }}
+            experimentalStyle={{
+              background: isMpv ? "rgba(8,12,18,0.35)" : "transparent",
+              backdropFilter: "blur(18px) saturate(1.25)",
+              WebkitBackdropFilter: "blur(18px) saturate(1.25)",
+            }}
             className={`
               group
               h-full
@@ -140,6 +149,7 @@ export const PanelsLayer = memo(function PanelsLayer({
 
       {isSeriesPlayback && (
         <EpisodePanel
+          engine={engine}
           open={episodePanelOpen && !episodesHidden}
           onClose={onCloseEpisodePanel}
           meta={meta}
@@ -164,6 +174,7 @@ export const PanelsLayer = memo(function PanelsLayer({
       )}
 
       {showHeaderWarning && <HeaderWarning onPickAnother={onPickAnother} />}
+
       {showNoAudioWarning && <NoAudioWarning onUseMpv={onUseMpv} onDismiss={onDismissNoAudio} />}
     </>
   );

--- a/src/views/player/player-overlay-layers.tsx
+++ b/src/views/player/player-overlay-layers.tsx
@@ -255,6 +255,7 @@ export const PlayerOverlayLayers = memo(function PlayerOverlayLayers(p: PlayerOv
       )}
 
       <ToolsLayer
+        engine={p.engine}
         pipMode={p.pipMode}
         drawMode={p.drawMode}
         showWaiting={p.showWaiting}
@@ -443,6 +444,7 @@ export const PlayerOverlayLayers = memo(function PlayerOverlayLayers(p: PlayerOv
       />
 
       <PanelsLayer
+        engine={p.engine}
         isSeriesPlayback={p.isSeriesPlayback}
         meta={p.src.meta}
         currentEpisode={p.src.episode}

--- a/src/views/player/skip-pill-container.tsx
+++ b/src/views/player/skip-pill-container.tsx
@@ -13,6 +13,7 @@ export function nextEpisodeLead(setting: number, durationSec: number): number {
 }
 
 export function SkipPillContainer({
+  engine,
   skipSegments,
   durationSec,
   hasNextEpisode,
@@ -25,6 +26,7 @@ export function SkipPillContainer({
   onNextEpisode,
   onCancelAutoNext,
 }: {
+  engine: "html5" | "mpv";
   skipSegments: SkipSegment[];
   durationSec: number;
   hasNextEpisode: boolean;
@@ -96,7 +98,10 @@ export function SkipPillContainer({
       : null;
   useEffect(() => {
     if (!buttonKey || settings.skipButtonHideSec <= 0) return;
-    const id = window.setTimeout(() => setAutoHiddenKey(buttonKey), settings.skipButtonHideSec * 1000);
+    const id = window.setTimeout(
+      () => setAutoHiddenKey(buttonKey),
+      settings.skipButtonHideSec * 1000,
+    );
     return () => window.clearTimeout(id);
   }, [buttonKey, settings.skipButtonHideSec]);
   const skipHidden =
@@ -106,6 +111,7 @@ export function SkipPillContainer({
 
   return (
     <SkipPill
+      engine={engine}
       segment={activeSkip}
       hasNextEp={hasNextEpDisplay && leadSec > 0}
       nextEp={nextEp}

--- a/src/views/player/tools-layer.tsx
+++ b/src/views/player/tools-layer.tsx
@@ -12,6 +12,7 @@ type SkipProps = ComponentProps<typeof SkipPillContainer>;
 type QuickToolsProps = ComponentProps<typeof QuickTools>;
 
 export const ToolsLayer = memo(function ToolsLayer({
+  engine,
   pipMode,
   drawMode,
   showWaiting,
@@ -34,6 +35,7 @@ export const ToolsLayer = memo(function ToolsLayer({
   gif,
   clip,
 }: {
+  engine: "html5" | "mpv";
   pipMode: boolean;
   drawMode: boolean;
   showWaiting: boolean;
@@ -64,6 +66,7 @@ export const ToolsLayer = memo(function ToolsLayer({
         pendingResumeSec == null &&
         pendingSeekSec == null && (
           <SkipPillContainer
+            engine={engine}
             skipSegments={skipSegments}
             durationSec={durationSec}
             hasNextEpisode={hasNextEpisode}


### PR DESCRIPTION
Since Liquid Glass cannot be rendered reliably over the native MPV video surface, this change applies the full Liquid Glass effect when using the HTML5 player.

When MPV is active, the same controls use a darker translucent fallback theme to maintain readability and visual consistency without relying on unsupported backdrop sampling.

HTML5
<img width="2547" height="1411" alt="Screenshot 2026-07-23 183318" src="https://github.com/user-attachments/assets/b6a14948-96ca-4c96-b05d-b8de592c7caf" />

MPV
<img width="2546" height="1412" alt="Screenshot 2026-07-23 183336" src="https://github.com/user-attachments/assets/1e70a6c6-8c88-4df8-bd44-47ee4731e9a2" />
