### PR TITLE
feat(library): virtualize local grid, merge duplicate versions, add hero, genre filter and local Continue Watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "harbor",
-  "private": true,
   "version": "0.9.115",
-  "type": "module",
+  "private": true,
   "license": "MIT",
-  "packageManager": "pnpm@11.9.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -21,6 +20,7 @@
   },
   "dependencies": {
     "@mediapipe/tasks-vision": "0.10.35",
+    "@tanstack/react-virtual": "^3.14.6",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -56,6 +56,7 @@
     "vite": "^7.0.4",
     "vite-plugin-static-copy": "^2.0.0"
   },
+  "packageManager": "pnpm@11.9.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mediapipe/tasks-vision':
         specifier: 0.10.35
         version: 0.10.35
+      '@tanstack/react-virtual':
+        specifier: ^3.14.6
+        version: 3.14.9(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
@@ -722,6 +725,15 @@ packages:
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-virtual@3.14.9':
+    resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
@@ -1684,7 +1696,7 @@ packages:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webworkify-webpack@https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef}
+    resolution: {gitHosted: true, integrity: sha512-DPqNW8CSRNB+5wfoia6e63A04AuOnkFPsBZMtEB2TMbQbBDcmrsBgwmppiCZZlvl1ve9i2p6f9ivCMtkz8q87A==, tarball: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef}
     version: 2.1.5
 
   whatwg-encoding@3.1.1:
