### PR TITLE
feat(player): add Windows media controls

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,6 +76,10 @@ windows = { version = "0.61", features = [
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_SystemInformation",
   "Win32_System_LibraryLoader",
+  "Win32_System_WinRT",
+  "Media",
+  "Foundation",
+  "Storage_Streams",
 ] }
 window-vibrancy = "0.6"
 wasapi = "0.15"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod fullscreen;
 mod hdr_overlay;
 mod http_fetch;
 mod local_lib;
+mod media_controls;
 mod modal_overlay;
 mod mpv;
 mod multiview;
@@ -539,6 +540,7 @@ pub fn run() {
             webview_helpers::install_process_failure_watchdog(&app.handle(), "main");
             #[cfg(windows)]
             install_maximize_guard(&app.handle());
+            media_controls::ensure_started_on_setup(&app.handle());
             ensure_window_on_screen(&app.handle());
             // Fail-open: if PageLoadEvent::Finished never arrives (WebView hang),
             // still show the main window so the user is not stuck on a blank frame.
@@ -643,6 +645,8 @@ pub fn run() {
             harbor_startup_ready,
             close_aux_windows,
             power::power_inhibit,
+            media_controls::media_controls_update,
+            media_controls::media_controls_clear,
             harbor_set_webview_memory_low,
             harbor_set_webview_visible,
             harbor_try_suspend_webview,

--- a/src-tauri/src/media_controls.rs
+++ b/src-tauri/src/media_controls.rs
@@ -1,0 +1,127 @@
+#[cfg(windows)]
+mod win {
+    use std::sync::OnceLock;
+    use tauri::{AppHandle, Emitter, Manager};
+    use windows::core::HSTRING;
+    use windows::Foundation::TypedEventHandler;
+    use windows::Media::{
+        MediaPlaybackStatus, MediaPlaybackType, SystemMediaTransportControls,
+        SystemMediaTransportControlsButton, SystemMediaTransportControlsButtonPressedEventArgs,
+    };
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::System::WinRT::ISystemMediaTransportControlsInterop;
+
+    static SMTC: OnceLock<Option<SystemMediaTransportControls>> = OnceLock::new();
+
+    fn controls() -> Option<&'static SystemMediaTransportControls> {
+        SMTC.get().and_then(|controls| controls.as_ref())
+    }
+
+    pub fn init(app: &AppHandle) {
+        let created = SMTC.get_or_init(|| match build(app) {
+            Ok(controls) => Some(controls),
+            Err(error) => {
+                eprintln!("[harbor::media] SMTC init failed: {error:?}");
+                None
+            }
+        });
+        if created.is_some() {
+            eprintln!("[harbor::media] SMTC session registered");
+        }
+    }
+
+    fn build(app: &AppHandle) -> windows::core::Result<SystemMediaTransportControls> {
+        let window = app
+            .get_webview_window("main")
+            .ok_or_else(windows::core::Error::empty)?;
+        let raw = window.hwnd().map_err(|_| windows::core::Error::empty())?;
+        let hwnd = HWND(raw.0 as *mut _);
+        let interop = windows::core::factory::<
+            SystemMediaTransportControls,
+            ISystemMediaTransportControlsInterop,
+        >()?;
+        let controls: SystemMediaTransportControls = unsafe { interop.GetForWindow(hwnd)? };
+        controls.SetIsPlayEnabled(true)?;
+        controls.SetIsPauseEnabled(true)?;
+        controls.SetIsNextEnabled(true)?;
+        controls.SetIsPreviousEnabled(true)?;
+        controls.SetIsStopEnabled(true)?;
+        controls.SetIsEnabled(false)?;
+
+        let handle = app.clone();
+        controls.ButtonPressed(&TypedEventHandler::new(
+            move |_,
+                  args: windows::core::Ref<
+                '_,
+                SystemMediaTransportControlsButtonPressedEventArgs,
+            >| {
+                if let Some(args) = args.as_ref() {
+                    let action = match args.Button()? {
+                        SystemMediaTransportControlsButton::Play => "play",
+                        SystemMediaTransportControlsButton::Pause => "pause",
+                        SystemMediaTransportControlsButton::Next => "next",
+                        SystemMediaTransportControlsButton::Previous => "previous",
+                        SystemMediaTransportControlsButton::Stop => "stop",
+                        _ => return Ok(()),
+                    };
+                    let _ = handle.emit("harbor://media-key", action);
+                }
+                Ok(())
+            },
+        ))?;
+        Ok(controls)
+    }
+
+    pub fn update(playing: bool, title: &str, subtitle: &str) {
+        let Some(controls) = controls() else {
+            return;
+        };
+        let _ = controls.SetIsEnabled(true);
+        let _ = controls.SetPlaybackStatus(if playing {
+            MediaPlaybackStatus::Playing
+        } else {
+            MediaPlaybackStatus::Paused
+        });
+        if let Ok(updater) = controls.DisplayUpdater() {
+            let _ = updater.SetType(MediaPlaybackType::Video);
+            if let Ok(video) = updater.VideoProperties() {
+                let _ = video.SetTitle(&HSTRING::from(title));
+                let _ = video.SetSubtitle(&HSTRING::from(subtitle));
+            }
+            let _ = updater.Update();
+        }
+    }
+
+    pub fn clear() {
+        let Some(controls) = controls() else {
+            return;
+        };
+        let _ = controls.SetPlaybackStatus(MediaPlaybackStatus::Closed);
+        if let Ok(updater) = controls.DisplayUpdater() {
+            let _ = updater.ClearAll();
+            let _ = updater.Update();
+        }
+        let _ = controls.SetIsEnabled(false);
+    }
+}
+
+pub fn ensure_started_on_setup(app: &tauri::AppHandle) {
+    #[cfg(windows)]
+    win::init(app);
+    #[cfg(not(windows))]
+    let _ = app;
+}
+
+#[tauri::command]
+pub fn media_controls_update(playing: bool, title: String, subtitle: String) {
+    #[cfg(windows)]
+    win::update(playing, &title, &subtitle);
+    #[cfg(not(windows))]
+    let _ = (playing, title, subtitle);
+}
+
+#[tauri::command]
+pub fn media_controls_clear() {
+    #[cfg(windows)]
+    win::clear();
+}

--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -1,0 +1,106 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type MediaControlAction = "playpause" | "play" | "pause" | "stop" | "next" | "previous";
+
+const MEDIA_CONTROL_ACTIONS: ReadonlySet<string> = new Set([
+  "playpause",
+  "play",
+  "pause",
+  "stop",
+  "next",
+  "previous",
+]);
+
+type NativeInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+type MediaControlState = {
+  playing: boolean;
+  playPause: () => void;
+  next?: () => void;
+  previous?: () => void;
+  hasNext: boolean;
+  hasPrevious: boolean;
+};
+
+const isTauri = () => typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+export function isMediaControlAction(value: unknown): value is MediaControlAction {
+  return typeof value === "string" && MEDIA_CONTROL_ACTIONS.has(value);
+}
+
+export function createMediaControlsSession(
+  desktopAvailable: () => boolean,
+  invokeNative: NativeInvoke,
+) {
+  let lastState = "";
+
+  return {
+    update(playing: boolean, title: string, subtitle: string): boolean {
+      if (!desktopAvailable()) return false;
+      const state = JSON.stringify([playing, title, subtitle]);
+      if (state === lastState) return false;
+      lastState = state;
+      void invokeNative("media_controls_update", { playing, title, subtitle }).catch(() => {});
+      return true;
+    },
+    clear(): boolean {
+      if (!desktopAvailable() || lastState === "") return false;
+      lastState = "";
+      void invokeNative("media_controls_clear").catch(() => {});
+      return true;
+    },
+  };
+}
+
+export function createMediaKeyGate(cooldownMs = 350): (now?: number) => boolean {
+  let lastAcceptedAt = Number.NEGATIVE_INFINITY;
+  return (now = Date.now()) => {
+    if (now - lastAcceptedAt < cooldownMs) return false;
+    lastAcceptedAt = now;
+    return true;
+  };
+}
+
+export function dispatchMediaControlAction(
+  action: MediaControlAction,
+  state: MediaControlState,
+  gate: () => boolean,
+): boolean {
+  let run: (() => void) | undefined;
+  switch (action) {
+    case "playpause":
+      run = state.playPause;
+      break;
+    case "play":
+      if (!state.playing) run = state.playPause;
+      break;
+    case "pause":
+    case "stop":
+      if (state.playing) run = state.playPause;
+      break;
+    case "next":
+      if (state.hasNext) run = state.next;
+      break;
+    case "previous":
+      if (state.hasPrevious) run = state.previous;
+      break;
+  }
+  if (!run || !gate()) return false;
+  run();
+  return true;
+}
+
+const nativeSession = createMediaControlsSession(isTauri, (command, args) => invoke(command, args));
+const acceptMediaKey = createMediaKeyGate();
+
+export function mediaKeyGate(): boolean {
+  return acceptMediaKey();
+}
+
+export function updateMediaControls(playing: boolean, title: string, subtitle: string): void {
+  nativeSession.update(playing, title, subtitle);
+}
+
+export function clearMediaControls(): void {
+  nativeSession.clear();
+}

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -83,6 +83,7 @@ import { markStreamDead, STUB_TTL_MS } from "@/lib/dead-streams";
 import type { VolumeIndicatorState } from "@/components/player/volume-indicator";
 import type { ToastInfo } from "@/views/addons/addons-types";
 import { SFX } from "@/lib/sfx";
+import { clearMediaControls, updateMediaControls } from "@/lib/media-session";
 
 let hdrFallbackNoticeShown = false;
 
@@ -659,6 +660,23 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     videoFill,
     onVolumeFeedback: showVolumeFeedback,
   });
