### PR TITLE
fix(linux): bundle AppImage media framework

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -52,6 +52,10 @@ jobs:
             libasound2-dev \
             libmpv-dev \
             libgtk-3-dev \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-libav \
             patchelf
 
       - name: Install Mac deps

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,6 +65,9 @@
       "icons/icon.ico"
     ],
     "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      },
       "deb": {
         "depends": [
           "libmpv2 | libmpv1",


### PR DESCRIPTION
## Summary

Bundle Tauri's Linux media framework in AppImages and install the GStreamer plugin sets used by the Linux packaging workflow.

## Why

The AppImage did not include the GStreamer runtime plugins WebKitGTK needs for media playback. System packages can use distribution dependencies, but the AppImage needs these plugins bundled to provide the same playback and audio support.

## Verification

- Ran `vp fmt --check` on the changed YAML and JSON files.
- Ran `vp check --no-fmt` with 0 errors.
- Ran the TypeScript and Cargo checks successfully.
- Built the Linux release binary, DEB, and RPM.
- Built and extracted a Fedora 44 validation AppImage.
- Confirmed the AppImage contains 241 GStreamer plugins, including `libgstapp.so`, `libgstautodetect.so`, and `gst-plugin-scanner`.
- Manually verified video playback, TrueHD audio, navigation, and seek-preview behavior on Fedora KDE Wayland.
- Confirmed JSON and workflow YAML parsing and `git diff --check`.

The local Fedora AppImage validation used `NO_STRIP=1` because the `linuxdeploy` binary bundled by the local Tauri tooling cannot strip Fedora's newer `.relr.dyn` binaries. This was only a local packaging workaround and is not part of the patch.

## Platform Impact

Linux AppImage only. DEB and RPM dependency behavior remains unchanged. Windows and macOS are unaffected.

## UI Changes

None.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes. No TypeScript files changed; the equivalent TypeScript check passed.
- [x] I ran the relevant Cargo checks after Rust changes. No Rust files changed; `cargo check --offline --locked` passed.
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I used the closest applicable regression verification for this packaging-only change: artifact extraction plus runtime playback testing.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