@@ -2142,6 +2154,14 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
       vite: 7.3.2(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.7
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@tauri-apps/api@2.10.1': {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { HarborErrorBoundary } from "@/components/error-boundary";
 import { ContextMenu } from "@/components/context-menu";
 import { WatchLocalModal } from "@/components/player/watch-local-modal";
 import { LocalEpisodesModal } from "@/components/player/local-episodes-modal";
+import { LocalVersionsModal } from "@/components/player/local-versions-modal";
 import { CurfewGuard } from "@/components/curfew-guard";
 import { HoverPreview } from "@/components/hover-preview";
 import { CustomHoverCssMount } from "@/components/custom-hover-css-mount";
@@ -46,7 +47,9 @@ import { ScreensaverRoot } from "@/components/screensaver/screensaver-root";
 import { CustomCodeMount } from "@/components/custom-code-mount";
 import { MemoryHud } from "@/components/memory-hud";
 import { OfflineBanner } from "@/chrome/offline-banner";
-const MobileShell = lazy(() => import("@/views/mobile/mobile-shell").then((m) => ({ default: m.MobileShell })));
+const MobileShell = lazy(() =>
+  import("@/views/mobile/mobile-shell").then((m) => ({ default: m.MobileShell })),
+);
 import { WebhookLoopMount } from "@/components/webhook-loop-mount";
 import { ListToastHost } from "@/components/lists/list-toast";
 import { DiagnosticsConsentHost } from "@/components/diagnostics/diagnostics-consent-host";
@@ -166,15 +169,25 @@ const FilterView = lazy(() => importFilter().then((m) => ({ default: m.FilterVie
 const GridView = lazy(() => importGrid().then((m) => ({ default: m.GridView })));
 const PersonView = lazy(() => importPerson().then((m) => ({ default: m.PersonView })));
 const PeopleView = lazy(() => importPeople().then((m) => ({ default: m.PeopleView })));
-const ProfileView = lazy(() => import("@/views/profile/profile").then((m) => ({ default: m.ProfileView })));
-const SharedListView = lazy(() => import("@/views/shared-list").then((m) => ({ default: m.SharedListView })));
+const ProfileView = lazy(() =>
+  import("@/views/profile/profile").then((m) => ({ default: m.ProfileView })),
+);
+const SharedListView = lazy(() =>
+  import("@/views/shared-list").then((m) => ({ default: m.SharedListView })),
+);
 const FeedView = lazy(() => import("@/views/feed").then((m) => ({ default: m.FeedView })));
 const GroupsView = lazy(() => import("@/views/groups").then((m) => ({ default: m.GroupsView })));
 const GroupView = lazy(() => import("@/views/group").then((m) => ({ default: m.GroupView })));
 const CollectionView = lazy(() => importCollection().then((m) => ({ default: m.CollectionView })));
-const AddonCollectionView = lazy(() => import("@/views/addon-collection").then((m) => ({ default: m.AddonCollectionView })));
-const EpisodeDetailView = lazy(() => importEpisodeDetail().then((m) => ({ default: m.EpisodeDetailView })));
-const CollectionsView = lazy(() => import("@/views/collections").then((m) => ({ default: m.CollectionsView })));
+const AddonCollectionView = lazy(() =>
+  import("@/views/addon-collection").then((m) => ({ default: m.AddonCollectionView })),
+);
+const EpisodeDetailView = lazy(() =>
+  importEpisodeDetail().then((m) => ({ default: m.EpisodeDetailView })),
+);
+const CollectionsView = lazy(() =>
+  import("@/views/collections").then((m) => ({ default: m.CollectionsView })),
+);
 const PlayPicker = lazy(() => importPlayPicker().then((m) => ({ default: m.PlayPicker })));
 const PlayerView = lazy(() => importPlayer().then((m) => ({ default: m.PlayerView })));
 const Movies = lazy(() => importMovies().then((m) => ({ default: m.Movies })));
@@ -188,11 +201,15 @@ const Settings = lazy(() => importSettings().then((m) => ({ default: m.Settings 
 const Shows = lazy(() => importShows().then((m) => ({ default: m.Shows })));
 const LibraryView = lazy(() => importLibrary().then((m) => ({ default: m.LibraryView })));
 const LiveView = lazy(() => importLive().then((m) => ({ default: m.LiveView })));
-const MatchDetailView = lazy(() => importMatchDetail().then((m) => ({ default: m.MatchDetailView })));
+const MatchDetailView = lazy(() =>
+  importMatchDetail().then((m) => ({ default: m.MatchDetailView })),
+);
 const PlaylistVodView = lazy(() => importVod().then((m) => ({ default: m.PlaylistVodView })));
 const DownloadsView = lazy(() => importDownloads().then((m) => ({ default: m.DownloadsView })));
 const MangaView = lazy(() => import("@/views/manga").then((m) => ({ default: m.MangaView })));
-const OnboardingModal = lazy(() => importOnboarding().then((m) => ({ default: m.OnboardingModal })));
+const OnboardingModal = lazy(() =>
+  importOnboarding().then((m) => ({ default: m.OnboardingModal })),
+);
 
 function useViewPreloader(tmdbKey: string) {
   const keyRef = useRef(tmdbKey);
@@ -236,9 +253,7 @@ function useViewPreloader(tmdbKey: string) {
       void importWrapped();
       void importKids();
       if (keyRef.current) {
-        void import("@/lib/feed/pool")
-          .then((m) => m.getPool(keyRef.current))
-          .catch(() => {});
+        void import("@/lib/feed/pool").then((m) => m.getPool(keyRef.current)).catch(() => {});
       }
     });
     return () => {
@@ -296,116 +311,117 @@ export function App({ onReady }: { onReady?: () => void }) {
   return (
     <SettingsProvider>
       <ProfilesProvider>
-      <ParentalProvider>
-      <TraktProvider>
-      <AnilistProvider>
-      <MalProvider>
-      <SimklProvider>
-      <LetterboxdProvider>
-      <RankingsProvider>
-        <AuthProvider>
-          <OnboardingProvider>
-            <TogetherProvider>
-              <ViewProvider>
-                <SearchProvider>
-                <DvrProvider>
-                <FavoritesProvider>
-                <MediaFavoritesProvider>
-                <CharacterFavoritesProvider>
-                <MangaFavoritesProvider>
-                <LocalWatchlistProvider>
-                <ContextMenuProvider>
-                  <TopRankModalProvider>
-                    <HarborErrorBoundary>
-                      <ProfileIdentitySync />
-                      <HarborAvatarSync />
-                      <HarborNameSync />
-                      <SettingsProfileBridge />
-                      <TrackerProfileBridge />
-                      <AnilistAvatarSync />
-                      <MalAvatarSync />
-                      <MiddleClickScroll />
-                      <ThemeBackdrop />
-                      <WatchlistSync />
-                      {isMobileWeb() || isRemoteRoute() ? (
-                        <>
-                          <Suspense fallback={null}>
-                            <MobileShell />
-                          </Suspense>
-                          <RevealOnMount onReady={onReady} />
-                        </>
-                      ) : (
-                        <Shell onReady={onReady} />
-                      )}
-                      {!isMobileWeb() && !isRemoteRoute() && (
-                        <Suspense fallback={null}>
-                          <OnboardingModal />
-                        </Suspense>
-                      )}
-                      <TogetherInviteToast />
-                      <TogetherFloater />
-                      <TogetherHostLeavingPrompt />
-                      <TogetherSummonToast />
-                      <TogetherParticipantLeftToast />
-                      <AnilistSyncToast />
-                      <MalSyncToast />
-                      <ListToastHost />
-                      <DiagnosticsConsentHost />
-                      <TogetherLeaveForLiveModal />
-                      <TogetherLocationPublisher />
-                      <IdleAwayRunner />
-                      <SessionRefreshRunner />
-                      <StatsSyncRunner />
-                      <FeaturedListsSyncRunner />
-                      <RatingsSyncRunner />
-                      <ActivitySyncRunner />
-                      <AutoDownloadRunner />
-                      <RemindersRunner />
-                      <MangaTrackingRunner />
-                      <RemoteHostMount />
-                      <RemoteOpenBridge />
-                      <GamepadRunner />
-                      <DiscordPresence />
-                      <WatchPresenceRunner />
-                      <ContextMenu />
-                      <AnnouncementGlobal />
-                      <WatchLocalModal />
-                      <LocalEpisodesModal />
-                      <HoverPreview />
-                      <CustomHoverCssMount />
-                      <TopRankModal />
-                      <ProfilePickerModal />
-                      <CurfewGuard />
-                      <SearchOverlay />
-                      <SearchHotkey />
-                      <EmbedViewportRoot />
-                      <InstallerViewportRoot />
-                      <UpdateRoot />
-                      <VoyageRoot />
-                      <ScreensaverRoot />
-                    </HarborErrorBoundary>
-                    <ErrorView />
-                    <DevErrorTrigger />
-                  </TopRankModalProvider>
-                </ContextMenuProvider>
-                </LocalWatchlistProvider>
-                </MangaFavoritesProvider>
-                </CharacterFavoritesProvider>
-                </MediaFavoritesProvider>
-                </FavoritesProvider>
-                </DvrProvider>
-                </SearchProvider>
-              </ViewProvider>
-            </TogetherProvider>
-          </OnboardingProvider>
-        </AuthProvider>
-      </RankingsProvider>
-      </LetterboxdProvider>
-      </SimklProvider>
-      </MalProvider>
-      </AnilistProvider>
-      </TraktProvider>
-      </ParentalProvider>
+        <ParentalProvider>
+          <TraktProvider>
+            <AnilistProvider>
+              <MalProvider>
+                <SimklProvider>
+                  <LetterboxdProvider>
+                    <RankingsProvider>
+                      <AuthProvider>
+                        <OnboardingProvider>
+                          <TogetherProvider>
+                            <ViewProvider>
+                              <SearchProvider>
+                                <DvrProvider>
+                                  <FavoritesProvider>
+                                    <MediaFavoritesProvider>
+                                      <CharacterFavoritesProvider>
+                                        <MangaFavoritesProvider>
+                                          <LocalWatchlistProvider>
+                                            <ContextMenuProvider>
+                                              <TopRankModalProvider>
+                                                <HarborErrorBoundary>
+                                                  <ProfileIdentitySync />
+                                                  <HarborAvatarSync />
+                                                  <HarborNameSync />
+                                                  <SettingsProfileBridge />
+                                                  <TrackerProfileBridge />
+                                                  <AnilistAvatarSync />
+                                                  <MalAvatarSync />
+                                                  <MiddleClickScroll />
+                                                  <ThemeBackdrop />
+                                                  <WatchlistSync />
+                                                  {isMobileWeb() || isRemoteRoute() ? (
+                                                    <>
+                                                      <Suspense fallback={null}>
+                                                        <MobileShell />
+                                                      </Suspense>
+                                                      <RevealOnMount onReady={onReady} />
+                                                    </>
+                                                  ) : (
+                                                    <Shell onReady={onReady} />
+                                                  )}
+                                                  {!isMobileWeb() && !isRemoteRoute() && (
+                                                    <Suspense fallback={null}>
+                                                      <OnboardingModal />
+                                                    </Suspense>
+                                                  )}
+                                                  <TogetherInviteToast />
+                                                  <TogetherFloater />
+                                                  <TogetherHostLeavingPrompt />
+                                                  <TogetherSummonToast />
+                                                  <TogetherParticipantLeftToast />
+                                                  <AnilistSyncToast />
+                                                  <MalSyncToast />
+                                                  <ListToastHost />
+                                                  <DiagnosticsConsentHost />
+                                                  <TogetherLeaveForLiveModal />
+                                                  <TogetherLocationPublisher />
+                                                  <IdleAwayRunner />
+                                                  <SessionRefreshRunner />
+                                                  <StatsSyncRunner />
+                                                  <FeaturedListsSyncRunner />
+                                                  <RatingsSyncRunner />
+                                                  <ActivitySyncRunner />
+                                                  <AutoDownloadRunner />
+                                                  <RemindersRunner />
+                                                  <MangaTrackingRunner />
+                                                  <RemoteHostMount />
+                                                  <RemoteOpenBridge />
+                                                  <GamepadRunner />
+                                                  <DiscordPresence />
+                                                  <WatchPresenceRunner />
+                                                  <ContextMenu />
+                                                  <AnnouncementGlobal />
+                                                  <WatchLocalModal />
+                                                  <LocalEpisodesModal />
+                                                  <LocalVersionsModal />
+                                                  <HoverPreview />
+                                                  <CustomHoverCssMount />
+                                                  <TopRankModal />
+                                                  <ProfilePickerModal />
+                                                  <CurfewGuard />
+                                                  <SearchOverlay />
+                                                  <SearchHotkey />
+                                                  <EmbedViewportRoot />
+                                                  <InstallerViewportRoot />
+                                                  <UpdateRoot />
+                                                  <VoyageRoot />
+                                                  <ScreensaverRoot />
+                                                </HarborErrorBoundary>
+                                                <ErrorView />
+                                                <DevErrorTrigger />
+                                              </TopRankModalProvider>
+                                            </ContextMenuProvider>
+                                          </LocalWatchlistProvider>
+                                        </MangaFavoritesProvider>
+                                      </CharacterFavoritesProvider>
+                                    </MediaFavoritesProvider>
+                                  </FavoritesProvider>
+                                </DvrProvider>
+                              </SearchProvider>
+                            </ViewProvider>
+                          </TogetherProvider>
+                        </OnboardingProvider>
+                      </AuthProvider>
+                    </RankingsProvider>
+                  </LetterboxdProvider>
+                </SimklProvider>
+              </MalProvider>
+            </AnilistProvider>
+          </TraktProvider>
+        </ParentalProvider>
       </ProfilesProvider>
     </SettingsProvider>
   );
@@ -522,7 +538,11 @@ function TogetherLocationPublisher() {
           kind: "player" as const,
           meta: metaToLoc(player.meta),
           episode: player.episode
-            ? { season: player.episode.season, episode: player.episode.episode, name: player.episode.name }
+            ? {
+                season: player.episode.season,
+                episode: player.episode.episode,
+                name: player.episode.name,
+              }
             : undefined,
         };
       }
@@ -531,7 +551,11 @@ function TogetherLocationPublisher() {
           kind: "picker" as const,
           meta: metaToLoc(picker.meta),
           episode: picker.episode
-            ? { season: picker.episode.season, episode: picker.episode.episode, name: picker.episode.name }
+            ? {
+                season: picker.episode.season,
+                episode: picker.episode.episode,
+                name: picker.episode.name,
+              }
             : undefined,
         };
       }
@@ -579,8 +603,10 @@ function WatchPresenceRunner() {
 }
 
 function filterReactKey(f: MetaFilter): string {
-  if (f.kind === "year" || f.kind === "runtime") return `filter-${f.kind}-${f.mediaType}-${f.value}`;
-  if (f.kind === "country" || f.kind === "language") return `filter-${f.kind}-${f.mediaType}-${f.iso}`;
+  if (f.kind === "year" || f.kind === "runtime")
+    return `filter-${f.kind}-${f.mediaType}-${f.value}`;
+  if (f.kind === "country" || f.kind === "language")
+    return `filter-${f.kind}-${f.mediaType}-${f.iso}`;
   return `filter-${f.kind}-${f.mediaType}-${f.id}`;
 }
 
@@ -602,7 +628,41 @@ function RevealOnMount({ onReady }: { onReady?: () => void }) {
 }
 
 function Shell({ onReady }: { onReady?: () => void }) {
-  const { topKind, service, meta, metaLiveContext, metaEpisodeHint, episodeDetail, personId, profileHandle, feedOpen, groupsOpen, groupId, listHandle, listId, openList, collectionId, addonCollectionMeta, filter, grid, awardType, animeAwardSource, picker, player, setView, canGoBack, goBack, canGoForward, goForward, openMeta, openManga, peopleInit, openPlayer, stackKinds, chromeHidden } = useView();
+  const {
+    topKind,
+    service,
+    meta,
+    metaLiveContext,
+    metaEpisodeHint,
+    episodeDetail,
+    personId,
+    profileHandle,
+    feedOpen,
+    groupsOpen,
+    groupId,
+    listHandle,
+    listId,
+    openList,
+    collectionId,
+    addonCollectionMeta,
+    filter,
+    grid,
+    awardType,
+    animeAwardSource,
+    picker,
+    player,
+    setView,
+    canGoBack,
+    goBack,
+    canGoForward,
+    goForward,
+    openMeta,
+    openManga,
+    peopleInit,
+    openPlayer,
+    stackKinds,
+    chromeHidden,
+  } = useView();
   const { settings, update } = useSettings();
   const { setOpen: setSearchOpen } = useSearch();
   const uiScaleRef = useRef(settings.uiScale);
@@ -785,8 +845,7 @@ function Shell({ onReady }: { onReady?: () => void }) {
       usesZoomModifier(e) && (e.key === "+" || e.key === "=");
     const isDefaultUiScaleDown = (e: KeyboardEvent) =>
       usesZoomModifier(e) && (e.key === "-" || e.key === "_");
-    const isDefaultUiScaleReset = (e: KeyboardEvent) =>
-      usesZoomModifier(e) && e.key === "0";
+    const isDefaultUiScaleReset = (e: KeyboardEvent) => usesZoomModifier(e) && e.key === "0";
     const onKey = (e: KeyboardEvent) => {
       if (!shouldHandleGlobalKeyboardEvent(e)) return;
       const binding = eventToBinding(e);
@@ -795,11 +854,14 @@ function Shell({ onReady }: { onReady?: () => void }) {
       const uiScaleDownCustom = "globalUiScaleDown" in overrides;
       const uiScaleResetCustom = "globalUiScaleReset" in overrides;
       const matchesUp =
-        effectiveBinding("globalUiScaleUp", overrides) === binding || (!uiScaleUpCustom && isDefaultUiScaleUp(e));
+        effectiveBinding("globalUiScaleUp", overrides) === binding ||
+        (!uiScaleUpCustom && isDefaultUiScaleUp(e));
       const matchesDown =
-        effectiveBinding("globalUiScaleDown", overrides) === binding || (!uiScaleDownCustom && isDefaultUiScaleDown(e));
+        effectiveBinding("globalUiScaleDown", overrides) === binding ||
+        (!uiScaleDownCustom && isDefaultUiScaleDown(e));
       const matchesReset =
-        effectiveBinding("globalUiScaleReset", overrides) === binding || (!uiScaleResetCustom && isDefaultUiScaleReset(e));
+        effectiveBinding("globalUiScaleReset", overrides) === binding ||
+        (!uiScaleResetCustom && isDefaultUiScaleReset(e));
       if (!matchesUp && !matchesDown && !matchesReset) return;
       if (player && matchesReset) return;
       e.preventDefault();
@@ -916,9 +978,7 @@ function Shell({ onReady }: { onReady?: () => void }) {
 
   useEffect(() => {
     if (topKind !== "live") {
-      void import("@/lib/multiview/bridge").then(({ mvStopAll }) =>
-        mvStopAll().catch(() => {}),
-      );
+      void import("@/lib/multiview/bridge").then(({ mvStopAll }) => mvStopAll().catch(() => {}));
     }
   }, [topKind]);
 
@@ -930,38 +990,59 @@ function Shell({ onReady }: { onReady?: () => void }) {
 
   useEffect(() => {
     let dispose: (() => void) | null = null;
-    void import("@/lib/deep-link").then(({ startDeepLinkBridge, onDeepLinkInstall, onDeepLinkOpen, onDeepLinkOpenList, onOpenLocalFile, onOpenProfileEdit, isProfileEditUrl }) => {
-      void startDeepLinkBridge().then((stopBridge) => {
-        const stopListener = onDeepLinkInstall((rawUrl) => {
-          if (window.__harborInstallerOpen) return;
-          if (isProfileEditUrl(rawUrl)) return;
-          setView("addons");
+    void import("@/lib/deep-link").then(
+      ({
+        startDeepLinkBridge,
+        onDeepLinkInstall,
+        onDeepLinkOpen,
+        onDeepLinkOpenList,
+        onOpenLocalFile,
+        onOpenProfileEdit,
+        isProfileEditUrl,
+      }) => {
+        void startDeepLinkBridge().then((stopBridge) => {
+          const stopListener = onDeepLinkInstall((rawUrl) => {
+            if (window.__harborInstallerOpen) return;
+            if (isProfileEditUrl(rawUrl)) return;
+            setView("addons");
+          });
+          const stopOpen = onDeepLinkOpen(({ type, id, videoId }) => {
+            const hint = parseDeepLinkEpisode(videoId);
+            openMeta(
+              { id, type: type as MetaType, name: "" },
+              hint ? { episodeHint: hint } : undefined,
+            );
+          });
+          const stopOpenList = onDeepLinkOpenList(({ handle, listId }) => {
+            openList(handle, listId);
+          });
+          const stopEdit = onOpenProfileEdit(() => {
+            const handle = currentAuthor()?.handle;
+            if (handle) requestEditProfile(handle);
+          });
+          const stopFile = onOpenLocalFile((path) => {
+            const name = (path.replace(/\\/g, "/").split("/").pop() || "Video").replace(
+              /\.[^.]+$/,
+              "",
+            );
+            openPlayer({
+              meta: { id: `local:${path}`, type: "movie", name },
+              url: path,
+              title: name,
+              notWebReady: true,
+            });
+          });
+          dispose = () => {
+            stopBridge();
+            stopListener();
+            stopOpen();
+            stopOpenList();
+            stopEdit();
+            stopFile();
+          };
         });
-        const stopOpen = onDeepLinkOpen(({ type, id, videoId }) => {
-          const hint = parseDeepLinkEpisode(videoId);
-          openMeta({ id, type: type as MetaType, name: "" }, hint ? { episodeHint: hint } : undefined);
-        });
-        const stopOpenList = onDeepLinkOpenList(({ handle, listId }) => {
-          openList(handle, listId);
-        });
-        const stopEdit = onOpenProfileEdit(() => {
-          const handle = currentAuthor()?.handle;
-          if (handle) requestEditProfile(handle);
-        });
-        const stopFile = onOpenLocalFile((path) => {
-          const name = (path.replace(/\\/g, "/").split("/").pop() || "Video").replace(/\.[^.]+$/, "");
-          openPlayer({ meta: { id: `local:${path}`, type: "movie", name }, url: path, title: name, notWebReady: true });
-        });
-        dispose = () => {
-          stopBridge();
-          stopListener();
-          stopOpen();
-          stopOpenList();
-          stopEdit();
-          stopFile();
-        };
-      });
-    });
+      },
+    );
     return () => {
       dispose?.();
     };
@@ -1050,7 +1131,8 @@ function Shell({ onReady }: { onReady?: () => void }) {
 
   useEffect(() => {
     const root = document.documentElement;
-    if (playerActive || pickerTop || immersive || settingsTop || chromeHidden) root.dataset.chromeHidden = "true";
+    if (playerActive || pickerTop || immersive || settingsTop || chromeHidden)
+      root.dataset.chromeHidden = "true";
     else delete root.dataset.chromeHidden;
   }, [playerActive, pickerTop, immersive, settingsTop, chromeHidden]);
 
@@ -1117,21 +1199,37 @@ function Shell({ onReady }: { onReady?: () => void }) {
 
   return (
     <div data-kids={kidsTop || kid ? "on" : undefined} className="relative flex h-full">
-      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "sidebar" && <Sidebar />}
-      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "dracula" && <DraculaSidebar />}
-      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "nord" && <NordSidebar />}
-      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "forest" && <ForestSidebar />}
-      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "stremio" && <StremioRail />}
+      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "sidebar" && (
+        <Sidebar />
+      )}
+      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "dracula" && (
+        <DraculaSidebar />
+      )}
+      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "nord" && (
+        <NordSidebar />
+      )}
+      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "forest" && (
+        <ForestSidebar />
+      )}
+      {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "stremio" && (
+        <StremioRail />
+      )}
       {!settingsTop && !playerActive && !pickerTop && layout === "topdock" && <TopDock />}
-      {!settingsTop && !playerActive && !pickerTop && layout === "cinematic" && <CinematicOverlay />}
+      {!settingsTop && !playerActive && !pickerTop && layout === "cinematic" && (
+        <CinematicOverlay />
+      )}
       {!settingsTop && !playerActive && !pickerTop && layout === "royal" && <RoyalTopbar />}
       {!settingsTop && !playerActive && !pickerTop && layout === "rail" && <SideRail />}
       {!playerActive && !pickerTop && layout === "minui" && <MinUIDock />}
       {!playerActive && !pickerTop && layout === "topdock" && <FloatingBack offsetTop={92} />}
       {!playerActive && !pickerTop && layout === "cinematic" && <FloatingBack offsetTop={92} />}
       {!playerActive && !pickerTop && layout === "royal" && <FloatingBack offsetTop={92} />}
-      {!playerActive && !pickerTop && layout === "rail" && <FloatingBack offsetLeft={settings.sidebarCollapsed ? 88 : 220} offsetTop={28} />}
-      {!playerActive && !pickerTop && layout === "custom" && <FloatingBack offsetLeft={20} offsetTop={20} />}
+      {!playerActive && !pickerTop && layout === "rail" && (
+        <FloatingBack offsetLeft={settings.sidebarCollapsed ? 88 : 220} offsetTop={28} />
+      )}
+      {!playerActive && !pickerTop && layout === "custom" && (
+        <FloatingBack offsetLeft={20} offsetTop={20} />
+      )}
       {!playerActive && !pickerTop && layout === "custom" && (
         <div className="fixed end-3 top-3 z-[120]">
           <WindowControls />
@@ -1139,7 +1237,9 @@ function Shell({ onReady }: { onReady?: () => void }) {
       )}
       {!playerActive && <WindowResizeEdges />}
       <HybridTitleBar suppressed={playerActive || immersive || chromeHidden} />
-      <div className={`relative flex min-h-0 min-w-0 flex-1 flex-col ${playerActive ? "invisible" : ""}`}>
+      <div
+        className={`relative flex min-h-0 min-w-0 flex-1 flex-col ${playerActive ? "invisible" : ""}`}
+      >
         <div className={parkLayer(homeTop)}>
           <Home active={homeTop} onReady={onReady} />
         </div>
@@ -1273,9 +1373,18 @@ function Shell({ onReady }: { onReady?: () => void }) {
           <div className={layer(detailTop)}>
             <Suspense fallback={null}>
               {kid ? (
-                <KidsDetailView key={`kid-meta-${meta.id}`} meta={meta} episodeHint={metaEpisodeHint ?? undefined} />
+                <KidsDetailView
+                  key={`kid-meta-${meta.id}`}
+                  meta={meta}
+                  episodeHint={metaEpisodeHint ?? undefined}
+                />
               ) : (
-                <DetailView key={`meta-${meta.id}`} meta={meta} liveContext={metaLiveContext} episodeHint={metaEpisodeHint ?? undefined} />
+                <DetailView
+                  key={`meta-${meta.id}`}
+                  meta={meta}
+                  liveContext={metaLiveContext}
+                  episodeHint={metaEpisodeHint ?? undefined}
+                />
               )}
             </Suspense>
           </div>
@@ -1301,7 +1410,9 @@ function Shell({ onReady }: { onReady?: () => void }) {
                   }
                   const animeIsh = /^(kitsu|mal|anilist|anidb):/i.test(id);
                   const t: MetaType =
-                    kind === "series" || kind === "tv" || kind === "anime" || animeIsh ? "series" : "movie";
+                    kind === "series" || kind === "tv" || kind === "anime" || animeIsh
+                      ? "series"
+                      : "movie";
                   openMeta({ id, type: t, name: hint?.name ?? "", poster: hint?.poster });
                 }}
               />
@@ -1344,7 +1455,9 @@ function Shell({ onReady }: { onReady?: () => void }) {
                   }
                   const animeIsh = /^(kitsu|mal|anilist|anidb):/i.test(id);
                   const t: MetaType =
-                    kind === "series" || kind === "tv" || kind === "anime" || animeIsh ? "series" : "movie";
+                    kind === "series" || kind === "tv" || kind === "anime" || animeIsh
+                      ? "series"
+                      : "movie";
                   openMeta({ id, type: t, name: hint?.name ?? "", poster: hint?.poster });
                 }}
               />
@@ -1361,7 +1474,10 @@ function Shell({ onReady }: { onReady?: () => void }) {
         {addonCollectionAlive && addonCollectionMeta && (
           <div className={layer(addonCollectionTop)}>
             <Suspense fallback={null}>
-              <AddonCollectionView key={`addon-collection-${addonCollectionMeta.id}`} meta={addonCollectionMeta} />
+              <AddonCollectionView
+                key={`addon-collection-${addonCollectionMeta.id}`}
+                meta={addonCollectionMeta}
+              />
             </Suspense>
           </div>
         )}
@@ -1446,7 +1562,9 @@ function Shell({ onReady }: { onReady?: () => void }) {
           className="pointer-events-none absolute inset-x-0 top-0 z-30 h-24 bg-gradient-to-b from-canvas/85 via-canvas/40 to-transparent"
         />
         {!immersive &&
-          (themeHasTopbar || (settingsTop && layout !== "minui" && layout !== "custom")) && <Topbar />}
+          (themeHasTopbar || (settingsTop && layout !== "minui" && layout !== "custom")) && (
+            <Topbar />
+          )}
         {!immersive && !playerActive && !pickerTop && layout === "custom" && (
           <div aria-hidden className="harbor-chrome-proxy fixed end-3 top-3 z-[40]">
             <TogetherButton />
@@ -1461,7 +1579,10 @@ function Shell({ onReady }: { onReady?: () => void }) {
       </div>
       {player && (
         <Suspense fallback={null}>
-          <PlayerView key={player.meta.id.startsWith("iptv:") ? "player-live" : `player-${player.meta.id}`} src={player} />
+          <PlayerView
+            key={player.meta.id.startsWith("iptv:") ? "player-live" : `player-${player.meta.id}`}
+            src={player}
+          />
         </Suspense>
       )}
       <CustomCodeMount />

--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -8,7 +8,12 @@ import { tmdbIdFromImdb } from "@/lib/providers/tmdb";
 import { useContextMenu } from "@/lib/context-menu";
 import { useT } from "@/lib/i18n";
 import { readSnapshot, useSnapshotVersion } from "@/lib/snapshots";
-import { episodeFromVideoId, isAnimeCwItem, libraryMetaType, type LibraryItem } from "@/lib/stremio";
+import {
+  episodeFromVideoId,
+  isAnimeCwItem,
+  libraryMetaType,
+  type LibraryItem,
+} from "@/lib/stremio";
 import { useHasNewEpisode } from "@/lib/new-episodes";
 import { Tooltip } from "@/views/detail/tooltip";
 import { useProfiles } from "@/lib/profiles";
@@ -28,9 +33,20 @@ type Props = {
   item: LibraryItem;
   watched?: boolean;
   onDismiss?: (item: LibraryItem) => void;
+  /**
+   * Overrides the default play behaviour. The local library row passes this
+   * because it already knows the file on disk, whereas the default path
+   * re-resolves through playLocalAware and cannot handle a `local:` id.
+   */
+  onPlayOverride?: (episode: PlayEpisode | undefined) => void;
 };
 
-export const ContinueCard = memo(function ContinueCard({ item, watched = false, onDismiss }: Props) {
+export const ContinueCard = memo(function ContinueCard({
+  item,
+  watched = false,
+  onDismiss,
+  onPlayOverride,
+}: Props) {
   const { openMeta, openPicker, openPlayer } = useView();
   const t = useT();
   const { settings, update } = useSettings();
@@ -51,7 +67,9 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
   const remaining = dur > 0 && !isExternal ? formatRemaining(t, dur - off) : "";
   const upNext = item.upNext === true;
   const waitingForAir = (item as Record<string, unknown>).waitingForAir === true;
-  const nextAirDate = waitingForAir ? ((item as Record<string, unknown>).nextAirDate as string | undefined) : undefined;
+  const nextAirDate = waitingForAir
+    ? ((item as Record<string, unknown>).nextAirDate as string | undefined)
+    : undefined;
   const [now, setNow] = useState(Date.now());
   useEffect(() => {
     if (!waitingForAir || !nextAirDate) return;
@@ -65,8 +83,10 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
     const days = Math.floor(diff / 86400000);
     const hours = Math.floor((diff % 86400000) / 3600000);
     const minutes = Math.floor((diff % 3600000) / 60000);
-    if (days > 0) return t("Next in {days}d {hours}h", { days: String(days), hours: String(hours) });
-    if (hours > 0) return t("Next in {hours}h {minutes}m", { hours: String(hours), minutes: String(minutes) });
+    if (days > 0)
+      return t("Next in {days}d {hours}h", { days: String(days), hours: String(hours) });
+    if (hours > 0)
+      return t("Next in {hours}h {minutes}m", { hours: String(hours), minutes: String(minutes) });
     return t("Next in {minutes}m", { minutes: String(Math.max(1, minutes)) });
   }, [nextAirDate, now, t]);
   const kitsuThreeSeg =
@@ -243,7 +263,10 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
   const episodeTitle = epTitle ?? kitsuVideo?.title ?? null;
 
   const animeSeasonMapped =
-    kitsuVideo && kitsuVideo.imdbSeason != null && kitsuVideo.imdbSeason >= 2 && kitsuVideo.imdbEpisode != null
+    kitsuVideo &&
+    kitsuVideo.imdbSeason != null &&
+    kitsuVideo.imdbSeason >= 2 &&
+    kitsuVideo.imdbEpisode != null
       ? { season: kitsuVideo.imdbSeason, episode: kitsuVideo.imdbEpisode }
       : null;
   const sub = animeSeasonMapped
@@ -321,6 +344,10 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
       const animeId = getAnimeCwId(item._id);
       if (animeId) episode = { ...episode, sourceMetaId: animeId };
     }
+    if (onPlayOverride) {
+      onPlayOverride(episode);
+      return;
+    }
     playLocalAware({
       meta,
       episode: episode ?? null,
@@ -353,109 +380,119 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
         onContextMenu={(e) => openContextMenu(e, { kind: "meta", meta })}
         className="flex w-full min-w-0 flex-col gap-2.5 text-start"
       >
-      <div className="harbor-poster relative aspect-[16/9] overflow-hidden rounded-xl bg-elevated shadow-[0_2px_8px_-2px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.06)] will-change-transform [transform:translate3d(0,0,0)] transition-transform duration-[220ms] ease-[cubic-bezier(0.22,0.61,0.36,1)] group-hover:scale-[1.02]">
-        <div className="absolute inset-0 bg-gradient-to-br from-raised via-elevated to-surface" />
-        {src && (
-          <img
-            key={src}
-            src={src}
-            alt=""
-            decoding="async"
-            onError={() => setImgIdx((i) => i + 1)}
-            className="absolute inset-0 h-full w-full object-cover brightness-95"
-          />
-        )}
-        <div className="absolute inset-0 shadow-[inset_0_0_100px_rgba(0,0,0,0.45)]" />
-        {watched && (
-          <span
-            className="absolute start-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-400/22 text-emerald-200 ring-1 ring-emerald-400/40 backdrop-blur-sm"
-            title={t("Watched on Trakt")}
-          >
-            <Check size={12} strokeWidth={3} />
-          </span>
-        )}
-        {newEpisode > 0 && (
-          <span className={`absolute top-2 ${watched ? "start-10" : "start-2"}`}>
-            <Tooltip
-              label={
-                newEpisode === 1
-                  ? t("1 new episode since you last watched")
-                  : t("{n} new episodes since you last watched", { n: newEpisode })
-              }
-              side="bottom"
-            >
-              <span className="flex h-6 items-center rounded-full bg-accent/90 px-2 text-[10px] font-bold tracking-[0.1em] text-canvas">
-                +{newEpisode}
-              </span>
-            </Tooltip>
-          </span>
-        )}
-        {logo && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-6">
+        <div className="harbor-poster relative aspect-[16/9] overflow-hidden rounded-xl bg-elevated shadow-[0_2px_8px_-2px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.06)] will-change-transform [transform:translate3d(0,0,0)] transition-transform duration-[220ms] ease-[cubic-bezier(0.22,0.61,0.36,1)] group-hover:scale-[1.02]">
+          <div className="absolute inset-0 bg-gradient-to-br from-raised via-elevated to-surface" />
+          {src && (
             <img
-              src={logo}
+              key={src}
+              src={src}
               alt=""
-              loading="lazy"
               decoding="async"
-              className="max-h-[55%] w-auto max-w-[78%] object-contain opacity-80 transition-opacity duration-[220ms] ease-[cubic-bezier(0.22,0.61,0.36,1)] group-hover:opacity-25"
+              onError={() => setImgIdx((i) => i + 1)}
+              className="absolute inset-0 h-full w-full object-cover brightness-95"
             />
-          </div>
-        )}
-        <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-canvas/80 to-transparent" />
-        {(sub || remaining || isExternal || upNext || episodeTitle) && (
-          <div className="absolute bottom-2 start-2 flex max-w-[calc(100%-16px)] items-center gap-1.5 rounded-md bg-canvas/95 px-2 py-1 text-[11px]">
-            {isExternal ? (
-              <img src={simklLogo} alt="" className="h-3.5 w-3.5 shrink-0 rounded-sm" title={t("Paused on Simkl")} />
-            ) : (
-              <Play size={11} fill="currentColor" className="shrink-0 text-ink" />
-            )}
-            {sub && <span className="shrink-0 font-medium text-ink">{sub}</span>}
-            {waitingForAir && countdown ? (
-              <span className="shrink-0 font-medium text-amber">{countdown}</span>
-            ) : upNext ? (
-              <>
-                {sub && <span className="shrink-0 text-ink-subtle">·</span>}
-                <span className="shrink-0 font-medium text-accent">{t("Up Next")}</span>
-              </>
-            ) : episodeTitle ? (
-              <>
-                {sub && <span className="shrink-0 text-ink-subtle">·</span>}
-                <span className="min-w-0 truncate text-ink-muted">{episodeTitle}</span>
-              </>
-            ) : (
-              remaining && (
+          )}
+          <div className="absolute inset-0 shadow-[inset_0_0_100px_rgba(0,0,0,0.45)]" />
+          {watched && (
+            <span
+              className="absolute start-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-400/22 text-emerald-200 ring-1 ring-emerald-400/40 backdrop-blur-sm"
+              title={t("Watched on Trakt")}
+            >
+              <Check size={12} strokeWidth={3} />
+            </span>
+          )}
+          {newEpisode > 0 && (
+            <span className={`absolute top-2 ${watched ? "start-10" : "start-2"}`}>
+              <Tooltip
+                label={
+                  newEpisode === 1
+                    ? t("1 new episode since you last watched")
+                    : t("{n} new episodes since you last watched", { n: newEpisode })
+                }
+                side="bottom"
+              >
+                <span className="flex h-6 items-center rounded-full bg-accent/90 px-2 text-[10px] font-bold tracking-[0.1em] text-canvas">
+                  +{newEpisode}
+                </span>
+              </Tooltip>
+            </span>
+          )}
+          {logo && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-6">
+              <img
+                src={logo}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                className="max-h-[55%] w-auto max-w-[78%] object-contain opacity-80 transition-opacity duration-[220ms] ease-[cubic-bezier(0.22,0.61,0.36,1)] group-hover:opacity-25"
+              />
+            </div>
+          )}
+          <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-canvas/80 to-transparent" />
+          {(sub || remaining || isExternal || upNext || episodeTitle) && (
+            <div className="absolute bottom-2 start-2 flex max-w-[calc(100%-16px)] items-center gap-1.5 rounded-md bg-canvas/95 px-2 py-1 text-[11px]">
+              {isExternal ? (
+                <img
+                  src={simklLogo}
+                  alt=""
+                  className="h-3.5 w-3.5 shrink-0 rounded-sm"
+                  title={t("Paused on Simkl")}
+                />
+              ) : (
+                <Play size={11} fill="currentColor" className="shrink-0 text-ink" />
+              )}
+              {sub && <span className="shrink-0 font-medium text-ink">{sub}</span>}
+              {waitingForAir && countdown ? (
+                <span className="shrink-0 font-medium text-amber">{countdown}</span>
+              ) : upNext ? (
                 <>
                   {sub && <span className="shrink-0 text-ink-subtle">·</span>}
-                  <span className="shrink-0 text-ink-muted">{remaining}</span>
+                  <span className="shrink-0 font-medium text-accent">{t("Up Next")}</span>
                 </>
-              )
-            )}
-          </div>
-        )}
-        {showWatcher && watcher && (
-          <div
-            className="absolute bottom-2.5 end-2 z-[1]"
-            title={t("Watched by {name}", { name: watcher.name })}
-          >
-            <span
-              className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-elevated text-[11px] font-bold text-white"
-              style={{ boxShadow: `0 0 0 2px ${watcher.color}, 0 2px 8px rgba(0,0,0,0.5)` }}
-            >
-              {watcher.avatar ? (
-                <img src={watcher.avatar} alt="" className="h-full w-full object-cover" draggable={false} />
+              ) : episodeTitle ? (
+                <>
+                  {sub && <span className="shrink-0 text-ink-subtle">·</span>}
+                  <span className="min-w-0 truncate text-ink-muted">{episodeTitle}</span>
+                </>
               ) : (
-                (watcher.name.trim()[0]?.toUpperCase() ?? "?")
+                remaining && (
+                  <>
+                    {sub && <span className="shrink-0 text-ink-subtle">·</span>}
+                    <span className="shrink-0 text-ink-muted">{remaining}</span>
+                  </>
+                )
               )}
-            </span>
+            </div>
+          )}
+          {showWatcher && watcher && (
+            <div
+              className="absolute bottom-2.5 end-2 z-[1]"
+              title={t("Watched by {name}", { name: watcher.name })}
+            >
+              <span
+                className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-elevated text-[11px] font-bold text-white"
+                style={{ boxShadow: `0 0 0 2px ${watcher.color}, 0 2px 8px rgba(0,0,0,0.5)` }}
+              >
+                {watcher.avatar ? (
+                  <img
+                    src={watcher.avatar}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    draggable={false}
+                  />
+                ) : (
+                  (watcher.name.trim()[0]?.toUpperCase() ?? "?")
+                )}
+              </span>
+            </div>
+          )}
+          <div className="absolute inset-x-0 bottom-0 h-[3px] bg-canvas/40">
+            <div className="h-full bg-accent" style={{ width: `${progress * 100}%` }} />
           </div>
-        )}
-        <div className="absolute inset-x-0 bottom-0 h-[3px] bg-canvas/40">
-          <div className="h-full bg-accent" style={{ width: `${progress * 100}%` }} />
         </div>
-      </div>
-      <p className="truncate text-[13px] font-medium text-ink">
-        {translatedTitle || hydratedMeta?.name?.trim() || item.name}
-      </p>
+        <p className="truncate text-[13px] font-medium text-ink">
+          {translatedTitle || hydratedMeta?.name?.trim() || item.name}
+        </p>
       </button>
       <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex aspect-[16/9] items-center justify-center">
         <ThreeLiquidGlassSurface
@@ -466,7 +503,9 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
             background:
               "linear-gradient(145deg, rgba(8,12,18,0.50), rgba(8,12,18,0.38) 52%, rgba(8,12,18,0.44))",
           }}
-          style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -1px 0 rgba(0,0,0,0.05)" }}
+          style={{
+            boxShadow: "inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -1px 0 rgba(0,0,0,0.05)",
+          }}
           className="pointer-events-none h-14 w-14 scale-95 rounded-full border border-white/[0.10] opacity-0 transition-[opacity,transform] duration-[120ms] group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100 focus-within:pointer-events-auto focus-within:scale-100 focus-within:opacity-100"
           contentClassName="flex h-full w-full"
         >
@@ -491,7 +530,9 @@ export const ContinueCard = memo(function ContinueCard({ item, watched = false, 
               background:
                 "linear-gradient(145deg, rgba(8,12,18,0.50), rgba(8,12,18,0.38) 52%, rgba(8,12,18,0.44))",
             }}
-            style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -1px 0 rgba(0,0,0,0.05)" }}
+            style={{
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.10), inset 0 -1px 0 rgba(0,0,0,0.05)",
+            }}
             className="pointer-events-none h-9 w-9 scale-95 rounded-full border border-white/[0.09] opacity-0 transition-[opacity,transform] duration-[120ms] group-hover:pointer-events-auto group-hover:scale-100 group-hover:opacity-100 focus-within:pointer-events-auto focus-within:scale-100 focus-within:opacity-100"
             contentClassName="flex h-full w-full"
           >
@@ -532,7 +573,10 @@ async function resolveTmdbBackdrop(
   return lite?.background ?? undefined;
 }
 
-function formatRemaining(t: (key: string, vars?: Record<string, string | number>) => string, ms: number) {
+function formatRemaining(
+  t: (key: string, vars?: Record<string, string | number>) => string,
+  ms: number,
+) {
   const minutes = Math.max(0, Math.round(ms / 60000));
   if (minutes < 60) return t("{m}m left", { m: minutes });
   const h = Math.floor(minutes / 60);

--- a/src/components/hero-carousel.tsx
+++ b/src/components/hero-carousel.tsx
@@ -7,9 +7,11 @@ import { Hero } from "./hero";
 import { NavChevron } from "@/components/nav-arrow";
 import type { Meta } from "@/lib/cinemeta";
 
+/** `rank` renders a "#N in … Today" trending pill; omit it where that framing
+ * doesn't apply, such as the library hero. */
 export type Slide = {
   meta: Meta;
-  rank: { label: string; position: number; sources?: Array<{ label: string; rank: number }> };
+  rank?: { label: string; position: number; sources?: Array<{ label: string; rank: number }> };
 };
 
 const EASE_OUT = "cubic-bezier(0.32, 0.72, 0.24, 1)";
@@ -94,7 +96,9 @@ export function HeroCarousel({
 
   if (slides.length === 0) {
     return (
-      <div className={`harbor-hero-stage animate-pulse border border-edge-soft bg-elevated/30 ${full ? "min-h-[max(78vh,640px)] rounded-none" : "min-h-[560px] rounded-[28px]"}`} />
+      <div
+        className={`harbor-hero-stage animate-pulse border border-edge-soft bg-elevated/30 ${full ? "min-h-[max(78vh,640px)] rounded-none" : "min-h-[560px] rounded-[28px]"}`}
+      />
     );
   }
 
@@ -254,7 +258,9 @@ export function HeroCarousel({
                     playTrailer={playTrailers && isActive && !dragging}
                   />
                 ) : (
-                  <div className={`harbor-hero-stage w-full bg-elevated/30 ${full ? "h-[78vh] min-h-[640px] rounded-none" : "h-[560px] rounded-[28px]"}`} />
+                  <div
+                    className={`harbor-hero-stage w-full bg-elevated/30 ${full ? "h-[78vh] min-h-[640px] rounded-none" : "h-[560px] rounded-[28px]"}`}
+                  />
                 )}
               </div>
             );
@@ -291,9 +297,7 @@ export function HeroCarousel({
       </div>
       {slides.length > 1 && (
         <div
-          className={`flex justify-center gap-2.5 ${
-            full ? "absolute bottom-4 inset-x-0" : "pt-1"
-          }`}
+          className={`flex justify-center gap-2.5 ${full ? "absolute bottom-4 inset-x-0" : "pt-1"}`}
         >
           {slides.map((_, i) => (
             <button

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -20,14 +20,20 @@ import { meta as fetchMeta, narrowMediaType, type Meta } from "@/lib/cinemeta";
 import { useT } from "@/lib/i18n";
 import { omdbPrefetch, useOmdbScores } from "@/lib/providers/omdb";
 import { useImdbRating } from "@/lib/imdb-rating";
-import { tmdbImdbId, tmdbLogo, tmdbMovieImages, tmdbTrailerList, useTmdbImdbId } from "@/lib/providers/tmdb";
+import { tmdbImdbId, tmdbMovieImages, tmdbTrailerList, useTmdbImdbId } from "@/lib/providers/tmdb";
+import { peekCachedLogo, resolveLogo } from "@/lib/logo";
 import { useSettings } from "@/lib/settings";
 import { useTitleLogo } from "@/lib/title-logo";
 import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { fetchTrailer, prefetchTrailer, trailerSrc, type TrailerInfo } from "@/lib/trailer";
 import { useView } from "@/lib/view";
 import { useProfiles } from "@/lib/profiles";
-import { getHeroMuted, setHeroMuted, subscribeHeroMuted, syncHeroMutedFromSetting } from "@/lib/hero-mute";
+import {
+  getHeroMuted,
+  setHeroMuted,
+  subscribeHeroMuted,
+  syncHeroMutedFromSetting,
+} from "@/lib/hero-mute";
 import { getHeroEnded, setHeroEnded } from "@/lib/hero-ended";
 import { usePageVisible } from "@/lib/visibility";
 import { toggleWatchlist, useInWatchlist } from "@/lib/watchlist";
@@ -117,46 +123,51 @@ export const Hero = memo(function Hero({
   }, [meta.id, meta.type, settings.tmdbKey, playTrailer, trailerCandidates.length]);
 
   useEffect(() => {
-    setLogo(meta.logo);
+    // peekCachedLogo, not meta.logo: when the image language is not English the
+    // meta's own (English) logo is not final, and must be re-resolved below.
+    const seed = peekCachedLogo(settings.tmdbKey, meta);
+    setLogo(seed);
     setLogoLoaded(false);
-    setLogoResolved(!!meta.logo);
+    setLogoResolved(!!seed);
     setBgUrl(meta.background);
     setBgResolved(!!meta.background);
-  }, [meta.id, meta.logo, meta.background]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [meta.id, meta.logo, meta.background, settings.tmdbKey]);
 
   useEffect(() => {
     if (logoResolved && bgResolved) return;
     let cancelled = false;
-    const isTmdb = meta.id.startsWith("tmdb:");
-    const resolve: Promise<{ logo?: string; background?: string }> = isTmdb
-      ? Promise.all([
-          tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage),
-          tmdbMovieImages(settings.tmdbKey, meta.id).then((urls) => urls[0]),
-        ]).then(([logo, background]) => ({ logo, background }))
-      : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => ({
-          logo: full?.logo,
-          background: full?.background,
-        }));
-    resolve
-      .then(({ logo: l, background: b }) => {
-        if (cancelled) return;
-        if (!logoResolved) {
+    if (!logoResolved) {
+      // resolveLogo honours the configured image languages for tt ids too, by
+      // mapping them to a TMDB id first. Resolving it here rather than inline
+      // is what keeps Cinemeta's English logo from winning on those.
+      resolveLogo(settings.tmdbKey, meta)
+        .then((l) => {
+          if (cancelled) return;
           setLogo(l);
           setLogoResolved(true);
-        }
-        if (!bgResolved) {
-          if (b) setBgUrl(b);
-          setBgResolved(true);
-        }
-      })
-      .catch(() => {
+        })
+        .catch(() => {
+          if (!cancelled) setLogoResolved(true);
+        });
+    }
+    if (!bgResolved) {
+      const isTmdb = meta.id.startsWith("tmdb:");
+      const bg: Promise<string | undefined> = isTmdb
+        ? tmdbMovieImages(settings.tmdbKey, meta.id).then((urls) => urls[0])
+        : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.background);
+      bg.then((b) => {
         if (cancelled) return;
-        setLogoResolved(true);
+        if (b) setBgUrl(b);
         setBgResolved(true);
+      }).catch(() => {
+        if (!cancelled) setBgResolved(true);
       });
+    }
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [logoResolved, bgResolved, meta.id, meta.type, settings.tmdbKey]);
 
   useEffect(() => {
@@ -332,14 +343,19 @@ export const Hero = memo(function Hero({
       <div className="absolute inset-x-0 bottom-0 h-2/5 bg-gradient-to-t from-canvas via-canvas/70 via-50% to-transparent" />
       <MetaAwardsCorner meta={meta} imdbId={resolvedImdb} />
 
-      <div className={`harbor-hero-content relative flex h-full flex-col justify-center p-14 ${full ? "pt-28 lg:pt-32" : ""}`}>
+      <div
+        className={`harbor-hero-content relative flex h-full flex-col justify-center p-14 ${full ? "pt-28 lg:pt-32" : ""}`}
+      >
         <div className="max-w-2xl">
           {rank && (
             <div className="group/rank relative mb-5 inline-flex self-start">
               <div className="inline-flex cursor-help items-center gap-1.5 rounded-md bg-canvas/85 px-2.5 py-1 text-[12px] font-semibold text-ink">
                 <TrendingUp size={12} className="text-accent" />
                 <span>
-                  {t("#{position} in {label} Today", { position: rank.position, label: t(rank.label) })}
+                  {t("#{position} in {label} Today", {
+                    position: rank.position,
+                    label: t(rank.label),
+                  })}
                 </span>
               </div>
               {rank.sources && rank.sources.length > 0 && (
@@ -349,14 +365,19 @@ export const Hero = memo(function Hero({
                   </div>
                   <div className="flex flex-col gap-1.5">
                     {rank.sources.map((s) => (
-                      <div key={s.label} className="flex items-center justify-between gap-8 text-[12.5px]">
+                      <div
+                        key={s.label}
+                        className="flex items-center justify-between gap-8 text-[12.5px]"
+                      >
                         <span className="inline-flex items-center gap-2 text-ink-muted">
                           {SOURCE_ICON[s.label] && (
                             <img
                               src={SOURCE_ICON[s.label]}
                               alt=""
                               className={`h-5 w-5 shrink-0 ${
-                                ROUNDED_ICON.has(s.label) ? "rounded-full object-cover" : "object-contain"
+                                ROUNDED_ICON.has(s.label)
+                                  ? "rounded-full object-cover"
+                                  : "object-contain"
                               }`}
                             />
                           )}
@@ -373,7 +394,17 @@ export const Hero = memo(function Hero({
               )}
             </div>
           )}
-          <HeroTitlePlate name={meta.name} logo={logo} loaded={logoLoaded} resolved={logoResolved} onLoad={() => setLogoLoaded(true)} onError={() => { setLogo(undefined); setLogoResolved(true); }} />
+          <HeroTitlePlate
+            name={meta.name}
+            logo={logo}
+            loaded={logoLoaded}
+            resolved={logoResolved}
+            onLoad={() => setLogoLoaded(true)}
+            onError={() => {
+              setLogo(undefined);
+              setLogoResolved(true);
+            }}
+          />
           {description && (
             <p className="mt-6 line-clamp-3 max-w-xl text-[16px] leading-relaxed text-ink-muted">
               {description}
@@ -423,7 +454,11 @@ export const Hero = memo(function Hero({
               }}
               className="flex h-12 items-center gap-2.5 rounded-full border border-edge bg-canvas/55 px-6 text-[15px] font-medium text-ink shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition-colors duration-200 hover:border-ink-subtle hover:bg-canvas/75"
             >
-              {inWatchlist ? <Check size={18} strokeWidth={2.4} /> : <Plus size={18} strokeWidth={2} />}
+              {inWatchlist ? (
+                <Check size={18} strokeWidth={2.4} />
+              ) : (
+                <Plus size={18} strokeWidth={2} />
+              )}
               {inWatchlist ? t("In Watchlist") : t("Add to Watchlist")}
             </button>
           </div>

--- a/src/components/local-badge.tsx
+++ b/src/components/local-badge.tsx
@@ -1,15 +1,11 @@
 import { HardDrive } from "lucide-react";
 
-export function LocalBadge({
-  label,
-  className = "",
-}: {
-  label: string;
-  className?: string;
-}) {
+export function LocalBadge({ label, className = "" }: { label: string; className?: string }) {
+  // No backdrop-filter: this badge sits on every poster in the library grid,
+  // and N simultaneous backdrop layers is a measurable compositor cost.
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-md bg-canvas/85 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-ink-muted backdrop-blur-sm ${className}`}
+      className={`inline-flex items-center gap-1 rounded-md bg-canvas/90 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-ink-muted ${className}`}
     >
       <HardDrive size={9} strokeWidth={2.4} />
       {label}
@@ -17,13 +13,7 @@ export function LocalBadge({
   );
 }
 
-export function LocalDot({
-  className = "",
-  title,
-}: {
-  className?: string;
-  title?: string;
-}) {
+export function LocalDot({ className = "", title }: { className?: string; title?: string }) {
   return (
     <span
       className={`pointer-events-none absolute flex h-6 w-6 items-center justify-center rounded-full bg-canvas/85 text-ink ring-1 ring-edge-soft/70 backdrop-blur-sm ${className}`}

--- a/src/components/local-version-badges.tsx
+++ b/src/components/local-version-badges.tsx
@@ -1,0 +1,36 @@
+import type { LocalEntry } from "@/lib/local-library";
+import { parseLocalEntry } from "@/lib/local-library/versions";
+import { formatBytes } from "@/lib/together/source-descriptor";
+import { FormatBadge, streamBadges, type BadgeSize } from "@/components/format-badge";
+
+/**
+ * The same badge stack addon streams get (source · resolution · codec · HDR ·
+ * audio), driven by the parsed filename of a local file, plus its size.
+ */
+export function LocalVersionBadges({
+  entry,
+  size = "sm",
+  className = "",
+}: {
+  entry: LocalEntry;
+  size?: BadgeSize;
+  className?: string;
+}) {
+  const parsed = parseLocalEntry(entry);
+  const badges = streamBadges(parsed);
+  const bytes = parsed.size ?? entry.size ?? null;
+  const sizeLabel = bytes != null ? formatBytes(bytes) : "";
+  if (badges.length === 0 && !sizeLabel) return null;
+  return (
+    <span className={`flex flex-wrap items-center gap-1.5 ${className}`}>
+      {badges.map((kind) => (
+        <FormatBadge key={kind} kind={kind} size={size} />
+      ))}
+      {sizeLabel && (
+        <span className="rounded-md bg-raised px-1.5 py-0.5 text-[10.5px] font-semibold tabular-nums text-ink-muted">
+          {sizeLabel}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/player/local-episodes-modal.tsx
+++ b/src/components/player/local-episodes-modal.tsx
@@ -4,6 +4,8 @@ import { ArrowDownWideNarrow, ArrowUpNarrowWide, Play, Wifi, X } from "lucide-re
 import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
 import { useLocalLibrary, type LocalEntry } from "@/lib/local-library";
+import { sortVersions } from "@/lib/local-library/versions";
+import { LocalVersionBadges } from "@/components/local-version-badges";
 import { meta as fetchCinemetaMeta, type Meta } from "@/lib/cinemeta";
 import { lastPlayedEpisode, readResumeEntry } from "@/lib/resume";
 import { formatRelativeWatched } from "@/lib/episode-progress";
@@ -17,10 +19,16 @@ import {
 export function LocalEpisodesModal() {
   const state = useSyncExternalStore(subscribeLocalEpisodes, getLocalEpisodes);
   if (!state.open || !state.payload) return null;
-  return <GridModal key={state.payload.tmdbId ?? state.payload.imdbId ?? state.payload.title} payload={state.payload} />;
+  return (
+    <GridModal
+      key={state.payload.tmdbId ?? state.payload.imdbId ?? state.payload.title}
+      payload={state.payload}
+    />
+  );
 }
 
-type SeasonMap = Map<number, Map<number, LocalEntry>>;
+/** Episode -> every file on disk for it, best version first. */
+type SeasonMap = Map<number, Map<number, LocalEntry[]>>;
 
 function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
   const t = useT();
@@ -61,7 +69,15 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
     for (const e of localEps) {
       if (e.season == null || e.episode == null) continue;
       if (!m.has(e.season)) m.set(e.season, new Map());
-      m.get(e.season)!.set(e.episode, e);
+      const byEp = m.get(e.season)!;
+      const arr = byEp.get(e.episode);
+      if (arr) arr.push(e);
+      else byEp.set(e.episode, [e]);
+    }
+    for (const byEp of m.values()) {
+      for (const [ep, arr] of byEp) {
+        if (arr.length > 1) byEp.set(ep, sortVersions(arr));
+      }
     }
     return m;
   }, [localEps]);
@@ -94,7 +110,10 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
   }, [videos]);
 
   const gridSeasons = useMemo(
-    () => Array.from(seasonEpisodeCount.keys()).filter((s) => s > 0).sort((a, b) => a - b),
+    () =>
+      Array.from(seasonEpisodeCount.keys())
+        .filter((s) => s > 0)
+        .sort((a, b) => a - b),
     [seasonEpisodeCount],
   );
   const globalMax = useMemo(
@@ -103,7 +122,10 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
   );
 
   const localSeasons = useMemo(
-    () => Array.from(localBySeason.keys()).filter((s) => s > 0).sort((a, b) => a - b),
+    () =>
+      Array.from(localBySeason.keys())
+        .filter((s) => s > 0)
+        .sort((a, b) => a - b),
     [localBySeason],
   );
   const hasSpecials = localBySeason.has(0);
@@ -134,7 +156,9 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
   }, [resumeIds.join("|"), all]);
 
   const hlSeason =
-    payload.highlightEpisode != null ? payload.initialSeason ?? null : lastWatched?.season ?? null;
+    payload.highlightEpisode != null
+      ? (payload.initialSeason ?? null)
+      : (lastWatched?.season ?? null);
   const hlEpisode = payload.highlightEpisode ?? lastWatched?.episode ?? null;
 
   const initialSeason =
@@ -142,7 +166,7 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
       ? payload.initialSeason
       : hlSeason != null && localBySeason.has(hlSeason)
         ? hlSeason
-        : localSeasons[0] ?? (hasSpecials ? 0 : 1);
+        : (localSeasons[0] ?? (hasSpecials ? 0 : 1));
   const [selected, setSelected] = useState<number>(initialSeason);
   useEffect(() => {
     const valid = selected === 0 ? hasSpecials : localSeasons.includes(selected);
@@ -150,11 +174,21 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
   }, [localSeasons, hasSpecials, selected]);
 
   const listEps = useMemo(() => {
-    const eps = Array.from(localBySeason.get(selected)?.values() ?? []).sort(
-      (a, b) => (a.episode ?? 0) - (b.episode ?? 0),
+    // Flatten versions so a second file for the same episode stays reachable.
+    const byEp = Array.from(localBySeason.get(selected)?.entries() ?? []).sort(
+      (a, b) => a[0] - b[0],
     );
-    return sortDesc ? eps.reverse() : eps;
+    if (sortDesc) byEp.reverse();
+    return byEp.flatMap(([, versions]) => versions);
   }, [localBySeason, selected, sortDesc]);
+
+  const multiVersionEpisodes = useMemo(() => {
+    const out = new Set<number>();
+    for (const [ep, versions] of localBySeason.get(selected) ?? []) {
+      if (versions.length > 1) out.add(ep);
+    }
+    return out;
+  }, [localBySeason, selected]);
 
   const epLabel = (n: number | null | undefined) => `E${String(n ?? 0).padStart(2, "0")}`;
   const sortLabel =
@@ -206,11 +240,16 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
             />
           )}
           <div className="flex min-w-0 flex-1 flex-col">
-            <h2 className="truncate font-display text-[18px] font-medium text-ink" title={payload.title}>
+            <h2
+              className="truncate font-display text-[18px] font-medium text-ink"
+              title={payload.title}
+            >
               {payload.title}
             </h2>
             <span className="text-[12px] text-ink-subtle">
-              {localEps.length === 1 ? t("1 episode on disk") : t("{n} episodes on disk", { n: localEps.length })}
+              {localEps.length === 1
+                ? t("1 episode on disk")
+                : t("{n} episodes on disk", { n: localEps.length })}
             </span>
           </div>
           <button
@@ -324,57 +363,63 @@ function GridModal({ payload }: { payload: LocalEpisodesPayload }) {
                 pr && ep.runtime && ep.runtime > 0 ? Math.min(1, pr.ms / (ep.runtime * 60_000)) : 0;
               const watchedAgo = pr ? formatRelativeWatched(pr.t) : "";
               return (
-              <button
-                key={ep.id}
-                type="button"
-                onClick={() => play(ep)}
-                className={`group/ep relative flex items-center gap-3 overflow-hidden rounded-xl px-3 py-2.5 text-start transition-colors hover:bg-raised ${
-                  isHighlight ? "bg-accent/10 ring-1 ring-accent" : ""
-                }`}
-              >
-                <span className="flex h-8 w-11 shrink-0 items-center justify-center rounded-md bg-canvas/60 font-mono text-[12px] font-bold tabular-nums text-ink-muted ring-1 ring-edge-soft">
-                  {`E${String(ep.episode ?? 0).padStart(2, "0")}`}
-                </span>
-                <span className="flex min-w-0 flex-1 flex-col">
-                  <span className="truncate text-[13px] text-ink" title={ep.filename}>
-                    {episodeNames.get(`${ep.season}x${ep.episode}`) ?? ep.filename}
+                <button
+                  key={ep.id}
+                  type="button"
+                  onClick={() => play(ep)}
+                  autoFocus={isHighlight}
+                  data-tv-initial-focus={isHighlight || undefined}
+                  className={`group/ep relative flex items-center gap-3 overflow-hidden rounded-xl px-3 py-2.5 text-start transition-colors hover:bg-raised ${
+                    isHighlight ? "bg-accent/10 ring-1 ring-accent" : ""
+                  }`}
+                >
+                  <span className="flex h-8 w-11 shrink-0 items-center justify-center rounded-md bg-canvas/60 font-mono text-[12px] font-bold tabular-nums text-ink-muted ring-1 ring-edge-soft">
+                    {`E${String(ep.episode ?? 0).padStart(2, "0")}`}
                   </span>
-                  {episodeNames.has(`${ep.season}x${ep.episode}`) && (
-                    <span className="truncate text-[11px] text-ink-subtle" title={ep.filename}>
-                      {ep.filename}
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-[13px] text-ink" title={ep.filename}>
+                      {episodeNames.get(`${ep.season}x${ep.episode}`) ?? ep.filename}
+                    </span>
+                    {episodeNames.has(`${ep.season}x${ep.episode}`) && (
+                      <span className="truncate text-[11px] text-ink-subtle" title={ep.filename}>
+                        {ep.filename}
+                      </span>
+                    )}
+                    {pr &&
+                      (ratio > 0.01 ? (
+                        <span className="text-[11px] text-accent/85">
+                          {t("{pct}% watched", { pct: Math.round(ratio * 100) })}
+                          {watchedAgo ? ` · ${watchedAgo}` : ""}
+                        </span>
+                      ) : (
+                        watchedAgo && (
+                          <span className="text-[11px] text-emerald-300/85">
+                            {t("Watched {ago}", { ago: watchedAgo })}
+                          </span>
+                        )
+                      ))}
+                  </span>
+                  {ep.episode != null && multiVersionEpisodes.has(ep.episode) ? (
+                    <LocalVersionBadges entry={ep} className="shrink-0 justify-end" />
+                  ) : (
+                    ep.resolution && (
+                      <span className="shrink-0 rounded-md bg-raised px-2 py-0.5 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-ink-muted">
+                        {ep.resolution}
+                      </span>
+                    )
+                  )}
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-ink-subtle transition-colors group-hover/ep:bg-ink group-hover/ep:text-canvas">
+                    <Play size={13} strokeWidth={2.4} fill="currentColor" className="ml-0.5" />
+                  </span>
+                  {ratio > 0.01 && (
+                    <span className="absolute inset-x-0 bottom-0 h-[2px] bg-edge">
+                      <span
+                        className="block h-full bg-accent"
+                        style={{ width: `${Math.max(2, ratio * 100)}%` }}
+                      />
                     </span>
                   )}
-                  {pr &&
-                    (ratio > 0.01 ? (
-                      <span className="text-[11px] text-accent/85">
-                        {t("{pct}% watched", { pct: Math.round(ratio * 100) })}
-                        {watchedAgo ? ` · ${watchedAgo}` : ""}
-                      </span>
-                    ) : (
-                      watchedAgo && (
-                        <span className="text-[11px] text-emerald-300/85">
-                          {t("Watched {ago}", { ago: watchedAgo })}
-                        </span>
-                      )
-                    ))}
-                </span>
-                {ep.resolution && (
-                  <span className="shrink-0 rounded-md bg-raised px-2 py-0.5 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-ink-muted">
-                    {ep.resolution}
-                  </span>
-                )}
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-ink-subtle transition-colors group-hover/ep:bg-ink group-hover/ep:text-canvas">
-                  <Play size={13} strokeWidth={2.4} fill="currentColor" className="ml-0.5" />
-                </span>
-                {ratio > 0.01 && (
-                  <span className="absolute inset-x-0 bottom-0 h-[2px] bg-edge">
-                    <span
-                      className="block h-full bg-accent"
-                      style={{ width: `${Math.max(2, ratio * 100)}%` }}
-                    />
-                  </span>
-                )}
-              </button>
+                </button>
               );
             })}
             {listEps.length === 0 && (
@@ -417,7 +462,9 @@ function SeasonPill({
       type="button"
       onClick={onClick}
       className={`shrink-0 rounded-full px-3.5 py-1.5 text-[12.5px] font-semibold transition-colors ${
-        active ? "bg-ink text-canvas" : "bg-elevated/40 text-ink-muted ring-1 ring-edge-soft/60 hover:bg-raised hover:text-ink"
+        active
+          ? "bg-ink text-canvas"
+          : "bg-elevated/40 text-ink-muted ring-1 ring-edge-soft/60 hover:bg-raised hover:text-ink"
       }`}
     >
       {children}

--- a/src/components/player/local-versions-modal.tsx
+++ b/src/components/player/local-versions-modal.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+import { HardDrive, Play, X } from "lucide-react";
+import { useT } from "@/lib/i18n";
+import { LocalVersionBadges } from "@/components/local-version-badges";
+import {
+  closeLocalVersions,
+  getLocalVersions,
+  subscribeLocalVersions,
+  type LocalVersionsPayload,
+} from "@/lib/player/local-versions-modal";
+
+export function LocalVersionsModal() {
+  const state = useSyncExternalStore(subscribeLocalVersions, getLocalVersions);
+  if (!state.open || !state.payload) return null;
+  return <VersionsModal payload={state.payload} />;
+}
+
+function VersionsModal({ payload }: { payload: LocalVersionsPayload }) {
+  const t = useT();
+  const { entries } = payload;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeLocalVersions();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const play = (entry: LocalVersionsPayload["entries"][number]) => {
+    const fn = payload.onPlayLocal;
+    closeLocalVersions();
+    fn(entry);
+  };
+
+  return createPortal(
+    <div
+      data-tv-focus-scope
+      className="animate-fade-in fixed inset-0 z-[210] flex items-center justify-center bg-canvas/80 p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeLocalVersions();
+      }}
+    >
+      <div className="animate-modal-in flex max-h-[86vh] w-[min(94vw,620px)] flex-col rounded-2xl border border-edge-soft bg-elevated shadow-[0_30px_80px_-20px_rgba(0,0,0,0.6)]">
+        <div className="flex items-center gap-3 border-b border-edge-soft px-5 pb-3.5 pt-4">
+          {payload.poster && (
+            <img
+              src={payload.poster}
+              alt=""
+              className="h-11 w-8 shrink-0 rounded-md object-cover ring-1 ring-edge-soft"
+            />
+          )}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2
+              className="truncate font-display text-[18px] font-medium text-ink"
+              title={payload.title}
+            >
+              {payload.title}
+            </h2>
+            <span className="text-[12px] text-ink-subtle">
+              {t("{n} versions on your disk", { n: entries.length })}
+            </span>
+          </div>
+          <button
+            type="button"
+            data-tv-modal-close
+            onClick={() => closeLocalVersions()}
+            aria-label={t("Close")}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-ink-subtle transition-colors hover:bg-raised hover:text-ink"
+          >
+            <X size={17} />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-1.5 overflow-y-auto p-4">
+          {entries.map((entry, i) => (
+            <button
+              key={entry.id}
+              type="button"
+              onClick={() => play(entry)}
+              autoFocus={i === 0}
+              data-tv-initial-focus={i === 0 || undefined}
+              className="group/v flex items-center gap-3 rounded-xl px-3 py-3 text-start transition-colors hover:bg-raised"
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent/15 text-accent">
+                <HardDrive size={16} strokeWidth={2} />
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col gap-1">
+                <span className="truncate text-[13.5px] text-ink" title={entry.path}>
+                  {entry.filename}
+                </span>
+                <LocalVersionBadges entry={entry} />
+              </span>
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-ink-subtle transition-colors group-hover/v:bg-ink group-hover/v:text-canvas">
+                <Play size={13} strokeWidth={2.4} fill="currentColor" className="ml-0.5" />
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/virtual-grid.tsx
+++ b/src/components/virtual-grid.tsx
@@ -1,0 +1,94 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useEffect, useRef, useState, type ReactNode, type RefObject } from "react";
+
+/**
+ * Multi-column CSS-grid style virtualizer for large poster grids.
+ * Only mounts visible rows (+ overscan) for smooth scroll on big catalogs.
+ */
+export function VirtualGrid<T>({
+  items,
+  scrollRef,
+  estimateRowHeight = 280,
+  minColumnWidth = 150,
+  gapX = 16,
+  gapY = 32,
+  overscan = 3,
+  renderItem,
+  className = "",
+  getKey,
+}: {
+  items: T[];
+  scrollRef: RefObject<HTMLElement | null>;
+  estimateRowHeight?: number;
+  minColumnWidth?: number;
+  gapX?: number;
+  gapY?: number;
+  overscan?: number;
+  renderItem: (item: T, index: number) => ReactNode;
+  className?: string;
+  getKey?: (item: T, index: number) => string | number;
+}) {
+  "use no memo";
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cols, setCols] = useState(1);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => {
+      const w = el.clientWidth;
+      if (w <= 0) return;
+      const next = Math.max(1, Math.floor((w + gapX) / (minColumnWidth + gapX)));
+      setCols(next);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [gapX, minColumnWidth]);
+
+  const rowCount = Math.max(1, Math.ceil(items.length / cols));
+  const rowVirtualizer = useVirtualizer({
+    count: items.length === 0 ? 0 : rowCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => estimateRowHeight + gapY,
+    // Each virtual item contains exactly one CSS-grid row, so `rowGap` would
+    // not create spacing between virtual rows. Include the gap in measurement
+    // as well as the estimate, otherwise measured rows stack flush together.
+    measureElement: (element) => element.getBoundingClientRect().height + gapY,
+    overscan,
+  });
+
+  if (items.length === 0) return null;
+
+  return (
+    <div ref={containerRef} className={className}>
+      <div className="relative w-full" style={{ height: rowVirtualizer.getTotalSize() }}>
+        {rowVirtualizer.getVirtualItems().map((row) => {
+          const start = row.index * cols;
+          const slice = items.slice(start, start + cols);
+          return (
+            <div
+              key={row.key}
+              data-index={row.index}
+              ref={rowVirtualizer.measureElement}
+              className="absolute start-0 grid w-full"
+              style={{
+                transform: `translateY(${row.start}px)`,
+                gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+                columnGap: gapX,
+              }}
+            >
+              {slice.map((item, i) => {
+                const index = start + i;
+                const key = getKey ? getKey(item, index) : index;
+                return <div key={key}>{renderItem(item, index)}</div>;
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/continue-watching.ts
+++ b/src/lib/continue-watching.ts
@@ -24,7 +24,7 @@ export type CwCard = {
   at: number;
 };
 
-function localToLibraryItem(e: ReturnType<typeof listLocalCw>[number]): LibraryItem {
+export function localToLibraryItem(e: ReturnType<typeof listLocalCw>[number]): LibraryItem {
   return {
     _id: e.id,
     type: e.type,
@@ -36,7 +36,9 @@ function localToLibraryItem(e: ReturnType<typeof listLocalCw>[number]): LibraryI
       duration: e.durationMs,
       season: e.season,
       episode: e.episode,
-      video_id: e.videoId,
+      video_id:
+        e.videoId ??
+        (e.season != null && e.episode != null ? `${e.id}:${e.season}:${e.episode}` : undefined),
       flaggedWatched: e.durationMs > 0 && e.positionMs / e.durationMs >= 0.9 ? 1 : 0,
       lastWatched: new Date(e.t).toISOString(),
     },

--- a/src/lib/local-library.ts
+++ b/src/lib/local-library.ts
@@ -12,8 +12,12 @@ export type LocalEntry = {
   year: number | null;
   type: "movie" | "show";
   resolution?: string | null;
+  /** Bytes on disk; absent for libraries scanned before versions were tracked. */
+  size?: number | null;
   rating?: number | null;
   runtime?: number | null;
+  /** Absent for entries scanned before genres were captured; never backfilled. */
+  genres?: string[] | null;
   poster?: string | null;
   tmdbId?: number | null;
   imdbId?: string | null;
@@ -27,18 +31,31 @@ export type LocalEntry = {
   localArt?: { poster?: string; logo?: string; backdrop?: string };
 };
 
+// Parsing the whole library out of localStorage on every read is O(n) per call,
+// and read() is hit once per subscriber per mutation. Cache the parsed array and
+// bump a generation counter so derived caches can invalidate against it.
+let cache: LocalEntry[] | null = null;
+let generation = 0;
+
 function read(): LocalEntry[] {
+  if (cache) return cache;
+  let parsed: LocalEntry[] = [];
   try {
     const raw = localStorage.getItem(KEY);
-    if (!raw) return [];
-    const arr = JSON.parse(raw);
-    return Array.isArray(arr) ? (arr as LocalEntry[]) : [];
+    if (raw) {
+      const arr = JSON.parse(raw);
+      if (Array.isArray(arr)) parsed = arr as LocalEntry[];
+    }
   } catch {
-    return [];
+    parsed = [];
   }
+  cache = parsed;
+  return cache;
 }
 
 function write(entries: LocalEntry[]): void {
+  cache = entries;
+  generation += 1;
   try {
     localStorage.setItem(KEY, JSON.stringify(entries));
   } catch {
@@ -47,11 +64,19 @@ function write(entries: LocalEntry[]): void {
   for (const s of subs) s();
 }
 
+/** Bumped on every mutation; derived caches key off this. */
+export function localLibraryGeneration(): number {
+  return generation;
+}
+
 export function readLocalLibrary(): LocalEntry[] {
   return read();
 }
 
-export function localShowEpisodes(show: { imdbId?: string | null; title?: string | null }): LocalEntry[] {
+export function localShowEpisodes(show: {
+  imdbId?: string | null;
+  title?: string | null;
+}): LocalEntry[] {
   const wantImdb = show.imdbId ?? null;
   const wantTitle = (show.title ?? "").trim().toLowerCase();
   return read()
@@ -68,9 +93,7 @@ export function findLocalEpisode(
   season: number,
   episode: number,
 ): LocalEntry | null {
-  return (
-    localShowEpisodes(show).find((e) => e.season === season && e.episode === episode) ?? null
-  );
+  return localShowEpisodes(show).find((e) => e.season === season && e.episode === episode) ?? null;
 }
 
 export function addLocalEntries(entries: LocalEntry[]): void {
@@ -109,10 +132,7 @@ export function clearLocalLibrary(): void {
   write([]);
 }
 
-export function findLocalMovie(
-  tmdbId?: number | null,
-  imdbId?: string | null,
-): LocalEntry | null {
+export function findLocalMovie(tmdbId?: number | null, imdbId?: string | null): LocalEntry | null {
   return (
     read().find(
       (e) =>
@@ -155,7 +175,7 @@ export function findLocalSeriesEpisodes(
 
 export function localEntryToMeta(entry: LocalEntry): Meta | null {
   const kind = entry.type === "show" ? "tv" : "movie";
-  const id = entry.tmdbId != null ? `tmdb:${kind}:${entry.tmdbId}` : entry.imdbId ?? null;
+  const id = entry.tmdbId != null ? `tmdb:${kind}:${entry.tmdbId}` : (entry.imdbId ?? null);
   if (!id) return null;
   return {
     id,
@@ -177,7 +197,10 @@ export function useLocalLibrary(): LocalEntry[] {
   return items;
 }
 
+let idSetCache: { gen: number; set: Set<string> } | null = null;
+
 function localLibraryIdSet(): Set<string> {
+  if (idSetCache && idSetCache.gen === generation) return idSetCache.set;
   const out = new Set<string>();
   for (const e of read()) {
     if (e.tmdbId != null) {
@@ -186,6 +209,7 @@ function localLibraryIdSet(): Set<string> {
     }
     if (e.imdbId) out.add(e.imdbId);
   }
+  idSetCache = { gen: generation, set: out };
   return out;
 }
 
@@ -221,7 +245,19 @@ export function useInLocalLibrary(
 }
 
 const VIDEO_EXTS = new Set([
-  "mkv", "mp4", "m4v", "mov", "avi", "wmv", "webm", "ts", "m2ts", "mpg", "mpeg", "flv", "ogv",
+  "mkv",
+  "mp4",
+  "m4v",
+  "mov",
+  "avi",
+  "wmv",
+  "webm",
+  "ts",
+  "m2ts",
+  "mpg",
+  "mpeg",
+  "flv",
+  "ogv",
 ]);
 
 export function isVideoFile(name: string): boolean {
@@ -230,11 +266,41 @@ export function isVideoFile(name: string): boolean {
 }
 
 const NOISE = [
-  "1080p", "720p", "2160p", "4k", "uhd", "hdr", "hdr10", "dv",
-  "bluray", "bdrip", "brrip", "webrip", "web-dl", "webdl", "hdtv", "dvdrip", "remux",
-  "x264", "x265", "h264", "h265", "hevc", "av1", "10bit",
-  "atmos", "ddp", "dts", "ac3", "aac",
-  "yify", "yts", "rarbg", "fgt", "evo", "psa",
+  "1080p",
+  "720p",
+  "2160p",
+  "4k",
+  "uhd",
+  "hdr",
+  "hdr10",
+  "dv",
+  "bluray",
+  "bdrip",
+  "brrip",
+  "webrip",
+  "web-dl",
+  "webdl",
+  "hdtv",
+  "dvdrip",
+  "remux",
+  "x264",
+  "x265",
+  "h264",
+  "h265",
+  "hevc",
+  "av1",
+  "10bit",
+  "atmos",
+  "ddp",
+  "dts",
+  "ac3",
+  "aac",
+  "yify",
+  "yts",
+  "rarbg",
+  "fgt",
+  "evo",
+  "psa",
 ];
 const NOISE_RX = new RegExp(`\\b(${NOISE.join("|")})\\b`, "gi");
 const TV_RX =

--- a/src/lib/local-library/group-key.ts
+++ b/src/lib/local-library/group-key.ts
@@ -1,0 +1,34 @@
+import type { LocalEntry } from "@/lib/local-library";
+
+// Deliberately self-contained (type-only imports): tests run under `node --test`
+// with no path-alias resolution, so anything with runtime imports is untestable.
+// Mirrors the normalizer in @/lib/streams/library.
+function normalizeTitle(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\s.\-_()[\]:;,!?'"‘’“”–—]+/g, "");
+}
+
+/**
+ * Identity of the *title* a file belongs to. Metadata id wins; normalized
+ * title + year is the fallback for files that never resolved to an id.
+ */
+export function localTitleKey(entry: LocalEntry): string {
+  if (entry.tmdbId != null) {
+    return `tmdb:${entry.type === "show" ? "tv" : "movie"}:${entry.tmdbId}`;
+  }
+  if (entry.imdbId) return entry.imdbId;
+  const title = normalizeTitle(entry.title || entry.filename);
+  return `title:${entry.type}:${title}:${entry.year ?? "?"}`;
+}
+
+/**
+ * Identity of the thing a poster/row represents: a movie, or one episode of a
+ * show. Two files sharing this key are two versions of the same content.
+ */
+export function localGroupKey(entry: LocalEntry): string {
+  const base = localTitleKey(entry);
+  if (entry.type !== "show") return base;
+  return `${base}:s${entry.season ?? 0}e${entry.episode ?? 0}`;
+}

--- a/src/lib/local-library/playback.ts
+++ b/src/lib/local-library/playback.ts
@@ -1,12 +1,17 @@
 import type { Meta } from "@/lib/cinemeta";
-import { findLocalEpisodeByIds, findLocalMovie, type LocalEntry } from "@/lib/local-library";
+import { type LocalEntry } from "@/lib/local-library";
+import { findLocalEpisodeVersions, findLocalMovieVersions } from "@/lib/local-library/versions";
+import { openLocalVersions } from "@/lib/player/local-versions-modal";
 import { episodeLabel } from "@/lib/local-library/player-src";
 import { readResumeMs } from "@/lib/resume";
 import { openWatchLocalConfirm } from "@/lib/player/watch-local-confirm";
 
 export type LocalPlaybackMode = "ask" | "local" | "stream";
 
-function idsFromMeta(meta: Meta, extraImdb?: string | null): { tmdbId: number | null; imdbId: string | null } {
+function idsFromMeta(
+  meta: Meta,
+  extraImdb?: string | null,
+): { tmdbId: number | null; imdbId: string | null } {
   let tmdbId: number | null = null;
   let imdbId: string | null = extraImdb ?? null;
   const id = meta.id;
@@ -16,17 +21,26 @@ function idsFromMeta(meta: Meta, extraImdb?: string | null): { tmdbId: number | 
   return { tmdbId, imdbId };
 }
 
+/** Every local file for this title/episode, best version first. */
+export function resolveLocalPlayVersions(
+  meta: Meta,
+  episode?: { season: number; episode: number } | null,
+  extraImdb?: string | null,
+): LocalEntry[] {
+  const { tmdbId, imdbId } = idsFromMeta(meta, extraImdb);
+  if (tmdbId == null && imdbId == null) return [];
+  if (episode && episode.season != null && episode.episode != null) {
+    return findLocalEpisodeVersions(episode.season, episode.episode, tmdbId, imdbId);
+  }
+  return findLocalMovieVersions(tmdbId, imdbId);
+}
+
 export function resolveLocalPlay(
   meta: Meta,
   episode?: { season: number; episode: number } | null,
   extraImdb?: string | null,
 ): LocalEntry | null {
-  const { tmdbId, imdbId } = idsFromMeta(meta, extraImdb);
-  if (tmdbId == null && imdbId == null) return null;
-  if (episode && episode.season != null && episode.episode != null) {
-    return findLocalEpisodeByIds(episode.season, episode.episode, tmdbId, imdbId);
-  }
-  return findLocalMovie(tmdbId, imdbId);
+  return resolveLocalPlayVersions(meta, episode, extraImdb)[0] ?? null;
 }
 
 export function playLocalAware(opts: {
@@ -41,13 +55,33 @@ export function playLocalAware(opts: {
   resumeId?: string;
 }): void {
   const { meta, episode, extraImdb, mode, source, playLocal, playStream, setMode, resumeId } = opts;
-  const local = mode === "stream" ? null : resolveLocalPlay(meta, episode, extraImdb);
+  const versions = mode === "stream" ? [] : resolveLocalPlayVersions(meta, episode, extraImdb);
+  const local = versions[0] ?? null;
   if (!local) {
     playStream();
     return;
   }
-  if (source === "auto" || mode === "local") {
+  // Autoplay must not stall on a dialog, so it takes the best version. A
+  // deliberate press with more than one file on disk always gets to choose.
+  if (source === "auto") {
     playLocal(local);
+    return;
+  }
+  // Runs after the local-vs-stream decision, never instead of it.
+  const goLocal = (fromStart?: boolean) => {
+    if (versions.length < 2) {
+      playLocal(local, { fromStart });
+      return;
+    }
+    openLocalVersions({
+      title: local.title || meta.name,
+      poster: meta.poster ?? null,
+      entries: versions,
+      onPlayLocal: (entry) => playLocal(entry, { fromStart }),
+    });
+  };
+  if (mode === "local") {
+    goLocal();
     return;
   }
   const rid = resumeId ?? local.imdbId ?? `local:${local.id}`;
@@ -61,7 +95,7 @@ export function playLocalAware(opts: {
     onChoose: (choice, remember) => {
       if (remember) setMode(choice === "stream" ? "stream" : "local");
       if (choice === "stream") playStream();
-      else playLocal(local, { fromStart: choice === "local-restart" });
+      else goLocal(choice === "local-restart");
     },
   });
 }

--- a/src/lib/local-library/sidecars.ts
+++ b/src/lib/local-library/sidecars.ts
@@ -9,6 +9,7 @@ export type ParsedNfo = {
   showTitle?: string;
   rating?: number | null;
   runtime?: number | null;
+  genres?: string[];
   art?: LocalArt;
 };
 
@@ -99,13 +100,25 @@ export async function findLocalArt(videoPath: string): Promise<LocalArt> {
   const index = await dirIndex(dir);
   const [poster, backdrop, logo] = await Promise.all([
     resolveIn(dir, index, [
-      `${stem}-poster.jpg`, `${stem}-poster.png`, "poster.jpg", "poster.png", "folder.jpg", "cover.jpg",
+      `${stem}-poster.jpg`,
+      `${stem}-poster.png`,
+      "poster.jpg",
+      "poster.png",
+      "folder.jpg",
+      "cover.jpg",
     ]),
     resolveIn(dir, index, [
-      `${stem}-fanart.jpg`, `${stem}-fanart.png`, "fanart.jpg", "fanart.png", "backdrop.jpg",
+      `${stem}-fanart.jpg`,
+      `${stem}-fanart.png`,
+      "fanart.jpg",
+      "fanart.png",
+      "backdrop.jpg",
     ]),
     resolveIn(dir, index, [
-      `${stem}-clearlogo.png`, `${stem}-logo.png`, "clearlogo.png", "logo.png",
+      `${stem}-clearlogo.png`,
+      `${stem}-logo.png`,
+      "clearlogo.png",
+      "logo.png",
     ]),
   ]);
   const art: LocalArt = {};
@@ -121,17 +134,16 @@ export async function findShowNfo(videoPath: string): Promise<string | null> {
   return resolveInDirs(await dirAndParent(dir), ["tvshow.nfo"]);
 }
 
-export async function findShowArt(
-  videoPath: string,
-  season: number | null,
-): Promise<LocalArt> {
+export async function findShowArt(videoPath: string, season: number | null): Promise<LocalArt> {
   if (!isTauri) return {};
   const { dir } = await splitVideoPath(videoPath);
   const dirs = await dirAndParent(dir);
-  const seasonTag =
-    season != null ? `season${String(season).padStart(2, "0")}-poster` : null;
+  const seasonTag = season != null ? `season${String(season).padStart(2, "0")}-poster` : null;
   const posterNames = [
-    "poster.jpg", "poster.png", "folder.jpg", "cover.jpg",
+    "poster.jpg",
+    "poster.png",
+    "folder.jpg",
+    "cover.jpg",
     ...(seasonTag ? [`${seasonTag}.jpg`, `${seasonTag}.png`] : []),
   ];
   const [poster, backdrop, logo] = await Promise.all([
@@ -174,8 +186,7 @@ export function parseNfo(xml: string): ParsedNfo {
   out.showTitle = text("showtitle");
 
   const yearRaw =
-    text("year") ??
-    (text("premiered") || text("aired") || text("releasedate"))?.slice(0, 4);
+    text("year") ?? (text("premiered") || text("aired") || text("releasedate"))?.slice(0, 4);
   const yearNum = yearRaw ? parseInt(yearRaw, 10) : NaN;
   out.year = Number.isFinite(yearNum) ? yearNum : null;
 
@@ -189,6 +200,14 @@ export function parseNfo(xml: string): ParsedNfo {
   const runtimeRaw = text("runtime");
   const runtimeNum = runtimeRaw ? parseInt(runtimeRaw.replace(/\D/g, ""), 10) : NaN;
   out.runtime = Number.isFinite(runtimeNum) && runtimeNum > 0 ? runtimeNum : null;
+
+  // Kodi NFOs carry one <genre> element per genre; export.ts already writes them.
+  const genres: string[] = [];
+  for (const el of Array.from(doc.querySelectorAll("genre"))) {
+    const val = el.textContent?.trim();
+    if (val && !genres.includes(val)) genres.push(val);
+  }
+  out.genres = genres.length > 0 ? genres : undefined;
 
   let tmdb: string | undefined;
   let imdb: string | undefined;
@@ -217,8 +236,7 @@ export function parseNfo(xml: string): ParsedNfo {
 function parseNfoArt(doc: Document): LocalArt | undefined {
   const thumbs = Array.from(doc.querySelectorAll("thumb"));
   const val = (el: Element | undefined) => el?.textContent?.trim() || undefined;
-  const byAspect = (aspect: string) =>
-    thumbs.filter((el) => el.getAttribute("aspect") === aspect);
+  const byAspect = (aspect: string) => thumbs.filter((el) => el.getAttribute("aspect") === aspect);
 
   const poster = val(byAspect("poster").find((el) => !el.getAttribute("season")));
 

--- a/src/lib/local-library/use-local-cw.ts
+++ b/src/lib/local-library/use-local-cw.ts
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from "react";
+import { findLocalSeriesEpisodes, useLocalLibrary, type LocalEntry } from "@/lib/local-library";
+import { localTitleKey } from "@/lib/local-library/group-key";
+import { listLocalCw, subscribeLocalCw } from "@/lib/local-cw";
+import { localToLibraryItem } from "@/lib/continue-watching";
+import { cwSortKey, episodeFromVideoId, isCwMember, type LibraryItem } from "@/lib/stremio";
+import { isCwDismissed } from "@/lib/cw-dismiss";
+
+/** Matches local-cw's own finished threshold. */
+const FINISHED_RATIO = 0.92;
+const MAX_CARDS = 20;
+
+export type LocalCwCard = {
+  /** Shaped for ContinueCard, exactly as the Home row builds them. */
+  item: LibraryItem;
+  /** The file on disk this card should play. */
+  entry: LocalEntry;
+};
+
+/**
+ * Every id a local play can be saved under. localPlayerSrc uses
+ * `imdbId ?? local:<hash>`, but a play started from a detail page carries that
+ * page's meta id instead, which may be a tmdb one.
+ */
+function playIdsFor(entry: LocalEntry): string[] {
+  const out: string[] = [`local:${entry.id}`];
+  if (entry.imdbId) out.push(entry.imdbId);
+  if (entry.tmdbId != null)
+    out.push(`tmdb:${entry.type === "show" ? "tv" : "movie"}:${entry.tmdbId}`);
+  return out;
+}
+
+function episodeOf(item: LibraryItem): { season: number; episode: number } | null {
+  const season = item.state?.season;
+  const episode = item.state?.episode;
+  if (season != null && episode != null) return { season, episode };
+  return episodeFromVideoId(item.state?.video_id);
+}
+
+function isFinished(item: LibraryItem): boolean {
+  const duration = item.state?.duration ?? 0;
+  const offset = item.state?.timeOffset ?? 0;
+  return duration > 0 && offset / duration >= FINISHED_RATIO;
+}
+
+/**
+ * Continue Watching restricted to titles backed by a file on disk. Uses the same
+ * store, item shape and membership predicates as the Home row; the only local
+ * additions are the on-disk filter and next-episode lookup.
+ */
+export function useLocalContinueWatching(): LocalCwCard[] {
+  const library = useLocalLibrary();
+  const [cwVersion, setCwVersion] = useState(0);
+  useEffect(() => subscribeLocalCw(() => setCwVersion((v) => v + 1)), []);
+
+  return useMemo(() => {
+    void cwVersion;
+    const byPlayId = new Map<string, LocalEntry[]>();
+    for (const entry of library) {
+      for (const id of playIdsFor(entry)) {
+        const arr = byPlayId.get(id);
+        if (arr) arr.push(entry);
+        else byPlayId.set(id, [entry]);
+      }
+    }
+    if (byPlayId.size === 0) return [];
+
+    const eligible = listLocalCw()
+      .map(localToLibraryItem)
+      .filter(
+        (i) =>
+          (i.type as string) !== "other" &&
+          !i._id.startsWith("iptv:") &&
+          byPlayId.has(i._id) &&
+          !isCwDismissed(i) &&
+          isCwMember(i),
+      )
+      .map((i) => ({ i, k: cwSortKey(i) }))
+      .sort((a, b) => b.k - a.k)
+      .map((e) => e.i);
+
+    // One card per title: a series is stored per-episode, so keep only the most
+    // recently watched episode of each show (the list is already sorted).
+    const seenTitle = new Set<string>();
+    const out: LocalCwCard[] = [];
+    for (const item of eligible) {
+      const candidates = byPlayId.get(item._id) ?? [];
+      const ep = item.type === "movie" ? null : episodeOf(item);
+      let entry =
+        ep == null
+          ? candidates[0]
+          : (candidates.find((c) => c.season === ep.season && c.episode === ep.episode) ??
+            candidates[0]);
+      if (!entry) continue;
+
+      const titleKey = localTitleKey(entry);
+      if (seenTitle.has(titleKey)) continue;
+
+      let card = item;
+      if (entry.type === "show" && isFinished(item)) {
+        // Advance to the next episode that actually exists on disk. Deliberately
+        // not useCwAdvance, which resolves episode lists over TMDB and cannot
+        // handle a `local:` id.
+        const next = nextLocalEpisode(entry);
+        if (!next) continue;
+        entry = next;
+        card = {
+          ...item,
+          state: {
+            ...item.state,
+            duration: item.state?.duration ?? 0,
+            timeOffset: 0,
+            season: next.season ?? undefined,
+            episode: next.episode ?? undefined,
+            video_id: `${item._id}:${next.season ?? 0}:${next.episode ?? 0}`,
+            flaggedWatched: 0,
+          },
+          upNext: true,
+        };
+      }
+
+      seenTitle.add(titleKey);
+      out.push({ item: card, entry });
+      if (out.length >= MAX_CARDS) break;
+    }
+    return out;
+  }, [library, cwVersion]);
+}
+
+function nextLocalEpisode(current: LocalEntry): LocalEntry | null {
+  const episodes = findLocalSeriesEpisodes(current.tmdbId, current.imdbId);
+  if (episodes.length === 0) return null;
+  const season = current.season ?? 0;
+  const episode = current.episode ?? 0;
+  return (
+    episodes.find(
+      (e) => (e.season ?? 0) > season || ((e.season ?? 0) === season && (e.episode ?? 0) > episode),
+    ) ?? null
+  );
+}

--- a/src/lib/local-library/use-series-play.ts
+++ b/src/lib/local-library/use-series-play.ts
@@ -2,7 +2,8 @@ import { useCallback } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import { useView, type PlayEpisode } from "@/lib/view";
 import { useSettings } from "@/lib/settings";
-import { findLocalEpisodeByIds } from "@/lib/local-library";
+import { findLocalEpisodeVersions } from "@/lib/local-library/versions";
+import { openLocalVersions } from "@/lib/player/local-versions-modal";
 import { localPlayerSrc } from "@/lib/local-library/player-src";
 import { metaIsAnime } from "@/lib/player/anime-src";
 import { openLocalEpisodes } from "@/lib/player/local-episodes-modal";
@@ -30,12 +31,27 @@ export function useLocalAwareSeriesPlay() {
       const m = meta.id.match(/^tmdb:tv:(\d+)$/);
       const tmdbId = m ? parseInt(m[1], 10) : null;
       const seriesImdb = imdbId ?? (meta.id.startsWith("tt") ? meta.id : null);
-      const thisLocal = findLocalEpisodeByIds(episode.season, episode.episode, tmdbId, seriesImdb);
+      const versions = findLocalEpisodeVersions(
+        episode.season,
+        episode.episode,
+        tmdbId,
+        seriesImdb,
+      );
+      const thisLocal = versions[0];
       if (!thisLocal) {
         stream();
         return;
       }
       if (settings.localPlaybackMode === "local") {
+        if (versions.length > 1) {
+          openLocalVersions({
+            title: meta.name,
+            poster: meta.poster,
+            entries: versions,
+            onPlayLocal: (e) => openPlayer(localPlayerSrc(e, srcIsAnime)),
+          });
+          return;
+        }
         openPlayer(localPlayerSrc(thisLocal, srcIsAnime));
         return;
       }

--- a/src/lib/local-library/versions.ts
+++ b/src/lib/local-library/versions.ts
@@ -1,0 +1,129 @@
+import { localLibraryGeneration, readLocalLibrary, type LocalEntry } from "@/lib/local-library";
+import { parseStream } from "@/lib/streams/parser";
+import { tierOf } from "@/lib/streams/scoring/scoring-resolution";
+import type { ParsedStream, Stream, Tier } from "@/lib/streams/types";
+
+export { localGroupKey, localTitleKey } from "./group-key";
+
+export const LOCAL_ADDON_ID = "harbor-local-files";
+export const LOCAL_ADDON_NAME = "Local files";
+
+/**
+ * Feed a local file through the real stream parser instead of the scanner's
+ * regex, so version rows get the same source/codec/HDR/audio facets as addon
+ * streams. Mirrors buildLibraryStream in @/lib/streams/library.
+ */
+export function localEntryToStream(entry: LocalEntry): Stream {
+  return {
+    name: entry.filename,
+    url: entry.path,
+    behaviorHints: {
+      filename: entry.filename,
+      videoSize: entry.size ?? undefined,
+      notWebReady: true,
+    },
+    addonId: LOCAL_ADDON_ID,
+    addonName: LOCAL_ADDON_NAME,
+  };
+}
+
+const parseCache = new Map<string, ParsedStream>();
+let parseCacheGen = -1;
+
+/** Parsed facets for a local file, memoized against the store generation. */
+export function parseLocalEntry(entry: LocalEntry): ParsedStream {
+  const gen = localLibraryGeneration();
+  if (gen !== parseCacheGen) {
+    parseCache.clear();
+    parseCacheGen = gen;
+  }
+  const hit = parseCache.get(entry.path);
+  if (hit) return hit;
+  const parsed = parseStream(localEntryToStream(entry));
+  // A file on disk is never debrid-cached; don't let filename noise imply it.
+  parsed.cached = {};
+  parsed.inLibrary = {};
+  if (parsed.size == null && entry.size != null) parsed.size = entry.size;
+  parseCache.set(entry.path, parsed);
+  return parsed;
+}
+
+const TIER_RANK: Record<Tier, number> = {
+  "4K_DV": 7,
+  "4K_HDR": 6,
+  "4K": 5,
+  "1080p_HDR": 4,
+  "1080p": 3,
+  "720p": 2,
+  SD: 1,
+  ROUGH: 0,
+};
+
+const SOURCE_RANK: Record<string, number> = {
+  REMUX: 6,
+  BluRay: 5,
+  "WEB-DL": 4,
+  WEBRip: 3,
+  BDRip: 3,
+  HDRip: 2,
+  DVDRip: 2,
+  HDTV: 1,
+};
+
+function versionRank(entry: LocalEntry): number[] {
+  const p = parseLocalEntry(entry);
+  return [TIER_RANK[tierOf(p)] ?? 0, p.remux ? 1 : 0, SOURCE_RANK[p.source] ?? 0, p.size ?? 0];
+}
+
+/** Best version first. Ties fall back to filename for a stable order. */
+export function sortVersions(entries: LocalEntry[]): LocalEntry[] {
+  if (entries.length < 2) return entries;
+  return entries
+    .map((entry) => ({ entry, rank: versionRank(entry) }))
+    .sort((a, b) => {
+      for (let i = 0; i < a.rank.length; i++) {
+        if (a.rank[i] !== b.rank[i]) return b.rank[i] - a.rank[i];
+      }
+      return a.entry.filename.localeCompare(b.entry.filename);
+    })
+    .map((x) => x.entry);
+}
+
+/**
+ * Every local file for a movie, best first. The singular findLocalMovie in
+ * @/lib/local-library returns only the first match; this is the version-aware
+ * counterpart. It lives here rather than beside it to avoid an import cycle
+ * with sortVersions.
+ */
+export function findLocalMovieVersions(
+  tmdbId?: number | null,
+  imdbId?: string | null,
+): LocalEntry[] {
+  if (tmdbId == null && imdbId == null) return [];
+  return sortVersions(
+    readLocalLibrary().filter(
+      (e) =>
+        e.type === "movie" &&
+        ((tmdbId != null && e.tmdbId === tmdbId) || (imdbId != null && e.imdbId === imdbId)),
+    ),
+  );
+}
+
+/** Every local file for one episode, best first. */
+export function findLocalEpisodeVersions(
+  season: number,
+  episode: number,
+  tmdbId?: number | null,
+  imdbId?: string | null,
+): LocalEntry[] {
+  if (tmdbId == null && imdbId == null) return [];
+  return sortVersions(
+    readLocalLibrary().filter(
+      (e) =>
+        e.type === "show" &&
+        e.season === season &&
+        e.episode === episode &&
+        ((tmdbId != null && e.tmdbId === tmdbId) || (imdbId != null && e.imdbId === imdbId)),
+    ),
+  );
+}

--- a/src/lib/player/local-versions-modal.ts
+++ b/src/lib/player/local-versions-modal.ts
@@ -1,0 +1,39 @@
+import type { LocalEntry } from "@/lib/local-library";
+
+export type LocalVersionsPayload = {
+  title: string;
+  poster?: string | null;
+  entries: LocalEntry[];
+  onPlayLocal: (entry: LocalEntry) => void;
+};
+
+type LocalVersionsState = { open: boolean; payload: LocalVersionsPayload | null };
+
+let state: LocalVersionsState = { open: false, payload: null };
+const subs = new Set<() => void>();
+
+function emit(): void {
+  for (const fn of subs) fn();
+}
+
+export function openLocalVersions(payload: LocalVersionsPayload): void {
+  state = { open: true, payload };
+  emit();
+}
+
+export function closeLocalVersions(): void {
+  if (!state.open) return;
+  state = { open: false, payload: null };
+  emit();
+}
+
+export function getLocalVersions(): LocalVersionsState {
+  return state;
+}
+
+export function subscribeLocalVersions(fn: () => void): () => void {
+  subs.add(fn);
+  return () => {
+    subs.delete(fn);
+  };
+}

--- a/src/views/library.tsx
+++ b/src/views/library.tsx
@@ -1,5 +1,5 @@
 import { BarChart3, Bookmark, Clock, HardDrive, Layers, Library, Star } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import traktLogo from "@/assets/trakt.svg";
 import anilistLogo from "@/assets/anilist.png";
 import simklLogo from "@/assets/simkl.png";
@@ -27,6 +27,9 @@ import { TraktTab } from "./library/trakt-tab";
 import { WatchlistTab } from "./library/watchlist-tab";
 import { LetterboxdTab } from "./library/letterboxd-tab";
 import { pushActivityHint } from "@/lib/discord/activity-hint";
+import { HeroCarousel } from "@/components/hero-carousel";
+import { LibraryFeaturedProvider, useLibraryFeatured } from "./library/featured-context";
+import { pickFeatured } from "./library/featured-picks";
 
 const LIBRARY_TAB_KEY = "harbor.library.tab";
 
@@ -106,14 +109,14 @@ export function LibraryView({ active }: { active: boolean }) {
           : tab === "lists"
             ? "Browsing their lists"
             : tab === "trakt"
-            ? "Browsing their Trakt library"
-            : tab === "simkl"
-              ? "Browsing their Simkl library"
-              : tab === "letterboxd"
-                ? "Browsing their Letterboxd library"
-              : tab === "mal"
-                ? "Browsing their MyAnimeList library"
-                : "Browsing their Stremio library";
+              ? "Browsing their Trakt library"
+              : tab === "simkl"
+                ? "Browsing their Simkl library"
+                : tab === "letterboxd"
+                  ? "Browsing their Letterboxd library"
+                  : tab === "mal"
+                    ? "Browsing their MyAnimeList library"
+                    : "Browsing their Stremio library";
     return pushActivityHint({ details: label, state: "Library" });
   }, [active, tab]);
 
@@ -122,30 +125,48 @@ export function LibraryView({ active }: { active: boolean }) {
       ref={scrollRef}
       className="flex-1 overflow-y-auto px-5 pt-24 pb-14 sm:px-8 lg:px-12 lg:pt-28"
     >
-      <div {...contentDrag} className="flex flex-col gap-7">
-        <Header
-          tab={tab}
-          onTab={setTab}
-          traktConnected={traktConnected}
-          anilistConnected={anilistConnected}
-          malConnected={malConnected}
-          simklConnected={simklConnected}
-          lbConnected={lb.isActive}
-        />
-        {tab === "library" && <WatchlistTab mode="library" />}
-        {tab === "watchlist" && <WatchlistTab mode="watchlist" />}
-        {tab === "history" && <HistoryTab />}
-        {tab === "local" && <LocalTab />}
-        {tab === "lists" && <MyListsTab />}
-        {tab === "favorites" && <FavoritesTab />}
-        {tab === "trakt" && traktConnected && <TraktTab />}
-        {tab === "anilist" && anilistConnected && <AnilistTab />}
-        {tab === "simkl" && simklConnected && <SimklTab />}
-        {tab === "letterboxd" && lb.isActive && <LetterboxdTab />}
-        {tab === "mal" && malConnected && <MalTab />}
-      </div>
+      <LibraryFeaturedProvider>
+        <div {...contentDrag} className="flex flex-col gap-7">
+          <LibraryHero tabKey={tab} />
+          <Header
+            tab={tab}
+            onTab={setTab}
+            traktConnected={traktConnected}
+            anilistConnected={anilistConnected}
+            malConnected={malConnected}
+            simklConnected={simklConnected}
+            lbConnected={lb.isActive}
+          />
+          {tab === "library" && <WatchlistTab mode="library" />}
+          {tab === "watchlist" && <WatchlistTab mode="watchlist" />}
+          {tab === "history" && <HistoryTab />}
+          {tab === "local" && <LocalTab scrollRef={scrollRef} />}
+          {tab === "lists" && <MyListsTab />}
+          {tab === "favorites" && <FavoritesTab />}
+          {tab === "trakt" && traktConnected && <TraktTab />}
+          {tab === "anilist" && anilistConnected && <AnilistTab />}
+          {tab === "simkl" && simklConnected && <SimklTab />}
+          {tab === "letterboxd" && lb.isActive && <LetterboxdTab />}
+          {tab === "mal" && malConnected && <MalTab />}
+        </div>
+      </LibraryFeaturedProvider>
     </main>
   );
+}
+
+/**
+ * Featured carousel above the tab bar, drawn from whatever the open tab is
+ * showing. Hidden below two slides so a small or unhydrated tab doesn't render
+ * a dead carousel.
+ */
+function LibraryHero({ tabKey }: { tabKey: Tab }) {
+  const metas = useLibraryFeatured();
+  const slides = useMemo(
+    () => pickFeatured(metas, tabKey).map((meta) => ({ meta })),
+    [metas, tabKey],
+  );
+  if (slides.length < 2) return null;
+  return <HeroCarousel slides={slides} />;
 }
 
 function Header({
@@ -179,7 +200,9 @@ function Header({
             {t("Your collection.")}
           </h1>
           <p className="text-[14px] leading-snug text-ink-muted">
-            {t("Library is everything from Stremio, Trakt, and this device. Watchlist is only titles you haven't watched yet. History is what you've watched. Local is files on your computer.")}
+            {t(
+              "Library is everything from Stremio, Trakt, and this device. Watchlist is only titles you haven't watched yet. History is what you've watched. Local is files on your computer.",
+            )}
           </p>
         </div>
         {settings.wrappedButton && (

--- a/src/views/library/featured-context.tsx
+++ b/src/views/library/featured-context.tsx
@@ -1,0 +1,44 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { Meta } from "@/lib/cinemeta";
+
+type Ctx = {
+  metas: Meta[];
+  report: (metas: Meta[]) => void;
+};
+
+const FeaturedContext = createContext<Ctx | null>(null);
+
+/**
+ * Lets the open library tab publish what it is currently showing, so the hero
+ * above the tab bar can reflect it without lifting each tab's data pipeline.
+ * Only one tab is mounted at a time, so a single slot is enough.
+ */
+export function LibraryFeaturedProvider({ children }: { children: React.ReactNode }) {
+  const [metas, setMetas] = useState<Meta[]>([]);
+  const report = useCallback((next: Meta[]) => {
+    setMetas((prev) => (sameIds(prev, next) ? prev : next));
+  }, []);
+  const value = useMemo(() => ({ metas, report }), [metas, report]);
+  return <FeaturedContext.Provider value={value}>{children}</FeaturedContext.Provider>;
+}
+
+export function useLibraryFeatured(): Meta[] {
+  return useContext(FeaturedContext)?.metas ?? [];
+}
+
+/** Called by a tab with the list it is displaying. Clears on unmount. */
+export function useReportFeatured(metas: Meta[]): void {
+  const ctx = useContext(FeaturedContext);
+  const report = ctx?.report;
+  useEffect(() => {
+    if (!report) return;
+    report(metas);
+    return () => report([]);
+  }, [report, metas]);
+}
+
+function sameIds(a: Meta[], b: Meta[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i].id !== b[i].id) return false;
+  return true;
+}

--- a/src/views/library/featured-picks.ts
+++ b/src/views/library/featured-picks.ts
@@ -1,0 +1,54 @@
+import type { Meta } from "@/lib/cinemeta";
+
+export const FEATURED_COUNT = 4;
+
+/**
+ * Session-stable random picks, keyed by tab. The first call for a tab shuffles;
+ * later calls reuse the same ids, dropping any that have since disappeared and
+ * topping back up. Survives tab switches and re-renders; resets on restart.
+ *
+ * Deliberately free of runtime imports so it can be covered by the `node --test`
+ * harness, which does not resolve `@/` path aliases.
+ */
+const chosen = new Map<string, string[]>();
+
+export function pickFeatured(metas: Meta[], key: string, count = FEATURED_COUNT): Meta[] {
+  const byId = new Map<string, Meta>();
+  for (const m of metas) if (m.id && !byId.has(m.id)) byId.set(m.id, m);
+  if (byId.size === 0) {
+    chosen.delete(key);
+    return [];
+  }
+
+  const kept = (chosen.get(key) ?? []).filter((id) => byId.has(id));
+  if (kept.length < count) {
+    // Titles that already have artwork look right on first paint; Hero can
+    // self-heal the rest, so they are a fallback rather than a filter.
+    const taken = new Set(kept);
+    const rest = Array.from(byId.values()).filter((m) => !taken.has(m.id));
+    const withArt = shuffle(rest.filter((m) => !!m.background));
+    const withoutArt = shuffle(rest.filter((m) => !m.background));
+    for (const m of [...withArt, ...withoutArt]) {
+      if (kept.length >= count) break;
+      kept.push(m.id);
+    }
+  }
+
+  const ids = kept.slice(0, count);
+  chosen.set(key, ids);
+  return ids.map((id) => byId.get(id)!).filter(Boolean);
+}
+
+/** Test seam: forget the session's picks. */
+export function resetFeaturedPicks(): void {
+  chosen.clear();
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}

--- a/src/views/library/history-tab.tsx
+++ b/src/views/library/history-tab.tsx
@@ -27,6 +27,7 @@ import {
   type WatchlistMerged,
 } from "./shared";
 import { HistoryEpisodeCard } from "./history-episode-card";
+import { useReportFeatured } from "./featured-context";
 
 export type HistoryEntry = WatchlistMerged & {
   season?: number;
@@ -124,8 +125,8 @@ export function HistoryTab() {
   const toggleFlat = useCallback(() => {
     setFlat((v) => !v);
   }, []);
-  const [view, setView] = useState<HistoryView>(
-    () => (localStorage.getItem("harbor.history.view") === "episodes" ? "episodes" : "posters"),
+  const [view, setView] = useState<HistoryView>(() =>
+    localStorage.getItem("harbor.history.view") === "episodes" ? "episodes" : "posters",
   );
   const setViewPersist = useCallback((next: HistoryView) => {
     setView(next);
@@ -135,6 +136,7 @@ export function HistoryTab() {
   }, []);
   const counts = useMemo(() => countByType(merged), [merged]);
   const visible = useMemo(() => applyFilter(merged, type, query), [merged, type, query]);
+  useReportFeatured(useMemo(() => visible.map((v) => v.meta), [visible]));
   const groups = useMemo(() => {
     if (settings.librarySort !== "recent") return sortedGroups(visible, settings.librarySort);
     if (flat) {
@@ -257,7 +259,9 @@ function HistoryViewToggle({
       <button
         onClick={() => view !== "posters" && onChange("posters")}
         className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-semibold transition-colors ${
-          view === "posters" ? "bg-ink text-canvas" : "text-ink-muted hover:bg-raised hover:text-ink"
+          view === "posters"
+            ? "bg-ink text-canvas"
+            : "text-ink-muted hover:bg-raised hover:text-ink"
         }`}
       >
         {t("Posters")}
@@ -265,7 +269,9 @@ function HistoryViewToggle({
       <button
         onClick={() => view !== "episodes" && onChange("episodes")}
         className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-semibold transition-colors ${
-          view === "episodes" ? "bg-ink text-canvas" : "text-ink-muted hover:bg-raised hover:text-ink"
+          view === "episodes"
+            ? "bg-ink text-canvas"
+            : "text-ink-muted hover:bg-raised hover:text-ink"
         }`}
       >
         {t("Episodes")}
@@ -335,8 +341,7 @@ function filterHistory(items: LibraryItem[]): LibraryItem[] {
     )
     .sort(
       (a, b) =>
-        Date.parse(b.state?.lastWatched ?? b._mtime) -
-        Date.parse(a.state?.lastWatched ?? a._mtime),
+        Date.parse(b.state?.lastWatched ?? b._mtime) - Date.parse(a.state?.lastWatched ?? a._mtime),
     );
 }
 
@@ -392,7 +397,7 @@ function mergeHistory(stremio: LibraryItem[], trakt: HistoryItem[]): HistoryEntr
       meta: {
         id,
         type: h.type === "movie" ? "movie" : "series",
-        name: h.type === "movie" ? h.title : (h.showImdb ? "" : h.title),
+        name: h.type === "movie" ? h.title : h.showImdb ? "" : h.title,
       },
       date: parseTs(h.watchedAt),
       progress: 0,

--- a/src/views/library/letterboxd-tab.tsx
+++ b/src/views/library/letterboxd-tab.tsx
@@ -14,6 +14,7 @@ import {
   type TypeKey,
   type WatchlistMerged,
 } from "./shared";
+import { useReportFeatured } from "./featured-context";
 
 export function LetterboxdTab() {
   const tr = useT();
@@ -66,6 +67,7 @@ export function LetterboxdTab() {
 
   const counts = useMemo(() => countByType(items), [items]);
   const visible = useMemo(() => applyFilter(items, type, query), [items, type, query]);
+  useReportFeatured(useMemo(() => visible.map((v) => v.meta), [visible]));
 
   return (
     <section className="flex flex-col gap-6">
@@ -80,28 +82,20 @@ export function LetterboxdTab() {
         />
       )}
 
-      {status === "loading" && (
-        <p className="text-[13px] text-ink-muted">{tr("Loading…")}</p>
-      )}
+      {status === "loading" && <p className="text-[13px] text-ink-muted">{tr("Loading…")}</p>}
       {status === "error" && (
         <p className="rounded-lg bg-danger/15 px-3 py-2 text-[12px] text-danger ring-1 ring-danger/30">
           {tr("Couldn't reach Letterboxd. Try refreshing.")}
         </p>
       )}
       {status === "ready" && items.length === 0 && (
-        <p className="text-[13px] text-ink-muted">
-          {tr("Your Letterboxd watchlist is empty.")}
-        </p>
+        <p className="text-[13px] text-ink-muted">{tr("Your Letterboxd watchlist is empty.")}</p>
       )}
       {status === "ready" && visible.length === 0 && items.length > 0 && (
-        <p className="text-[13px] text-ink-muted">
-          {tr("No matches for these filters.")}
-        </p>
+        <p className="text-[13px] text-ink-muted">{tr("No matches for these filters.")}</p>
       )}
 
-      {visible.length > 0 && (
-        <GroupedGrid groups={sortedGroups(visible, settings.librarySort)} />
-      )}
+      {visible.length > 0 && <GroupedGrid groups={sortedGroups(visible, settings.librarySort)} />}
     </section>
   );
 }

--- a/src/views/library/local-tab.tsx
+++ b/src/views/library/local-tab.tsx
@@ -1,5 +1,12 @@
-import { AlertTriangle, CheckSquare, FolderOpen, FolderPlus, HardDrive, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  CheckSquare,
+  FolderOpen,
+  FolderPlus,
+  HardDrive,
+  Loader2,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
   localEntryToMeta,
   removeLocalEntry,
@@ -11,19 +18,33 @@ import { confirmDialog } from "@/lib/dialog";
 import { useView } from "@/lib/view";
 import { useT } from "@/lib/i18n";
 import { FilterBar, Grid, type TypeKey } from "./shared";
+import { VirtualGrid } from "@/components/virtual-grid";
 import { groupLocal, ShowGroupCard } from "./local-tab/show-group";
 import { ScanModeModal } from "./local-tab/scan-mode-modal";
 import { IdentifyModal, type IdentifyResolution } from "./local-tab/identify-modal";
 import { type LocalCardProps } from "./local-tab/card-actions";
 import { OwnedCard } from "./local-tab/movie-card";
-import { BulkBar, SortMenu, sortGroups, type LocalSortKey, type SortDir } from "./local-tab/toolbar";
+import {
+  BulkBar,
+  GenreMenu,
+  SortMenu,
+  sortGroups,
+  type GenreOption,
+  type LocalSortKey,
+  type SortDir,
+} from "./local-tab/toolbar";
+import { useSettings } from "@/lib/settings";
 import { FoldersModal } from "./local-tab/folders-modal";
 import { useLocalExport } from "./local-tab/use-local-export";
 import { useLocalScan } from "./local-tab/use-local-scan";
+import { LocalCwRow } from "./local-tab/cw-row";
+import { useReportFeatured } from "./featured-context";
 
 type Tr = (key: string, vars?: Record<string, string | number>) => string;
 
-export function LocalTab() {
+/** `scrollRef` is the scroll container the grid virtualizes against. The cast
+ *  modal has no scroller of its own, so it renders the plain grid instead. */
+export function LocalTab({ scrollRef }: { scrollRef?: RefObject<HTMLElement | null> }) {
   const t = useT();
   const { openMeta } = useView();
   const items = useLocalLibrary();
@@ -82,6 +103,8 @@ export function LocalTab() {
     exitSelect();
   }, [selected, exitSelect, t]);
 
+  const { settings } = useSettings();
+
   const bulkExport = useCallback(async () => {
     const list = items.filter((i) => selected.has(i.id) && i.tmdbId != null);
     if (list.length === 0) {
@@ -99,15 +122,41 @@ export function LocalTab() {
     exitSelect();
   }, [items, selected, runExport, exitSelect, t]);
 
+  // Matches the column width Grid derives in ./shared, so the virtualized rows
+  // keep the same density as the rest of the library tabs.
+  const posterWidth = Math.round(150 * settings.posterScale);
   const [type, setType] = useState<TypeKey>("all");
   const [query, setQuery] = useState("");
   const [sortKey, setSortKey] = useState<LocalSortKey>("added");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [genres, setGenres] = useState<Set<string>>(() => new Set());
+  const genreOptions = useMemo<GenreOption[]>(() => {
+    const counts = new Map<string, number>();
+    for (const it of items) {
+      for (const g of it.genres ?? []) counts.set(g, (counts.get(g) ?? 0) + 1);
+    }
+    return Array.from(counts, ([name, count]) => ({ name, count })).sort(
+      (a, b) => b.count - a.count || a.name.localeCompare(b.name),
+    );
+  }, [items]);
+  const toggleGenre = useCallback((genre: string) => {
+    setGenres((prev) => {
+      const next = new Set(prev);
+      if (next.has(genre)) next.delete(genre);
+      else next.add(genre);
+      return next;
+    });
+  }, []);
+  const clearGenres = useCallback(() => setGenres(new Set()), []);
   const reviewGroups = useMemo(
     () =>
       groupLocal(items)
-        .filter((g) => (g.kind === "movie" ? g.entry.needsReview : g.episodes.some((e) => e.needsReview)))
-        .map((g) => (g.kind === "movie" ? [g.entry] : g.episodes)),
+        .filter((g) =>
+          g.kind === "movie"
+            ? g.versions.some((e) => e.needsReview)
+            : g.episodes.some((e) => e.needsReview),
+        )
+        .map((g) => (g.kind === "movie" ? g.versions : g.episodes)),
     [items],
   );
   const reviewCount = reviewGroups.length;
@@ -125,9 +174,12 @@ export function LocalTab() {
       if (type === "movie" && it.type !== "movie") return false;
       if (type === "series" && it.type !== "show") return false;
       if (q && !(it.title ?? "").toLowerCase().includes(q)) return false;
+      // OR across selected genres; entries scanned before genres were captured
+      // have none and drop out while a genre filter is active.
+      if (genres.size > 0 && !(it.genres ?? []).some((g) => genres.has(g))) return false;
       return true;
     });
-  }, [items, type, query]);
+  }, [items, type, query, genres]);
   const groups = useMemo(
     () => sortGroups(groupLocal(visible), sortKey, sortDir),
     [visible, sortKey, sortDir],
@@ -156,6 +208,18 @@ export function LocalTab() {
       toggleSelect(ids);
     },
     [groups, toggleSelect],
+  );
+
+  // localEntryToMeta returns null without a tmdb/imdb id, and the hero needs a
+  // resolvable id to fetch a backdrop, so unidentified files are left out.
+  useReportFeatured(
+    useMemo(
+      () =>
+        groups
+          .map((g) => localEntryToMeta(g.kind === "movie" ? g.entry : g.head))
+          .filter((m): m is NonNullable<typeof m> => m != null),
+      [groups],
+    ),
   );
 
   const openFirstReview = useCallback(() => {
@@ -189,6 +253,29 @@ export function LocalTab() {
     void scan.onAddFolder();
   }, [scan]);
 
+  const onFixMatchCb = useCallback((e: LocalEntry | LocalEntry[]) => {
+    setIdentify(Array.isArray(e) ? e : [e]);
+  }, []);
+  const onOpenDetailCb = useCallback(
+    (e: LocalEntry) => {
+      const m = localEntryToMeta(e);
+      if (m) openMeta(m);
+    },
+    [openMeta],
+  );
+  // Stable identity keeps the memoized cards from re-rendering on every toast,
+  // scan-progress tick or selection change.
+  const cardProps: LocalCardProps = useMemo(
+    () => ({
+      selectMode,
+      onToggleSelect: selectItems,
+      onFixMatch: onFixMatchCb,
+      onExport: onExportOne,
+      onOpenDetail: onOpenDetailCb,
+    }),
+    [selectMode, selectItems, onFixMatchCb, onExportOne, onOpenDetailCb],
+  );
+
   const modals = (
     <>
       <ScanModeModal
@@ -197,7 +284,11 @@ export function LocalTab() {
         onPick={scan.onPickMode}
         onClose={() => scan.setPending(null)}
       />
-      <IdentifyModal target={identify} onClose={() => setIdentify(null)} onResolved={onResolveIdentify} />
+      <IdentifyModal
+        target={identify}
+        onClose={() => setIdentify(null)}
+        onResolved={onResolveIdentify}
+      />
       <FoldersModal
         isOpen={showFolders}
         folders={scan.folders}
@@ -222,22 +313,15 @@ export function LocalTab() {
     return (
       <>
         {modals}
-        <EmptyOwned onAddFolder={scan.onAddFolder} busy={scan.busy} error={scan.error} progress={scan.progress} />
+        <EmptyOwned
+          onAddFolder={scan.onAddFolder}
+          busy={scan.busy}
+          error={scan.error}
+          progress={scan.progress}
+        />
       </>
     );
   }
-
-  const cardProps: LocalCardProps = {
-    selectMode,
-    selected,
-    onToggleSelect: selectItems,
-    onFixMatch: (e) => setIdentify(Array.isArray(e) ? e : [e]),
-    onExport: onExportOne,
-    onOpenDetail: (e) => {
-      const m = localEntryToMeta(e);
-      if (m) openMeta(m);
-    },
-  };
 
   return (
     <section className="flex flex-col gap-4">
@@ -250,6 +334,12 @@ export function LocalTab() {
         counts={counts}
         trailing={
           <div className="ms-auto flex items-center gap-2">
+            <GenreMenu
+              options={genreOptions}
+              selected={genres}
+              onToggle={toggleGenre}
+              onClear={clearGenres}
+            />
             <SortMenu
               sortKey={sortKey}
               setSortKey={setSortKey}
@@ -294,6 +384,7 @@ export function LocalTab() {
           </div>
         }
       />
+      {!selectMode && <LocalCwRow />}
       {selectMode ? (
         <BulkBar
           count={selected.size}
@@ -323,8 +414,14 @@ export function LocalTab() {
       ) : null}
       <span className="text-[12px] text-ink-muted">
         {items.length === 1
-          ? t("{shown} of {total} file from your computer", { shown: visible.length, total: items.length })
-          : t("{shown} of {total} files from your computer", { shown: visible.length, total: items.length })}
+          ? t("{shown} of {total} file from your computer", {
+              shown: visible.length,
+              total: items.length,
+            })
+          : t("{shown} of {total} files from your computer", {
+              shown: visible.length,
+              total: items.length,
+            })}
       </span>
       {scan.error && (
         <p className="rounded-lg bg-danger/15 px-3 py-2 text-[12px] text-danger ring-1 ring-danger/30">
@@ -332,16 +429,62 @@ export function LocalTab() {
         </p>
       )}
       {groups.length === 0 ? (
-        <p className="rounded-2xl border border-dashed border-edge-soft bg-canvas/30 px-6 py-10 text-center text-[13px] text-ink-muted">
-          {t("No matches for these filters.")}
-        </p>
+        <div className="flex flex-col gap-1.5 rounded-2xl border border-dashed border-edge-soft bg-canvas/30 px-6 py-10 text-center">
+          <p className="text-[13px] text-ink-muted">{t("No matches for these filters.")}</p>
+          {genres.size > 0 && (
+            <p className="text-[12px] text-ink-subtle">
+              {t(
+                "Genres are only recorded for files scanned after this feature was added — re-add a folder to pick them up.",
+              )}
+            </p>
+          )}
+        </div>
+      ) : scrollRef ? (
+        <VirtualGrid
+          items={groups}
+          scrollRef={scrollRef}
+          minColumnWidth={posterWidth}
+          gapX={16}
+          gapY={32}
+          estimateRowHeight={Math.round(posterWidth * 1.5) + 46}
+          getKey={(g) => g.key}
+          renderItem={(g) =>
+            g.kind === "movie" ? (
+              <OwnedCard
+                entry={g.entry}
+                versions={g.versions}
+                isSelected={g.versions.every((v) => selected.has(v.id))}
+                {...cardProps}
+              />
+            ) : (
+              <ShowGroupCard
+                head={g.head}
+                episodes={g.episodes}
+                isSelected={g.episodes.every((e) => selected.has(e.id))}
+                {...cardProps}
+              />
+            )
+          }
+        />
       ) : (
         <Grid>
           {groups.map((g) =>
             g.kind === "movie" ? (
-              <OwnedCard key={g.entry.id} entry={g.entry} {...cardProps} />
+              <OwnedCard
+                key={g.key}
+                entry={g.entry}
+                versions={g.versions}
+                isSelected={g.versions.every((v) => selected.has(v.id))}
+                {...cardProps}
+              />
             ) : (
-              <ShowGroupCard key={g.key} head={g.head} episodes={g.episodes} {...cardProps} />
+              <ShowGroupCard
+                key={g.key}
+                head={g.head}
+                episodes={g.episodes}
+                isSelected={g.episodes.every((e) => selected.has(e.id))}
+                {...cardProps}
+              />
             ),
           )}
         </Grid>
@@ -373,7 +516,9 @@ function EmptyOwned({
       <div className="flex flex-col gap-1.5">
         <h2 className="text-[18px] font-semibold text-ink">{t("Add files from your computer")}</h2>
         <p className="max-w-md text-[13px] leading-relaxed text-ink-muted">
-          {t("Point Harbor at a folder. We scan it for movies and shows, parse titles from filenames, and enrich them with TMDB so they look the same as everything else here. We just remember the path; nothing is copied or moved.")}
+          {t(
+            "Point Harbor at a folder. We scan it for movies and shows, parse titles from filenames, and enrich them with TMDB so they look the same as everything else here. We just remember the path; nothing is copied or moved.",
+          )}
         </p>
       </div>
       <button
@@ -382,7 +527,11 @@ function EmptyOwned({
         disabled={busy}
         className="flex h-11 items-center gap-2 rounded-full bg-ink px-5 text-[13.5px] font-semibold text-canvas transition-colors hover:bg-ink/90 disabled:cursor-wait disabled:opacity-60"
       >
-        {busy ? <Loader2 size={15} className="animate-spin" /> : <FolderPlus size={15} strokeWidth={2.2} />}
+        {busy ? (
+          <Loader2 size={15} className="animate-spin" />
+        ) : (
+          <FolderPlus size={15} strokeWidth={2.2} />
+        )}
         {busy ? scanLabel(progress, t) : t("Choose folder")}
       </button>
       {error && (

--- a/src/views/library/local-tab/card-actions.tsx
+++ b/src/views/library/local-tab/card-actions.tsx
@@ -1,8 +1,12 @@
 import type { LocalEntry } from "@/lib/local-library";
 
+/**
+ * Shared, stable-identity props for every local card. Selection is passed as a
+ * per-card boolean rather than the Set, so replacing the Set on each toggle
+ * doesn't defeat React.memo across the whole grid.
+ */
 export type LocalCardProps = {
   selectMode: boolean;
-  selected: Set<string>;
   onToggleSelect: (ids: string[], range?: boolean) => void;
   onFixMatch: (entries: LocalEntry | LocalEntry[]) => void;
   onExport: (entries: LocalEntry | LocalEntry[]) => void;
@@ -27,7 +31,7 @@ export function CardIconButton({
       }}
       aria-label={title}
       title={title}
-      className="flex h-7 w-7 items-center justify-center rounded-full bg-canvas/70 text-ink opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.4)] backdrop-blur-sm transition-all duration-200 hover:bg-canvas/90 group-hover:opacity-100"
+      className="flex h-7 w-7 items-center justify-center rounded-full bg-canvas/70 text-ink opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-opacity duration-200 hover:bg-canvas/90 group-hover:opacity-100"
     >
       {children}
     </button>

--- a/src/views/library/local-tab/cw-row.tsx
+++ b/src/views/library/local-tab/cw-row.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from "react";
+import { ContinueCard } from "@/components/continue-card";
+import { Row } from "@/components/row";
+import { useT } from "@/lib/i18n";
+import { useView } from "@/lib/view";
+import { clearLocalCw } from "@/lib/local-cw";
+import type { LibraryItem } from "@/lib/stremio";
+import type { LocalEntry } from "@/lib/local-library";
+import { localPlayerSrc } from "@/lib/local-library/player-src";
+import { findLocalMovieVersions, findLocalEpisodeVersions } from "@/lib/local-library/versions";
+import { openLocalVersions } from "@/lib/player/local-versions-modal";
+import { useLocalContinueWatching } from "@/lib/local-library/use-local-cw";
+
+/**
+ * Continue Watching for files on disk. Same store, item shape and card as the
+ * Home row; scoped to the local library and hidden when nothing is in progress.
+ */
+export function LocalCwRow() {
+  const t = useT();
+  const { openPlayer } = useView();
+  const cards = useLocalContinueWatching();
+
+  const play = useCallback(
+    (entry: LocalEntry, item: LibraryItem) => {
+      const versions =
+        entry.type === "show" && entry.season != null && entry.episode != null
+          ? findLocalEpisodeVersions(entry.season, entry.episode, entry.tmdbId, entry.imdbId)
+          : findLocalMovieVersions(entry.tmdbId, entry.imdbId);
+      const start = (target: LocalEntry) => {
+        const src = localPlayerSrc(target);
+        // Keep the CW id so playback resumes and updates the same entry.
+        openPlayer({ ...src, meta: { ...src.meta, id: item._id } });
+      };
+      if (versions.length > 1) {
+        openLocalVersions({
+          title: entry.title,
+          poster: item.poster ?? entry.poster ?? null,
+          entries: versions,
+          onPlayLocal: start,
+        });
+        return;
+      }
+      start(entry);
+    },
+    [openPlayer],
+  );
+
+  const onDismiss = useCallback((item: LibraryItem) => clearLocalCw(item._id), []);
+
+  if (cards.length === 0) return null;
+
+  return (
+    <Row title={t("Continue Watching")} min={260} shape="landscape" scrollKey="library:local:cw">
+      {cards.map(({ item, entry }) => (
+        <ContinueCard
+          key={item._id}
+          item={item}
+          onDismiss={onDismiss}
+          onPlayOverride={() => play(entry, item)}
+        />
+      ))}
+    </Row>
+  );
+}

--- a/src/views/library/local-tab/movie-card.tsx
+++ b/src/views/library/local-tab/movie-card.tsx
@@ -3,13 +3,14 @@ import {
   CheckSquare,
   Download,
   Info,
+  Layers,
   Play,
   RefreshCw,
   Square,
   Trash2,
   Wand2,
 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { Poster } from "@/components/poster";
 import { removeLocalEntry, type LocalEntry } from "@/lib/local-library";
 import { useView } from "@/lib/view";
@@ -18,35 +19,50 @@ import { LocalBadge } from "@/components/local-badge";
 import { CardIconButton, type LocalCardProps } from "./card-actions";
 import { episodeLabel, localPlayerSrc } from "./show-group";
 import { useLocalPoster } from "./use-local-poster";
+import { openLocalVersions } from "@/lib/player/local-versions-modal";
 
-export function OwnedCard({
+function OwnedCardImpl({
   entry,
+  versions,
   selectMode,
-  selected,
+  isSelected,
   onToggleSelect,
   onFixMatch,
   onExport,
   onOpenDetail,
-}: { entry: LocalEntry } & LocalCardProps) {
+}: { entry: LocalEntry; versions: LocalEntry[]; isSelected: boolean } & LocalCardProps) {
   const t = useT();
   const [confirm, setConfirm] = useState(false);
   const { openPlayer } = useView();
-  const isSelected = selected.has(entry.id);
   const poster = useLocalPoster(entry);
 
   const epLabel = episodeLabel(entry);
+  const versionCount = versions.length;
+  const ids = useMemo(() => versions.map((v) => v.id), [versions]);
   const onActivate = useCallback(
     (range = false) => {
-      if (selectMode) onToggleSelect([entry.id], range);
-      else openPlayer(localPlayerSrc(entry));
+      if (selectMode) {
+        onToggleSelect(ids, range);
+        return;
+      }
+      if (versionCount > 1) {
+        openLocalVersions({
+          title: entry.title,
+          poster: poster.src,
+          entries: versions,
+          onPlayLocal: (v) => openPlayer(localPlayerSrc(v)),
+        });
+        return;
+      }
+      openPlayer(localPlayerSrc(entry));
     },
-    [selectMode, entry, openPlayer, onToggleSelect],
+    [selectMode, entry, versions, versionCount, ids, poster.src, openPlayer, onToggleSelect],
   );
 
   return (
     <div
       className="group relative flex flex-col gap-2 text-start"
-      onMouseLeave={() => setConfirm(false)}
+      onMouseLeave={() => confirm && setConfirm(false)}
     >
       <div
         role="button"
@@ -67,9 +83,15 @@ export function OwnedCard({
           onError={poster.onError}
           seed={entry.id}
           lazy
-          className="h-full w-full transition-transform duration-200 group-hover:scale-[1.02]"
+          className="h-full w-full transition-transform duration-200 will-change-transform [transform:translate3d(0,0,0)] group-hover:scale-[1.02]"
         />
         <LocalBadge label={entry.resolution ?? t("local")} className="absolute start-2 top-2" />
+        {versionCount > 1 && (
+          <span className="absolute bottom-2 end-2 inline-flex items-center gap-1 rounded-md bg-canvas/85 px-2 py-0.5 text-[10.5px] font-semibold text-ink">
+            <Layers size={11} strokeWidth={2.2} />
+            {versionCount}
+          </span>
+        )}
         {entry.needsReview && !selectMode && (
           <span className="absolute bottom-2 start-2 inline-flex items-center gap-1 rounded-md bg-amber-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-black">
             <AlertTriangle size={9} strokeWidth={2.6} />
@@ -79,10 +101,16 @@ export function OwnedCard({
         {selectMode && (
           <span
             className={`absolute end-2 top-2 flex h-6 w-6 items-center justify-center rounded-md ${
-              isSelected ? "bg-accent text-white" : "bg-canvas/80 text-ink-subtle ring-1 ring-edge-soft"
+              isSelected
+                ? "bg-accent text-white"
+                : "bg-canvas/80 text-ink-subtle ring-1 ring-edge-soft"
             }`}
           >
-            {isSelected ? <CheckSquare size={14} strokeWidth={2.4} /> : <Square size={14} strokeWidth={2.2} />}
+            {isSelected ? (
+              <CheckSquare size={14} strokeWidth={2.4} />
+            ) : (
+              <Square size={14} strokeWidth={2.2} />
+            )}
           </span>
         )}
         {!selectMode && (
@@ -98,11 +126,14 @@ export function OwnedCard({
                   <Info size={11} strokeWidth={2.2} />
                 </CardIconButton>
               )}
-              <CardIconButton title={t("Fix match")} onClick={() => onFixMatch([entry])}>
+              <CardIconButton title={t("Fix match")} onClick={() => onFixMatch(versions)}>
                 <Wand2 size={11} strokeWidth={2.2} />
               </CardIconButton>
               {entry.tmdbId != null && (
-                <CardIconButton title={t("Export .nfo and artwork")} onClick={() => onExport(entry)}>
+                <CardIconButton
+                  title={t("Export .nfo and artwork")}
+                  onClick={() => onExport(versions)}
+                >
                   <Download size={11} strokeWidth={2.2} />
                 </CardIconButton>
               )}
@@ -111,41 +142,59 @@ export function OwnedCard({
                 onClick={(e) => {
                   e.stopPropagation();
                   if (confirm) {
-                    removeLocalEntry(entry.id);
+                    for (const v of versions) removeLocalEntry(v.id);
                     setConfirm(false);
                   } else {
                     setConfirm(true);
                   }
                 }}
-                className={`flex h-7 w-7 items-center justify-center rounded-full text-white shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-all duration-200 ${
+                className={`flex h-7 w-7 items-center justify-center rounded-full text-white shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-[opacity,background-color] duration-200 ${
                   confirm
                     ? "bg-danger"
-                    : "bg-canvas/70 opacity-0 backdrop-blur-sm hover:bg-canvas/90 group-hover:opacity-100"
+                    : "bg-canvas/80 opacity-0 hover:bg-canvas/95 group-hover:opacity-100"
                 }`}
-                aria-label={confirm ? t("Confirm remove") : t("Remove from library")}
+                aria-label={
+                  confirm
+                    ? versionCount > 1
+                      ? t("Confirm removing {n} files", { n: versionCount })
+                      : t("Confirm remove")
+                    : t("Remove from library")
+                }
               >
-                {confirm ? <RefreshCw size={11} strokeWidth={2.4} /> : <Trash2 size={11} strokeWidth={2.2} />}
+                {confirm ? (
+                  <RefreshCw size={11} strokeWidth={2.4} />
+                ) : (
+                  <Trash2 size={11} strokeWidth={2.2} />
+                )}
               </button>
             </div>
           </>
         )}
       </div>
       <button type="button" onClick={(e) => onActivate(e.shiftKey)} className="text-start">
-        <p className="truncate text-[13px] font-medium text-ink transition-colors hover:text-accent" title={entry.filename}>
+        <p
+          className="truncate text-[13px] font-medium text-ink transition-colors hover:text-accent"
+          title={entry.filename}
+        >
           {entry.title}
         </p>
         {epLabel ? (
           <p className="-mt-1.5 truncate text-[11.5px] text-ink-subtle">
             {epLabel}
             {entry.year ? ` · ${entry.year}` : ""}
+            {versionCount > 1 && ` · ${t("{n} versions", { n: versionCount })}`}
           </p>
-        ) : entry.year != null ? (
+        ) : entry.year != null || versionCount > 1 ? (
           <p className="-mt-1.5 truncate text-[11.5px] text-ink-subtle">
-            {entry.year}
+            {entry.year ?? ""}
             {entry.type === "show" && t(" · Series")}
+            {versionCount > 1 &&
+              `${entry.year != null ? " · " : ""}${t("{n} versions", { n: versionCount })}`}
           </p>
         ) : null}
       </button>
     </div>
   );
 }
+
+export const OwnedCard = memo(OwnedCardImpl);

--- a/src/views/library/local-tab/scan.ts
+++ b/src/views/library/local-tab/scan.ts
@@ -22,6 +22,7 @@ export type TmdbLookup = {
   rating?: number;
   runtime?: number;
   isAnime?: boolean;
+  genres?: string[];
 };
 
 const ANIMATION_GENRE_ID = 16;
@@ -40,7 +41,8 @@ export async function buildTmdbEntry(
   tmdbKey: string | null,
 ): Promise<LocalEntry> {
   let tmdb: TmdbLookup = {};
-  if (tmdbKey) tmdb = await tmdbLookup(tmdbKey, parsed.title, parsed.year, parsed.type).catch(() => ({}));
+  if (tmdbKey)
+    tmdb = await tmdbLookup(tmdbKey, parsed.title, parsed.year, parsed.type).catch(() => ({}));
   const needsReview = tmdbKey ? lowConfidence(parsed, tmdb) : false;
   const identified = tmdb.tmdbId != null && !needsReview;
   return {
@@ -51,8 +53,10 @@ export async function buildTmdbEntry(
     year: (identified ? tmdb.matchedYear : null) ?? parsed.year,
     type: parsed.type,
     resolution: parsed.resolution,
+    size: f.size ?? null,
     rating: tmdb.rating ?? null,
     runtime: tmdb.runtime ?? null,
+    genres: tmdb.genres ?? null,
     poster: tmdb.poster ?? null,
     tmdbId: tmdb.tmdbId ?? null,
     imdbId: tmdb.imdbId ?? null,
@@ -99,15 +103,20 @@ export async function buildNfoEntry(
   let rating = meta?.rating ?? null;
   let runtime = meta?.runtime ?? null;
   let isAnime = false;
+  // The .nfo wins; TMDB only fills the gap when the file carries no <genre>.
+  let genres = meta?.genres ?? nfo?.genres ?? null;
 
   if (tmdbKey && !tmdbId) {
-    const look = await tmdbLookup(tmdbKey, title, year, parsed.type).catch(() => ({} as TmdbLookup));
+    const look = await tmdbLookup(tmdbKey, title, year, parsed.type).catch(
+      () => ({}) as TmdbLookup,
+    );
     if (look.tmdbId) tmdbId = look.tmdbId;
     if (!imdbId && look.imdbId) imdbId = look.imdbId;
     if (!art.poster && look.poster) poster = look.poster;
     if (rating == null && look.rating != null) rating = look.rating;
     if (runtime == null && look.runtime != null) runtime = look.runtime;
     if (look.isAnime) isAnime = true;
+    if (genres == null && look.genres != null) genres = look.genres;
     const hadNfoTitle = isShow ? !!(meta?.title || nfo?.showTitle) : !!nfo?.title;
     if (!hadNfoTitle && look.matchedTitle) title = look.matchedTitle.trim();
   }
@@ -123,8 +132,10 @@ export async function buildNfoEntry(
     year,
     type: parsed.type,
     resolution: parsed.resolution,
+    size: f.size ?? null,
     rating,
     runtime,
+    genres,
     poster,
     tmdbId,
     imdbId,
@@ -184,6 +195,7 @@ async function tmdbLookup(
   let rating: number | undefined;
   let runtime: number | undefined;
   let isAnime = Array.isArray(top.genre_ids) && top.genre_ids.includes(ANIMATION_GENRE_ID);
+  let genres: string[] | undefined;
   try {
     const dparams = new URLSearchParams({ api_key: key, append_to_response: "external_ids" });
     if (lang) dparams.set("language", lang);
@@ -193,13 +205,18 @@ async function tmdbLookup(
       const imdb = dj.imdb_id ?? dj.external_ids?.imdb_id;
       if (typeof imdb === "string" && imdb.startsWith("tt")) imdbId = imdb;
       if (typeof dj.vote_average === "number" && dj.vote_average > 0) rating = dj.vote_average;
-      if (type === "movie" && typeof dj.runtime === "number" && dj.runtime > 0) runtime = dj.runtime;
+      if (type === "movie" && typeof dj.runtime === "number" && dj.runtime > 0)
+        runtime = dj.runtime;
       if (type === "show" && Array.isArray(dj.episode_run_time) && dj.episode_run_time[0] > 0) {
         runtime = dj.episode_run_time[0];
       }
+      // Already in the response we fetch for imdb_id/runtime — no extra request.
       if (Array.isArray(dj.genres)) {
-        isAnime =
-          isAnime || dj.genres.some((g: { id?: number }) => g.id === ANIMATION_GENRE_ID);
+        isAnime = isAnime || dj.genres.some((g: { id?: number }) => g.id === ANIMATION_GENRE_ID);
+        const names = dj.genres
+          .map((g: { name?: unknown }) => (typeof g?.name === "string" ? g.name.trim() : ""))
+          .filter((n: string) => n.length > 0);
+        if (names.length > 0) genres = names;
       }
     }
   } catch {
@@ -218,5 +235,6 @@ async function tmdbLookup(
     rating,
     runtime,
     isAnime,
+    genres,
   };
 }

--- a/src/views/library/local-tab/show-group.tsx
+++ b/src/views/library/local-tab/show-group.tsx
@@ -9,9 +9,10 @@ import {
   Trash2,
   Wand2,
 } from "lucide-react";
-import { useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { Poster } from "@/components/poster";
 import { removeLocalEntry, type LocalEntry } from "@/lib/local-library";
+import { localGroupKey, sortVersions } from "@/lib/local-library/versions";
 import { useView } from "@/lib/view";
 import { useT } from "@/lib/i18n";
 import { LocalBadge } from "@/components/local-badge";
@@ -23,15 +24,26 @@ import { useLocalPoster } from "./use-local-poster";
 export { episodeLabel, localPlayerSrc };
 
 export type LocalGroup =
-  | { kind: "movie"; entry: LocalEntry }
+  /** `entry` is the best version; `versions` holds every file for this movie. */
+  | { kind: "movie"; key: string; entry: LocalEntry; versions: LocalEntry[] }
   | { kind: "show"; key: string; head: LocalEntry; episodes: LocalEntry[] };
 
 export function groupLocal(items: LocalEntry[]): LocalGroup[] {
   const out: LocalGroup[] = [];
   const showIdx = new Map<string, number>();
+  const movieIdx = new Map<string, number>();
   for (const it of items) {
     if (it.type !== "show") {
-      out.push({ kind: "movie", entry: it });
+      // Two files of the same movie (different quality, source or cut) collapse
+      // into a single card; the versions are offered when you press play.
+      const key = localGroupKey(it);
+      const at = movieIdx.get(key);
+      if (at != null) {
+        (out[at] as { versions: LocalEntry[] }).versions.push(it);
+      } else {
+        movieIdx.set(key, out.length);
+        out.push({ kind: "movie", key, entry: it, versions: [it] });
+      }
       continue;
     }
     const key = (it.imdbId || it.title || it.filename).toLowerCase();
@@ -44,31 +56,39 @@ export function groupLocal(items: LocalEntry[]): LocalGroup[] {
     }
   }
   for (const g of out) {
-    if (g.kind !== "show") continue;
-    g.episodes.sort((a, b) => (a.season ?? 0) - (b.season ?? 0) || (a.episode ?? 0) - (b.episode ?? 0));
+    if (g.kind === "movie") {
+      if (g.versions.length > 1) {
+        g.versions = sortVersions(g.versions);
+        g.entry = g.versions[0];
+      }
+      continue;
+    }
+    g.episodes.sort(
+      (a, b) => (a.season ?? 0) - (b.season ?? 0) || (a.episode ?? 0) - (b.episode ?? 0),
+    );
     g.head = g.episodes.find((e) => e.poster) ?? g.episodes[0];
   }
   return out;
 }
 
-export function ShowGroupCard({
+function ShowGroupCardImpl({
   head,
   episodes,
   selectMode,
-  selected,
+  isSelected,
   onToggleSelect,
   onFixMatch,
   onExport,
   onOpenDetail,
-}: { head: LocalEntry; episodes: LocalEntry[] } & LocalCardProps) {
+}: { head: LocalEntry; episodes: LocalEntry[]; isSelected: boolean } & LocalCardProps) {
   const t = useT();
   const { openPlayer } = useView();
   const [confirm, setConfirm] = useState(false);
   const poster = useLocalPoster(head);
-  const episodeIds = episodes.map((e) => e.id);
-  const isSelected = episodeIds.every((id) => selected.has(id));
+  const episodeIds = useMemo(() => episodes.map((e) => e.id), [episodes]);
   const needsReview = episodes.some((e) => e.needsReview);
-  const countLabel = episodes.length === 1 ? t("1 episode") : t("{n} episodes", { n: episodes.length });
+  const countLabel =
+    episodes.length === 1 ? t("1 episode") : t("{n} episodes", { n: episodes.length });
   const onActivate = (range = false) => {
     if (selectMode) {
       onToggleSelect(episodeIds, range);
@@ -83,7 +103,10 @@ export function ShowGroupCard({
     });
   };
   return (
-    <div className="group relative flex flex-col gap-2 text-start" onMouseLeave={() => setConfirm(false)}>
+    <div
+      className="group relative flex flex-col gap-2 text-start"
+      onMouseLeave={() => confirm && setConfirm(false)}
+    >
       <div
         role="button"
         tabIndex={0}
@@ -103,10 +126,10 @@ export function ShowGroupCard({
           onError={poster.onError}
           seed={head.id}
           lazy
-          className="h-full w-full transition-transform duration-200 group-hover:scale-[1.02]"
+          className="h-full w-full transition-transform duration-200 will-change-transform [transform:translate3d(0,0,0)] group-hover:scale-[1.02]"
         />
         <LocalBadge label={t("local")} className="absolute start-2 top-2" />
-        <span className="absolute bottom-2 end-2 inline-flex items-center gap-1 rounded-md bg-canvas/85 px-2 py-0.5 text-[10.5px] font-semibold text-ink backdrop-blur-sm">
+        <span className="absolute bottom-2 end-2 inline-flex items-center gap-1 rounded-md bg-canvas/90 px-2 py-0.5 text-[10.5px] font-semibold text-ink">
           <ListVideo size={11} strokeWidth={2.2} />
           {episodes.length}
         </span>
@@ -119,10 +142,16 @@ export function ShowGroupCard({
         {selectMode && (
           <span
             className={`absolute end-2 top-2 flex h-6 w-6 items-center justify-center rounded-md ${
-              isSelected ? "bg-accent text-white" : "bg-canvas/80 text-ink-subtle ring-1 ring-edge-soft"
+              isSelected
+                ? "bg-accent text-white"
+                : "bg-canvas/80 text-ink-subtle ring-1 ring-edge-soft"
             }`}
           >
-            {isSelected ? <CheckSquare size={14} strokeWidth={2.4} /> : <Square size={14} strokeWidth={2.2} />}
+            {isSelected ? (
+              <CheckSquare size={14} strokeWidth={2.4} />
+            ) : (
+              <Square size={14} strokeWidth={2.2} />
+            )}
           </span>
         )}
         {!selectMode && (
@@ -142,7 +171,10 @@ export function ShowGroupCard({
                 <Wand2 size={11} strokeWidth={2.2} />
               </CardIconButton>
               {head.tmdbId != null && (
-                <CardIconButton title={t("Export .nfo and artwork")} onClick={() => onExport(episodes)}>
+                <CardIconButton
+                  title={t("Export .nfo and artwork")}
+                  onClick={() => onExport(episodes)}
+                >
                   <Download size={11} strokeWidth={2.2} />
                 </CardIconButton>
               )}
@@ -157,21 +189,28 @@ export function ShowGroupCard({
                     setConfirm(true);
                   }
                 }}
-                className={`flex h-7 w-7 items-center justify-center rounded-full text-white shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-all duration-200 ${
+                className={`flex h-7 w-7 items-center justify-center rounded-full text-white shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-[opacity,background-color] duration-200 ${
                   confirm
                     ? "bg-danger"
-                    : "bg-canvas/70 opacity-0 backdrop-blur-sm hover:bg-canvas/90 group-hover:opacity-100"
+                    : "bg-canvas/80 opacity-0 hover:bg-canvas/95 group-hover:opacity-100"
                 }`}
                 aria-label={confirm ? t("Confirm remove") : t("Remove from library")}
               >
-                {confirm ? <RefreshCw size={11} strokeWidth={2.4} /> : <Trash2 size={11} strokeWidth={2.2} />}
+                {confirm ? (
+                  <RefreshCw size={11} strokeWidth={2.4} />
+                ) : (
+                  <Trash2 size={11} strokeWidth={2.2} />
+                )}
               </button>
             </div>
           </>
         )}
       </div>
       <button type="button" onClick={(e) => onActivate(e.shiftKey)} className="text-start">
-        <p className="truncate text-[13px] font-medium text-ink transition-colors hover:text-accent" title={head.title}>
+        <p
+          className="truncate text-[13px] font-medium text-ink transition-colors hover:text-accent"
+          title={head.title}
+        >
           {head.title}
         </p>
         <p className="-mt-1.5 truncate text-[11.5px] text-ink-subtle">{countLabel}</p>
@@ -179,3 +218,5 @@ export function ShowGroupCard({
     </div>
   );
 }
+
+export const ShowGroupCard = memo(ShowGroupCardImpl);

--- a/src/views/library/local-tab/toolbar.tsx
+++ b/src/views/library/local-tab/toolbar.tsx
@@ -7,7 +7,10 @@ import {
   ChevronDown,
   Download,
   FlipHorizontal2,
+  Square,
+  Tags,
   Trash2,
+  X,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
@@ -18,7 +21,9 @@ export type LocalSortKey = "added" | "title" | "year" | "rating" | "runtime";
 export type SortDir = "asc" | "desc";
 
 function groupSortEntry(g: LocalGroup): { entry: LocalEntry; added: number } {
-  if (g.kind === "movie") return { entry: g.entry, added: g.entry.addedAt };
+  if (g.kind === "movie") {
+    return { entry: g.entry, added: Math.max(...g.versions.map((v) => v.addedAt)) };
+  }
   return { entry: g.head, added: Math.max(...g.episodes.map((e) => e.addedAt)) };
 }
 
@@ -27,7 +32,10 @@ export function sortGroups(groups: LocalGroup[], key: LocalSortKey, dir: SortDir
   const decorated = groups.map((g) => ({ g, ...groupSortEntry(g) }));
   decorated.sort((a, b) => {
     if (key === "title") {
-      return mul * (a.entry.title ?? "").localeCompare(b.entry.title ?? "", undefined, { sensitivity: "base" });
+      return (
+        mul *
+        (a.entry.title ?? "").localeCompare(b.entry.title ?? "", undefined, { sensitivity: "base" })
+      );
     }
     if (key === "runtime") {
       const ra = a.g.kind === "show" ? 0 : 1;
@@ -35,7 +43,13 @@ export function sortGroups(groups: LocalGroup[], key: LocalSortKey, dir: SortDir
       if (ra !== rb) return ra - rb;
     }
     const pick = (e: LocalEntry, added: number): number | null =>
-      key === "year" ? e.year ?? null : key === "rating" ? e.rating ?? null : key === "runtime" ? e.runtime ?? null : added;
+      key === "year"
+        ? (e.year ?? null)
+        : key === "rating"
+          ? (e.rating ?? null)
+          : key === "runtime"
+            ? (e.runtime ?? null)
+            : added;
     const av = pick(a.entry, a.added);
     const bv = pick(b.entry, b.added);
     if (av == null && bv == null) return 0;
@@ -44,6 +58,100 @@ export function sortGroups(groups: LocalGroup[], key: LocalSortKey, dir: SortDir
     return mul * (av - bv);
   });
   return decorated.map((d) => d.g);
+}
+
+export type GenreOption = { name: string; count: number };
+
+/**
+ * Multi-select genre picker. Follows SortMenu's dropdown idiom (outside-click +
+ * Escape close) so it stays native to this toolbar; options are the genres
+ * actually present in the library, most common first.
+ */
+export function GenreMenu({
+  options,
+  selected,
+  onToggle,
+  onClear,
+}: {
+  options: GenreOption[];
+  selected: Set<string>;
+  onToggle: (genre: string) => void;
+  onClear: () => void;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+  if (options.length === 0) return null;
+  const count = selected.size;
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`flex h-9 items-center gap-1.5 rounded-full px-3.5 text-[12.5px] font-semibold transition-colors ${
+          count > 0
+            ? "bg-ink text-canvas"
+            : "bg-raised text-ink-muted hover:bg-elevated hover:text-ink"
+        }`}
+      >
+        <Tags size={13} strokeWidth={2.2} />
+        {count === 0 ? t("Genre") : t("{n} genres", { n: count })}
+        <ChevronDown size={13} className={`transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+      {open && (
+        <div className="absolute end-0 top-[calc(100%+6px)] z-50 max-h-[320px] w-56 overflow-y-auto rounded-xl border border-edge bg-elevated p-1 shadow-[0_18px_50px_-15px_rgba(0,0,0,0.7)] animate-popover-in">
+          {count > 0 && (
+            <button
+              type="button"
+              onClick={onClear}
+              className="flex h-9 w-full items-center gap-2 rounded-lg px-3 text-start text-[13px] text-ink-muted transition-colors hover:bg-raised/60 hover:text-ink"
+            >
+              <X size={13} strokeWidth={2.4} />
+              {t("Clear genres")}
+            </button>
+          )}
+          {options.map((o) => {
+            const on = selected.has(o.name);
+            return (
+              <button
+                key={o.name}
+                type="button"
+                onClick={() => onToggle(o.name)}
+                className={`flex h-9 w-full items-center justify-between gap-3 rounded-lg px-3 text-start text-[13px] transition-colors ${
+                  on ? "bg-raised text-ink" : "text-ink-muted hover:bg-raised/60 hover:text-ink"
+                }`}
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  {on ? (
+                    <CheckSquare size={14} strokeWidth={2.4} className="shrink-0 text-accent" />
+                  ) : (
+                    <Square size={14} strokeWidth={2.2} className="shrink-0" />
+                  )}
+                  <span className="truncate">{o.name}</span>
+                </span>
+                <span className="shrink-0 text-[11.5px] tabular-nums text-ink-subtle">
+                  {o.count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function SortMenu({
@@ -105,7 +213,9 @@ export function SortMenu({
                   setOpen(false);
                 }}
                 className={`flex h-9 w-full items-center justify-between gap-3 rounded-lg px-3 text-start text-[13px] transition-colors ${
-                  sortKey === k ? "bg-raised text-ink" : "text-ink-muted hover:bg-raised/60 hover:text-ink"
+                  sortKey === k
+                    ? "bg-raised text-ink"
+                    : "text-ink-muted hover:bg-raised/60 hover:text-ink"
                 }`}
               >
                 <span>{label}</span>

--- a/src/views/library/simkl-tab.tsx
+++ b/src/views/library/simkl-tab.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSettings } from "@/lib/settings";
 import { useT } from "@/lib/i18n";
-import { getLocalCache, syncWatchlistCache, type SimklCacheItem, type SimklCache } from "@/lib/simkl/activities";
+import {
+  getLocalCache,
+  syncWatchlistCache,
+  type SimklCacheItem,
+  type SimklCache,
+} from "@/lib/simkl/activities";
 import {
   groupAnimeByFranchise,
   enhanceGroupsWithRelations,
@@ -20,6 +25,7 @@ import {
   countByType,
   applyFilter,
 } from "./shared";
+import { useReportFeatured } from "./featured-context";
 
 const STATUS_LABELS: Record<string, string> = {
   watching: "Watching",
@@ -292,7 +298,11 @@ export function SimklTab() {
   }, [cache, subTab, statusFilter, enhancedFranchises]);
 
   const counts = useMemo(() => countByType(filteredItems), [filteredItems]);
-  const visible = useMemo(() => applyFilter(filteredItems, type, query), [filteredItems, type, query]);
+  const visible = useMemo(
+    () => applyFilter(filteredItems, type, query),
+    [filteredItems, type, query],
+  );
+  useReportFeatured(useMemo(() => visible.map((v) => v.meta), [visible]));
 
   return (
     <section className="flex flex-col gap-6">

--- a/src/views/library/trakt-tab.tsx
+++ b/src/views/library/trakt-tab.tsx
@@ -17,6 +17,7 @@ import {
   type TypeKey,
   type WatchlistMerged,
 } from "./shared";
+import { useReportFeatured } from "./featured-context";
 
 export function TraktTab() {
   const tr = useT();
@@ -66,12 +67,21 @@ export function TraktTab() {
     [watchlistEntries, historyEntries],
   );
   const counts = useMemo(() => countByType(combined), [combined]);
-  const visibleW = useMemo(() => applyFilter(watchlistEntries, type, query), [watchlistEntries, type, query]);
-  const visibleH = useMemo(() => applyFilter(historyEntries, type, query), [historyEntries, type, query]);
+  const visibleW = useMemo(
+    () => applyFilter(watchlistEntries, type, query),
+    [watchlistEntries, type, query],
+  );
+  const visibleH = useMemo(
+    () => applyFilter(historyEntries, type, query),
+    [historyEntries, type, query],
+  );
+  useReportFeatured(
+    useMemo(() => [...visibleW, ...visibleH].map((v) => v.meta), [visibleW, visibleH]),
+  );
 
   return (
     <section className="flex flex-col gap-10">
-      {(watchlistEntries.length + historyEntries.length) > 0 && (
+      {watchlistEntries.length + historyEntries.length > 0 && (
         <FilterBar
           type={type}
           setType={setType}
@@ -84,13 +94,17 @@ export function TraktTab() {
       <div className="flex flex-col gap-4">
         <div className="flex items-baseline gap-3">
           <h2 className="text-[18px] font-semibold text-ink">{tr("Trakt watchlist")}</h2>
-          <span className="text-[12px] text-ink-muted">{tr("{shown} of {total}", { shown: visibleW.length, total: watchlistEntries.length })}</span>
+          <span className="text-[12px] text-ink-muted">
+            {tr("{shown} of {total}", { shown: visibleW.length, total: watchlistEntries.length })}
+          </span>
         </div>
         {status === "loading" ? (
           <p className="text-[13px] text-ink-muted">{tr("Loading…")}</p>
         ) : visibleW.length === 0 ? (
           <p className="text-[13px] text-ink-muted">
-            {watchlistEntries.length === 0 ? tr("Nothing saved on Trakt yet.") : tr("No matches for these filters.")}
+            {watchlistEntries.length === 0
+              ? tr("Nothing saved on Trakt yet.")
+              : tr("No matches for these filters.")}
           </p>
         ) : (
           <GroupedGrid groups={sortedGroups(visibleW, settings.librarySort)} />
@@ -99,13 +113,17 @@ export function TraktTab() {
       <div className="flex flex-col gap-4">
         <div className="flex items-baseline gap-3">
           <h2 className="text-[18px] font-semibold text-ink">{tr("Trakt history")}</h2>
-          <span className="text-[12px] text-ink-muted">{tr("{shown} of {total}", { shown: visibleH.length, total: historyEntries.length })}</span>
+          <span className="text-[12px] text-ink-muted">
+            {tr("{shown} of {total}", { shown: visibleH.length, total: historyEntries.length })}
+          </span>
         </div>
         {status === "loading" ? (
           <p className="text-[13px] text-ink-muted">{tr("Loading…")}</p>
         ) : visibleH.length === 0 ? (
           <p className="text-[13px] text-ink-muted">
-            {historyEntries.length === 0 ? tr("No history yet.") : tr("No matches for these filters.")}
+            {historyEntries.length === 0
+              ? tr("No history yet.")
+              : tr("No matches for these filters.")}
           </p>
         ) : (
           <GroupedGrid groups={sortedGroups(visibleH, settings.librarySort)} />

--- a/src/views/library/watchlist-tab.tsx
+++ b/src/views/library/watchlist-tab.tsx
@@ -2,12 +2,22 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/lib/auth";
 import { useSettings } from "@/lib/settings";
 import { type Meta } from "@/lib/cinemeta";
-import { library, libraryMetaType, removeStremioLibraryItem, type LibraryItem } from "@/lib/stremio";
+import {
+  library,
+  libraryMetaType,
+  removeStremioLibraryItem,
+  type LibraryItem,
+} from "@/lib/stremio";
 import { fetchWatchlist } from "@/lib/trakt/watchlist";
 import { useTrakt } from "@/lib/trakt/provider";
 import { traktItemToMeta } from "@/lib/trakt/to-meta";
 import type { TraktItem } from "@/lib/trakt/types";
-import { readLocalEntries, removeFromWatchlist, subscribeWatchlist, type LocalEntry } from "@/lib/watchlist";
+import {
+  readLocalEntries,
+  removeFromWatchlist,
+  subscribeWatchlist,
+  type LocalEntry,
+} from "@/lib/watchlist";
 import { useT } from "@/lib/i18n";
 import {
   applyFilter,
@@ -22,6 +32,7 @@ import {
   type TypeKey,
   type WatchlistMerged,
 } from "./shared";
+import { useReportFeatured } from "./featured-context";
 
 export function WatchlistTab({ mode }: { mode: "library" | "watchlist" }) {
   const tr = useT();
@@ -121,6 +132,7 @@ export function WatchlistTab({ mode }: { mode: "library" | "watchlist" }) {
   }, []);
   const counts = useMemo(() => countByType(merged), [merged]);
   const visible = useMemo(() => applyFilter(merged, type, query), [merged, type, query]);
+  useReportFeatured(useMemo(() => visible.map((v) => v.meta), [visible]));
 
   const subtitle = (() => {
     const parts: string[] = [];
@@ -166,7 +178,12 @@ export function WatchlistTab({ mode }: { mode: "library" | "watchlist" }) {
         <GroupedGrid groups={sortedGroups(visible, settings.librarySort)} onRemove={handleRemove} />
       ) : flat ? (
         <GroupedGrid
-          groups={[{ label: "Everything", items: [...visible].sort((a, b) => (b.date ?? -Infinity) - (a.date ?? -Infinity)) }]}
+          groups={[
+            {
+              label: "Everything",
+              items: [...visible].sort((a, b) => (b.date ?? -Infinity) - (a.date ?? -Infinity)),
+            },
+          ]}
           onRemove={handleRemove}
         />
       ) : (
@@ -220,7 +237,11 @@ function mergeWatchlist(
   stremio: LibraryItem[],
   trakt: TraktItem[],
 ): WatchlistMerged[] {
-  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "").trim();
+  const norm = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "")
+      .trim();
   const byKey = new Map<string, WatchlistMerged>();
   const setOrUpgrade = (key: string, entry: WatchlistMerged) => {
     const existing = byKey.get(key);
@@ -243,7 +264,12 @@ function mergeWatchlist(
       background: item.background,
     };
     const dedupKey = `${item.type}:${norm(item.name ?? "")}`;
-    setOrUpgrade(dedupKey, { key: item._id, meta, date: parseTs(item._mtime), stremioId: item._id });
+    setOrUpgrade(dedupKey, {
+      key: item._id,
+      meta,
+      date: parseTs(item._mtime),
+      stremioId: item._id,
+    });
   }
   for (const t of trakt) {
     const m = traktItemToMeta(t);
@@ -255,7 +281,10 @@ function mergeWatchlist(
   for (const e of localEntries) {
     let dupById = false;
     for (const v of byKey.values()) {
-      if (v.meta.id === e.id) { dupById = true; break; }
+      if (v.meta.id === e.id) {
+        dupById = true;
+        break;
+      }
     }
     if (dupById) continue;
     const nameKey = e.name ? `${e.type}:${norm(e.name)}` : null;

--- a/src/views/play-picker.tsx
+++ b/src/views/play-picker.tsx
@@ -15,7 +15,12 @@ import { StreamModeToggle } from "@/components/stream-mode-toggle";
 import { isP2pStream } from "@/lib/streams/cached";
 import { consumeRecentStubEvent } from "@/lib/dead-streams";
 import { peekCachedLogo, resolveLogo } from "@/lib/logo";
-import { readPlayback, readLastSeriesPlayback, streamMatchesEntry, streamMatchesSource } from "@/lib/playback-history";
+import {
+  readPlayback,
+  readLastSeriesPlayback,
+  streamMatchesEntry,
+  streamMatchesSource,
+} from "@/lib/playback-history";
 import { readSeasonLock } from "@/lib/season-lock";
 import { useSettings } from "@/lib/settings";
 import type { ScoredStream, Tier } from "@/lib/streams/types";
@@ -60,9 +65,9 @@ import { useAnimeAltTitles } from "./play-picker/use-anime-alt-titles";
 import { useImdbId } from "./play-picker/use-imdb-id";
 import { usePipelineResult } from "./play-picker/use-pipeline-result";
 import { useStreamIds } from "./play-picker/use-stream-ids";
-import { findLocalEpisodeByIds, findLocalMovie } from "@/lib/local-library";
+import { findLocalEpisodeVersions, findLocalMovieVersions } from "@/lib/local-library/versions";
 import { localPlayerSrc } from "@/lib/local-library/player-src";
-import { LocalStreamCard } from "./play-picker/local-stream-card";
+import { LocalStreamList } from "./play-picker/local-stream-card";
 import { SubtitleSelectStep } from "./play-picker/subtitle-select-step";
 
 const TIER_ORDER: Tier[] = ["4K_DV", "4K_HDR", "4K", "1080p_HDR", "1080p", "720p", "SD", "ROUGH"];
@@ -94,7 +99,16 @@ export function PlayPicker({
   const fs = useWindowFullscreen();
   const { authKey } = useAuth();
   const debrids = useDebridClients();
-  const { snapshot: roomSnapshot, sendInvite, claimHost, wasInvitedTo, clientId, hostSource, roomGuestPick, lastInviteProto } = useTogether();
+  const {
+    snapshot: roomSnapshot,
+    sendInvite,
+    claimHost,
+    wasInvitedTo,
+    clientId,
+    hostSource,
+    roomGuestPick,
+    lastInviteProto,
+  } = useTogether();
   const inSession = roomSnapshot.state === "joined";
   const resolvedImdb = useImdbId(meta, settings.tmdbKey);
   useEffect(() => {
@@ -102,13 +116,13 @@ export function PlayPicker({
   }, [meta, episode]);
   const imdbId = resolvedImdb.id;
   const streamIds = useStreamIds(meta, episode, imdbId);
-  const localMatch = useMemo(() => {
+  const localMatches = useMemo(() => {
     const m = meta.id.match(/^tmdb:(?:movie|tv):(\d+)$/);
     const tmdbId = m ? parseInt(m[1], 10) : null;
-    if (tmdbId == null && !imdbId) return null;
+    if (tmdbId == null && !imdbId) return [];
     return episode
-      ? findLocalEpisodeByIds(episode.season, episode.episode, tmdbId, imdbId)
-      : findLocalMovie(tmdbId, imdbId);
+      ? findLocalEpisodeVersions(episode.season, episode.episode, tmdbId, imdbId)
+      : findLocalMovieVersions(tmdbId, imdbId);
   }, [meta.id, imdbId, episode]);
   const { addons } = useAddons(authKey, settings);
   const [seasonLogo, setSeasonLogo] = useState<string | undefined>(() =>
@@ -189,18 +203,19 @@ export function PlayPicker({
   );
   const [cachedOnly, setCachedOnly] = useState(false);
 
-  const { inviteKey, canInvite, inviteSentRef, hostSourceForMedia, expectHostSource } = useRoomInvite({
-    meta,
-    episode,
-    inSession,
-    roomSnapshot,
-    clientId,
-    hostSource,
-    lastInviteProto,
-    wasInvitedTo,
-    claimHost,
-    sendInvite,
-  });
+  const { inviteKey, canInvite, inviteSentRef, hostSourceForMedia, expectHostSource } =
+    useRoomInvite({
+      meta,
+      episode,
+      inSession,
+      roomSnapshot,
+      clientId,
+      hostSource,
+      lastInviteProto,
+      wasInvitedTo,
+      claimHost,
+      sendInvite,
+    });
 
   useEffect(() => {
     setStrictMode(settings.streamFilterLevel === "strict");
@@ -208,7 +223,8 @@ export function PlayPicker({
   }, [meta.id, episode?.season, episode?.episode, settings.streamFilterLevel]);
 
   const hostMatch = useMemo(
-    () => (hostSourceForMedia && result ? buildMatchScores(result.picker.all, hostSourceForMedia) : null),
+    () =>
+      hostSourceForMedia && result ? buildMatchScores(result.picker.all, hostSourceForMedia) : null,
     [result, hostSourceForMedia],
   );
   const matchFor = useCallback(
@@ -282,12 +298,19 @@ export function PlayPicker({
     );
     const primary = primaryCandidates[0] ?? null;
     return { primary, byTier, all, allRaw, fellBack };
-  }, [result, langFilter, preferredLangs, cachedOnly, debrids.length, isCached, hostMatch, activeStreamFilter, settings.streamMode]);
+  }, [
+    result,
+    langFilter,
+    preferredLangs,
+    cachedOnly,
+    debrids.length,
+    isCached,
+    hostMatch,
+    activeStreamFilter,
+    settings.streamMode,
+  ]);
 
-  const anyAddonRanked = useMemo(
-    () => (addons ?? []).some((a) => isAddonRanked(a)),
-    [addons],
-  );
+  const anyAddonRanked = useMemo(() => (addons ?? []).some((a) => isAddonRanked(a)), [addons]);
   const addonOrderMode = settings.streamSort === "addon" || anyAddonRanked;
   const displayStreams = useMemo(() => {
     const all = filteredPicker?.all ?? [];
@@ -318,16 +341,15 @@ export function PlayPicker({
 
   const isAnimeMetaId = /^(kitsu|mal|anilist|anidb):/.test(meta.id);
   const previousPlayback = useMemo(
-  () =>
-    settings.rememberLastStream
-      ? readPlayback(meta.id, episode?.season, episode?.episode)
-      : null,
-  [meta.id, episode?.season, episode?.episode, settings.rememberLastStream],
+    () =>
+      settings.rememberLastStream ? readPlayback(meta.id, episode?.season, episode?.episode) : null,
+    [meta.id, episode?.season, episode?.episode, settings.rememberLastStream],
   );
 
   const seasonLock = settings.seasonSourceLock && (meta.type === "series" || isAnimeMetaId);
   const seasonLockEntry = useMemo(
-    () => (seasonLock ? readSeasonLock(meta.id, isAnimeMetaId ? null : episode?.season ?? null) : null),
+    () =>
+      seasonLock ? readSeasonLock(meta.id, isAnimeMetaId ? null : (episode?.season ?? null)) : null,
     [seasonLock, meta.id, episode?.season, isAnimeMetaId],
   );
   const lastSeriesSource = useMemo(
@@ -353,8 +375,8 @@ export function PlayPicker({
     hostSource: hostSourceForMedia,
     prefer1080: !!kidProfile,
     preferPacks: seasonLock,
-    season: !isAnimeMetaId ? episode?.season ?? null : null,
-    episode: !isAnimeMetaId ? episode?.episode ?? null : null,
+    season: !isAnimeMetaId ? (episode?.season ?? null) : null,
+    episode: !isAnimeMetaId ? (episode?.episode ?? null) : null,
     expectedTitle: meta.name,
     expectedTitles: animeTitles,
     isAnime: isAnimeRequest,
@@ -385,7 +407,13 @@ export function PlayPicker({
     const m = filteredPicker.allRaw.find((s) => streamMatchesEntry(s, previousPlayback)) ?? null;
     if (!m || isAnimeMetaId || !episode) return m;
     if (m.episode != null && m.episode !== episode.episode) return null;
-    if (m.episode != null && m.season != null && episode.season != null && m.season !== episode.season) return null;
+    if (
+      m.episode != null &&
+      m.season != null &&
+      episode.season != null &&
+      m.season !== episode.season
+    )
+      return null;
     return m;
   }, [filteredPicker, previousPlayback, episode, isAnimeMetaId]);
 
@@ -397,10 +425,10 @@ export function PlayPicker({
   const currentPick: ScoredStream | null = useMemo(() => {
     if (!filteredPicker) return null;
     if (selectedTier && filteredPicker.byTier[selectedTier]) {
-    return filteredPicker.byTier[selectedTier]!;
-  }
+      return filteredPicker.byTier[selectedTier]!;
+    }
     if (previousMatch) return previousMatch;
-    if (sameSourceMatch) return sameSourceMatch;   
+    if (sameSourceMatch) return sameSourceMatch;
     return filteredPicker.primary;
   }, [filteredPicker, selectedTier, previousMatch, sameSourceMatch]);
 
@@ -425,7 +453,17 @@ export function PlayPicker({
     [settings.subtitlePreselect, isDownload, inSession, openPlayer],
   );
 
-  const { onPlay, onCache, queuedHash, debridDown, resetDebridDown, abortResolve, p2pConfirm, confirmP2p, cancelP2p } = usePickHandler({
+  const {
+    onPlay,
+    onCache,
+    queuedHash,
+    debridDown,
+    resetDebridDown,
+    abortResolve,
+    p2pConfirm,
+    confirmP2p,
+    cancelP2p,
+  } = usePickHandler({
     meta: metaForDisplay,
     imdbId,
     imdbIdVerified: resolvedImdb.verified,
@@ -500,8 +538,8 @@ export function PlayPicker({
     isTorrentioStream,
     expectHostSource,
     hostSource: hostSourceForMedia,
-    season: !isAnimeMetaId ? episode?.season ?? null : null,
-    episode: !isAnimeMetaId ? episode?.episode ?? null : null,
+    season: !isAnimeMetaId ? (episode?.season ?? null) : null,
+    episode: !isAnimeMetaId ? (episode?.episode ?? null) : null,
     addonQuorum,
     pipelineStartedAt,
     autoFiredRef,
@@ -511,16 +549,15 @@ export function PlayPicker({
   });
 
   const allCount = filteredPicker?.all.length ?? 0;
-  const rawCount =
-    (result?.raw.addon.length ?? 0) +
-    (result?.raw.library.length ?? 0);
+  const rawCount = (result?.raw.addon.length ?? 0) + (result?.raw.library.length ?? 0);
   const addonCount = useMemo(() => {
     if (!filteredPicker) return 0;
     return new Set(filteredPicker.all.map((s) => s.addonId)).size;
   }, [filteredPicker]);
   const addonLogoMap = useMemo(() => {
     const m = new Map<string, string | null>();
-    for (const a of addons ?? []) m.set(a.manifest.id, resolveAddonLogo(a.manifest.logo, a.transportUrl));
+    for (const a of addons ?? [])
+      m.set(a.manifest.id, resolveAddonLogo(a.manifest.logo, a.transportUrl));
     return m;
   }, [addons]);
   const lookupLogo = (id: string): string | null => addonLogoMap.get(id) ?? null;
@@ -529,7 +566,11 @@ export function PlayPicker({
     const seen = new Map<string, { id: string; name: string; logo: string | null }>();
     for (const s of filteredPicker.all) {
       if (seen.has(s.addonId)) continue;
-      seen.set(s.addonId, { id: s.addonId, name: s.addonName, logo: addonLogoMap.get(s.addonId) ?? null });
+      seen.set(s.addonId, {
+        id: s.addonId,
+        name: s.addonName,
+        logo: addonLogoMap.get(s.addonId) ?? null,
+      });
     }
     return [...seen.values()];
   }, [result, addonLogoMap]);
@@ -606,8 +647,7 @@ export function PlayPicker({
   }, [attempt, episode, meta.id]);
   useScrollMemory(pickerScrollKey, mainRef, !showAutoTransition);
 
-  const noSourcesConfigured =
-    addons !== null && addons.length === 0 && debrids.length === 0;
+  const noSourcesConfigured = addons !== null && addons.length === 0 && debrids.length === 0;
 
   if (pendingPreselect) {
     return (
@@ -659,11 +699,7 @@ export function PlayPicker({
 
   if (debridDown) {
     return (
-      <DebridDownModal
-        meta={meta}
-        onTryAgain={resetDebridDown}
-        onBack={() => backToDetail()}
-      />
+      <DebridDownModal meta={meta} onTryAgain={resetDebridDown} onBack={() => backToDetail()} />
     );
   }
 
@@ -685,14 +721,21 @@ export function PlayPicker({
     <main ref={mainRef} className="absolute inset-0 z-50 overflow-y-auto bg-canvas">
       <BackdropLayer src={backdropSrc} />
 
-      <div aria-hidden data-tauri-drag-region={fs ? "false" : "true"} className="absolute start-0 end-6 top-0 z-10 h-20" />
+      <div
+        aria-hidden
+        data-tauri-drag-region={fs ? "false" : "true"}
+        className="absolute start-0 end-6 top-0 z-10 h-20"
+      />
 
       <div className="relative mx-auto flex min-h-full w-full max-w-5xl flex-col gap-12 px-12 pb-32 pt-32">
         <PickerNav onBack={backToDetail} onRefresh={refresh} refreshing={loading} />
         <PickerHeader meta={metaForDisplay} episode={episode} />
 
-        {!isDownload && localMatch && (
-          <LocalStreamCard entry={localMatch} onPlay={() => openPlayerGated(localPlayerSrc(localMatch))} />
+        {!isDownload && (
+          <LocalStreamList
+            entries={localMatches}
+            onPlay={(entry) => openPlayerGated(localPlayerSrc(entry))}
+          />
         )}
 
         {hostSourceForMedia && <HostSourceBanner source={hostSourceForMedia} />}
@@ -712,7 +755,8 @@ export function PlayPicker({
         {torrentsDisabled() && (
           <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-amber-300/30 bg-amber-400/10 px-5 py-3.5 text-[13px] text-amber-100">
             <span>
-              Torrents are disabled in settings. Uncached streams will not play unless they come from a debrid service or a direct link.
+              Torrents are disabled in settings. Uncached streams will not play unless they come
+              from a debrid service or a direct link.
             </span>
             <button
               type="button"
@@ -731,9 +775,12 @@ export function PlayPicker({
         {result?.debridErrors && result.debridErrors.length > 0 && (
           <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-accent-soft px-5 py-3.5 text-[13px] ring-1 ring-edge-soft">
             <div className="flex min-w-0 flex-1 flex-col">
-              <p className="font-semibold text-accent">{debridBannerTitle(result.debridErrors[0])}</p>
+              <p className="font-semibold text-accent">
+                {debridBannerTitle(result.debridErrors[0])}
+              </p>
               <p className="text-[12.5px] leading-snug text-ink-muted">
-                Some of your cached sources may be missing from this list. This is a debrid-side issue, not a problem with your subscription.
+                Some of your cached sources may be missing from this list. This is a debrid-side
+                issue, not a problem with your subscription.
               </p>
             </div>
             <button
@@ -778,7 +825,9 @@ export function PlayPicker({
           />
         )}
 
-        {(settings.pickerLayout === "stremio" || isDownload) && filteredPicker && filteredPicker.all.length > 0 ? (
+        {(settings.pickerLayout === "stremio" || isDownload) &&
+        filteredPicker &&
+        filteredPicker.all.length > 0 ? (
           <StremioLayout
             streams={displayStreams}
             addons={addons}
@@ -793,9 +842,7 @@ export function PlayPicker({
           />
         ) : (
           <>
-            {!loading && result && (
-              <SourceDiagnostic result={result} debrids={debrids} />
-            )}
+            {!loading && result && <SourceDiagnostic result={result} debrids={debrids} />}
 
             {!loading && currentPick && (
               <PrimaryCard
@@ -807,9 +854,7 @@ export function PlayPicker({
                 onPlay={() => playManually(currentPick)}
                 onCache={() => onCache(currentPick)}
                 resolving={resolving?.stream === currentPick}
-                queued={
-                  currentPick.infoHash != null && queuedHash === currentPick.infoHash
-                }
+                queued={currentPick.infoHash != null && queuedHash === currentPick.infoHash}
                 inSession={inSession}
                 isPreviouslyPlayed={previousMatch === currentPick}
                 match={matchFor(currentPick)}
@@ -882,14 +927,16 @@ export function PlayPicker({
           </div>
         )}
       </div>
-      {(settings.pickerLayout === "stremio" || isDownload) && filteredPicker && filteredPicker.all.length > 0 && (
-        <PickerScrollTop
-          scrollRef={mainRef}
-          onBack={backToDetail}
-          onRefresh={refresh}
-          refreshing={loading}
-        />
-      )}
+      {(settings.pickerLayout === "stremio" || isDownload) &&
+        filteredPicker &&
+        filteredPicker.all.length > 0 && (
+          <PickerScrollTop
+            scrollRef={mainRef}
+            onBack={backToDetail}
+            onRefresh={refresh}
+            refreshing={loading}
+          />
+        )}
     </main>
   );
 }
@@ -909,7 +956,9 @@ function ActiveFilterHint({
   return (
     <div
       className={`flex items-center gap-2.5 rounded-2xl px-4 py-2.5 text-[13px] ring-1 ${
-        fellBack ? "bg-accent/10 text-ink ring-accent/30" : "bg-elevated/50 text-ink-muted ring-edge-soft"
+        fellBack
+          ? "bg-accent/10 text-ink ring-accent/30"
+          : "bg-elevated/50 text-ink-muted ring-edge-soft"
       }`}
     >
       <Filter size={14} strokeWidth={2.2} className="shrink-0 text-ink-subtle" />

--- a/src/views/play-picker/local-stream-card.tsx
+++ b/src/views/play-picker/local-stream-card.tsx
@@ -1,9 +1,18 @@
 import { HardDrive, Play } from "lucide-react";
 import type { LocalEntry } from "@/lib/local-library";
 import { episodeLabel } from "@/lib/local-library/player-src";
+import { LocalVersionBadges } from "@/components/local-version-badges";
 import { useT } from "@/lib/i18n";
 
-export function LocalStreamCard({ entry, onPlay }: { entry: LocalEntry; onPlay: () => void }) {
+export function LocalStreamCard({
+  entry,
+  onPlay,
+  showBadges = false,
+}: {
+  entry: LocalEntry;
+  onPlay: () => void;
+  showBadges?: boolean;
+}) {
   const t = useT();
   const ep = episodeLabel(entry);
   return (
@@ -18,15 +27,51 @@ export function LocalStreamCard({ entry, onPlay }: { entry: LocalEntry; onPlay: 
         <span className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-accent">
           {t("On your disk")}
           {ep && (
-            <span className="rounded-full bg-accent/15 px-1.5 py-0.5 text-[10px] tracking-normal">{ep}</span>
+            <span className="rounded-full bg-accent/15 px-1.5 py-0.5 text-[10px] tracking-normal">
+              {ep}
+            </span>
           )}
         </span>
         <span className="truncate text-[14.5px] font-semibold text-ink">{entry.filename}</span>
+        {showBadges && <LocalVersionBadges entry={entry} className="mt-1" />}
       </span>
       <span className="flex h-10 shrink-0 items-center gap-2 rounded-full bg-accent px-4 text-[13.5px] font-semibold text-canvas transition-opacity group-hover:opacity-90">
         <Play size={15} fill="currentColor" />
         {t("Play")}
       </span>
     </button>
+  );
+}
+
+/**
+ * Every local file for this movie/episode, best first. Multiple versions of the
+ * same title each get their own row with the format badges that tell them apart.
+ */
+export function LocalStreamList({
+  entries,
+  onPlay,
+}: {
+  entries: LocalEntry[];
+  onPlay: (entry: LocalEntry) => void;
+}) {
+  const t = useT();
+  if (entries.length === 0) return null;
+  const multi = entries.length > 1;
+  return (
+    <div className="flex flex-col gap-2">
+      {multi && (
+        <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-ink-subtle">
+          {t("{n} versions on your disk", { n: entries.length })}
+        </span>
+      )}
+      {entries.map((entry) => (
+        <LocalStreamCard
+          key={entry.id}
+          entry={entry}
+          showBadges={multi}
+          onPlay={() => onPlay(entry)}
+        />
+      ))}
+    </div>
   );
 }

--- a/tests/library-featured-picks.test.ts
+++ b/tests/library-featured-picks.test.ts
@@ -1,0 +1,80 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { pickFeatured, resetFeaturedPicks } from "../src/views/library/featured-picks.ts";
+import type { Meta } from "../src/lib/cinemeta.ts";
+
+function metas(n: number, withArt = true): Meta[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `tt${1000 + i}`,
+    type: "movie" as const,
+    name: `Title ${i}`,
+    background: withArt ? `https://example.test/${i}.jpg` : undefined,
+  }));
+}
+
+test("returns at most the requested count", () => {
+  resetFeaturedPicks();
+  assert.equal(pickFeatured(metas(20), "local").length, 4);
+});
+
+test("returns everything when the library is smaller than the count", () => {
+  resetFeaturedPicks();
+  assert.equal(pickFeatured(metas(2), "local").length, 2);
+});
+
+test("is stable across repeated calls in a session", () => {
+  resetFeaturedPicks();
+  const first = pickFeatured(metas(30), "local").map((m) => m.id);
+  for (let i = 0; i < 5; i++) {
+    assert.deepEqual(
+      pickFeatured(metas(30), "local").map((m) => m.id),
+      first,
+    );
+  }
+});
+
+test("keys picks per tab, so tabs don't share a selection", () => {
+  resetFeaturedPicks();
+  const pool = metas(30);
+  const local = pickFeatured(pool, "local").map((m) => m.id);
+  const watchlist = pickFeatured(pool, "watchlist").map((m) => m.id);
+  assert.deepEqual(
+    pickFeatured(pool, "local").map((m) => m.id),
+    local,
+  );
+  assert.deepEqual(
+    pickFeatured(pool, "watchlist").map((m) => m.id),
+    watchlist,
+  );
+});
+
+test("drops picks that disappear and tops back up", () => {
+  resetFeaturedPicks();
+  const pool = metas(10);
+  const first = pickFeatured(pool, "local");
+  const dropped = first[0].id;
+  const shrunk = pool.filter((m) => m.id !== dropped);
+  const second = pickFeatured(shrunk, "local");
+  assert.equal(second.length, 4);
+  assert.ok(!second.some((m) => m.id === dropped));
+  // The survivors from the first pick are retained, not reshuffled.
+  for (const m of first.slice(1)) assert.ok(second.some((s) => s.id === m.id));
+});
+
+test("prefers titles that already have a backdrop", () => {
+  resetFeaturedPicks();
+  const withArt = metas(4);
+  const withoutArt = metas(10, false).map((m, i) => ({ ...m, id: `tt9${i}` }));
+  const picked = pickFeatured([...withoutArt, ...withArt], "local");
+  assert.deepEqual(picked.map((m) => m.id).sort(), withArt.map((m) => m.id).sort());
+});
+
+test("an empty library yields no slides and forgets the previous pick", () => {
+  resetFeaturedPicks();
+  pickFeatured(metas(10), "local");
+  assert.deepEqual(pickFeatured([], "local"), []);
+  const after = pickFeatured(metas(10), "local");
+  assert.equal(after.length, 4);
+});

--- a/tests/local-library-grouping.test.ts
+++ b/tests/local-library-grouping.test.ts
@@ -1,0 +1,76 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { localGroupKey, localTitleKey } from "../src/lib/local-library/group-key.ts";
+import type { LocalEntry } from "../src/lib/local-library.ts";
+
+function entry(over: Partial<LocalEntry> = {}): LocalEntry {
+  return {
+    id: "local-x",
+    path: "/movies/x.mkv",
+    filename: "x.mkv",
+    title: "The Thing",
+    year: 1982,
+    type: "movie",
+    addedAt: 0,
+    ...over,
+  };
+}
+
+test("two files of the same movie share a group key via tmdb id", () => {
+  const bluray = entry({
+    path: "/a/The.Thing.1982.1080p.BluRay.x264.mkv",
+    filename: "The.Thing.1982.1080p.BluRay.x264.mkv",
+    tmdbId: 1091,
+  });
+  const remux = entry({
+    path: "/b/The.Thing.1982.2160p.UHD.BluRay.REMUX.HDR.mkv",
+    filename: "The.Thing.1982.2160p.UHD.BluRay.REMUX.HDR.mkv",
+    tmdbId: 1091,
+  });
+  assert.equal(localGroupKey(bluray), localGroupKey(remux));
+  assert.equal(localGroupKey(bluray), "tmdb:movie:1091");
+});
+
+test("imdb id groups files when no tmdb id is present", () => {
+  const a = entry({ path: "/a/a.mkv", imdbId: "tt0084787" });
+  const b = entry({ path: "/b/b.mkv", imdbId: "tt0084787", title: "The Thing (1982)" });
+  assert.equal(localGroupKey(a), localGroupKey(b));
+  assert.equal(localGroupKey(a), "tt0084787");
+});
+
+test("unidentified files fall back to normalized title and year", () => {
+  const a = entry({ path: "/a/a.mkv", title: "The Thing" });
+  const b = entry({ path: "/b/b.mkv", title: "the  thing." });
+  assert.equal(localGroupKey(a), localGroupKey(b));
+  assert.equal(localGroupKey(a), "title:movie:thething:1982");
+});
+
+test("a remake with a different year is not merged", () => {
+  const original = entry({ title: "The Thing", year: 1982 });
+  const remake = entry({ path: "/b/b.mkv", title: "The Thing", year: 2011 });
+  assert.notEqual(localGroupKey(original), localGroupKey(remake));
+});
+
+test("a movie and a show with the same title do not merge", () => {
+  const movie = entry({ title: "Fargo", year: 1996 });
+  const show = entry({ path: "/b/b.mkv", title: "Fargo", year: 1996, type: "show" });
+  assert.notEqual(localTitleKey(movie), localTitleKey(show));
+});
+
+test("episodes group per episode, not per series", () => {
+  const s1e1a = entry({ type: "show", tmdbId: 60622, season: 1, episode: 1 });
+  const s1e1b = entry({ path: "/b/b.mkv", type: "show", tmdbId: 60622, season: 1, episode: 1 });
+  const s1e2 = entry({ path: "/c/c.mkv", type: "show", tmdbId: 60622, season: 1, episode: 2 });
+  assert.equal(localGroupKey(s1e1a), localGroupKey(s1e1b));
+  assert.notEqual(localGroupKey(s1e1a), localGroupKey(s1e2));
+  assert.equal(localGroupKey(s1e1a), "tmdb:tv:60622:s1e1");
+});
+
+test("a missing year still groups identical titles together", () => {
+  const a = entry({ title: "Some Rip", year: null });
+  const b = entry({ path: "/b/b.mkv", title: "Some Rip", year: null });
+  assert.equal(localGroupKey(a), localGroupKey(b));
+  assert.equal(localGroupKey(a), "title:movie:somerip:?");
+});


### PR DESCRIPTION
## Summary

The local library became sluggish at ~145 items and couldn't represent a movie held in more than one quality. This fixes both, then builds three requested additions on top, plus one logo-language bug found along the way.

Now rebased onto `beta-branch`. One new dependency: `@tanstack/react-virtual` (see Notes).

## Performance

The local tab rendered every item at once, and every toast tick or selection toggle re-rendered all of them.

- **Virtualized** the grid with a new `VirtualGrid` component (`@tanstack/react-virtual`), threading the scroll ref down from `LibraryView`. Previously each item mounted a card carrying ~10 hooks and 5 effects through `Poster`.
- **Memoized** `OwnedCard` / `ShowGroupCard` and stabilized `cardProps`. Selection is now passed as a per-card boolean rather than the `Set`, which was replaced wholesale on every toggle and defeated memoization across the entire grid. The React Compiler isn't enabled, so this is manual.
- **Cached the store** — `read()` in `local-library.ts` re-parsed the whole library out of `localStorage` on every call, once per subscriber per mutation.
- **Cheapened hover** — `will-change`/`translate3d` on scaled posters, targeted transitions instead of `transition-all`, and no `backdrop-filter` on always-mounted card chrome.

## Duplicate versions in one entry

Two rips of the same film appeared as two posters, and only the first was ever reachable (`findLocalMovie` used `.find()`).

- Movies group by metadata id, falling back to normalized title + year, into a single poster with a version-count pill.
- Local filenames now go through the **real stream parser** rather than the scanner's regex, so version rows get source / codec / HDR / audio facets. File size is kept from the scan — `harbor_scan_folder` already returned it and TypeScript discarded it.
- Play on a multi-version entry opens a picker showing each file with the same badge stack as addon streams. It sits *after* the local-vs-stream decision, and autoplay still takes the best version rather than blocking on a dialog.
- Fixes a silent bug: the local episodes modal keyed episodes as `Map<number, LocalEntry>`, so a second file for the same episode was **invisible**, not merely unselectable.

## Genre filter (local tab)

- Genres are captured on scan from `.nfo` `<genre>` tags, falling back to TMDB. The TMDB side costs **no extra request** — that detail response was already being fetched for `imdb_id`/`runtime` and its `genres` array thrown away. This also closes a round-trip gap, since `export.ts` was already *writing* `<genre>` tags nothing read back.
- Multi-select menu in the local toolbar, ORing selections, with per-genre counts.
- Not backfilled by design, so the empty state explains why previously-scanned entries don't match.

## Continue Watching in the local collection

- A row above the local grid reusing `Row`, `ContinueCard` and the existing CW predicates (`isCwMember`, `cwSortKey`, `isCwDismissed`) — no parallel logic.
- Series collapse to one card and advance only to a next episode that **exists on disk**. Deliberately not `useCwAdvance`, which resolves episode lists over TMDB and can't handle a `local:` id.
- `ContinueCard` gains an optional `onPlayOverride` so the row plays the actual file; the default path silently falls back to the streaming picker. It is optional, so Home / Movies / Shows / Anime are unchanged.

## Featured hero on the library page

- `HeroCarousel` above the library tab bar, fed by whichever tab is open through a small context, with picks held stable for the session.
- `Slide.rank` is now optional — the "#N in … Today" trending pill doesn't apply to a personal library.
- Not shown on MAL / AniList, whose entries aren't `Meta`s with resolvable ids.

## Logo language fix

`Hero` resolved logos itself and only took the language-aware TMDB path for `tmdb:` ids. History and Trakt produce metas with **IMDb (`tt…`) ids**, so they fell through to Cinemeta and always showed the English logo regardless of the configured image language. It now uses `resolveLogo` / `peekCachedLogo`, which map `tt` ids to TMDB first and honour `tmdbImageLangs`. Since `Hero` is shared, this also corrects Home for any `tt`-id slide.

## Testing

Verified against `beta-branch`, using the same steps and tool version CI uses:

- `vp fmt --check` on all 39 changed files (vite-plus 0.2.6, matching `setup-vp@v1`) — clean
- `vp check --no-fmt` on the changed code files — 0 errors, 7 warnings, all pre-existing in untouched regions
- `tsc --noEmit -p tsconfig.json` — 15 errors, byte-identical to the `beta-branch` baseline; **0 introduced**
- `node --test tests/*.test.ts` — 79 pass / 3 fail, the same 3 that fail on clean `beta-branch` (`player-buffer-policy`, `rtx-hdr-policy`, an auto-sync subtest). 14 of the passing tests are new here.
- `pnpm install --frozen-lockfile` — passes with the updated lockfile

No Rust changes, so `cargo check` isn't applicable.

## Notes for reviewers

- **New dependency.** `beta-branch` has neither `@tanstack/react-virtual` nor a `VirtualGrid` component, so both arrive here — the dependency in its own commit (`build:`) so it can be reviewed separately from the feature. Happy to drop virtualization and keep the plain grid if you'd rather not take the dependency; the rest of the PR does not need it.
- **Formatting churn.** `App.tsx`, `library.tsx`, `local-tab.tsx` and `package.json` are already unformatted on `beta-branch`, and CI runs `vp fmt --check` over changed files, so touching them forces a reformat. `git diff -w --ignore-blank-lines` shows the real change is 2161 lines of the 2488 total; `App.tsx` in particular is ~2 real lines and the rest is formatter output.
- **`LocalTab` takes an optional `scrollRef`.** `cast-modal/library-panel.tsx` renders `<LocalTab />` with no scroll container, so that path keeps the non-virtualized grid rather than being forced to invent a scroller.
- Existing libraries are **not** migrated. New fields (`size`, `genres`) are optional and previously-scanned entries keep working; genres populate on future scans only.
- Conflicts with `beta-branch`'s refactors were resolved in favour of beta throughout — beta's `useLocalExport` hook replaced an inline export block, and beta's shift-range `selectItems` is kept and routed through the memoized card props.

## Screenshots
<img width="1920" height="1080" alt="Screenshot-2026-07-28_01-33-05" src="https://github.com/user-attachments/assets/cae3afd6-ee13-40b6-8d52-19bb56858c38" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b990aecf-04f6-49eb-9883-2b4830c0294d" />
<img width="1920" height="1080" alt="1785192042734760975" src="https://github.com/user-attachments/assets/48958772-e054-4978-9dfe-281d82115608" />
<img width="1920" height="1080" alt="1785192010110249526" src="https://github.com/user-attachments/assets/e2091974-b94d-456f-86ca-d2cd03acb5f8" />



