### PR TITLE
fix(build): restore documented setup command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:build:linux-system": "tauri build --config src-tauri/tauri.linux-system.conf.json",
+    "setup": "pnpm run setup:binaries && pnpm run setup:libmpv && pnpm run setup:mpv && pnpm run setup:fonts",
+    "setup:binaries": "node scripts/fetch-binaries.mjs",
     "setup:libmpv": "node scripts/fetch-libmpv.mjs",
     "setup:mpv": "node scripts/fetch-mpv.mjs",
     "setup:ffmpeg": "node scripts/fetch-ffmpeg.mjs",


### PR DESCRIPTION
## Summary

- restore the documented top-level `pnpm run setup` command on `beta-branch`
- reuse the existing binary, libmpv, mpv, and font setup scripts

## Why

The README instructs contributors to run `pnpm run setup` before the first build, but the latest beta sync removed the `setup` and `setup:binaries` entries from `package.json`. A fresh beta checkout therefore fails immediately with `ERR_PNPM_NO_SCRIPT`.

This restores the same setup flow already present on `main`, without changing runtime behavior or introducing a new abstraction.

## Verification

- `pnpm run setup` — passed twice and remained idempotent
- `pnpm exec tsc -b --pretty false` — passed
- `pnpm run build` — passed
- `CARGO_BUILD_JOBS=6 nice -n 10 cargo check --manifest-path src-tauri/Cargo.toml --locked -j 6` — passed
- `CARGO_BUILD_JOBS=6 nice -n 10 pnpm tauri:build:linux-system` — release binary, Debian package, and RPM built successfully
- launched the release binary on Fedora 44 with KDE Plasma and Wayland

The beta branch currently does not define the `check` or `typecheck` package scripts, so those package-level commands were unavailable. The direct TypeScript build completed successfully.

## Platform Impact

Restores the documented setup entry point for supported platforms. The complete flow was verified on Fedora 44 x86_64. No runtime, playback, navigation, or UI behavior changed.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files. The command is unavailable on the current beta branch.
- [ ] I ran `vp run typecheck` after TypeScript changes. No TypeScript files were changed; direct `tsc -b --pretty false` passed.
- [x] I ran the relevant Cargo checks after Rust changes. No Rust files changed, and `cargo check` passed.
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes. No test file was needed; the setup command was executed twice.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.

### AI assistance

AI assistance was used for investigation, implementation, and validation. The resulting behavior was verified locally.
