### PR TITLE
feat(profile): import ratings, watched, and watchlist from Letterboxd

### DIFF
--- a/src/components/letterboxd/letterboxd-import-modal.tsx
+++ b/src/components/letterboxd/letterboxd-import-modal.tsx
@@ -1,0 +1,612 @@
+/**
+ * LetterboxdImportModal
+ *
+ * A full-screen panel (stacked over Profile Settings, same pattern as
+ * CustomizationPanel) with a 4-step import flow:
+ *
+ *   Step 1 — Picker:       ZIP file selector
+ *   Step 2 — Processing:   parse + resolve with progress bar
+ *   Step 3 — Review:       summary + per-film table + toggles + confirm
+ *   Step 4 — Done:         success screen
+ */
+
+import {
+  AlertCircle,
+  ArrowLeft,
+  Check,
+  CheckSquare,
+  Download,
+  Film,
+  Loader2,
+  Square,
+  Upload,
+  X,
+} from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+import { useSettings } from "@/lib/settings";
+import { parseLbxZip, LbxImportError, type LbxParseResult } from "@/lib/letterboxd-import/parser";
+import { resolveItems, unmatchedToCsv, type ResolvedItem, type ResolveProgress } from "@/lib/letterboxd-import/resolver";
+import { setRatingLocal } from "@/lib/ratings/store";
+import { setMovieWatchedLocal } from "@/lib/movie-watched";
+import { setWatchedFlag } from "@/lib/watched-flag";
+import { addToWatchlist } from "@/lib/watchlist";
+import type { MyRating } from "@/lib/ratings/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function downloadCsv(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+  sublabel,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  sublabel?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <div className="text-[13px] font-medium text-ink">{label}</div>
+        {sublabel && <div className="text-[12px] text-ink-subtle">{sublabel}</div>}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        style={{ minHeight: 0 }}
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors ${checked ? "bg-accent" : "bg-edge"}`}
+      >
+        <span
+          className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${checked ? "translate-x-5" : "translate-x-0"}`}
+        />
+      </button>
+    </div>
+  );
+}
+
+function StatusBadge({ status, exists }: { status: "matched" | "unmatched"; exists?: boolean }) {
+  if (status === "unmatched") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-danger/12 px-2 py-0.5 text-[11px] font-medium text-danger">
+        <X size={10} /> Unmatched
+      </span>
+    );
+  }
+  if (exists) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-accent/12 px-2 py-0.5 text-[11px] font-medium text-accent">
+        Update
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-success/15 px-2 py-0.5 text-[11px] font-medium text-success">
+      <Check size={10} /> New
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Picker
+// ---------------------------------------------------------------------------
+
+function PickerStep({
+  onPicked,
+}: {
+  onPicked: (buffer: ArrayBuffer, name: string) => void;
+  onClose: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const handleFile = useCallback(
+    (file: File) => {
+      if (!file.name.toLowerCase().endsWith(".zip")) {
+        setError("Please select a Letterboxd export ZIP file.");
+        return;
+      }
+      setError(null);
+      file.arrayBuffer().then((buf) => onPicked(buf, file.name)).catch(() => {
+        setError("Could not read the selected file.");
+      });
+    },
+    [onPicked],
+  );
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-12">
+      <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-elevated ring-1 ring-edge-soft">
+        <Film size={36} className="text-ink-muted" />
+      </div>
+      <div className="text-center">
+        <h3 className="font-display text-[18px] text-ink">Import from Letterboxd</h3>
+        <p className="mt-1.5 max-w-sm text-[13px] text-ink-subtle">
+          Export your data from{" "}
+          <span className="font-medium text-ink">letterboxd.com → Settings → Import &amp; Export → Export Your Data</span>{" "}
+          then select the downloaded ZIP below.
+        </p>
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".zip"
+        className="sr-only"
+        id="lbx-zip-input"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleFile(file);
+        }}
+      />
+
+      <div
+        className={`w-full max-w-sm cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-colors ${
+          dragging
+            ? "border-accent bg-accent/8"
+            : "border-edge-soft bg-elevated hover:border-edge hover:bg-surface"
+        }`}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          const file = e.dataTransfer.files?.[0];
+          if (file) handleFile(file);
+        }}
+      >
+        <Upload size={24} className="mx-auto mb-3 text-ink-muted" />
+        <p className="text-[13px] font-medium text-ink">Drop ZIP here, or click to browse</p>
+        <p className="mt-1 text-[11px] text-ink-subtle">letterboxd-export.zip</p>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg bg-danger/12 px-3 py-2 text-[12px] text-danger ring-1 ring-danger/25">
+          <AlertCircle size={14} />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Processing
+// ---------------------------------------------------------------------------
+
+function ProcessingStep({ progress }: { progress: ResolveProgress }) {
+  const pct = progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-12">
+      <Loader2 size={36} className="animate-spin text-accent" />
+      <div className="text-center">
+        <h3 className="font-display text-[18px] text-ink">Matching films…</h3>
+        <p className="mt-1 text-[13px] text-ink-subtle">
+          {progress.done} / {progress.total} resolved
+        </p>
+      </div>
+      <div className="w-full max-w-xs overflow-hidden rounded-full bg-elevated ring-1 ring-edge-soft">
+        <div
+          className="h-2 rounded-full bg-accent transition-all duration-300"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — Review
+// ---------------------------------------------------------------------------
+
+type ImportToggles = { ratings: boolean; watched: boolean; watchlist: boolean };
+
+function ReviewStep({
+  parseResult,
+  items,
+  onConfirm,
+  onClose,
+}: {
+  parseResult: LbxParseResult;
+  items: ResolvedItem[];
+  onConfirm: (items: ResolvedItem[], toggles: ImportToggles) => void;
+  onClose: () => void;
+}) {
+  const [rows, setRows] = useState<ResolvedItem[]>(items);
+  const [toggles, setToggles] = useState<ImportToggles>({
+    ratings: true,
+    watched: true,
+    watchlist: true,
+  });
+
+  const matchedCount = rows.filter((r) => r.status === "matched").length;
+  const unmatchedCount = rows.filter((r) => r.status === "unmatched").length;
+  const checkedCount = rows.filter((r) => r.checked).length;
+
+  const toggleRow = (idx: number) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === idx ? { ...r, checked: !r.checked } : r)),
+    );
+  };
+
+  const toggleAll = (checked: boolean) => {
+    setRows((prev) => prev.map((r) => ({ ...r, checked: r.status === "matched" ? checked : false })));
+  };
+
+  const handleDownloadUnmatched = () => {
+    const csv = unmatchedToCsv(rows);
+    downloadCsv(csv, "letterboxd-unmatched.csv");
+  };
+
+  const allMatchedChecked = rows.filter((r) => r.status === "matched").every((r) => r.checked);
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {/* Summary header */}
+      <div className="shrink-0 space-y-4 border-b border-edge-soft bg-elevated px-6 py-4">
+        <div className="flex flex-wrap gap-3">
+          <Pill value={parseResult.films.length} label="Total films" />
+          <Pill value={parseResult.ratedCount} label="Rated" accent />
+          <Pill value={parseResult.watchedCount} label="Watched" />
+          <Pill value={parseResult.watchlistCount} label="Watchlist" />
+          <Pill value={matchedCount} label="Matched" success />
+          {unmatchedCount > 0 && <Pill value={unmatchedCount} label="Unmatched" danger />}
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <Toggle
+            checked={toggles.ratings}
+            onChange={(v) => setToggles((t) => ({ ...t, ratings: v }))}
+            label="Import ratings"
+          />
+          <Toggle
+            checked={toggles.watched}
+            onChange={(v) => setToggles((t) => ({ ...t, watched: v }))}
+            label="Import watched"
+          />
+          <Toggle
+            checked={toggles.watchlist}
+            onChange={(v) => setToggles((t) => ({ ...t, watchlist: v }))}
+            label="Import watchlist"
+          />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-y-auto">
+        <table className="w-full text-[12.5px]">
+          <thead className="sticky top-0 z-10 bg-canvas">
+            <tr className="border-b border-edge-soft text-left text-[11px] text-ink-subtle">
+              <th className="px-4 py-2.5">
+                <button
+                  type="button"
+                  onClick={() => toggleAll(!allMatchedChecked)}
+                  className="flex items-center gap-1 hover:text-ink"
+                >
+                  {allMatchedChecked ? (
+                    <CheckSquare size={13} className="text-accent" />
+                  ) : (
+                    <Square size={13} />
+                  )}
+                </button>
+              </th>
+              <th className="px-3 py-2.5 font-medium">Title</th>
+              <th className="px-3 py-2.5 font-medium">Year</th>
+              <th className="px-3 py-2.5 font-medium">Lbx ★</th>
+              <th className="px-3 py-2.5 font-medium">Harbor ★</th>
+              <th className="px-3 py-2.5 font-medium">Actions</th>
+              <th className="px-3 py-2.5 font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr
+                key={row.film.uri || idx}
+                className={`border-b border-edge-soft/50 transition-colors ${
+                  row.checked ? "bg-transparent" : "opacity-50"
+                } ${row.status === "unmatched" ? "bg-danger/4" : "hover:bg-elevated/40"}`}
+              >
+                <td className="px-4 py-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleRow(idx)}
+                    disabled={row.status === "unmatched"}
+                    className="flex items-center gap-1 text-ink-muted hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    {row.checked ? (
+                      <CheckSquare size={13} className="text-accent" />
+                    ) : (
+                      <Square size={13} />
+                    )}
+                  </button>
+                </td>
+                <td className="max-w-[180px] truncate px-3 py-2 font-medium text-ink">
+                  {row.film.name}
+                </td>
+                <td className="px-3 py-2 text-ink-muted">{row.film.year || "—"}</td>
+                <td className="px-3 py-2 text-ink-muted">
+                  {row.film.lbxRating != null ? `${row.film.lbxRating}/5` : "—"}
+                </td>
+                <td className="px-3 py-2 font-medium text-ink">
+                  {row.film.harborRating != null ? `${row.film.harborRating}/10` : "—"}
+                </td>
+                <td className="px-3 py-2 text-ink-subtle">
+                  {Array.from(row.film.actions).join(" · ")}
+                </td>
+                <td className="px-3 py-2">
+                  <StatusBadge
+                    status={row.status}
+                    exists={row.ratingExists || row.watchedExists}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Footer */}
+      <div className="flex shrink-0 items-center justify-between gap-3 border-t border-edge-soft bg-canvas px-6 py-3">
+        <div className="flex items-center gap-2">
+          {unmatchedCount > 0 && (
+            <button
+              type="button"
+              onClick={handleDownloadUnmatched}
+              className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-[12.5px] text-ink-muted ring-1 ring-edge-soft hover:bg-elevated hover:text-ink"
+            >
+              <Download size={13} />
+              Download unmatched ({unmatchedCount})
+            </button>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-[12px] text-ink-subtle">{checkedCount} films to import</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex min-h-9 items-center rounded-[10px] px-4 text-[13.5px] font-medium text-ink-muted hover:bg-elevated"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(rows, toggles)}
+            disabled={checkedCount === 0}
+            className="inline-flex min-h-9 items-center gap-2 rounded-[10px] bg-accent px-5 text-[13.5px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-40"
+          >
+            <Check size={15} /> Confirm import
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Pill({
+  value,
+  label,
+  accent,
+  success,
+  danger,
+}: {
+  value: number;
+  label: string;
+  accent?: boolean;
+  success?: boolean;
+  danger?: boolean;
+}) {
+  const cls = accent
+    ? "bg-accent/12 text-accent"
+    : success
+      ? "bg-success/15 text-success"
+      : danger
+        ? "bg-danger/12 text-danger"
+        : "bg-elevated text-ink-muted ring-1 ring-edge-soft";
+  return (
+    <span className={`inline-flex items-baseline gap-1.5 rounded-full px-3 py-1 text-[12px] font-medium ${cls}`}>
+      <span className="text-[15px] font-bold tabular-nums">{value}</span>
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — Done
+// ---------------------------------------------------------------------------
+
+function DoneStep({
+  importedCount,
+  onClose,
+}: {
+  importedCount: number;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-12">
+      <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-success/15 ring-1 ring-success/30">
+        <Check size={36} className="text-success" />
+      </div>
+      <div className="text-center">
+        <h3 className="font-display text-[20px] text-ink">Import complete</h3>
+        <p className="mt-1.5 text-[13px] text-ink-subtle">
+          Successfully imported <span className="font-semibold text-ink">{importedCount} films</span> into your library.
+        </p>
+        <p className="mt-1 text-[12px] text-ink-subtle">
+          Ratings are visible on detail pages. Watched films will sync on next app refresh.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="inline-flex min-h-11 items-center rounded-[10px] bg-accent px-6 text-[14px] font-semibold text-canvas hover:opacity-90"
+      >
+        Done
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Import execution
+// ---------------------------------------------------------------------------
+
+function executeImport(
+  items: ResolvedItem[],
+  toggles: ImportToggles,
+): number {
+  let count = 0;
+  const now = Date.now();
+
+  for (const item of items) {
+    if (!item.checked || item.status === "unmatched" || !item.meta) continue;
+    const meta = item.meta;
+    const film = item.film;
+
+    // Ratings
+    if (toggles.ratings && film.actions.has("rated") && film.harborRating != null) {
+      const rating: MyRating = {
+        itemKey: meta.id,
+        mediaType: "movie",
+        score: film.harborRating,
+        title: meta.name || film.name,
+        poster: meta.poster,
+        updatedAt: now,
+      };
+      setRatingLocal(rating);
+      count++;
+    }
+
+    // Watched (always also sets movie-watched flag)
+    if (toggles.watched && film.actions.has("watched")) {
+      setMovieWatchedLocal(meta.id, true);
+      setWatchedFlag(meta.id, true);
+      if (!film.actions.has("rated")) count++; // only count once per film
+    }
+
+    // Watchlist
+    if (toggles.watchlist && film.actions.has("watchlist")) {
+      addToWatchlist({
+        id: meta.id,
+        type: "movie",
+        name: meta.name || film.name,
+        poster: meta.poster,
+      });
+      if (!film.actions.has("rated") && !film.actions.has("watched")) count++;
+    }
+  }
+
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type Step = "picker" | "processing" | "review" | "done";
+
+export function LetterboxdImportModal({ onClose }: { onClose: () => void }) {
+  const { settings } = useSettings();
+  const [step, setStep] = useState<Step>("picker");
+  const [progress, setProgress] = useState<ResolveProgress>({ done: 0, total: 0 });
+  const [parseResult, setParseResult] = useState<LbxParseResult | null>(null);
+  const [resolvedItems, setResolvedItems] = useState<ResolvedItem[]>([]);
+  const [importedCount, setImportedCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFilePicked = useCallback(
+    async (buffer: ArrayBuffer) => {
+      setError(null);
+      setStep("processing");
+      setProgress({ done: 0, total: 1 });
+      try {
+        const parsed = await parseLbxZip(buffer);
+        setParseResult(parsed);
+        setProgress({ done: 0, total: parsed.films.length });
+        const resolved = await resolveItems(
+          parsed.films,
+          settings.tmdbKey ?? "",
+          (p) => setProgress(p),
+        );
+        setResolvedItems(resolved);
+        setStep("review");
+      } catch (e) {
+        const msg =
+          e instanceof LbxImportError
+            ? e.message
+            : "An unexpected error occurred while processing the ZIP.";
+        setError(msg);
+        setStep("picker");
+      }
+    },
+    [settings.tmdbKey],
+  );
+
+  const handleConfirm = useCallback(
+    (items: ResolvedItem[], toggles: ImportToggles) => {
+      const n = executeImport(items, toggles);
+      setImportedCount(n);
+      setStep("done");
+    },
+    [],
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-canvas">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-edge-soft bg-canvas px-6 py-3">
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="flex h-10 w-10 items-center justify-center rounded-[10px] text-ink-muted transition-colors hover:bg-elevated"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <h2 className="font-display text-[18px] text-ink">Import from Letterboxd</h2>
+      </div>
+
+      {error && (
+        <div className="shrink-0 flex items-center gap-2 bg-danger/10 px-6 py-2.5 text-[12.5px] text-danger">
+          <AlertCircle size={14} />
+          {error}
+        </div>
+      )}
+
+      {step === "picker" && (
+        <PickerStep onPicked={handleFilePicked} onClose={onClose} />
+      )}
+      {step === "processing" && <ProcessingStep progress={progress} />}
+      {step === "review" && parseResult && (
+        <ReviewStep
+          parseResult={parseResult}
+          items={resolvedItems}
+          onConfirm={handleConfirm}
+          onClose={onClose}
+        />
+      )}
+      {step === "done" && <DoneStep importedCount={importedCount} onClose={onClose} />}
+    </div>
+  );
+}

--- a/src/lib/letterboxd-import/parser.ts
+++ b/src/lib/letterboxd-import/parser.ts
@@ -1,0 +1,298 @@
+/**
+ * letterboxd-import/parser.ts
+ *
+ * Parses a Letterboxd ZIP export (or a pre-extracted directory) into a
+ * deduplicated list of films with their actions (rated / watched / watchlist).
+ *
+ * Only reads: ratings.csv, watched.csv, watchlist.csv
+ * Ignores:   diary.csv, reviews.csv, comments.csv, profile.csv, likes/, etc.
+ */
+
+import { unzip } from "@/lib/unzip";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type LbxAction = "rated" | "watched" | "watchlist";
+
+/** One unique film from the export, with all applicable actions merged. */
+export type LbxFilm = {
+  /** Letterboxd canonical URI, e.g. "https://boxd.it/2b0k" — used as the primary key */
+  uri: string;
+  name: string;
+  year: number;
+  /** Letterboxd rating (0.5–5.0). Absent if the film was only watched/watchlisted. */
+  lbxRating?: number;
+  /** Harbor rating = lbxRating × 2 (1–10). Absent when lbxRating is absent. */
+  harborRating?: number;
+  /** The actions this film carries. A rated film is always also "watched". */
+  actions: Set<LbxAction>;
+};
+
+export type LbxParseResult = {
+  films: LbxFilm[];
+  /** Number of unique films that appear in ratings.csv */
+  ratedCount: number;
+  /** Number of unique films with the "watched" action (includes rated) */
+  watchedCount: number;
+  /** Number of unique films that appear in watchlist.csv */
+  watchlistCount: number;
+};
+
+export class LbxImportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LbxImportError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+/** Strip a UTF-8 BOM if present */
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+/**
+ * Minimal CSV parser.
+ * - Handles \r\n and \n line endings
+ * - Handles double-quoted fields (commas, newlines, double-quotes inside)
+ * - Returns rows as string[] arrays; skips completely blank lines
+ */
+export function parseCSV(text: string): string[][] {
+  const rows: string[][] = [];
+  const src = stripBom(text);
+  let i = 0;
+
+  while (i < src.length) {
+    // Skip blank lines
+    while (i < src.length && (src[i] === "\r" || src[i] === "\n")) i++;
+    if (i >= src.length) break;
+
+    const row: string[] = [];
+    let atRowStart = true;
+
+    while (i < src.length && src[i] !== "\n" && !(src[i] === "\r" && src[i + 1] === "\n")) {
+      if (atRowStart || src[i] === ",") {
+        if (!atRowStart) i++; // skip comma
+        atRowStart = false;
+
+        if (i < src.length && src[i] === '"') {
+          // Quoted field
+          i++; // skip opening quote
+          let field = "";
+          while (i < src.length) {
+            if (src[i] === '"' && src[i + 1] === '"') {
+              field += '"';
+              i += 2;
+            } else if (src[i] === '"') {
+              i++; // skip closing quote
+              break;
+            } else {
+              field += src[i++];
+            }
+          }
+          row.push(field);
+        } else {
+          // Unquoted field — read until comma or end of line
+          let field = "";
+          while (i < src.length && src[i] !== "," && src[i] !== "\n" && src[i] !== "\r") {
+            field += src[i++];
+          }
+          row.push(field);
+        }
+      } else {
+        // Should not reach here, but advance to avoid infinite loop
+        i++;
+      }
+    }
+
+    // Consume line ending
+    if (src[i] === "\r") i++;
+    if (src[i] === "\n") i++;
+
+    if (row.length > 0) rows.push(row);
+  }
+
+  return rows;
+}
+
+/** Build a column-name → index map from the header row */
+function headers(rows: string[][]): Record<string, number> {
+  if (rows.length === 0) return {};
+  const map: Record<string, number> = {};
+  for (let i = 0; i < rows[0].length; i++) {
+    map[rows[0][i].trim()] = i;
+  }
+  return map;
+}
+
+function cell(row: string[], col: number | undefined): string {
+  if (col === undefined || col < 0) return "";
+  return (row[col] ?? "").trim();
+}
+
+// ---------------------------------------------------------------------------
+// File-specific parsers
+// ---------------------------------------------------------------------------
+
+type RawRow = { name: string; year: number; uri: string; rating?: number };
+
+function parseRatingsRows(rows: string[][]): RawRow[] {
+  if (rows.length < 2) return [];
+  const h = headers(rows);
+  const out: RawRow[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    const uri = cell(row, h["Letterboxd URI"]);
+    const name = cell(row, h["Name"]);
+    const yearStr = cell(row, h["Year"]);
+    const ratingStr = cell(row, h["Rating"]);
+    if (!uri && !name) continue;
+    const year = parseInt(yearStr, 10) || 0;
+    const rating = ratingStr ? parseFloat(ratingStr) : undefined;
+    out.push({ name, year, uri, rating });
+  }
+  return out;
+}
+
+function parseWatchedRows(rows: string[][]): RawRow[] {
+  if (rows.length < 2) return [];
+  const h = headers(rows);
+  const out: RawRow[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    const uri = cell(row, h["Letterboxd URI"]);
+    const name = cell(row, h["Name"]);
+    const yearStr = cell(row, h["Year"]);
+    if (!uri && !name) continue;
+    const year = parseInt(yearStr, 10) || 0;
+    out.push({ name, year, uri });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Decoder
+// ---------------------------------------------------------------------------
+
+const decoder = new TextDecoder("utf-8");
+
+function decodeFile(bytes: Uint8Array): string {
+  return decoder.decode(bytes);
+}
+
+// ---------------------------------------------------------------------------
+// Main parse entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Letterboxd export ZIP buffer into a deduplicated list of LbxFilm objects.
+ * Throws `LbxImportError` for clearly invalid input.
+ */
+export async function parseLbxZip(buffer: ArrayBuffer): Promise<LbxParseResult> {
+  let files: Map<string, Uint8Array>;
+  try {
+    files = await unzip(buffer);
+  } catch {
+    throw new LbxImportError("The file you selected is not a valid ZIP archive.");
+  }
+
+  // Normalize file names to lowercase basenames for robust matching
+  const byName = new Map<string, Uint8Array>();
+  for (const [path, bytes] of files) {
+    const basename = path.split("/").pop()?.toLowerCase() ?? "";
+    byName.set(basename, bytes);
+  }
+
+  const hasAny =
+    byName.has("ratings.csv") ||
+    byName.has("watched.csv") ||
+    byName.has("watchlist.csv") ||
+    byName.has("diary.csv") ||
+    byName.has("profile.csv");
+
+  if (!hasAny) {
+    throw new LbxImportError(
+      "This doesn't look like a Letterboxd export. Expected files like ratings.csv, watched.csv, or watchlist.csv.",
+    );
+  }
+
+  // Parse each CSV file gracefully (absent = empty result)
+  function parseFile<T extends RawRow>(name: string, parser: (rows: string[][]) => T[]): T[] {
+    const bytes = byName.get(name);
+    if (!bytes) return [];
+    try {
+      const text = decodeFile(bytes);
+      const rows = parseCSV(text);
+      return parser(rows);
+    } catch {
+      return [];
+    }
+  }
+
+  const ratingsRows = parseFile("ratings.csv", parseRatingsRows);
+  const watchedRows = parseFile("watched.csv", parseWatchedRows);
+  const watchlistRows = parseFile("watchlist.csv", parseWatchedRows);
+
+  // ---------------------------------------------------------------------------
+  // Merge by URI into one deduped map
+  // ---------------------------------------------------------------------------
+
+  // Use URI as primary key; fall back to "name:year" for entries without URI
+  function filmKey(row: RawRow): string {
+    return row.uri || `${row.name.toLowerCase()}:${row.year}`;
+  }
+
+  const map = new Map<string, LbxFilm>();
+
+  function upsert(key: string, row: RawRow): LbxFilm {
+    const existing = map.get(key);
+    if (existing) return existing;
+    const film: LbxFilm = {
+      uri: row.uri,
+      name: row.name,
+      year: row.year,
+      actions: new Set(),
+    };
+    map.set(key, film);
+    return film;
+  }
+
+  // 1. Ratings — these imply "watched" too (can't rate without watching on Letterboxd)
+  for (const row of ratingsRows) {
+    const key = filmKey(row);
+    const film = upsert(key, row);
+    film.actions.add("rated");
+    film.actions.add("watched");
+    if (row.rating !== undefined && !Number.isNaN(row.rating)) {
+      film.lbxRating = row.rating;
+      film.harborRating = Math.round(row.rating * 2 * 10) / 10; // e.g. 4.5 → 9.0
+    }
+  }
+
+  // 2. Watched — may not have a rating
+  for (const row of watchedRows) {
+    const key = filmKey(row);
+    const film = upsert(key, row);
+    film.actions.add("watched");
+  }
+
+  // 3. Watchlist
+  for (const row of watchlistRows) {
+    const key = filmKey(row);
+    const film = upsert(key, row);
+    film.actions.add("watchlist");
+  }
+
+  const films = Array.from(map.values());
+
+  const ratedCount = films.filter((f) => f.actions.has("rated")).length;
+  const watchedCount = films.filter((f) => f.actions.has("watched")).length;
+  const watchlistCount = films.filter((f) => f.actions.has("watchlist")).length;
+
+  return { films, ratedCount, watchedCount, watchlistCount };
+}

--- a/src/lib/letterboxd-import/resolver.ts
+++ b/src/lib/letterboxd-import/resolver.ts
@@ -1,0 +1,221 @@
+/**
+ * letterboxd-import/resolver.ts
+ *
+ * Resolves a list of LbxFilm objects to Harbor-native IMDb IDs using:
+ *   1. Cinemeta search (free, always available) → produces tt… IDs
+ *   2. TMDB search (optional enhancement, when settings.tmdbKey is set)
+ *      → then resolves the TMDB ID to an IMDb ID via external_ids endpoint
+ *
+ * Films that cannot be resolved are returned with status "unmatched".
+ * Unmatched films are NOT written to any store; users can download them as CSV.
+ *
+ * Existing-library detection:
+ *   - If a film's IMDb ID is already in the ratings store → alreadyExists=true, action="Update"
+ *   - If a film's IMDb ID is already in the movie-watched store → watchedAlready=true
+ *   - If a film's IMDb ID is already in the watchlist → watchlistAlready=true
+ *   These flags inform the review table but do not block the import (user decides).
+ */
+
+import { safeFetch as fetch } from "@/lib/safe-fetch";
+import { tmdbSearchTitle } from "@/lib/providers/tmdb/tmdb-catalogs";
+import { tmdbImdbId } from "@/lib/providers/tmdb/tmdb-imdb-resolve";
+import { getRating } from "@/lib/ratings/store";
+import { isMovieWatchedLocal } from "@/lib/movie-watched";
+import { watchlistHas } from "@/lib/watchlist";
+import type { LbxFilm } from "./parser";
+import type { Meta } from "@/lib/cinemeta";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ResolvedStatus = "matched" | "unmatched";
+
+export type ResolvedItem = {
+  film: LbxFilm;
+  status: ResolvedStatus;
+  /** Resolved Harbor-native Meta object (IMDb id = tt…) */
+  meta?: Meta;
+  /** True if this item already has a rating in the local store */
+  ratingExists: boolean;
+  /** True if this item is already locally marked as watched */
+  watchedExists: boolean;
+  /** True if this item is already in the local watchlist */
+  watchlistExists: boolean;
+  /** Whether this row is checked (user-controlled, starts true for matched, false for unmatched) */
+  checked: boolean;
+};
+
+export type ResolveProgress = {
+  done: number;
+  total: number;
+};
+
+// ---------------------------------------------------------------------------
+// Cinemeta search
+// ---------------------------------------------------------------------------
+
+const CINEMETA = "https://v3-cinemeta.strem.io";
+
+type CinemCatalog = {
+  metas?: Array<{
+    id: string;
+    name: string;
+    type: string;
+    poster?: string;
+    background?: string;
+    releaseInfo?: string;
+  }>;
+};
+
+/**
+ * Search Cinemeta for a movie by title + optional year.
+ * Returns the best-matching Meta (by year proximity), or null.
+ */
+async function cinemetaSearch(name: string, year: number): Promise<Meta | null> {
+  const encoded = encodeURIComponent(name);
+  try {
+    const res = await fetch(
+      `${CINEMETA}/catalog/movie/top/search=${encoded}.json`,
+    );
+    if (!res.ok) return null;
+    const json = (await res.json()) as CinemCatalog;
+    const results = json.metas ?? [];
+    if (results.length === 0) return null;
+
+    // Pick the best match by title similarity and year proximity (±1)
+    const lower = name.toLowerCase();
+    const candidates = results.filter((m) => {
+      const mName = m.name?.toLowerCase() ?? "";
+      const mYear = parseInt(m.releaseInfo ?? "0", 10);
+      const nameMatch =
+        mName === lower ||
+        mName.includes(lower) ||
+        lower.includes(mName);
+      const yearMatch = year === 0 || Math.abs(mYear - year) <= 1;
+      return nameMatch && yearMatch;
+    });
+
+    const best = candidates[0] ?? results[0];
+    if (!best) return null;
+
+    return {
+      id: best.id,
+      type: "movie",
+      name: best.name,
+      poster: best.poster,
+      background: best.background,
+      releaseInfo: best.releaseInfo,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single-film resolver
+// ---------------------------------------------------------------------------
+
+async function resolveFilm(film: LbxFilm, tmdbKey: string): Promise<Meta | null> {
+  // --- Primary: Cinemeta ---
+  const cinemetaMeta = await cinemetaSearch(film.name, film.year);
+  if (cinemetaMeta && cinemetaMeta.id.startsWith("tt")) {
+    return cinemetaMeta;
+  }
+
+  // --- Secondary: TMDB (only when key present) ---
+  if (tmdbKey) {
+    const tmdbMeta = await tmdbSearchTitle(tmdbKey, "movie", film.name, film.year || undefined).catch(
+      () => null,
+    );
+    if (tmdbMeta) {
+      // Resolve TMDB ID → IMDb ID for a Harbor-native key
+      const imdbId = await tmdbImdbId(tmdbKey, tmdbMeta.id).catch(() => null);
+      if (imdbId) {
+        return { ...tmdbMeta, id: imdbId };
+      }
+      // If IMDb resolution failed, still return the tmdb: prefixed id as fallback
+      return tmdbMeta;
+    }
+  }
+
+  // --- Tertiary: if Cinemeta returned something non-tt, use it anyway ---
+  if (cinemetaMeta) return cinemetaMeta;
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Batch resolver — exported entry point
+// ---------------------------------------------------------------------------
+
+const CONCURRENCY = 5;
+
+/**
+ * Resolve all films in the Letterboxd parse result to Harbor native IDs.
+ * Calls `onProgress` after each film is resolved.
+ */
+export async function resolveItems(
+  films: LbxFilm[],
+  tmdbKey: string,
+  onProgress: (progress: ResolveProgress) => void,
+): Promise<ResolvedItem[]> {
+  const results: ResolvedItem[] = new Array(films.length);
+  let done = 0;
+
+  // Process in batches of CONCURRENCY
+  for (let start = 0; start < films.length; start += CONCURRENCY) {
+    const batch = films.slice(start, start + CONCURRENCY);
+    const settled = await Promise.allSettled(
+      batch.map((film) => resolveFilm(film, tmdbKey)),
+    );
+    for (let j = 0; j < batch.length; j++) {
+      const film = batch[j];
+      const result = settled[j];
+      const meta = result.status === "fulfilled" ? result.value ?? undefined : undefined;
+      const metaId = meta?.id;
+
+      const ratingExists = metaId ? getRating(metaId) !== null : false;
+      const watchedExists = metaId ? isMovieWatchedLocal(metaId) : false;
+      const watchlistExists = metaId ? watchlistHas(metaId) : false;
+
+      const status: ResolvedStatus = meta ? "matched" : "unmatched";
+
+      results[start + j] = {
+        film,
+        status,
+        meta,
+        ratingExists,
+        watchedExists,
+        watchlistExists,
+        // Checked by default only for matched items
+        checked: status === "matched",
+      };
+      done++;
+      onProgress({ done, total: films.length });
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// CSV export for unmatched films
+// ---------------------------------------------------------------------------
+
+export function unmatchedToCsv(items: ResolvedItem[]): string {
+  const unmatched = items.filter((i) => i.status === "unmatched");
+  const header = "Name,Year,Letterboxd URI,Letterboxd Rating";
+  const rows = unmatched.map((i) => {
+    const { name, year, uri, lbxRating } = i.film;
+    const escapeCsv = (s: string | number) =>
+      `"${String(s).replace(/"/g, '""')}"`;
+    return [
+      escapeCsv(name),
+      year,
+      escapeCsv(uri),
+      lbxRating ?? "",
+    ].join(",");
+  });
+  return [header, ...rows].join("\r\n");
+}

--- a/src/views/profile/profile-settings.tsx
+++ b/src/views/profile/profile-settings.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Check, Loader2, Palette } from "lucide-react";
+import { ArrowLeft, Check, Download, Loader2, Palette } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/lib/auth";
 import { useTogether } from "@/lib/together/provider";
@@ -12,6 +12,7 @@ import { ShownBadgesPicker, pickableBadges } from "./shown-badges-picker";
 import { ProfileMedia } from "./profile-media";
 import { LocationSelect } from "./location-select";
 import { CustomizationPanel } from "./customization/customization-panel";
+import { LetterboxdImportModal } from "@/components/letterboxd/letterboxd-import-modal";
 import { AboutEditor } from "./customization/about-editor";
 import { useCustomUrlAvailability, type UrlStatus } from "./use-customurl-availability";
 import type { Badge, ProfileSettingsInput, ProfileSummary } from "./profile-types";
@@ -79,6 +80,7 @@ export function ProfileSettings({
   const [pickingLists, setPickingLists] = useState(false);
   const [pickingBadges, setPickingBadges] = useState(false);
   const [customizing, setCustomizing] = useState(false);
+  const [importingLbx, setImportingLbx] = useState(false);
   const badgeOptions = pickableBadges(badges ?? []);
   const bodyRef = useRef<HTMLDivElement>(null);
   const urlStatus = useCustomUrlAvailability(form.customUrl, summary.handle, summary.customUrl ?? "");
@@ -241,6 +243,20 @@ export function ProfileSettings({
               </button>
             </div>
 
+            <div className="flex items-center justify-between gap-3 pt-1">
+              <div className="min-w-0">
+                <div className="text-[13px] font-medium text-ink">Import from Letterboxd</div>
+                <div className="text-[12px] text-ink-subtle">Import your ratings, watched films, and watchlist from a Letterboxd ZIP export</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setImportingLbx(true)}
+                className="inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-[10px] px-4 text-[14px] font-medium text-ink ring-1 ring-edge-soft hover:bg-elevated"
+              >
+                <Download size={16} /> Import
+              </button>
+            </div>
+
             <div className="flex items-center justify-between gap-3 rounded-[10px] bg-elevated px-3 py-2.5 ring-1 ring-edge-soft">
               <div className="min-w-0">
                 <div className="text-[13px] font-medium text-ink">Private profile</div>
@@ -314,6 +330,7 @@ export function ProfileSettings({
           onSaved={onSaved}
         />
       )}
+      {importingLbx && <LetterboxdImportModal onClose={() => setImportingLbx(false)} />}
     </>
   );
 }


### PR DESCRIPTION
### Summary
Adds an **Import from Letterboxd** flow under Edit Profile. Users can upload their Letterboxd export ZIP and import their rated films, watched films, and watchlist. Nothing is written until the user explicitly confirms on a review screen.

### What's included
- **New entry point:** Added to `ProfileSettings` (Edit Profile), matching existing row styling.
- **4-step modal:** Picker → Processing → Review → Done.
- **Parser:** Reuses existing `unzip()`; properly handles CRLF, BOM, and quoted CSV fields.
- **Deduplication:** Merges `ratings.csv`, `watched.csv`, and `watchlist.csv` into one deduplicated list keyed by Letterboxd URI (a rated film is also automatically marked as watched).
- **Rating conversion:** Converts Letterboxd scale (0.5–5) × 2 → Harbor scale (1–10 integer).
- **Resolution:** Uses the free Cinemeta path (IMDb `tt…` IDs) by default. TMDB is used only as an optional enhancement when a key is set. Uses a Year match tolerance of ±1.
- **Unmatched films:** Never written to storage; exposed instead as a downloadable CSV.
- **Duplicate-safe:** Ratings are keyed by `itemKey`, watched is a `Set`, and watchlist is keyed by `id`.
- **No new storage keys:** All writes go safely through `setRatingLocal`, `setMovieWatchedLocal`, and `addToWatchlist`.

### Notes / limitations
- `diary.csv` and `reviews.csv` are out of scope for this first version.
- Watched marks are written locally immediately; the History tab (Stremio cloud) updates on the next sync. Detail/pick badges are updated immediately.

### Verification
- `npx tsc -b --pretty false` → **zero errors**.
- Tested against a real Letterboxd export: `35 film`.

### Screenshots
<img width="1486" height="840" alt="‏لقطة الشاشة ١٤٤٨-٠٢-١١ في ٣ ٠١ ٠٠ ص" src="https://github.com/user-attachments/assets/79d26465-2a40-4060-ba81-fd9fceed235d" />
<img width="1486" height="840" alt="‏لقطة الشاشة ١٤٤٨-٠٢-١١ في ٣ ٠١ ٢٤ ص" src="https://github.com/user-attachments/assets/1b19bb36-acaa-4839-b6a2-15004f933f25" />
