### PR TITLE
fix: skip built-in OpenSubtitles when an OpenSubtitles addon is installed

### DIFF
--- a/src/lib/subtitles/search.ts
+++ b/src/lib/subtitles/search.ts
@@ -23,6 +23,18 @@ export type StreamHints = {
   preferHearingImpaired?: boolean;
 };
 
+// Matches the OpenSubtitles addon detection used by addon-logo.tsx.
+const OPENSUBTITLES_ADDON_RX = /opensubtitles/i;
+
+function hasOpenSubtitlesAddon(addons: Addon[] | undefined): boolean {
+  if (!addons || addons.length === 0) return false;
+  return addons.some(
+    (a) =>
+      OPENSUBTITLES_ADDON_RX.test(a.manifest?.id ?? "") ||
+      OPENSUBTITLES_ADDON_RX.test(a.manifest?.name ?? ""),
+  );
+}
+
 export async function searchSubtitles(
   q: SubSearchQuery,
   opts: SearchOptions,
@@ -30,7 +42,12 @@ export async function searchSubtitles(
   const want = opts.providers ?? {};
   const wyzieOn = want.wyzie === true;
   const addonsOn = want.addons ?? true;
-  const osOn = want.opensubtitles ?? true;
+  // The built-in OpenSubtitles search steps aside when an OpenSubtitles addon
+  // is installed and addon search is on, so results are never duplicated (#872).
+  const osAddonActive = addonsOn && hasOpenSubtitlesAddon(opts.addons);
+  const osOn = (want.opensubtitles ?? true) && !osAddonActive;
+  if (osAddonActive && (want.opensubtitles ?? true))
+    dinfo("[subs] built-in opensubtitles stepping aside: OpenSubtitles addon installed");
   dinfo("[subs] search", { q, providers: { osOn, addonsOn, wyzieOn }, addons: opts.addons?.length ?? 0 });
   const tasks: Array<{ name: string; p: Promise<SubResult[]> }> = [];
   if (osOn)


### PR DESCRIPTION
### What

Fixes #872 — the subtitle menu showed a duplicated OpenSubtitles provider when the user has an OpenSubtitles addon installed (e.g. OpenSubtitles PRO): both the addon and Harbor's built-in `opensubtitles-v3` search ran and returned overlapping result sets.

### Why

The Subtitle sources settings panel already promises this behavior:

> *"Harbor's built-in OpenSubtitles search, on by default. If you install an OpenSubtitles addon, this steps aside automatically so your results are never duplicated."*

But no step-aside logic existed anywhere in the search path. `searchSubtitles()` unconditionally ran the built-in provider whenever `subProvidersEnabled.opensubtitles` was on (the default), in parallel with `searchAddons()`. The URL-based dedup key (`lang|url|title|format`) can't merge the two sets because the built-in provider serves `opensubtitles-v3.strem.io` URLs while addons serve their own — so users saw both providers listed, exactly as reported.

### How

In `searchSubtitles()` (the single aggregator used by all four search paths — player subtitle menu, track autoload, play-picker choices, and autosync consensus):

- Detect an installed OpenSubtitles addon by manifest `id`/`name` (`/opensubtitles/i` — the same match `addon-logo.tsx` already uses).
- When one is present **and** addon search is enabled, disable the built-in `opensubtitles-v3` task for that search and log a debug line.

User control is preserved:
- Turning **Subtitle addons** off re-enables the built-in provider (no step-aside without an active addon path).
- Turning built-in **OpenSubtitles** off manually behaves as before.
- No settings schema changes; the settings UI needs no edits — the code now simply does what the UI already says.

One-line behavior table:

| OS addon installed | Addon search | Built-in OSv3 runs? |
|---|---|---|
| no | on | yes (as before) |
| yes | on | **no (steps aside)** |
| yes | off | yes |
| no | off | yes |

### Testing

- Behavioral test against the real `searchSubtitles()` module (Node, network disabled, provider-task selection inspected via debug output):
  - no addons → built-in ON
  - non-OS subtitle addon installed → built-in ON
  - OpenSubtitles addon installed → built-in **steps aside** ✅
- `pnpm run build` (`tsc -b && vite build`) — passes, no new warnings.
