### PR TITLE
feat(subtitles): normalize ASS dialogue size

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -651,6 +651,7 @@ pub fn run() {
             subsync::moviehash::compute_moviehash,
             subsync::sync_subtitle,
             sub_extract::subtitle_extract,
+            sub_extract::subtitle_extract_ass,
             cast_server::stop_stremio_sidecar,
             cast_server::cast_server_stop,
             web_server::web_serve_start,

--- a/src-tauri/src/sub_extract.rs
+++ b/src-tauri/src/sub_extract.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 
 const EXTRACT_TIMEOUT: Duration = Duration::from_secs(90);
 const MAX_SRT_BYTES: usize = 4 * 1024 * 1024;
+const ASS_EXTRACT_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_ASS_BYTES: usize = 2 * 1024 * 1024;
 
 #[tauri::command]
 pub async fn subtitle_extract(
@@ -52,4 +54,57 @@ pub async fn subtitle_extract(
         return Err("no subtitle content extracted".to_string());
     }
     Ok(text)
+}
+
+#[tauri::command]
+pub async fn subtitle_extract_ass(
+    source: String,
+    stream_index: Option<u32>,
+    headers: Option<HashMap<String, String>>,
+) -> Result<String, String> {
+    let ffmpeg = crate::transcode::locate_ffmpeg().ok_or_else(|| "ffmpeg not found".to_string())?;
+    let map = format!("0:s:{}", stream_index.unwrap_or(0));
+    let mut cmd = tokio::process::Command::new(&ffmpeg);
+    cmd.arg("-nostdin").arg("-loglevel").arg("error");
+    if let Some(headers) = &headers {
+        if let Some(user_agent) = headers
+            .get("User-Agent")
+            .or_else(|| headers.get("user-agent"))
+        {
+            cmd.arg("-user_agent").arg(user_agent);
+        }
+    }
+    cmd.arg("-i")
+        .arg(&source)
+        .arg("-map")
+        .arg(&map)
+        .arg("-c:s")
+        .arg("copy")
+        .arg("-f")
+        .arg("ass")
+        .arg("-");
+    #[cfg(windows)]
+    cmd.creation_flags(0x0800_0000);
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let output = crate::process::output_with_timeout(&mut cmd, ASS_EXTRACT_TIMEOUT)
+        .await
+        .map_err(|error| format!("ASS subtitle extraction: {error}"))?;
+    let mut bytes = output.stdout;
+    if bytes.len() > MAX_ASS_BYTES {
+        bytes.truncate(MAX_ASS_BYTES);
+    }
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    if text.contains("[V4+ Styles]") || text.contains("[V4 Styles]") {
+        return Ok(text);
+    }
+    if !output.status.success() {
+        let error = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "ffmpeg failed: {}",
+            error.chars().take(200).collect::<String>()
+        ));
+    }
+    Err("no ASS styles extracted".to_string())
 }

