### PR TITLE
fix: keep fullscreen when backing out of the stream picker to a detail page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1378,6 +1378,7 @@ function Shell({ onReady }: { onReady?: () => void }) {
                 attempt={picker.attempt}
                 intent={picker.intent}
                 resume={picker.resume}
+                playerActive={playerActive}
               />
             </Suspense>
           </div>

--- a/src/views/play-picker.tsx
+++ b/src/views/play-picker.tsx
@@ -74,6 +74,7 @@ export function PlayPicker({
   attempt,
   intent,
   resume,
+  playerActive,
 }: {
   meta: Meta;
   episode?: PlayEpisode;
@@ -81,11 +82,18 @@ export function PlayPicker({
   attempt?: number;
   intent?: "play" | "download";
   resume?: boolean;
+  // True when a player is open below the picker (playback -> picker). When the
+  // picker was opened from a detail page there is no player, and we must not
+  // leave app fullscreen on back (#1021).
+  playerActive?: boolean;
 }) {
   const isDownload = intent === "download";
   const { openPlayer, openSettings, exitPickerToDetail, setView } = useView();
   const backToDetail = () => {
-    void exitWindowFullscreen();
+    // Only leave fullscreen when backing out of active playback. Fullscreen is
+    // already released by the player-close path (App.tsx / use-player-exit);
+    // the picker must not exit it for the detail -> picker flow.
+    if (playerActive) void exitWindowFullscreen();
     exitPickerToDetail(meta);
   };
   const { settings, update } = useSettings();


### PR DESCRIPTION
### What

Fixes #1021 — pressing the back button in the stream picker dropped the user out of fullscreen when the picker was opened from a detail page (e.g. movie → sources → back).

### Why

`PlayPicker.backToDetail()` called `exitWindowFullscreen()` unconditionally. For a user running Harbor in app-level fullscreen, the detail → picker → back flow forced them out of fullscreen even though no playback was involved.

Notably, fullscreen on player close is **already** released by dedicated paths:
- `App.tsx`: `if (!playerActive) exitWindowFullscreenOnPlayerClose()`
- `use-player-exit.ts`: `await exitWindowFullscreenOnPlayerClose()` (settings-aware via `keepFullscreenOnExit`)

The picker's unconditional exit was redundant for the player case and harmful for the detail case. The redundancy was introduced when the picker fullscreen exit was added on 2026-06-25; it likely aimed to cover the player→picker→back flow, but it also fired for the detail→picker→back flow.

### How

Pass `playerActive` (already computed in `App.tsx` for the router) into `PlayPicker`, and only leave fullscreen when a player is actually open below the picker:

```ts
const backToDetail = () => {
  if (playerActive) void exitWindowFullscreen();
  exitPickerToDetail(meta);
};
```

Behavior matrix:

| From | Was fullscreen | Result after back |
|---|---|---|
| Detail → picker | yes | **stays fullscreen** (fixed) |
| Player → picker | yes | exits fullscreen (unchanged) |
| Detail / Player → picker | no | stays windowed (unchanged) |

This fixes the reported bug while preserving the existing player-back behavior exactly — including the `keepFullscreenOnExit` setting.

### Testing

- Behavioral test against the real `fullscreen-state` module covering all four flows above (detail/player × fullscreen/windowed): fullscreen correctly kept on detail→picker back, correctly exited on player→picker back.
- `pnpm run build` — passes, no new warnings.
