### PR TITLE
fix: defer Linux updates to package managers

### DIFF
--- a/src/components/update/update-root.tsx
+++ b/src/components/update/update-root.tsx
@@ -8,6 +8,7 @@ import {
   updateAvailable,
   useUpdate,
 } from "@/lib/updater/use-update";
+import { isLinuxDesktop } from "@/lib/platform";
 import { UpdateCard } from "./update-card";
 
 const AUTO_DISMISS_MS = 12_000;
@@ -33,6 +34,7 @@ export function UpdateRoot() {
   const [autoHidden, setAutoHidden] = useState<string | null>(null);
 
   useEffect(() => {
+    if (isLinuxDesktop()) return;
     startUpdateWatcher();
   }, []);
 
@@ -52,6 +54,8 @@ export function UpdateRoot() {
     const id = window.setTimeout(() => setAutoHidden(u.version), AUTO_DISMISS_MS);
     return () => window.clearTimeout(id);
   }, [pillVisible, u.status, u.version]);
+
+  if (isLinuxDesktop()) return null;
 
   if (u.panelOpen) return createPortal(<UpdateCard />, document.body);
   if (!pillVisible) return null;

--- a/src/views/settings/advanced-panel.tsx
+++ b/src/views/settings/advanced-panel.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/updater/use-update";
 import { BetaTag } from "@/components/beta-tag";
 import { IS_BETA_BUILD } from "@/lib/build-info";
+import { isLinuxDesktop } from "@/lib/platform";
 import { BackupRow } from "./backup-row";
 import { SettingsRecoverRow } from "./settings-recover-row";
 import { BuildFeedback } from "./build-feedback";
@@ -43,11 +44,12 @@ const SOURCE_URL = "https://github.com/harborstremio/harbor";
 
 export function AdvancedPanel() {
   const t = useT();
+  const supportsInAppUpdates = isTauri && !isLinuxDesktop();
   return (
     <>
       {!isTauri && <WebBuildBanner />}
 
-      {isTauri && (
+      {supportsInAppUpdates && (
         <Section
           title={t("Updates")}
           subtitle={t("Harbor checks harbor.site for new versions and installs them in place. Nothing installs until you choose to, and a dismissed update never nags you again.")}
@@ -799,4 +801,3 @@ function AnimeRepairRow() {
     />
   );
 }
-


### PR DESCRIPTION
## Summary
- hide the in-app Updates section on Linux
- disable the global update watcher and update prompt on Linux

Linux packages are updated by their package manager rather than Harbor's self-updater.

## Verification
- The beta branch does not define pnpm run check or pnpm run typecheck scripts.
- Confirmed the PR diff is limited to the Linux updater guards.