--- a/src/lib/player/ass-header.ts
+++ b/src/lib/player/ass-header.ts
@@ -1,0 +1,170 @@
+const REFERENCE_HEIGHT = 720;
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 6;
+const MIN_FONT_FRACTION = 0.02;
+const MAX_FONT_FRACTION = 0.22;
+const SIGN_TAGS = /\\(?:pos|move|i?clip|p[1-9])/i;
+const DIALOGUE_STYLE_NAME = /^(?:default|dialogue|dialog|main|regular)$/i;
+
+export type AssStyle = {
+  size: number;
+  order: number;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+function section(text: string, heading: RegExp): string | null {
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((line) => heading.test(line.trim()));
+  if (start < 0) return null;
+  const body: string[] = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^\s*\[.+\]\s*$/.test(lines[index])) break;
+    body.push(lines[index]);
+  }
+  return body.join("\n");
+}
+
+function integerValue(text: string, key: RegExp): number {
+  const match = key.exec(text);
+  if (!match) return 0;
+  const value = Number.parseInt(match[1], 10);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function splitEventFields(line: string, columnCount: number): string[] {
+  if (columnCount <= 0) return line.split(",");
+  const fields: string[] = [];
+  let remainder = line;
+  for (let index = 0; index < columnCount - 1; index += 1) {
+    const comma = remainder.indexOf(",");
+    if (comma < 0) {
+      fields.push(remainder);
+      remainder = "";
+      continue;
+    }
+    fields.push(remainder.slice(0, comma));
+    remainder = remainder.slice(comma + 1);
+  }
+  fields.push(remainder);
+  return fields;
+}
+
+function visibleLength(text: string): number {
+  return text
+    .replace(/\{[^}]*\}/g, "")
+    .replace(/\\[Nnh]/g, " ")
+    .trim().length;
+}
+
+export function inferPlayResY(text: string): number {
+  const explicitY = integerValue(text, /^PlayResY:\s*(\d+)/im);
+  if (explicitY > 0) return explicitY;
+  const explicitX = integerValue(text, /^PlayResX:\s*(\d+)/im);
+  if (explicitX > 0) return explicitX === 1280 ? 1024 : Math.floor((explicitX * 3) / 4);
+  return 288;
+}
+
+export function parseAssStyles(text: string): Map<string, AssStyle> {
+  const styles = new Map<string, AssStyle>();
+  const body = section(text, /^\[v4\+? styles\]$/i);
+  if (!body) return styles;
+  let nameColumn = -1;
+  let sizeColumn = -1;
+  let order = 0;
+  for (const line of body.split(/\r?\n/)) {
+    const format = /^Format:\s*(.*)$/i.exec(line);
+    if (format) {
+      const columns = format[1].split(",").map((column) => column.trim().toLowerCase());
+      nameColumn = columns.indexOf("name");
+      sizeColumn = columns.indexOf("fontsize");
+      continue;
+    }
+    const style = /^Style:\s*(.*)$/i.exec(line);
+    if (!style || nameColumn < 0 || sizeColumn < 0) continue;
+    const fields = style[1].split(",");
+    const name = (fields[nameColumn] ?? "").trim();
+    const size = Number.parseFloat((fields[sizeColumn] ?? "").trim());
+    if (!name || !Number.isFinite(size)) continue;
+    const previous = styles.get(name);
+    styles.set(name, { size, order: previous?.order ?? order++ });
+  }
+  return styles;
+}
+
+function fallbackStyle(styles: Map<string, AssStyle>): string {
+  let first = "";
+  let firstPositive = "";
+  for (const [name, style] of styles) {
+    if (!first) first = name;
+    if (style.size <= 0) continue;
+    if (/^default$/i.test(name)) return name;
+    if (!firstPositive) firstPositive = name;
+  }
+  return firstPositive || first;
+}
+
+export function dominantDialogueStyle(text: string, styles: Map<string, AssStyle>): string {
+  const body = section(text, /^\[events\]$/i);
+  const tally = new Map<string, { count: number; characters: number }>();
+  if (body) {
+    let styleColumn = -1;
+    let textColumn = -1;
+    let columnCount = 0;
+    for (const line of body.split(/\r?\n/)) {
+      const format = /^Format:\s*(.*)$/i.exec(line);
+      if (format) {
+        const columns = format[1].split(",").map((column) => column.trim().toLowerCase());
+        columnCount = columns.length;
+        styleColumn = columns.indexOf("style");
+        textColumn = columns.indexOf("text");
+        continue;
+      }
+      const dialogue = /^Dialogue:\s*(.*)$/i.exec(line);
+      if (!dialogue || styleColumn < 0 || textColumn < 0) continue;
+      const fields = splitEventFields(dialogue[1], columnCount);
+      const styleName = (fields[styleColumn] ?? "").trim();
+      const dialogueText = fields[textColumn] ?? "";
+      if (SIGN_TAGS.test(dialogueText) || !styles.has(styleName)) continue;
+      const current = tally.get(styleName) ?? { count: 0, characters: 0 };
+      current.count += 1;
+      current.characters += visibleLength(dialogueText);
+      tally.set(styleName, current);
+    }
+  }
+
+  const names = [...tally.keys()];
+  names.sort((left, right) => {
+    const leftTally = tally.get(left) as { count: number; characters: number };
+    const rightTally = tally.get(right) as { count: number; characters: number };
+    if (rightTally.count !== leftTally.count) return rightTally.count - leftTally.count;
+    if (rightTally.characters !== leftTally.characters) {
+      return rightTally.characters - leftTally.characters;
+    }
+    const leftIsDialogue = DIALOGUE_STYLE_NAME.test(left) ? 1 : 0;
+    const rightIsDialogue = DIALOGUE_STYLE_NAME.test(right) ? 1 : 0;
+    if (rightIsDialogue !== leftIsDialogue) return rightIsDialogue - leftIsDialogue;
+    return (styles.get(left)?.order ?? 0) - (styles.get(right)?.order ?? 0);
+  });
+  return names[0] ?? fallbackStyle(styles);
+}
+
+export function computeAssBaseFactor(text: string): number | null {
+  const styles = parseAssStyles(text);
+  if (styles.size === 0) return null;
+  const playResY = inferPlayResY(text);
+  const style = styles.get(dominantDialogueStyle(text, styles));
+  if (!style || style.size <= 0) return null;
+  const fraction = style.size / playResY;
+  if (fraction < MIN_FONT_FRACTION || fraction > MAX_FONT_FRACTION) return null;
+  const factor = playResY / (REFERENCE_HEIGHT * style.size);
+  return Number.isFinite(factor) && factor > 0 ? factor : null;
+}
+
+export function assScaleFromFactor(factor: number, targetFontSize: number): number {
+  const target = Number.isFinite(targetFontSize) ? targetFontSize : 32;
+  return clamp(factor * target, MIN_SCALE, MAX_SCALE);
+}

