### PR TITLE
feat(groups): mention links and quote replies in group posts

### DIFF
--- a/src/lib/social/bbcode.ts
+++ b/src/lib/social/bbcode.ts
@@ -237,30 +237,64 @@ const CODE_STYLE =
   "border-radius:6px;padding:1px 5px";
 const LIST_STYLE = "margin:8px 0;padding-inline-start:22px;list-style:disc";
 const LINK_STYLE = "color:var(--color-accent);text-decoration:underline";
+const MENTION_STYLE = "color:var(--color-accent);font-weight:600;cursor:pointer";
 
 function trimBr(s: string): string {
   return s.replace(/^(?:<br\/>)+/, "").replace(/(?:<br\/>)+$/, "").trim();
 }
 
-const BARE_URL_RE = /https?:\/\/[^\s<>"']+/gi;
+const HANDLE_RE = /^[a-z0-9_][a-z0-9_.-]{1,31}$/i;
+const INLINE_RE = /(https?:\/\/[^\s<>"']+)|@([a-z0-9_][a-z0-9_.-]{1,31})/gi;
+
+function mentionHtml(handle: string): string {
+  return (
+    `<span data-harbor-mention="${esc(handle)}" role="button" tabindex="0" style="${MENTION_STYLE}">` +
+    `@${esc(handle)}</span>`
+  );
+}
+
+export function extractMentions(body: string): string[] {
+  const out = new Set<string>();
+  const re = new RegExp(INLINE_RE.source, "gi");
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body))) {
+    if (m[1] || !m[2]) continue;
+    const h = m[2].replace(/[.-]+$/, "").toLowerCase();
+    if (HANDLE_RE.test(h)) out.add(h);
+  }
+  return [...out].slice(0, 20);
+}
 
 function linkifyEscaped(s: string): string {
   let out = "";
   let last = 0;
-  BARE_URL_RE.lastIndex = 0;
+  INLINE_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
-  while ((m = BARE_URL_RE.exec(s))) {
+  while ((m = INLINE_RE.exec(s))) {
     out += esc(s.slice(last, m.index));
-    let raw = m[0];
-    let trail = "";
-    while (/[.,;:!?)\]}'"]$/.test(raw)) {
-      trail = raw.slice(-1) + trail;
-      raw = raw.slice(0, -1);
+    if (m[1]) {
+      let raw = m[1];
+      let trail = "";
+      while (/[.,;:!?)\]}'"]$/.test(raw)) {
+        trail = raw.slice(-1) + trail;
+        raw = raw.slice(0, -1);
+      }
+      const href = linkUrl(raw);
+      out += href
+        ? `<a href="${esc(href)}" target="_blank" rel="noopener noreferrer nofollow" style="${LINK_STYLE}">${esc(raw)}</a>${esc(trail)}`
+        : esc(m[0]);
+    } else {
+      const prev = m.index > 0 ? s[m.index - 1] : "";
+      let h = m[2];
+      let trail = "";
+      while (/[.-]$/.test(h)) {
+        trail = h.slice(-1) + trail;
+        h = h.slice(0, -1);
+      }
+      out += /[a-z0-9_@/]/i.test(prev) || !HANDLE_RE.test(h)
+        ? esc(m[0])
+        : mentionHtml(h) + esc(trail);
     }
-    const href = linkUrl(raw);
-    out += href
-      ? `<a href="${esc(href)}" target="_blank" rel="noopener noreferrer nofollow" style="${LINK_STYLE}">${esc(raw)}</a>${esc(trail)}`
-      : esc(m[0]);
     last = m.index + m[0].length;
   }
   out += esc(s.slice(last));

--- a/src/views/group/group-posts.tsx
+++ b/src/views/group/group-posts.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, MessagesSquare } from "lucide-react";
 import { useT } from "@/lib/i18n";
 import { fetchGroupPosts, type GroupPost } from "@/lib/social/group-posts";