+
+  useEffect(() => {
+    const currentEpisode = src.episode;
+    const subtitle = currentEpisode
+      ? `S${currentEpisode.season} E${currentEpisode.episode}${
+          currentEpisode.name ? ` · ${currentEpisode.name}` : ""
+        }`
+      : "";
+    updateMediaControls(playing, src.meta.name, subtitle);
+  }, [playing, src.episode, src.meta.name]);
+
+  useEffect(
+    () => () => {
+      clearMediaControls();
+    },
+    [],
+  );
 
   const { pendingResumeSec, acknowledgeResume, pendingSeekSec, clearPendingSeek } = useBridgeLoad({
     bridgeRef,

--- a/src/views/player/hooks/use-keyboard-shortcuts.ts
+++ b/src/views/player/hooks/use-keyboard-shortcuts.ts
@@ -5,6 +5,13 @@ import { writePlayerVolume } from "@/lib/player-volume";
 import { effectiveBinding, eventToBinding, isTypingTarget, type HotkeyId } from "@/lib/hotkeys";
 import { isWindowsDesktop } from "@/lib/platform";
 import { isRtxHdrBlocked } from "@/lib/player/rtx-hdr-policy";
+import {
+  dispatchMediaControlAction,
+  isMediaControlAction,
+  mediaKeyGate,
+  type MediaControlAction,
+} from "@/lib/media-session";
+import { makeSafeTauriUnlisten } from "@/lib/tauri-unlisten";
 import { useSettings } from "@/lib/settings";
 import { round2 } from "../player-utils";
 import { SFX } from "@/lib/sfx";
@@ -96,6 +103,25 @@ export function useKeyboardShortcuts(params: {
     baseRate: number;
   }>({ key: null, timer: null, engaged: false, baseRate: 1 });
   const [holdSpeedActive, setHoldSpeedActive] = useState(false);
+  const mediaRef = useRef({
+    playing: snap.status === "playing",
+    playPause: playPauseToggle,
+    next: onNextEp,
+    previous: onPrevEp,
+    hasNext: !!hasNextEp,
+    hasPrevious: !!hasPrevEp,
+  });
+
+  useEffect(() => {
+    mediaRef.current = {
+      playing: snap.status === "playing",
+      playPause: playPauseToggle,
+      next: onNextEp,
+      previous: onPrevEp,
+      hasNext: !!hasNextEp,
+      hasPrevious: !!hasPrevEp,
+    };
+  }, [hasNextEp, hasPrevEp, onNextEp, onPrevEp, playPauseToggle, snap.status]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -103,20 +129,43 @@ export function useKeyboardShortcuts(params: {
 
       const binding = eventToBinding(e);
       const match = (id: HotkeyId): boolean => effectiveBinding(id, overrides) === binding;
+      const dispatchMediaKey = (action: MediaControlAction) =>
+        dispatchMediaControlAction(
+          action,
+          {
+            playing: snap.status === "playing",
+            playPause: playPauseToggle,
+            next: onNextEp,
+            previous: onPrevEp,
+            hasNext: !!hasNextEp,
+            hasPrevious: !!hasPrevEp,
+          },
+          mediaKeyGate,
+        );
 
       if (e.key === "MediaPlayPause") {
         e.preventDefault();
-        playPauseToggle();
+        dispatchMediaKey("playpause");
+        return;
+      }
+      if (e.key === "MediaPlay") {
+        e.preventDefault();
+        dispatchMediaKey("play");
+        return;
+      }
+      if (e.key === "MediaPause" || e.key === "MediaStop") {
+        e.preventDefault();
+        dispatchMediaKey(e.key === "MediaPause" ? "pause" : "stop");
         return;
       }
       if (e.key === "MediaTrackNext" && hasNextEp && onNextEp) {
         e.preventDefault();
-        onNextEp();
+        dispatchMediaKey("next");
         return;
       }
       if (e.key === "MediaTrackPrevious" && hasPrevEp && onPrevEp) {
         e.preventDefault();
-        onPrevEp();
+        dispatchMediaKey("previous");
         return;
       }
 
@@ -452,6 +501,33 @@ export function useKeyboardShortcuts(params: {
     svpActive,
     update,
   ]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) return;
+    let disposed = false;
+    let stopListening: (() => void) | undefined;
+
+    void (async () => {
+      try {
+        const { listen } = await import("@tauri-apps/api/event");
+        const unlisten = makeSafeTauriUnlisten(
+          await listen<unknown>("harbor://media-key", (event) => {
+            if (!isMediaControlAction(event.payload)) return;
+            dispatchMediaControlAction(event.payload, mediaRef.current, mediaKeyGate);
+          }),
+        );
+        if (disposed) unlisten();
+        else stopListening = unlisten;
+      } catch (error) {
+        console.warn("[media-controls] failed to register native controls", error);
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      stopListening?.();
+    };
+  }, []);
 
   return { holdSpeedActive };
 }

--- a/tests/media-controls.test.ts
+++ b/tests/media-controls.test.ts
@@ -1,0 +1,122 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  createMediaControlsSession,
+  createMediaKeyGate,
+  dispatchMediaControlAction,
+} from "../src/lib/media-session.ts";
+
+test("deduplicates identical media metadata and resets after clear", () => {
+  const calls: Array<{ command: string; args?: Record<string, unknown> }> = [];
+  const session = createMediaControlsSession(
+    () => true,
+    async (command, args) => {
+      calls.push({ command, args });
+    },
+  );
+
+  assert.equal(session.update(true, "Show", "S1 E2"), true);
+  assert.equal(session.update(true, "Show", "S1 E2"), false);
+  assert.equal(session.update(false, "Show", "S1 E2"), true);
+  assert.equal(session.clear(), true);
+  assert.equal(session.update(false, "Show", "S1 E2"), true);
+  assert.deepEqual(
+    calls.map(({ command }) => command),
+    [
+      "media_controls_update",
+      "media_controls_update",
+      "media_controls_clear",
+      "media_controls_update",
+    ],
+  );
+});
+
+test("does not invoke native media controls outside Tauri", () => {
+  let invoked = false;
+  const session = createMediaControlsSession(
+    () => false,
+    async () => {
+      invoked = true;
+    },
+  );
+
+  assert.equal(session.update(true, "Movie", ""), false);
+  assert.equal(session.clear(), false);
+  assert.equal(invoked, false);
+});
+
+test("media key gate rejects duplicate browser and SMTC events for 350ms", () => {
+  const gate = createMediaKeyGate(350);
+  assert.equal(gate(1_000), true);
+  assert.equal(gate(1_349), false);
+  assert.equal(gate(1_350), true);
+});
+
+test("dispatches only applicable media actions through the shared gate", () => {
+  const actions: string[] = [];
+  let allow = true;
+  const state = {
+    playing: false,
+    playPause: () => actions.push("toggle"),
+    next: () => actions.push("next"),
+    previous: () => actions.push("previous"),
+    hasNext: true,
+    hasPrevious: false,
+  };
+
+  assert.equal(
+    dispatchMediaControlAction("play", state, () => allow),
+    true,
+  );
+  assert.equal(
+    dispatchMediaControlAction("pause", state, () => allow),
+    false,
+  );
+  assert.equal(
+    dispatchMediaControlAction("next", state, () => allow),
+    true,
+  );
+  assert.equal(
+    dispatchMediaControlAction("previous", state, () => allow),
+    false,
+  );
+  allow = false;
+  assert.equal(
+    dispatchMediaControlAction("playpause", state, () => allow),
+    false,
+  );
+  assert.deepEqual(actions, ["toggle", "next"]);
+});
+
+test("registers native media control commands without changing non-Windows behavior", () => {
+  const tauriLib = readFileSync(new URL("../src-tauri/src/lib.rs", import.meta.url), "utf8");
+  const native = readFileSync(
+    new URL("../src-tauri/src/media_controls.rs", import.meta.url),
+    "utf8",
+  );
+  const cargo = readFileSync(new URL("../src-tauri/Cargo.toml", import.meta.url), "utf8");
+  const player = readFileSync(new URL("../src/views/player.tsx", import.meta.url), "utf8");
+  const keyboard = readFileSync(
+    new URL("../src/views/player/hooks/use-keyboard-shortcuts.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(tauriLib, /mod media_controls;/);
+  assert.match(tauriLib, /media_controls::ensure_started_on_setup/);
+  assert.match(tauriLib, /media_controls::media_controls_update/);
+  assert.match(tauriLib, /media_controls::media_controls_clear/);
+  assert.match(native, /#\[cfg\(windows\)\]/);
+  assert.match(native, /#\[cfg\(not\(windows\)\)\]/);
+  assert.match(cargo, /"Win32_System_WinRT"/);
+  assert.match(cargo, /"Media"/);
+  assert.match(cargo, /"Foundation"/);
+  assert.match(cargo, /"Storage_Streams"/);
+  assert.match(player, /updateMediaControls\(playing, src\.meta\.name, subtitle\)/);
+  assert.match(player, /clearMediaControls\(\)/);
+  assert.match(keyboard, /listen<unknown>\("harbor:\/\/media-key"/);
+  assert.match(keyboard, /dispatchMediaControlAction\(event\.payload, mediaRef\.current/);
+});


### PR DESCRIPTION
## Included
- Add Windows System Media Transport Controls metadata, playback state, and transport actions.
- Route Windows hardware media keys through existing player actions with duplicate-event protection.
- Keep non-Windows native implementations as no-ops.
- Cover session updates, clearing, deduplication, and action dispatch.

## Verification
- focused media-control tests — 5/5
- `pnpm test` — 90/90
- `pnpm run typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- GitHub Frontend and Native checks passed

## Platform note
- The macOS host cannot run Windows SMTC. A Windows runtime smoke test remains recommended after merge.
