### PR TITLE
feat(packaging): publish Harbor to WinGet on stable releases

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,72 @@
+name: WinGet
+
+on:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish to WinGet
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: winget-${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish
+    # Only the upstream repository has the winget-pkgs fork and the WINGET_TOKEN
+    # secret, so forks skip instead of failing on a missing credential.
+    if: github.repository == 'harborstremio/harbor'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Resolve release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Release tags are not consistently formatted (V0.9.21, v0.9.20,
+          # v.0.8.3-beta), so derive the WinGet PackageVersion rather than
+          # relying on the action's default "strip a leading v".
+          version="${TAG#[Vv]}"
+          version="${version#.}"
+          version="${version%%-*}"
+          if [ -z "$version" ]; then
+            echo "::error::Could not derive a version from tag '$TAG'."
+            exit 1
+          fi
+
+          # A release published without a Windows build is not an error; there is
+          # simply nothing to submit.
+          installer="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '[.assets[].name | select(test("_x64-setup\\.exe$"))] | first // ""')"
+          if [ -z "$installer" ]; then
+            echo "::warning::No _x64-setup.exe asset on $TAG; skipping WinGet submission."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Submitting $installer as version $version."
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Submit to winget-pkgs
+        if: steps.release.outputs.found == 'true'
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: HarborStremio.Harbor
+          version: ${{ steps.release.outputs.version }}
+          release-tag: ${{ steps.release.outputs.tag }}
+          installers-regex: '_x64-setup\.exe$'
+          fork-user: harborstremio
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Download the latest build for macOS or Windows from the [Releases page][releases
 | Platform    | Format                                                                                                   |
 | ----------- | -------------------------------------------------------------------------------------------------------- |
 | **macOS**   | `.dmg` (macOS 11.0 or newer)                                                                             |
-| **Windows** | `.exe` NSIS installer (current user install)                                                             |
+| **Windows** | `.exe` NSIS installer (current user install), or `winget install HarborStremio.Harbor`                   |
 | **Web**     | Open in any modern browser, nothing to install                                                           |
 | **Linux**   | [Unofficial `.deb`, `.rpm`, and Flatpak packages](https://github.com/AdityaHebballe/harbor-linux-builds) |
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ HARBOR IS A OPEN CONCEPT AND NOT A ENTITY. WE DO NOT PROFIT OR ACCEPT MONEY FOR 
 - **Casts across the room.** DLNA/UPnP, Chromecast, AirPlay, and Roku via a bundled Rust cast server and a web cast receiver.
 - **Integrations.** Feature rich discord rich presence integration, webhooks for Discord and Telegram, Trakt Sync, and native integrations to TMDB, OMDB, Fanart.Tv, RPDB and more! Customize the location and what badges are shown.
 - **And much more! (seriously this would be very long)**
+
 <p align="right"><a href="#readme-top">&#9650; back to top</a></p>
 
 ## Feature Tour

--- a/packaging/winget/HarborStremio.Harbor.installer.yaml
+++ b/packaging/winget/HarborStremio.Harbor.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: HarborStremio.Harbor
+PackageVersion: 0.9.21
+MinimumOSVersion: 10.0.17763.0
+InstallerType: nullsoft
+# The NSIS bundle is built with "installMode": "currentUser" in
+# src-tauri/tauri.conf.json, so Harbor installs per-user, not machine-wide.
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-11
+Installers:
+  # x64 only: the release workflow declares an aarch64-pc-windows-msvc matrix row,
+  # but no ARM64 asset has ever been attached to a release.
+  - Architecture: x64
+    InstallerUrl: https://github.com/harborstremio/harbor/releases/download/V0.9.21/Harbor_0.9.21_x64-setup.exe
+    InstallerSha256: C45F26729AB8EFAAA8E466EC616EC0D769E730D167E7ED47C0BC837FA1414C7F
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/HarborStremio.Harbor.locale.en-US.yaml
+++ b/packaging/winget/HarborStremio.Harbor.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: HarborStremio.Harbor
+PackageVersion: 0.9.21
+PackageLocale: en-US
+Publisher: Harbor
+PublisherUrl: https://harbor.site/
+PublisherSupportUrl: https://github.com/harborstremio/harbor/issues
+PackageName: Harbor
+PackageUrl: https://harbor.site/
+License: MIT
+LicenseUrl: https://github.com/harborstremio/harbor/blob/main/LICENSE
+Copyright: Copyright (c) Harbor contributors
+ShortDescription: A Stremio client built for adventure
+Description: Harbor is a desktop media client for browsing and playing content from Stremio addons.
+Moniker: harbor
+Tags:
+  - media
+  - mpv
+  - player
+  - stremio
+  - video
+ReleaseNotesUrl: https://github.com/harborstremio/harbor/releases/tag/V0.9.21
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/HarborStremio.Harbor.yaml
+++ b/packaging/winget/HarborStremio.Harbor.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: HarborStremio.Harbor
+PackageVersion: 0.9.21
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,90 @@
+# WinGet packaging
+
+Harbor on the [Windows Package Manager](https://github.com/microsoft/winget-pkgs), so Windows users
+can install and update with:
+
+```powershell
+winget install HarborStremio.Harbor
+winget upgrade HarborStremio.Harbor
+```
+
+## What is here
+
+| File                                     | Purpose                                 |
+| ---------------------------------------- | --------------------------------------- |
+| `HarborStremio.Harbor.yaml`              | Version manifest                        |
+| `HarborStremio.Harbor.installer.yaml`    | Installer manifest (x64 NSIS, per-user) |
+| `HarborStremio.Harbor.locale.en-US.yaml` | Store listing metadata                  |
+
+These are the **bootstrap** manifests, used once to create the package. After that,
+[`.github/workflows/winget.yml`](../../.github/workflows/winget.yml) submits every new stable release
+automatically and these files are only a reference.
+
+## Why `HarborStremio.Harbor` and not `site.harbor.Harbor`
+
+WinGet package identifiers are `Publisher.Package`, not reverse-DNS. `site.harbor.Harbor` is
+technically schema-valid, but it files the package under `manifests/s/site/harbor/Harbor/` with a
+publisher segment reading as "site". `HarborStremio.Harbor` matches the GitHub organisation and lands
+at `manifests/h/HarborStremio/Harbor/`. The Flatpak app ID stays `site.harbor.Harbor`; the two
+ecosystems have different conventions and are not expected to match.
+
+## Setup — one-time, maintainers only
+
+The workflow cannot run until these exist. Steps 1 and 2 require organisation access.
+
+1. **Fork `microsoft/winget-pkgs` into the `harborstremio` organisation.** The action pushes its
+   branch there before opening the upstream PR. If the fork lives under a different account, change
+   `fork-user:` in the workflow to match.
+2. **Add the `WINGET_TOKEN` secret.** A _classic_ personal access token with the `public_repo` scope,
+   stored as a repository secret on `harborstremio/harbor`. Fine-grained tokens do not work with the
+   action's fork-and-PR flow.
+3. **Submit the first version by hand.** `winget-releaser` deliberately fails if the package is not
+   already in `winget-pkgs` — its first step checks the manifest directory and exits if it 404s. Use
+   the files in this directory:
+
+   ```powershell
+   winget validate --manifest packaging\winget
+   # then open a PR against microsoft/winget-pkgs adding them under
+   # manifests/h/HarborStremio/Harbor/0.9.21/
+   ```
+
+   [`komac`](https://github.com/russellbanks/Komac) or `wingetcreate` will do the fork-and-PR for you.
+
+Once the package exists upstream, publishing a stable GitHub Release is all that is needed — the
+workflow does the rest.
+
+## How the workflow behaves
+
+- Triggers on `release: released`, which fires only for non-draft, **non-prerelease** publishes.
+  Pre-releases are ignored with no extra conditions.
+- Skips silently on forks (`if: github.repository == 'harborstremio/harbor'`), so this file being
+  merged cannot turn anyone's fork CI red.
+- Derives `PackageVersion` from the tag itself rather than trusting the action's default. Tag naming
+  has drifted over time (`V0.9.21` with a capital V, `v.0.8.3-beta` with a stray dot), and the default
+  only strips a lowercase `v`.
+- Skips with a warning, rather than failing, if a release has no `_x64-setup.exe` asset.
+- `workflow_dispatch` with a `tag` input re-runs a submission manually.
+
+## Known limitations
+
+- **Stable only.** The beta channel (0.9.11x) is distributed through
+  `https://harbor.site/updates/latest.json` and is never published as a GitHub Release, so there is no
+  artifact for a manifest to reference. Publishing beta to WinGet would require cutting beta GitHub
+  Releases first.
+- **x64 only.** No ARM64 Windows asset has ever been attached to a release.
+- **Installers are unsigned.** No code-signing secret exists in any workflow. WinGet accepts unsigned
+  installers, but SmartScreen warnings and occasional antivirus false positives during validation are
+  expected.
+- **Harbor's in-app updater is unaware of WinGet.** A user who installs through WinGet will still be
+  offered in-app updates, the same as a direct `.exe` install. On Linux this is already handled by
+  `isLinuxDesktop()` deferring to the package manager; an equivalent WinGet check does not exist and
+  is out of scope here.
+
+## Updating these files
+
+They only need refreshing if the bootstrap PR has not been merged yet. To point them at a newer
+release, update `PackageVersion`, `InstallerUrl`, `ReleaseDate`, `ReleaseNotesUrl` and the hash:
+
+```powershell
+winget hash Harbor_<version>_x64-setup.exe
+```


### PR DESCRIPTION
## Summary

Adds Harbor to the [Windows Package Manager](https://github.com/microsoft/winget-pkgs), with a workflow that submits every stable release automatically.

```powershell
winget install HarborStremio.Harbor
winget upgrade HarborStremio.Harbor
```

Windows is currently the only supported platform without a package manager entry. Linux has `.deb`, `.rpm`, Flatpak and the AUR through the community builds repo; Windows users have to find the Releases page and download an installer by hand, then rely on the in-app updater.

Nothing existing changes except one row in the README install table. `tauri-build.yml`, `ci.yml`, `app-build.yml` and `flatpak.yml` are untouched, and the manual release process stays exactly as it is.

## What's included

| File | Purpose |
| --- | --- |
| `.github/workflows/winget.yml` | Submits a `winget-pkgs` PR on every stable release |
| `packaging/winget/*.yaml` | Bootstrap manifests for 0.9.21 (v1.10.0 schema) |
| `packaging/winget/README.md` | Maintainer setup steps and known limitations |
| `README.md` | One row in the install table |

## Package identifier

`HarborStremio.Harbor`, **not** the Flatpak's `site.harbor.Harbor`.

WinGet identifiers are `Publisher.Package`, not reverse-DNS. `site.harbor.Harbor` is schema-valid (the pattern permits 2–8 dot-separated segments) but files the package under `manifests/s/site/harbor/Harbor/` with a publisher segment reading as "site", which moderators routinely push back on. `HarborStremio.Harbor` matches the GitHub organisation and lands at `manifests/h/HarborStremio/Harbor/`. The Flatpak app ID is unchanged.

## Setup required before this can run — maintainers only

I can't do these from a fork, and the workflow stays inert until they exist:

1. **Fork `microsoft/winget-pkgs` into the `harborstremio` org.** The action pushes its branch there before opening the upstream PR. If you'd rather host the fork elsewhere, change `fork-user:` in the workflow.
2. **Add a `WINGET_TOKEN` repository secret** — a *classic* PAT with `public_repo` scope. Fine-grained tokens don't work with the fork-and-PR flow.
3. **Submit the first manifest by hand.** `winget-releaser` deliberately fails if the package isn't already in `winget-pkgs` — its first step checks the manifest directory and exits on a 404. The files in `packaging/winget/` are ready for exactly this; `komac` or `wingetcreate` will do the fork-and-PR.

After that, publishing a stable release is all that's needed.

## Design notes

**Stable only, by construction.** The trigger is `release: released`, which fires only for non-draft, **non-prerelease** publishes — so the stable-only gate needs no extra condition. This is also the only thing that *can* work today: the beta line (0.9.11x) is distributed through `https://harbor.site/updates/latest.json` and is never cut as a GitHub Release, so there's no artifact for a manifest to reference. Publishing beta to WinGet would first require beta GitHub Releases.

**Forks skip rather than fail.** The job carries `if: github.repository == 'harborstremio/harbor'`, so merging this can't turn anyone's fork CI red over a secret they don't have.

**The version is derived, not assumed.** `winget-releaser` defaults to stripping a lowercase `v` from the tag. Tag naming has drifted — `V0.9.21` has a capital V, `v.0.8.3-beta` has a stray dot, older tags carry `-beta` suffixes — so a small shell step normalises it. I ran it against all 30 existing tags; every one yields clean semver.

**A missing installer is a skip, not a failure.** If a release has no `_x64-setup.exe`, the workflow warns and exits 0.

**`Scope: user` is load-bearing.** The NSIS bundle is built `"installMode": "currentUser"` in `src-tauri/tauri.conf.json`, so Harbor installs per-user. Declaring machine scope would make `winget upgrade` misbehave.

**x64 only.** `tauri-build.yml` declares an `aarch64-pc-windows-msvc` matrix row, but no ARM64 asset has ever been attached to a release.

## Verification

| Check | Result |
| --- | --- |
| YAML parses (4 files) | pass |
| Manifests vs. winget v1.10.0 JSON schemas | pass, all three |
| Version normaliser vs. all 30 historical tags | all yield clean semver |
| `_x64-setup\.exe$` regex vs. all 30 releases | exactly one match each |
| Workflow shell step, executed locally | correct on `V0.9.21`, `v.0.8.3-beta`, `v0.8.4-beta` |
| No-asset skip path | warns, `found=false`, exit 0 |
| `vp fmt --check` on all touched files | clean |

Two things I want to be upfront about:

- **The workflow itself has not been executed end to end**, and can't be until the fork and `WINGET_TOKEN` exist. I ran its shell step locally against live releases, including the skip path, but the `winget-releaser` invocation is unexercised. The fork guard is what makes merging an untested workflow safe — it cannot run anywhere it isn't configured.
- **The `InstallerSha256` came from GitHub's published `digest` field** for the release asset rather than from re-hashing the 280 MB installer locally. That digest is computed by GitHub over the stored file, but it's worth a `winget hash` before the bootstrap PR goes up.

`actionlint` and `shellcheck` weren't available in my environment, so the workflow is not statically linted.

## Out of scope, but noticed

- **Windows installers are unsigned.** No signing secret exists in any workflow. WinGet accepts unsigned installers, but expect SmartScreen warnings and the occasional AV false positive during validation.
- **The in-app updater doesn't know about WinGet.** A WinGet-installed user still gets in-app update prompts. Linux already defers to the package manager via `isLinuxDesktop()`; an equivalent WinGet check would be a sensible follow-up.
- **`matrix.platform.bundle: msi` in `tauri-build.yml` is inert** — it's declared but never passed to any step, so Windows actually emits NSIS `.exe` per `tauri.conf.json`. Harmless today since the upload step globs both, but the `*.msi` glob is dead. Left alone deliberately; happy to file it separately.

## Testing after setup

Once the manifest is live upstream:

```powershell
winget search Harbor
winget install HarborStremio.Harbor
winget list HarborStremio.Harbor
```

Then publish a stable release and confirm the workflow opens a PR against `microsoft/winget-pkgs` with the new version.