--- a/src/lib/player/ass-normalize-loader.ts
+++ b/src/lib/player/ass-normalize-loader.ts
@@ -1,0 +1,98 @@
+import { computeAssBaseFactor } from "./ass-header.ts";
+
+export type AssNormalizeTrack = {
+  id: string;
+  external?: boolean;
+  url?: string;
+  externalFilename?: string;
+};
+
+export type AssLoadRequest = {
+  sourceUrl: string;
+  track: AssNormalizeTrack;
+  tracks: AssNormalizeTrack[];
+  headers?: Record<string, string>;
+};
+
+export type AssLoaderDeps = {
+  loadExternal: (url: string, signal: AbortSignal) => Promise<string | null>;
+  loadEmbedded: (
+    sourceUrl: string,
+    streamIndex: number,
+    headers: Record<string, string> | undefined,
+  ) => Promise<string | null>;
+};
+
+const factorCache = new Map<string, number | null>();
+
+function abortError(): DOMException {
+  return new DOMException("The operation was aborted", "AbortError");
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortError();
+}
+
+function cacheKey(request: AssLoadRequest): string {
+  const externalUrl = request.track.url ?? request.track.externalFilename ?? "";
+  return [
+    request.sourceUrl,
+    request.track.id,
+    request.track.external === true || request.track.url ? "external" : "embedded",
+    externalUrl,
+  ].join("|");
+}
+
+function embeddedStreamIndex(tracks: AssNormalizeTrack[], trackId: string): number {
+  const index = tracks
+    .filter((track) => !track.external && !track.url)
+    .findIndex((track) => track.id === trackId);
+  return index >= 0 ? index : 0;
+}
+
+function isAbort(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+export async function loadAssBaseFactor(
+  request: AssLoadRequest,
+  deps: AssLoaderDeps,
+  signal: AbortSignal,
+): Promise<number | null> {
+  throwIfAborted(signal);
+  const key = cacheKey(request);
+  if (factorCache.has(key)) return factorCache.get(key) ?? null;
+
+  try {
+    const external = request.track.external === true || !!request.track.url;
+    const text = external
+      ? await loadExternalTrack(request.track, deps, signal)
+      : await deps.loadEmbedded(
+          request.sourceUrl,
+          embeddedStreamIndex(request.tracks, request.track.id),
+          request.headers,
+        );
+    throwIfAborted(signal);
+    const factor = text ? computeAssBaseFactor(text) : null;
+    factorCache.set(key, factor);
+    return factor;
+  } catch (error) {
+    if (signal.aborted || isAbort(error)) throw abortError();
+    factorCache.set(key, null);
+    return null;
+  }
+}
+
+async function loadExternalTrack(
+  track: AssNormalizeTrack,
+  deps: AssLoaderDeps,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const url = track.url ?? track.externalFilename;
+  if (!url) return null;
+  return deps.loadExternal(url, signal);
+}
+
+export function clearAssNormalizeCache(): void {
+  factorCache.clear();
+}

--- a/src/lib/player/sub-style.ts
+++ b/src/lib/player/sub-style.ts
@@ -33,6 +33,7 @@ function mpvFontFor(id: string): string {
 export type SubRenderContext = {
   assNativeActive: boolean;
   imageNativeActive: boolean;
+  assScale?: number;
 };
 
 export async function applySubStyle(
@@ -40,6 +41,11 @@ export async function applySubStyle(
   context: SubRenderContext = { assNativeActive: false, imageNativeActive: false },
 ): Promise<void> {
   const override = s.subAssOverride;
+  const normalizedScale =
+    typeof context.assScale === "number" && Number.isFinite(context.assScale)
+      ? clamp(context.assScale, 0.2, 6)
+      : null;
+  const effectiveOverride = normalizedScale == null ? override : "scale";
   const assMargins = context.assNativeActive && override !== "no" ? "yes" : "no";
   const marginY = clamp(Number(s.subMarginY) || 0, 0, 100);
   const opacity = clamp(Number(s.subOpacity ?? 1), 0.1, 1);
@@ -50,7 +56,10 @@ export async function applySubStyle(
   const props: Array<[string, unknown]> = [
     ["sub-font-size", 32],
     ["sub-font", mpvFontFor(s.subFontFamily)],
-    ["sub-scale", Math.min(4, Math.max(0.4, (Number(s.subFontSize) || 32) / 32))],
+    [
+      "sub-scale",
+      normalizedScale ?? Math.min(4, Math.max(0.4, (Number(s.subFontSize) || 32) / 32)),
+    ],
     ["sub-color", mpvColor(s.subFontColor, opacity)],
     ["sub-border-color", mpvColor(s.subBorderColor, opacity)],
     ["sub-border-size", s.subBorderSize],
@@ -59,7 +68,7 @@ export async function applySubStyle(
     ["sub-shadow-offset", isShadow ? 1.4 : 0],
     ["sub-margin-y", marginY],
     ["sub-align-x", s.subAlignX],
-    ["sub-ass-override", override],
+    ["sub-ass-override", effectiveOverride],
     ["sub-ass-force-margins", assMargins],
     ["sub-use-margins", assMargins],
     ["sub-spacing", s.subLineSpacing],
@@ -67,8 +76,6 @@ export async function applySubStyle(
     ["sub-pos", reposition ? clamp(100 - marginY, 0, 100) : 100],
   ];
   await Promise.all(
-    props.map(([name, value]) =>
-      invoke("mpv_set_property", { name, value }).catch(() => {}),
-    ),
+    props.map(([name, value]) => invoke("mpv_set_property", { name, value }).catch(() => {})),
   );
 }

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -196,6 +196,7 @@ export const DEFAULT: Settings = {
   subMarginY: 12,
   subAlignX: "center",
   subAssOverride: "no",
+  subAssNormalizeSize: false,
   subStyle: "shadow",
   subFontFamily: "inter",
   subBold: false,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -234,6 +234,7 @@ export type Settings = {
   subMarginY: number;
   subAlignX: "left" | "center" | "right";
   subAssOverride: "no" | "yes" | "force" | "scale" | "strip";
+  subAssNormalizeSize: boolean;
   subStyle: "shadow" | "outline" | "box";
   subFontFamily: string;
   subBold: boolean;

--- a/src/views/player/hooks/use-ass-normalize.ts
+++ b/src/views/player/hooks/use-ass-normalize.ts
@@ -1,0 +1,79 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+import { assScaleFromFactor } from "@/lib/player/ass-header";
+import {
+  loadAssBaseFactor,
+  type AssLoaderDeps,
+  type AssNormalizeTrack,
+} from "@/lib/player/ass-normalize-loader";
+import { safeFetch } from "@/lib/safe-fetch";
+import { decodeSubtitleBytes } from "@/lib/subtitles/encoding";
+import { resolveReadableUrl } from "@/lib/subtitles/extract";
+import type { TrackInfo } from "@/lib/player/bridge";
+
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+const deps: AssLoaderDeps = {
+  loadExternal: async (url, signal) => {
+    const readable = await resolveReadableUrl(url);
+    if (!readable) return null;
+    const response = await safeFetch(readable, { method: "GET", signal });
+    if (!response.ok) return null;
+    return decodeSubtitleBytes(new Uint8Array(await response.arrayBuffer()), {});
+  },
+  loadEmbedded: async (sourceUrl, streamIndex, headers) => {
+    if (!isTauri()) return null;
+    return invoke<string>("subtitle_extract_ass", {
+      source: sourceUrl,
+      streamIndex,
+      headers: headers ?? null,
+    });
+  },
+};
+
+export function useAssNormalize(params: {
+  enabled: boolean;
+  sourceUrl: string | null;
+  headers?: Record<string, string>;
+  track: TrackInfo | null;
+  tracks: TrackInfo[];
+  targetFontSize: number;
+}): number | undefined {
+  const { enabled, sourceUrl, headers, track, tracks, targetFontSize } = params;
+  const [result, setResult] = useState<{ key: string; factor: number | null }>({
+    key: "",
+    factor: null,
+  });
+  const key = enabled && sourceUrl && track ? `${sourceUrl}|${track.id}` : "";
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (!key || !sourceUrl || !track) {
+      return () => controller.abort();
+    }
+    void loadAssBaseFactor(
+      {
+        sourceUrl,
+        track: track as AssNormalizeTrack,
+        tracks: tracks as AssNormalizeTrack[],
+        headers,
+      },
+      deps,
+      controller.signal,
+    ).then(
+      (value) => setResult({ key, factor: value }),
+      (error: unknown) => {
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          setResult({ key, factor: null });
+        }
+      },
+    );
+    return () => controller.abort();
+  }, [key, sourceUrl, track, tracks, headers]);
+
+  return result.key !== key || result.factor == null
+    ? undefined
+    : assScaleFromFactor(result.factor, targetFontSize);
+}

--- a/src/views/player/hooks/use-player-media.ts
+++ b/src/views/player/hooks/use-player-media.ts
@@ -25,6 +25,7 @@ import { useResumeAutosave } from "./use-resume-autosave";
 import { useStremioSync } from "./use-stremio-sync";
 import { useSubDrop } from "./use-sub-drop";
 import { useSubStyleApply } from "./use-sub-style-apply";
+import { useAssNormalize } from "./use-ass-normalize";
 import { useTrackAutoload } from "./use-track-autoload";
 import { useAutoSync } from "./use-auto-sync";
 import { useVideoDownload } from "./use-video-download";
@@ -133,6 +134,15 @@ export function usePlayerMedia(params: {
   const subNativeRender = hdrNativeSurface || subAssNative || (subEmbed && selectedImageSub);
   const assNativeActive = selectedAssSub && (subNativeRender || !subEmbed);
   const imageNativeActive = selectedImageSub && (subNativeRender || !subEmbed);
+  const assNormalizeScale = useAssNormalize({
+    enabled:
+      engine === "mpv" && settings.subAssNormalizeSize && assNativeActive && !subAssOverridden,
+    sourceUrl: src.url ?? null,
+    headers: src.headers,
+    track: selectedSubTrack,
+    tracks: snap.subtitleTracks,
+    targetFontSize: settings.subFontSize,
+  });
   const mpvMediaReadyForStyle =
     snap.status !== "idle" &&
     snap.status !== "loading" &&
@@ -151,6 +161,8 @@ export function usePlayerMedia(params: {
     sourceGamma: snap.hdrGamma,
     bridgeKey,
     svpActive,
+    assScale: assNormalizeScale,
+    subTrackId: selectedSubTrack?.id,
   });
   useEffect(() => {
     if (!subEmbed && !hdrNativeSurface) return;

--- a/src/views/player/hooks/use-sub-style-apply.ts
+++ b/src/views/player/hooks/use-sub-style-apply.ts
@@ -15,6 +15,8 @@ export function useSubStyleApply(params: {
   sourceGamma: string;
   bridgeKey: string | number;
   svpActive: boolean;
+  assScale?: number;
+  subTrackId?: string;
 }) {
   const {
     engine,
@@ -26,13 +28,15 @@ export function useSubStyleApply(params: {
     sourceGamma,
     bridgeKey,
     svpActive,
+    assScale,
+    subTrackId,
   } = params;
 
   useEffect(() => {
     if (engine !== "mpv") return;
     if (!bridgeReady) return;
     if (!mediaReady) return;
-    void applySubStyle(settings, { assNativeActive, imageNativeActive });
+    void applySubStyle(settings, { assNativeActive, imageNativeActive, assScale });
   }, [
     engine,
     bridgeReady,
@@ -40,6 +44,9 @@ export function useSubStyleApply(params: {
     bridgeKey,
     assNativeActive,
     imageNativeActive,
+    assScale,
+    subTrackId,
+    settings.subAssNormalizeSize,
     settings.subFontSize,
     settings.subFontColor,
     settings.subBorderColor,

--- a/src/views/settings/player-panel/subtitle-section.tsx
+++ b/src/views/settings/player-panel/subtitle-section.tsx
@@ -12,9 +12,21 @@ export function SubtitleStylePanel() {
   const t = useT();
 
   const styles: Array<{ id: "shadow" | "outline" | "box"; label: string; sub: string }> = [
-    { id: "shadow", label: t("Drop shadow"), sub: t("Soft halo around the text. Cleanest on most content.") },
-    { id: "outline", label: t("Outline"), sub: t("Hard stroke around each letter. High contrast.") },
-    { id: "box", label: t("Black bar"), sub: t("Rounded background panel behind the text. Most readable.") },
+    {
+      id: "shadow",
+      label: t("Drop shadow"),
+      sub: t("Soft halo around the text. Cleanest on most content."),
+    },
+    {
+      id: "outline",
+      label: t("Outline"),
+      sub: t("Hard stroke around each letter. High contrast."),
+    },
+    {
+      id: "box",
+      label: t("Black bar"),
+      sub: t("Rounded background panel behind the text. Most readable."),
+    },
   ];
 
   const aligns: Array<{ id: "left" | "center" | "right"; label: string }> = [
@@ -24,9 +36,23 @@ export function SubtitleStylePanel() {
   ];
 
   const assModes: Array<{ id: "no" | "scale" | "force"; label: string; sub: string }> = [
-    { id: "no", label: t("Keep original"), sub: t("Styled (ASS) subs keep their own fonts, colors, and effects. Truest to the release.") },
-    { id: "scale", label: t("Resize only"), sub: t("Keep the original look but apply your size and position.") },
-    { id: "force", label: t("Use my style"), sub: t("Force your font, size, and color onto styled subs. Use this for Arabic or any subs showing boxes. Can affect karaoke and signs.") },
+    {
+      id: "no",
+      label: t("Keep original"),
+      sub: t("Styled (ASS) subs keep their own fonts, colors, and effects. Truest to the release."),
+    },
+    {
+      id: "scale",
+      label: t("Resize only"),
+      sub: t("Keep the original look but apply your size and position."),
+    },
+    {
+      id: "force",
+      label: t("Use my style"),
+      sub: t(
+        "Force your font, size, and color onto styled subs. Use this for Arabic or any subs showing boxes. Can affect karaoke and signs.",
+      ),
+    },
   ];
 
   const isDefault =
@@ -107,12 +133,28 @@ export function SubtitleStylePanel() {
           })}
         </div>
         <p className="text-[11.5px] leading-snug text-ink-muted">
-          {t("Seeing empty boxes instead of letters? Choose Arabic under Font and switch to Use my style.")}
+          {t(
+            "Seeing empty boxes instead of letters? Choose Arabic under Font and switch to Use my style.",
+          )}
         </p>
       </div>
 
+      {(settings.subAssOverride === "no" || settings.subAssOverride === "scale") && (
+        <ToggleRow
+          label={t("Normalize embedded subtitle size")}
+          sub={t(
+            "Auto-adjusts styled (ASS) subtitles so dialogue stays the same size across files, while keeping their colors, fonts, and sign placement.",
+          )}
+          value={settings.subAssNormalizeSize}
+          onChange={(value) => update({ subAssNormalizeSize: value })}
+        />
+      )}
+
       {settings.subStyle === "box" && (
-        <SubField label={t("Background opacity")} value={`${Math.round(settings.subBoxOpacity * 100)}%`}>
+        <SubField
+          label={t("Background opacity")}
+          value={`${Math.round(settings.subBoxOpacity * 100)}%`}
+        >
           <input
             type="range"
             min={0.2}
@@ -205,7 +247,9 @@ export function SubtitleStylePanel() {
                 type="button"
                 onClick={() => update({ subAlignX: a.id })}
                 className={`flex h-10 items-center justify-center rounded-xl border text-[12.5px] font-semibold transition-colors ${
-                  sel ? "border-ink bg-elevated text-ink" : "border-edge-soft bg-canvas/40 text-ink-muted hover:border-edge hover:text-ink"
+                  sel
+                    ? "border-ink bg-elevated text-ink"
+                    : "border-edge-soft bg-canvas/40 text-ink-muted hover:border-edge hover:text-ink"
                 }`}
               >
                 {a.label}
@@ -319,7 +363,8 @@ function SubtitlePreview() {
     }
     textShadow = offsets.map(([dx, dy]) => `${dx * 0.55}px ${dy * 0.55}px 0 ${c}`).join(", ");
   } else if (settings.subStyle === "shadow") {
-    textShadow = "0 1px 2px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55)";
+    textShadow =
+      "0 1px 2px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55)";
   }
 
   const boxRgb = (() => {
@@ -341,7 +386,8 @@ function SubtitlePreview() {
       : undefined;
 
   const align = settings.subAlignX || "center";
-  const justify = align === "left" ? "justify-start" : align === "right" ? "justify-end" : "justify-center";
+  const justify =
+    align === "left" ? "justify-start" : align === "right" ? "justify-end" : "justify-center";
 
   return (
     <div
@@ -349,7 +395,10 @@ function SubtitlePreview() {
       style={{ backgroundImage: `url(${godfatherStill})` }}
     >
       <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-transparent to-transparent" />
-      <div className={`absolute inset-x-0 flex ${justify} px-[6%]`} style={{ bottom: `${settings.subMarginY}%`, opacity: settings.subOpacity }}>
+      <div
+        className={`absolute inset-x-0 flex ${justify} px-[6%]`}
+        style={{ bottom: `${settings.subMarginY}%`, opacity: settings.subOpacity }}
+      >
         <div style={boxStyle}>
           <div
             style={{
@@ -363,7 +412,7 @@ function SubtitlePreview() {
               textAlign: align as "left" | "center" | "right",
             }}
           >
-                  I&apos;m gonna make him an offer he can&apos;t refuse.
+            I&apos;m gonna make him an offer he can&apos;t refuse.
           </div>
         </div>
       </div>
@@ -371,7 +420,10 @@ function SubtitlePreview() {
   );
 }
 
-const PRESET_FONTS: Array<{ id: "inter" | "system" | "rounded" | "serif" | "arabic"; label: string }> = [
+const PRESET_FONTS: Array<{
+  id: "inter" | "system" | "rounded" | "serif" | "arabic";
+  label: string;
+}> = [
   { id: "inter", label: "Inter" },
   { id: "system", label: "System" },
   { id: "rounded", label: "Rounded" },
@@ -379,7 +431,8 @@ const PRESET_FONTS: Array<{ id: "inter" | "system" | "rounded" | "serif" | "arab
   { id: "arabic", label: "Arabic" },
 ];
 
-const FONT_ACCEPT = ".ttf,.otf,.woff,.woff2,font/ttf,font/otf,font/woff,font/woff2,application/x-font-ttf,application/x-font-otf,application/font-woff,application/font-woff2";
+const FONT_ACCEPT =
+  ".ttf,.otf,.woff,.woff2,font/ttf,font/otf,font/woff,font/woff2,application/x-font-ttf,application/x-font-otf,application/font-woff,application/font-woff2";
 const MAX_FONT_BYTES = 4 * 1024 * 1024;
 
 function FontPicker() {
@@ -416,7 +469,8 @@ function FontPicker() {
     try {
       const dataUrl = await new Promise<string>((resolve, reject) => {
         const r = new FileReader();
-        r.onload = () => (typeof r.result === "string" ? resolve(r.result) : reject(new Error("read failed")));
+        r.onload = () =>
+          typeof r.result === "string" ? resolve(r.result) : reject(new Error("read failed"));
         r.onerror = () => reject(r.error);
         r.readAsDataURL(file);
       });
@@ -424,7 +478,12 @@ function FontPicker() {
       const baseName = file.name.replace(/\.(ttf|otf|woff2?|ttc)$/i, "");
       const next = [
         ...customFonts,
-        { id, name: baseName || `Custom ${customFonts.length + 1}`, dataUrl, format: formatMap[ext] },
+        {
+          id,
+          name: baseName || `Custom ${customFonts.length + 1}`,
+          dataUrl,
+          format: formatMap[ext],
+        },
       ];
       update({ customFonts: next, subFontFamily: `custom:${id}` });
     } catch (e) {

--- a/tests/ass-subtitle-normalization.test.ts
+++ b/tests/ass-subtitle-normalization.test.ts
@@ -1,0 +1,294 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+type AssStyle = { size: number; order: number };
+type AssHeaderModule = {
+  inferPlayResY: (text: string) => number;
+  parseAssStyles: (text: string) => Map<string, AssStyle>;
+  dominantDialogueStyle: (text: string, styles: Map<string, AssStyle>) => string;
+  computeAssBaseFactor: (text: string) => number | null;
+  assScaleFromFactor: (factor: number, targetFontSize: number) => number;
+};
+type AssTrack = {
+  id: string;
+  external?: boolean;
+  url?: string;
+  externalFilename?: string;
+};
+type AssLoadRequest = {
+  sourceUrl: string;
+  track: AssTrack;
+  tracks: AssTrack[];
+  headers?: Record<string, string>;
+};
+type AssLoaderDeps = {
+  loadExternal: (url: string, signal: AbortSignal) => Promise<string | null>;
+  loadEmbedded: (
+    sourceUrl: string,
+    streamIndex: number,
+    headers: Record<string, string> | undefined,
+  ) => Promise<string | null>;
+};
+type AssLoaderModule = {
+  loadAssBaseFactor: (
+    request: AssLoadRequest,
+    deps: AssLoaderDeps,
+    signal: AbortSignal,
+  ) => Promise<number | null>;
+  clearAssNormalizeCache: () => void;
+};
+
+const assHeader = (await import("../src/lib/player/ass-header.ts").catch(
+  () => ({}),
+)) as Partial<AssHeaderModule>;
+const assLoader = (await import("../src/lib/player/ass-normalize-loader.ts").catch(
+  () => ({}),
+)) as Partial<AssLoaderModule>;
+
+function requireParser(): AssHeaderModule {
+  assert.equal(typeof assHeader.inferPlayResY, "function");
+  assert.equal(typeof assHeader.parseAssStyles, "function");
+  assert.equal(typeof assHeader.dominantDialogueStyle, "function");
+  assert.equal(typeof assHeader.computeAssBaseFactor, "function");
+  assert.equal(typeof assHeader.assScaleFromFactor, "function");
+  return assHeader as AssHeaderModule;
+}
+
+function requireLoader(): AssLoaderModule {
+  assert.equal(typeof assLoader.loadAssBaseFactor, "function");
+  assert.equal(typeof assLoader.clearAssNormalizeCache, "function");
+  return assLoader as AssLoaderModule;
+}
+
+function assDocument({
+  playRes = "PlayResX: 1280\nPlayResY: 720",
+  styles,
+  events,
+}: {
+  playRes?: string;
+  styles: string;
+  events: string;
+}): string {
+  return `[Script Info]
+${playRes}
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour
+${styles}
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+${events}`;
+}
+
+test("ASS PlayResY prefers an explicit value and conservatively infers missing values", () => {
+  const { inferPlayResY } = requireParser();
+
+  assert.equal(inferPlayResY("[Script Info]\nPlayResX: 1920\nPlayResY: 1080"), 1080);
+  assert.equal(inferPlayResY("[Script Info]\nPlayResX: 1920"), 1440);
+  assert.equal(inferPlayResY("[Script Info]\nTitle: Missing dimensions"), 288);
+});
+
+test("ASS styles follow the declared format and preserve first-seen order", () => {
+  const { parseAssStyles } = requireParser();
+  const text = `[V4 Styles]
+Format: Fontname, Fontsize, Name, PrimaryColour
+Style: Arial, 36, Default, &H00FFFFFF
+Style: Arial, 48, Signs, &H00FFFFFF
+Style: Arial, 40, Default, &H00FFFFFF`;
+
+  assert.deepEqual(
+    [...parseAssStyles(text)],
+    [
+      ["Default", { size: 40, order: 0 }],
+      ["Signs", { size: 48, order: 1 }],
+    ],
+  );
+});
+
+test("dominant ASS dialogue ignores positioned, clipped, moved, and drawing events", () => {
+  const parser = requireParser();
+  const text = assDocument({
+    styles: ["Style: Default,Arial,36,&H00FFFFFF", "Style: Signs,Arial,60,&H00FFFFFF"].join("\n"),
+    events: [
+      "Dialogue: 0,0:00:01.00,0:00:02.00,Signs,,0,0,0,,{\\pos(320,40)}Store",
+      "Dialogue: 0,0:00:02.00,0:00:03.00,Signs,,0,0,0,,{\\move(0,0,100,100)}Moving",
+      "Dialogue: 0,0:00:03.00,0:00:04.00,Signs,,0,0,0,,{\\clip(0,0,100,100)}Clipped",
+      "Dialogue: 0,0:00:04.00,0:00:05.00,Signs,,0,0,0,,{\\p1}m 0 0 l 10 10",
+      "Dialogue: 0,0:00:05.00,0:00:06.00,Default,,0,0,0,,Hello, world",
+      "Dialogue: 0,0:00:06.00,0:00:07.00,Default,,0,0,0,,How are you?",
+    ].join("\n"),
+  });
+  const styles = parser.parseAssStyles(text);
+
+  assert.equal(parser.dominantDialogueStyle(text, styles), "Default");
+});
+
+test("dominant ASS dialogue falls back to a positive Default style", () => {
+  const parser = requireParser();
+  const text = assDocument({
+    styles: ["Style: Signs,Arial,70,&H00FFFFFF", "Style: Default,Arial,42,&H00FFFFFF"].join("\n"),
+    events: "",
+  });
+
+  assert.equal(parser.dominantDialogueStyle(text, parser.parseAssStyles(text)), "Default");
+});
+
+test("ASS base factor rejects implausible dialogue sizes outside 2–22% of PlayResY", () => {
+  const { computeAssBaseFactor } = requireParser();
+  const small = assDocument({
+    styles: "Style: Default,Arial,10,&H00FFFFFF",
+    events: "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello",
+  });
+  const plausible = assDocument({
+    styles: "Style: Default,Arial,36,&H00FFFFFF",
+    events: "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello",
+  });
+  const large = assDocument({
+    styles: "Style: Default,Arial,180,&H00FFFFFF",
+    events: "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello",
+  });
+
+  assert.equal(computeAssBaseFactor(small), null);
+  assert.equal(computeAssBaseFactor(plausible), 1 / 36);
+  assert.equal(computeAssBaseFactor(large), null);
+});
+
+test("ASS scale uses the requested font size and clamps unsafe results", () => {
+  const { assScaleFromFactor } = requireParser();
+
+  assert.equal(assScaleFromFactor(1 / 36, 54), 1.5);
+  assert.equal(assScaleFromFactor(0.001, 16), 0.2);
+  assert.equal(assScaleFromFactor(1, 120), 6);
+  assert.equal(assScaleFromFactor(Number.NaN, 32), 0.2);
+});
+
+test("ASS factor loader reads external tracks and caches successful factors", async () => {
+  const loader = requireLoader();
+  loader.clearAssNormalizeCache();
+  const calls: string[] = [];
+  const deps: AssLoaderDeps = {
+    loadExternal: async (url) => {
+      calls.push(url);
+      return assDocument({
+        styles: "Style: Default,Arial,36,&H00FFFFFF",
+        events: "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello",
+      });
+    },
+    loadEmbedded: async () => {
+      throw new Error("embedded loader should not run");
+    },
+  };
+  const request: AssLoadRequest = {
+    sourceUrl: "https://video.test/show.mkv",
+    track: {
+      id: "external-1",
+      external: true,
+      url: "https://subs.test/show.ass",
+    },
+    tracks: [],
+  };
+
+  assert.equal(await loader.loadAssBaseFactor(request, deps, new AbortController().signal), 1 / 36);
+  assert.equal(await loader.loadAssBaseFactor(request, deps, new AbortController().signal), 1 / 36);
+  assert.deepEqual(calls, ["https://subs.test/show.ass"]);
+});
+
+test("ASS factor loader maps embedded subtitle ids to ffmpeg stream indexes", async () => {
+  const loader = requireLoader();
+  loader.clearAssNormalizeCache();
+  const embeddedCalls: Array<{
+    sourceUrl: string;
+    streamIndex: number;
+    headers: Record<string, string> | undefined;
+  }> = [];
+  const deps: AssLoaderDeps = {
+    loadExternal: async () => {
+      throw new Error("external loader should not run");
+    },
+    loadEmbedded: async (sourceUrl, streamIndex, headers) => {
+      embeddedCalls.push({ sourceUrl, streamIndex, headers });
+      return assDocument({
+        styles: "Style: Default,Arial,36,&H00FFFFFF",
+        events: "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello",
+      });
+    },
+  };
+  const request: AssLoadRequest = {
+    sourceUrl: "https://video.test/show.mkv",
+    track: { id: "embedded-2" },
+    tracks: [{ id: "external", external: true }, { id: "embedded-1" }, { id: "embedded-2" }],
+    headers: { Authorization: "secret" },
+  };
+
+  assert.equal(await loader.loadAssBaseFactor(request, deps, new AbortController().signal), 1 / 36);
+  assert.deepEqual(embeddedCalls, [
+    {
+      sourceUrl: "https://video.test/show.mkv",
+      streamIndex: 1,
+      headers: { Authorization: "secret" },
+    },
+  ]);
+});
+
+test("ASS factor loader caches completed failures per source and track", async () => {
+  const loader = requireLoader();
+  loader.clearAssNormalizeCache();
+  let calls = 0;
+  const deps: AssLoaderDeps = {
+    loadExternal: async () => {
+      calls += 1;
+      throw new Error("network unavailable");
+    },
+    loadEmbedded: async () => null,
+  };
+  const request: AssLoadRequest = {
+    sourceUrl: "https://video.test/show.mkv",
+    track: { id: "external-failure", external: true, url: "https://subs.test/fail.ass" },
+    tracks: [],
+  };
+
+  assert.equal(await loader.loadAssBaseFactor(request, deps, new AbortController().signal), null);
+  assert.equal(await loader.loadAssBaseFactor(request, deps, new AbortController().signal), null);
+  assert.equal(calls, 1);
+});
+
+test("cancelled ASS loads do not publish or cache stale embedded results", async () => {
+  const loader = requireLoader();
+  loader.clearAssNormalizeCache();
+  let calls = 0;
+  let resolveFirst: ((text: string) => void) | undefined;
+  const text = assDocument({
+    styles: "Style: Default,Arial,36,&H00FFFFFF",
+    events: "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,Hello",
+  });
+  const deps: AssLoaderDeps = {
+    loadExternal: async () => null,
+    loadEmbedded: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return text;
+    },
+  };
+  const request: AssLoadRequest = {
+    sourceUrl: "file:///show.mkv",
+    track: { id: "embedded-cancel" },
+    tracks: [{ id: "embedded-cancel" }],
+  };
+  const controller = new AbortController();
+  const first = loader.loadAssBaseFactor(request, deps, controller.signal);
+  controller.abort();
+  resolveFirst?.(text);
+
+  await assert.rejects(first, (error: unknown) => {
+    return error instanceof DOMException && error.name === "AbortError";
+  });
+  assert.equal(await loader.loadAssBaseFactor(request, deps, new AbortController().signal), 1 / 36);
+  assert.equal(calls, 2);
+});


### PR DESCRIPTION
## Included
- Add opt-in ASS dialogue-size normalization while preserving authored styles and positioned signs.
- Inspect external and embedded ASS headers, cache safe scale factors, and cancel stale loads.
- Add bounded ffmpeg extraction for embedded ASS tracks.
- Apply the scale through the existing mpv subtitle-style path.

## Verification
- focused ASS tests — 10/10
- full TypeScript tests — 95/95
- `pnpm run typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- full Tauri production build
- GitHub Frontend and Native checks passed