@@ -23,6 +23,20 @@ export function GroupPosts({
   const [canPost, setCanPost] = useState(false);
   const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
   const [more, setMore] = useState(false);
+  const [quote, setQuote] = useState({ n: 0, text: "" });
+  const composeRef = useRef<HTMLDivElement>(null);
+
+  const startReply = (p: GroupPost) => {
+  const handle = p.author?.handle;
+  const plain = p.body
+    .replace(/\[[^\]\n]{1,40}\]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const short = plain.length > 120 ? `${plain.slice(0, 120)}…` : plain;
+  const head = handle ? `@${handle}: ` : "";
+  setQuote((q) => ({ n: q.n + 1, text: `[quote]${head}${short}[/quote]\n` }));
+  composeRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+};
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -63,14 +77,17 @@ export function GroupPosts({
   return (
     <div className="flex flex-col gap-3">
       {canPost && (
+      <div ref={composeRef}>
         <PostCompose
           groupId={detail.id}
           groupName={detail.name}
           meAvatar={meAvatar}
           meAlias={meAlias}
           onPosted={(p) => setPosts((cur) => sort([p, ...cur]))}
+          quote={quote}
         />
-      )}
+      </div>
+    )}
 
       {phase === "loading" ? (
         <div className="flex flex-col gap-3">
@@ -107,6 +124,7 @@ export function GroupPosts({
               onChanged={(next) => setPosts((cur) => sort(cur.map((x) => (x.id === next.id ? next : x))))}
               onRemoved={(id) => setPosts((cur) => cur.filter((x) => x.id !== id))}
               onOpenProfile={onOpenProfile}
+              onReply={canPost ? startReply : undefined}
             />
           ))}
           {cursor && (

--- a/src/views/group/post-compose.tsx
+++ b/src/views/group/post-compose.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Bold, Clapperboard, Eye, Image as ImageIcon, Link2, Loader2, Pencil, Send, Youtube } from "lucide-react";
 import { useT } from "@/lib/i18n";
 import { useAutosize } from "@/lib/use-autosize";
@@ -25,12 +25,14 @@ export function PostCompose({
   meAvatar,
   meAlias,
   onPosted,
+  quote,
 }: {
   groupId: string;
   groupName: string;
   meAvatar?: string;
   meAlias?: string;
   onPosted: (p: GroupPost) => void;
+  quote?: { n: number; text: string };
 }) {
   const t = useT();
   const [body, setBody] = useState("");
@@ -46,7 +48,18 @@ export function PostCompose({
   const left = MAX - body.length;
   useAutosize(boxRef, body);
   const active = focused || !!trimmed || busy || !!embed || picking;
-
+  useEffect(() => {
+    if (!quote?.n) return;
+    setBody((b) => (b ? `${quote.text}${b}` : quote.text).slice(0, MAX));
+    setPreview(false);
+    requestAnimationFrame(() => {
+      const el = boxRef.current;
+      el?.focus();
+      const pos = el?.value.length ?? 0;
+      el?.setSelectionRange(pos, pos);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [quote?.n]);
   const splice = (start: number, end: number, text: string) => {
     setBody((b) => (b.slice(0, start) + text + b.slice(end)).slice(0, MAX));
     requestAnimationFrame(() => {
@@ -55,13 +68,11 @@ export function PostCompose({
       boxRef.current?.setSelectionRange(pos, pos);
     });
   };
-
   const insertEmbed = (bbcode: string) => {
     const at = Math.min(caret.current, body.length);
     const pad = at > 0 && body[at - 1] !== "\n" ? "\n" : "";
     splice(at, at, `${pad}${bbcode}\n`);
   };
-
   const send = async () => {
     if (!trimmed || busy) return;
     setBusy(true);
@@ -75,7 +86,6 @@ export function PostCompose({
       setBusy(false);
     }
   };
-
   return (
     <div className="flex gap-3 rounded-[14px] bg-surface p-3.5 ring-1 ring-edge-soft transition-shadow focus-within:ring-edge">
       <Avatar src={meAvatar} size={38} alias={meAlias} />

--- a/src/views/group/post-item.tsx
+++ b/src/views/group/post-item.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from "react";
-import { Heart, Loader2, Pencil, Pin, PinOff, Trash2 } from "lucide-react";
+import { Heart, Loader2, Pencil, Pin, PinOff, Reply, Trash2 } from "lucide-react";
 import { useT } from "@/lib/i18n";
 import { useAutosize } from "@/lib/use-autosize";
 import { renderBbcode } from "@/lib/social/bbcode";
@@ -25,6 +25,7 @@ export function PostItem({
   onChanged,
   onRemoved,
   onOpenProfile,
+  onReply,
 }: {
   post: GroupPost;
   groupId: string;
@@ -32,6 +33,7 @@ export function PostItem({
   onChanged: (p: GroupPost) => void;
   onRemoved: (id: string) => void;
   onOpenProfile?: (handle: string) => void;
+  onReply?: (p: GroupPost) => void;
 }) {
   const t = useT();
   const { openMeta, openManga } = useView();
@@ -161,6 +163,13 @@ export function PostItem({
             className="max-w-none break-words text-[14px] leading-relaxed text-ink-muted [&_a]:break-words"
             onClick={(e) => {
               const el = e.target as HTMLElement;
+              const mention = el.closest?.("[data-harbor-mention]");
+              const mHandle = mention?.getAttribute("data-harbor-mention");
+              if (mHandle) {
+                e.preventDefault();
+                onOpenProfile?.(mHandle);
+                return;
+              }
               const card = el.closest?.("[data-harbor-media]");
               const mediaId = card?.getAttribute("data-harbor-media");
               if (mediaId) {
@@ -195,6 +204,16 @@ export function PostItem({
             <Heart size={14} strokeWidth={2.2} fill={post.liked ? "currentColor" : "none"} />
             {post.likeCount > 0 && <span className="tabular-nums">{post.likeCount}</span>}
           </button>
+
+          {onReply && !editing && (
+            <button
+              type="button"
+              onClick={() => onReply(post)}
+              className="flex h-8 items-center gap-1.5 rounded-full px-2.5 text-[12px] font-semibold text-ink-subtle transition-colors hover:bg-elevated hover:text-ink active:scale-[0.95]"
+            >
+              <Reply size={14} strokeWidth={2.2} /> {t("Reply")}
+            </button>
+          )}
 
           <div className="flex items-center gap-1 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover/post:opacity-100">
             {post.canEdit && !editing && (

--- a/src/views/profile/comment-compose.tsx
+++ b/src/views/profile/comment-compose.tsx
@@ -1,8 +1,11 @@
-import { Send } from "lucide-react";
+import { Send, X } from "lucide-react";
 import { useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
 import { useAutosize } from "@/lib/use-autosize";
-import { COMMENT_MAX, type ComposeIssue } from "./text-safety";
+import { MentionPopover } from "./mention-popover";
+import { COMMENT_MAX, activeMentionQuery, type ComposeIssue } from "./text-safety";
+import { useMentionSuggest, type MentionHit } from "./use-mention-suggest";
+import type { Friend, ReplyTarget } from "./profile-types";
 
 const ISSUE_TEXT: Record<Exclude<ComposeIssue, null>, string> = {
   empty: "Say something first",
@@ -16,23 +19,88 @@ export function CommentCompose({
   onSubmit,
   sending,
   disabled,
+  replyTo,
+  onCancelReply,
+  friends = [],
 }: {
   onSubmit: (raw: string) => Promise<ComposeIssue>;
   sending: boolean;
   disabled?: boolean;
+  replyTo?: ReplyTarget | null;
+  onCancelReply?: () => void;
+  friends?: Friend[];
 }) {
   const t = useT();
   const [text, setText] = useState("");
   const [issue, setIssue] = useState<ComposeIssue>(null);
+  const [mention, setMention] = useState<{ query: string; start: number } | null>(null);
+  const [active, setActive] = useState(0);
   const boxRef = useRef<HTMLTextAreaElement>(null);
   const remaining = COMMENT_MAX - text.length;
+  const hits = useMentionSuggest(mention?.query ?? null, friends);
   useAutosize(boxRef, text);
+
+  const sync = (el: HTMLTextAreaElement) => {
+    const next = activeMentionQuery(el.value, el.selectionStart ?? 0);
+    setMention(next);
+    setActive(0);
+  };
+
+  const pick = (hit: MentionHit) => {
+    if (!mention) return;
+    const el = boxRef.current;
+    const end = mention.start + 1 + mention.query.length;
+    const next = `${text.slice(0, mention.start)}@${hit.handle} ${text.slice(end)}`;
+    setText(next);
+    setMention(null);
+    requestAnimationFrame(() => {
+      if (!el) return;
+      const pos = mention.start + hit.handle.length + 2;
+      el.focus();
+      el.setSelectionRange(pos, pos);
+    });
+  };
 
   const send = async () => {
     if (sending) return;
     const result = await onSubmit(text);
     setIssue(result);
-    if (!result) setText("");
+    if (!result) {
+      setText("");
+      setMention(null);
+      onCancelReply?.();
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (mention && hits.length) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActive((i) => (i + 1) % hits.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActive((i) => (i - 1 + hits.length) % hits.length);
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        pick(hits[active]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMention(null);
+        return;
+      }
+    }
+    if (e.key === "Escape" && replyTo) {
+      e.preventDefault();
+      onCancelReply?.();
+      return;
+    }
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) void send();
   };
 
   if (disabled) {
@@ -44,20 +112,42 @@ export function CommentCompose({
   }
 
   return (
-    <div className="rounded-[10px] bg-elevated p-2 ring-1 ring-edge-soft focus-within:ring-edge">
+    <div className="relative rounded-[10px] bg-elevated p-2 ring-1 ring-edge-soft focus-within:ring-edge">
+      {replyTo && (
+        <div className="mb-1 flex items-start gap-2 rounded-[8px] border-s-2 border-accent bg-surface/60 px-2.5 py-1.5">
+          <div className="min-w-0 flex-1">
+            <span className="text-[12px] font-semibold text-ink">
+              {t("Replying to {alias}", { alias: replyTo.alias })}
+            </span>
+            <p className="truncate text-[12px] text-ink-subtle">{replyTo.excerpt}</p>
+          </div>
+          <button
+            onClick={() => onCancelReply?.()}
+            aria-label={t("Cancel reply")}
+            className="shrink-0 rounded-[6px] p-1 text-ink-subtle transition-colors hover:bg-elevated hover:text-ink"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
+
+      <MentionPopover hits={hits} active={active} onPick={pick} />
+
       <textarea
         ref={boxRef}
         value={text}
         onChange={(e) => {
           setText(e.target.value);
+          sync(e.currentTarget);
           if (issue) setIssue(null);
         }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) void send();
-        }}
+        onKeyUp={(e) => sync(e.currentTarget)}
+        onClick={(e) => sync(e.currentTarget)}
+        onBlur={() => window.setTimeout(() => setMention(null), 120)}
+        onKeyDown={onKeyDown}
         rows={1}
         maxLength={COMMENT_MAX + 40}
-        placeholder={t("Leave a comment. No links.")}
+        placeholder={replyTo ? t("Write a reply. Use @ to mention.") : t("Leave a comment. No links.")}
         className="harbor-scroll min-h-[52px] w-full resize-none bg-transparent px-2 py-1.5 text-[14px] leading-relaxed text-ink outline-none placeholder:text-ink-subtle"
       />
       <div className="flex items-center justify-between gap-3 px-2 pb-1">
@@ -69,7 +159,7 @@ export function CommentCompose({
           disabled={sending || !text.trim()}
           className="inline-flex min-h-11 items-center gap-2 rounded-[10px] bg-accent px-4 text-[14px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-40"
         >
-          <Send size={20} /> {sending ? t("Posting") : t("Post")}
+          <Send size={20} /> {sending ? t("Posting") : t(replyTo ? "Reply" : "Post")}
         </button>
       </div>
     </div>

--- a/src/views/profile/comment-item.tsx
+++ b/src/views/profile/comment-item.tsx
@@ -1,13 +1,13 @@
-import { Heart, Trash2 } from "lucide-react";
+import { Heart, Reply, Trash2 } from "lucide-react";
 import { useT } from "@/lib/i18n";
 import { Avatar, timeAgo } from "./profile-bits";
-import { segmentProfanity } from "./text-safety";
+import { segmentMentions, segmentProfanity } from "./text-safety";
 import { UserHoverCard } from "./user-hover-card";
 import { useSelfAvatar } from "./use-self-avatar";
 import type { Comment } from "./profile-types";
 import { VerifiedBadge } from "@/views/account/verified-badge";
 
-function SafeBody({ body }: { body: string }) {
+function SafeBody({ body, onOpenAuthor }: { body: string; onOpenAuthor?: (h: string) => void }) {
   const t = useT();
   const segments = segmentProfanity(body);
   return (
@@ -22,7 +22,19 @@ function SafeBody({ body }: { body: string }) {
             {s.text}
           </span>
         ) : (
-          <span key={i}>{s.text}</span>
+          segmentMentions(s.text).map((m, j) =>
+            m.handle ? (
+              <button
+                key={`${i}-${j}`}
+                onClick={() => onOpenAuthor?.(m.handle as string)}
+                className="rounded-[4px] font-medium text-accent transition-colors hover:underline"
+              >
+                {m.text}
+              </button>
+            ) : (
+              <span key={`${i}-${j}`}>{m.text}</span>
+            ),
+          )
         ),
       )}
     </p>
@@ -43,6 +55,7 @@ export function CommentItem({
   onDelete: (id: string) => void;
   onToggleLike?: (id: string) => void;
   onOpenAuthor?: (handle: string) => void;
+  onReply?: (c: Comment) => void;
 }) {
   const t = useT();
   const self = useSelfAvatar();
@@ -80,8 +93,20 @@ export function CommentItem({
             </span>
           )}
         </div>
-        <SafeBody body={c.body} />
-        <div className="mt-1.5">
+          {c.replyToId && (
+            <button
+              onClick={() => c.replyToHandle && onOpenAuthor?.(c.replyToHandle)}
+              className="mt-1 flex w-full items-center gap-1.5 rounded-[6px] border-s-2 border-edge bg-elevated/40 px-2 py-1 text-left"
+            >
+              <Reply size={12} className="shrink-0 text-ink-subtle" />
+              <span className="shrink-0 text-[12px] font-medium text-ink-subtle">
+                @{c.replyToHandle}
+              </span>
+              <span className="min-w-0 truncate text-[12px] text-ink-subtle">{c.replyToExcerpt}</span>
+            </button>
+          )}
+          <SafeBody body={c.body} onOpenAuthor={onOpenAuthor} />
+          <div className="mt-1.5 flex items-center gap-1">
           <button
             onClick={() => onToggleLike?.(c.id)}
             disabled={!signedIn}

--- a/src/views/profile/comments-section.tsx
+++ b/src/views/profile/comments-section.tsx
@@ -4,6 +4,7 @@ import { useT } from "@/lib/i18n";
 import { CommentCompose } from "./comment-compose";
 import { CommentItem } from "./comment-item";
 import { useComments } from "./use-comments";
+import type { Comment, Friend, ReplyTarget } from "./profile-types";
 
 const COMMENTS_PAGE = 5;
 const COMMENTS_STEP = 12;
@@ -13,19 +14,31 @@ export function CommentsSection({
   isOwner,
   signedIn,
   onOpenAuthor,
+  friends = [],
 }: {
   handle: string;
   isOwner: boolean;
   signedIn: boolean;
   onOpenAuthor?: (h: string) => void;
+  friends?: Friend[];
 }) {
   const t = useT();
   const { state, comments, total, hasMore, loadMore, submit, remove, toggleLike, sending } = useComments(handle);
   const [shown, setShown] = useState(COMMENTS_PAGE);
+  const [replyTo, setReplyTo] = useState<ReplyTarget | null>(null);
 
   useEffect(() => {
     setShown(COMMENTS_PAGE);
+    setReplyTo(null);
   }, [handle]);
+
+  const startReply = (c: Comment) =>
+    setReplyTo({
+      id: c.id,
+      handle: c.authorHandle,
+      alias: c.authorAlias,
+      excerpt: c.body.length > 80 ? `${c.body.slice(0, 80)}…` : c.body,
+    });
 
   const visible = comments.slice(0, shown);
   const hiddenLocal = Math.max(0, comments.length - shown);
@@ -45,7 +58,14 @@ export function CommentsSection({
       </div>
 
       <div className="mb-4">
-        <CommentCompose onSubmit={submit} sending={sending} disabled={!signedIn} />
+        <CommentCompose
+          onSubmit={(raw) => submit(raw, replyTo?.id)}
+          sending={sending}
+          disabled={!signedIn}
+          replyTo={replyTo}
+          onCancelReply={() => setReplyTo(null)}
+          friends={friends}
+        />
       </div>
 
       {state === "loading" && (
@@ -83,6 +103,7 @@ export function CommentsSection({
               onDelete={remove}
               onToggleLike={toggleLike}
               onOpenAuthor={onOpenAuthor}
+              onReply={startReply}
             />
           ))}
           {canShowMore && (

--- a/src/views/profile/mention-popover.tsx
+++ b/src/views/profile/mention-popover.tsx
@@ -1,0 +1,42 @@
+import { useT } from "@/lib/i18n";
+import { Avatar } from "./profile-bits";
+import type { MentionHit } from "./use-mention-suggest";
+
+export function MentionPopover({
+  hits,
+  active,
+  onPick,
+}: {
+  hits: MentionHit[];
+  active: number;
+  onPick: (hit: MentionHit) => void;
+}) {
+  const t = useT();
+  if (!hits.length) return null;
+  return (
+    <ul
+      role="listbox"
+      aria-label={t("Mention a user")}
+      className="absolute bottom-full left-2 z-30 mb-1 max-h-60 w-64 overflow-y-auto rounded-[10px] bg-raised p-1 shadow-lg ring-1 ring-edge"
+    >
+      {hits.map((h, i) => (
+        <li key={h.handle} role="option" aria-selected={i === active}>
+          <button
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onPick(h);
+            }}
+            className={`flex w-full items-center gap-2 rounded-[8px] px-2 py-1.5 text-left transition-colors ${
+              i === active ? "bg-elevated" : "hover:bg-elevated/60"
+            }`}
+          >
+            <Avatar src={h.avatarUrl} size={24} alias={h.alias} />
+            <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-ink">{h.alias}</span>
+            <span className="shrink-0 text-[12px] text-ink-subtle">@{h.handle}</span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/views/profile/profile-api.ts
+++ b/src/views/profile/profile-api.ts
@@ -71,11 +71,19 @@ export function fetchComments(handle: string, cursor?: string, signal?: AbortSig
   return getJson<CommentPage>(`/u/${encodeURIComponent(handle)}/comments${q}`, signal);
 }
 
-export async function postComment(handle: string, body: string): Promise<Comment> {
+export async function postComment(
+  handle: string,
+  body: string,
+  opts?: { replyToId?: string; mentions?: string[] },
+): Promise<Comment> {
   const res = await safeFetch(`${BASE}/u/${encodeURIComponent(handle)}/comments`, {
     method: "POST",
     headers: { ...authHeaders(), "content-type": "application/json" },
-    body: JSON.stringify({ body }),
+    body: JSON.stringify({
+      body,
+      ...(opts?.replyToId ? { replyToId: opts.replyToId } : {}),
+      ...(opts?.mentions?.length ? { mentions: opts.mentions } : {}),
+    }),
   });
   if (res.status === 429) throw new ProfileApiError(429);
   if (!res.ok) throw new ProfileApiError(res.status);

--- a/src/views/profile/profile-types.ts
+++ b/src/views/profile/profile-types.ts
@@ -141,6 +141,18 @@ export type Comment = {
   liked?: boolean;
   flagged?: boolean;
   edited?: boolean;
+  replyToId?: string;
+  replyToHandle?: string;
+  replyToAlias?: string;
+  replyToExcerpt?: string;
+  mentions?: string[];
+};
+
+export type ReplyTarget = {
+  id: string;
+  handle: string;
+  alias: string;
+  excerpt: string;
 };
 
 export type CommentPage = {

--- a/src/views/profile/text-safety.ts
+++ b/src/views/profile/text-safety.ts
@@ -64,3 +64,39 @@ export function validateComment(text: string, lastSentAt: number, now: number): 
   if (now - lastSentAt < COMMENT_COOLDOWN_MS) return "cooldown";
   return null;
 }
+
+export const MENTION_RE = /@([a-zA-Z0-9_.-]{2,32})/g;
+
+export function extractMentions(text: string): string[] {
+  const out = new Set<string>();
+  MENTION_RE.lastIndex = 0;
+  for (let m = MENTION_RE.exec(text); m; m = MENTION_RE.exec(text)) {
+    out.add(m[1].toLowerCase());
+  }
+  return [...out];
+}
+
+export type MentionSegment = { text: string; handle?: string };
+
+export function segmentMentions(text: string): MentionSegment[] {
+  const out: MentionSegment[] = [];
+  let last = 0;
+  MENTION_RE.lastIndex = 0;
+  for (let m = MENTION_RE.exec(text); m; m = MENTION_RE.exec(text)) {
+    if (m.index > last) out.push({ text: text.slice(last, m.index) });
+    out.push({ text: m[0], handle: m[1] });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) out.push({ text: text.slice(last) });
+  return out.length ? out : [{ text }];
+}
+
+export function activeMentionQuery(
+  value: string,
+  caret: number,
+): { query: string; start: number } | null {
+  const upto = value.slice(0, caret);
+  const m = /(?:^|\s)@([a-zA-Z0-9_.-]{0,32})$/.exec(upto);
+  if (!m) return null;
+  return { query: m[1], start: caret - m[1].length - 1 };
+}

--- a/src/views/profile/use-comments.ts
+++ b/src/views/profile/use-comments.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { currentAuthor, subscribeAuthor } from "@/lib/theme-auth";
 import { deleteComment, fetchComments, postComment, ProfileApiError, setCommentLike } from "./profile-api";
 import type { Comment, LoadState } from "./profile-types";
-import { stripUrls, validateComment, type ComposeIssue } from "./text-safety";
+import { extractMentions, stripUrls, validateComment, type ComposeIssue } from "./text-safety";
 
 export type CommentsController = {
   state: LoadState;
@@ -11,7 +11,7 @@ export type CommentsController = {
   cursor?: string;
   hasMore: boolean;
   loadMore: () => void;
-  submit: (raw: string) => Promise<ComposeIssue>;
+  submit: (raw: string, replyToId?: string) => Promise<ComposeIssue>;
   remove: (id: string) => void;
   toggleLike: (id: string) => void;
   sending: boolean;
@@ -57,14 +57,15 @@ export function useComments(handle: string): CommentsController {
   }, [handle, cursor, authKey]);
 
   const submit = useCallback(
-    async (raw: string): Promise<ComposeIssue> => {
+    async (raw: string, replyToId?: string): Promise<ComposeIssue> => {
       const issue = validateComment(raw, lastSentAt.current, Date.now());
       if (issue) return issue;
       if (!authKey) return "spam";
       const clean = stripUrls(raw.trim());
+      const mentions = extractMentions(clean);
       setSending(true);
       try {
-        const created = await postComment(handle, clean);
+        const created = await postComment(handle, clean, { replyToId, mentions });
         lastSentAt.current = Date.now();
         setComments((cur) => [created, ...cur]);
         setState("ready");

--- a/src/views/profile/use-mention-suggest.ts
+++ b/src/views/profile/use-mention-suggest.ts
@@ -1,0 +1,56 @@
+import { useEffect, useMemo, useState } from "react";
+import { searchUsers, type UserHit } from "@/lib/social/user-search";
+import type { Friend } from "./profile-types";
+
+export type MentionHit = { handle: string; alias: string; avatarUrl?: string };
+
+const MAX_HITS = 6;
+
+export function useMentionSuggest(query: string | null, friends: Friend[] = []): MentionHit[] {
+  const [remote, setRemote] = useState<MentionHit[]>([]);
+
+  useEffect(() => {
+    if (query === null || query.trim().length < 2) {
+      setRemote([]);
+      return;
+    }
+    const ctrl = new AbortController();
+    const id = window.setTimeout(() => {
+      searchUsers(query.trim(), ctrl.signal)
+        .then((hits: UserHit[]) => {
+          if (ctrl.signal.aborted) return;
+          setRemote(hits.map((h) => ({ handle: h.handle, alias: h.alias, avatarUrl: h.avatarUrl })));
+        })
+        .catch(() => !ctrl.signal.aborted && setRemote([]));
+    }, 220);
+    return () => {
+      ctrl.abort();
+      window.clearTimeout(id);
+    };
+  }, [query]);
+
+  return useMemo(() => {
+    if (query === null) return [];
+    const q = query.trim().toLowerCase();
+    const local = friends.filter(
+      (f) => !q || f.handle.toLowerCase().startsWith(q) || f.alias.toLowerCase().includes(q),
+    );
+    const seen = new Set<string>();
+    const out: MentionHit[] = [];
+    for (const f of local) {
+      const k = f.handle.toLowerCase();
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push({ handle: f.handle, alias: f.alias, avatarUrl: f.avatarUrl });
+      if (out.length >= MAX_HITS) return out;
+    }
+    for (const r of remote) {
+      const k = r.handle.toLowerCase();
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(r);
+      if (out.length >= MAX_HITS) break;
+    }
+    return out;
+  }, [query, friends, remote]);
+}


### PR DESCRIPTION
## Summary

Two additions to social posts and comments:

1. `@handle` in group posts now renders as a clickable link that opens that
   user's profile. Rendered in `src/lib/social/bbcode.ts` next to the existing
   URL linkifier so it shares the same escaping and the same `[code]` guard.
2. A Reply button under each group post that inserts
   `[quote]@handle: text[/quote]` into the composer. Replies are stored in the
   post body using the existing `[quote]` tag, so no API change is needed and
   every member can see them.

Profile comments also have a reply UI, but that part is not functional yet —
see Status below.

## Why

Users kept asking for replies in group posts. Threading normally needs a new
`replyToId` column and a new endpoint, but `[quote]` already exists in the
BBCode renderer, so quote replies work end to end with zero backend changes.

Mentions were rendered as plain text, so there was no way to reference or
reach another member from a post.

## Status

**Group posts — done and working on the live server.**

**Profile comments — not working.** It sends `replyToId` to `postComment` and
the server drops the field, so replies do not persist. `use-comments.ts` also
still has a `// TEMP: local echo` block so the reply appears locally. Included
here for review only — happy to split it into its own PR if you prefer.

## Server side needed for mention notifications

Mentions render, but nobody gets notified. The client only reads
`/social/me/notifications`, so only the server can create a notification for
another user.

`group-post` notifications already exist, and `socialToCenter` passes any
unknown `type` straight through, so a new kind renders in the notification
center without client changes. `friend-request` already follows the same
shape: user A acts, the server creates a notification for user B.

What I need:

- should `POST /social/groups/:id/posts` extract `@handle` from the body, or
  should the client send a `mentions` array?
- notifications should only go to members of that group, otherwise it is a
  spam vector the client cannot guard against

I have the rendering side written (icon, title, and a "View post" button using
`data.groupId`). Tell me the field name you want and I will match it. Not
included in this PR since it is untestable until the server sends the kind.

## Verification

- `npx tsc -b` passes
- `pnpm tauri dev` on Windows 11, tested in a live public group with 245 members

Manual scenarios:

- `@handle` renders colored and opens the correct profile
- `[code]@handle[/code]` stays plain and uncolored
- `test [at] gmail.com` stays plain text and is not turned into a mention
- Reply fills the composer with the quote and puts the caret on the line below
- Posting the reply shows it to all members, verified from a second account
- Preview renders the quote and the mention correctly
- Long posts are truncated to 120 chars in the quote

Note: the checklist mentions `vp check` and `vp run typecheck`, but neither
script exists in `package.json` on this branch — they moved into the staged
commit hooks. I used `npx tsc -b` instead. Let me know if there is another
command I should run.

## Platform Impact

Verified on Windows 11 only. The changes are React and BBCode rendering with
no platform-specific or native code, so no OS-specific behavior is expected.
No TV-style input changes — the Reply button is a regular focusable button.

RTL was checked with the Arabic UI. The quote bar uses the logical
`border-s-2` rather than `border-l-2` so it renders on the correct side.

## UI Changes

<img width="939" height="259" alt="image" src="https://github.com/user-attachments/assets/c576a25f-af13-4ee1-ba23-6bb1edba4b65" />

<img width="530" height="143" alt="image" src="https://github.com/user-attachments/assets/c62a0c5b-b4fc-49a3-8256-b5952d412254" />



Before: mentions were plain text and there was no Reply button.
After: mentions are colored links and every post has a Reply button next to
the like button.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes.
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.