### PR TITLE
fix(playback): force local engine after P2P confirmation

### DIFF
--- a/src/views/play-picker/use-pick-handler.ts
+++ b/src/views/play-picker/use-pick-handler.ts
@@ -82,7 +82,9 @@ export function usePickHandler({
 }) {
   const [queuedHash, setQueuedHash] = useState<string | null>(null);
   const [debridDown, setDebridDown] = useState(false);
-  const [p2pConfirm, setP2pConfirm] = useState<{ stream: ScoredStream; forceP2p?: boolean } | null>(null);
+  const [p2pConfirm, setP2pConfirm] = useState<{ stream: ScoredStream; forceP2p?: boolean } | null>(
+    null,
+  );
   const debridFailStreakRef = useRef(0);
   const resolveAcRef = useRef<AbortController | null>(null);
   const autoPickRef = useRef(false);
@@ -123,9 +125,19 @@ export function usePickHandler({
     resolveAcRef.current = ac;
     let opened = false;
     try {
-      const hint = episode ? { season: episode.season ?? null, episode: episode.episode ?? null } : undefined;
+      const hint = episode
+        ? { season: episode.season ?? null, episode: episode.episode ?? null }
+        : undefined;
       const allowP2pFallback = streamMode !== "addons";
-      const r = await resolveStream(stream, debrids, ac.signal, userCommitted, forceP2p, hint, allowP2pFallback);
+      const r = await resolveStream(
+        stream,
+        debrids,
+        ac.signal,
+        userCommitted,
+        forceP2p,
+        hint,
+        allowP2pFallback,
+      );
       if (ac.signal.aborted) return;
       if (!r.ok) {
         if (r.code === "web-page" && r.webUrl) {
@@ -161,7 +173,8 @@ export function usePickHandler({
         } catch (e) {
           setFailedStreams((prev) => new Set(prev).add(stream));
           const willRetry = autoActive && autoAttemptIdx + 1 < autoCandidatesLength;
-          if (!willRetry) setResolveError("Could not start the local stream proxy. Pick another stream.");
+          if (!willRetry)
+            setResolveError("Could not start the local stream proxy. Pick another stream.");
           advanceAuto();
           return;
         }
@@ -188,7 +201,9 @@ export function usePickHandler({
         const willRetry = autoActive && autoAttemptIdx + 1 < autoCandidatesLength;
         advanceAuto();
         if (!willRetry && !autoActive) {
-          setResolveError("This source isn't ready on your debrid yet. Try it again in a moment or pick another.");
+          setResolveError(
+            "This source isn't ready on your debrid yet. Try it again in a moment or pick another.",
+          );
         }
         return;
       }
@@ -200,7 +215,13 @@ export function usePickHandler({
           stream.name ||
           stream.addonName ||
           null;
-        void enqueueDownload({ meta, episode, streamLabel: label, url: r.data.url, headers: r.data.headers });
+        void enqueueDownload({
+          meta,
+          episode,
+          streamLabel: label,
+          url: r.data.url,
+          headers: r.data.headers,
+        });
         opened = true;
         setResolving(null);
         onDownloadStarted?.(label);
@@ -264,7 +285,7 @@ export function usePickHandler({
         savePlayback(meta.id, entry, episode?.season, episode?.episode);
         if (seasonLock && episode) {
           const animeId = /^(kitsu|mal|anilist|anidb):/.test(meta.id);
-          saveSeasonLock(meta.id, entry, animeId ? null : episode.season ?? null, animeId);
+          saveSeasonLock(meta.id, entry, animeId ? null : (episode.season ?? null), animeId);
         }
       }
     } finally {
@@ -310,7 +331,7 @@ export function usePickHandler({
       engineP2pEligible(stream) &&
       (hasUncachedMarker(stream) || (!stream.url && debrids.length === 0))
     ) {
-      setP2pConfirm({ stream });
+      setP2pConfirm({ stream, forceP2p: true });
       return;
     }
     startResolve(stream, committed);
@@ -372,5 +393,15 @@ export function usePickHandler({
     sameSourceRetryRef.current = 0;
   };
 
-  return { onPlay, onCache, queuedHash, debridDown, resetDebridDown, abortResolve, p2pConfirm, confirmP2p, cancelP2p };
+  return {
+    onPlay,
+    onCache,
+    queuedHash,
+    debridDown,
+    resetDebridDown,
+    abortResolve,
+    p2pConfirm,
+    confirmP2p,
+    cancelP2p,
+  };
 }

--- a/tests/p2p-confirmation.test.ts
+++ b/tests/p2p-confirmation.test.ts
@@ -1,0 +1,19 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+const pickHandlerSource = readFileSync(
+  new URL("../src/views/play-picker/use-pick-handler.ts", import.meta.url),
+  "utf8",
+);
+
+test("confirming the P2P modal always forces the local torrent engine", () => {
+  assert.equal(
+    pickHandlerSource.match(/setP2pConfirm\(\{\s*stream,\s*forceP2p:\s*true\s*\}\)/g)?.length,
+    2,
+  );
+  assert.doesNotMatch(pickHandlerSource, /setP2pConfirm\(\{\s*stream\s*\}\)/);
+});


### PR DESCRIPTION
## Summary

Forces the local torrent engine when the user confirms playback from the peer-to-peer confirmation dialog.

Adds a focused regression test covering both paths that open this dialog.

## Why

The confirmation dialog is shown for an engine-eligible uncached torrent, but one of its call sites did not preserve the `forceP2p` intent. After confirming, Harbor could run the regular resolution path again and remain on the `CONNECTING` screen instead of starting local peer discovery.

This change passes `forceP2p: true` through the existing confirmation state, matching the fallback path already present in the same handler.

## Verification

- `vp fmt --check` for the changed files: passed.
- `vp check --no-fmt` for the changed files: passed.
- `pnpm exec tsc -b --pretty false`: passed.
- `node --test tests/p2p-confirmation.test.ts`: passed.
- Manual A/B test using the same openSUSE Tumbleweed container, profile configuration, torrent, and official AppImage libraries:
  - Official payload remained on `CONNECTING`.
  - Patched payload entered `PREPARING STREAM` and found a peer.
- The Linux release binary built successfully. The final AppImage packaging stage still encounters the existing `linuxdeploy` packaging failure.

## Platform Impact

Verified on Linux using an openSUSE Tumbleweed container. The change is in the shared TypeScript playback flow and does not introduce platform-specific behavior.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran TypeScript typechecking after TypeScript changes.
- [x] No Rust files changed, so Cargo checks were not applicable.
- [x] I tested the affected behavior on Linux.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
