### PR TITLE
fix(security): SSRF guard authoritative on addon-install fetches

### DIFF
--- a/src/lib/safe-fetch.ts
+++ b/src/lib/safe-fetch.ts
@@ -123,6 +123,24 @@ function isIdempotent(method: string | undefined): boolean {
   return m === "GET" || m === "HEAD" || m === "OPTIONS";
 }
 
+function isLocalhost(host: string): boolean {
+  const h = host.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "localhost" || h === "127.0.0.1" || h === "::1") return true;
+  try {
+    const hostname = new URL(h.includes("://") ? h : `http://${h}`)
+      .hostname.replace(/^\[|\]$/g, "");
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return true;
+  } catch {
+  }
+  return false;
+}
+
+function guardRejectionHost(e: unknown): string | null {
+  const raw = typeof e === "string" ? e : ((e as { message?: string } | undefined)?.message ?? "");
+  const m = raw.match(/blocked internal target:\s*(\S+)/i);
+  return m ? m[1] : null;
+}
+
 // The Tauri http plugin rejects an aborted request with a plain Error("Request cancelled").
 // Normalize it to a standard AbortError so callers (and the global rejection handler) treat
 // a cancel as the benign abort it is instead of surfacing the app-wide error screen.
@@ -177,9 +195,11 @@ export const safeFetch: typeof fetch = (input, init) => {
   if (isTauri) {
     if (typeof input === "string") {
       const exec = isIdempotent(init?.method)
-        ? tauriHarborFetch(input, init).catch(
-            () => normalizeAbort(tauriFetchImpl(input as string, init as RequestInit) as Promise<Response>),
-          )
+        ? tauriHarborFetch(input, init).catch((e) => {
+            const blocked = guardRejectionHost(e);
+            if (blocked !== null && !isLocalhost(blocked)) throw e;
+            return normalizeAbort(tauriFetchImpl(input as string, init as RequestInit) as Promise<Response>);
+          })
         : tauriHarborFetch(input, init);
       return withDeadline(exec, init?.signal);
     }


### PR DESCRIPTION
## Summary

Addon manifest and install fetches go through `safeFetch` (`src/lib/safe-fetch.ts`),
which calls the guarded Rust `harbor_fetch` command (`http_fetch.rs`,
`validate_target`). That command rejects internal/loopback targets the app
should not reach.

The previous code swallowed any rejection from `harbor_fetch` and fell back to
the **unguarded** `@tauri-apps/plugin-http` `fetch`. As a result, the Rust SSRF
guard could be bypassed entirely for addon-install flows: the guard rejected an
internal target (e.g. `169.254.169.254`, `192.168.x.x`), the `.catch` fired, and
the plaintext fallback request went out anyway.

This change makes the guard authoritative: when `harbor_fetch` rejects an
internal target, the rejection is re-thrown so the addon install genuinely
fails. The unguarded fallback is now used only when the rejected target is the
loopback interface (`localhost`, `127.0.0.1`, `::1`), which is required so
self-hosted addons keep working — the repo intentionally permits loopback for
addons (`subsync/url_guard.rs`, `web_server.rs`, `remote-image-proxy.ts`,
`theme-scan.js`, `manga/host-http.ts`).

## Changes

- `src/lib/safe-fetch.ts`: in the idempotent fetch path, inspect a `harbor_fetch`
  rejection. If it is a guard rejection for a non-loopback internal host,
  re-throw it. Otherwise (loopback, transport error, timeout) fall back to the
  previous behavior.

Success-path fetches and external addon URLs are unchanged.

## Verification

- `pnpm run build` passes (no type errors, no new warnings).
- Decision logic unit-tested against the exact Tauri v2 error wire format
  (`Result<_, String>` → `InvokeError` → JSON body → `response.json()` → JS
  string rejection):
  - internal targets (`169.254.169.254`, `0.0.0.0`, `192.168.1.50`) → blocked
  - loopback (`localhost`, `127.0.0.1`, `::1`) → fallback preserved
  - transport errors / timeouts → fallback preserved