### PR TITLE
fix(subtitles): keep image tracks out of the second subtitle slot

### DIFF
--- a/src/components/player/subtitle-menu/menu-body.tsx
+++ b/src/components/player/subtitle-menu/menu-body.tsx
@@ -21,7 +21,8 @@ const ALL_LANGS = "__all__";
 
 export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
   const tr = useT();
-  const { tracks, selectedId, onSelect, onClose, delaySec, metaReleaseDate, onOpenStyleBar } = props;
+  const { tracks, selectedId, onSelect, onClose, delaySec, metaReleaseDate, onOpenStyleBar } =
+    props;
   const groups = useMemo(() => groupByLang(tracks), [tracks]);
   const [searchSettled, setSearchSettled] = useState(false);
   const [activeLang, setActiveLang] = useState<string | null>(null);
@@ -73,7 +74,10 @@ export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
   const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
   const [localError, setLocalError] = useState<string | null>(null);
   const delayNonZero = delaySec !== 0;
-  const selectedTrack = useMemo(() => tracks.find((t) => t.id === selectedId) ?? null, [tracks, selectedId]);
+  const selectedTrack = useMemo(
+    () => tracks.find((t) => t.id === selectedId) ?? null,
+    [tracks, selectedId],
+  );
   const secondaryTrack = useMemo(() => tracks.find((t) => t.secondary) ?? null, [tracks]);
   const pickSecondary = props.onSelectSecondary ?? setSecondarySub;
   const search = useSubtitleSearch();
@@ -215,9 +219,7 @@ export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
               >
                 <Flag language={g.langDisplay} size="sm" showLabel={false} />
                 <span className="flex-1 truncate font-medium">{g.langDisplay}</span>
-                {hasSelected && (
-                  <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-accent" />
-                )}
+                {hasSelected && <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-accent" />}
                 <span className="text-[10.5px] tabular-nums text-ink-subtle">
                   {g.variants.length}
                 </span>
@@ -344,4 +346,3 @@ export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
     </div>
   );
 }
-

--- a/src/components/player/subtitle-menu/menu-body.tsx
+++ b/src/components/player/subtitle-menu/menu-body.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Flag } from "@/components/flag";
 import { markImportedSub } from "@/lib/player/imported-subs";
 import { setSecondarySub } from "@/lib/player/secondary-sub";
+import { canBeSecondarySub } from "@/lib/player/sub-format";
 import { useT } from "@/lib/i18n";
 import { Tooltip } from "../transport/tooltip";
 import { SearchSection } from "./search-section";
@@ -300,8 +301,10 @@ export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
                       onPick={() => {
                         onSelect(t.id);
                       }}
-                      onPickSecondary={() =>
-                        pickSecondary(t.id === secondaryTrack?.id ? null : t.id)
+                      onPickSecondary={
+                        canBeSecondarySub(t)
+                          ? () => pickSecondary(t.id === secondaryTrack?.id ? null : t.id)
+                          : undefined
                       }
                     />
                   ))}

--- a/src/lib/player/sub-format.ts
+++ b/src/lib/player/sub-format.ts
@@ -15,6 +15,13 @@ export function isAssTrack(track: TrackInfo | null | undefined): boolean {
   return /\.(ass|ssa)$/.test(title);
 }
 
+/** The second subtitle is drawn from mpv's `secondary-sub-text`, which only ever
+ *  carries text. An image track put in that slot decodes to nothing, so it would
+ *  read as a silently broken second subtitle. */
+export function canBeSecondarySub(track: TrackInfo | null | undefined): boolean {
+  return !!track && !isImageSubTrack(track);
+}
+
 export function isImageSubTrack(track: TrackInfo | null | undefined): boolean {
   if (!track) return false;
   const codec = (track.codec ?? "").toUpperCase();

--- a/src/views/player/hooks/use-secondary-sub.ts
+++ b/src/views/player/hooks/use-secondary-sub.ts
@@ -2,10 +2,11 @@ import { useEffect, useRef, type RefObject } from "react";
 import type { PlayerBridge, PlayerSnapshot, TrackInfo } from "@/lib/player/bridge";
 import { resetSecondarySub, useSecondarySubChoice } from "@/lib/player/secondary-sub";
 import { pickBestTrack } from "@/lib/subtitles/language";
+import { canBeSecondarySub } from "@/lib/player/sub-format";
 
 function autoPick(tracks: TrackInfo[], lang: string, primaryId: string | null): string | null {
   if (!lang.trim()) return null;
-  const pool = tracks.filter((t) => t.id !== primaryId);
+  const pool = tracks.filter((t) => t.id !== primaryId && canBeSecondarySub(t));
   return pickBestTrack(pool, [lang])?.id ?? null;
 }
 
@@ -34,7 +35,13 @@ export function useSecondarySub({
     const primaryId = snap.subtitleTracks.find((t) => t.selected)?.id ?? null;
     const currentId = snap.subtitleTracks.find((t) => t.secondary)?.id ?? null;
     const wanted = choice === "auto" ? autoPick(snap.subtitleTracks, lang, primaryId) : choice;
-    const target = wanted != null && wanted !== primaryId ? wanted : null;
+    // Gate on the resolved track, not just the id, so an explicit choice from any
+    // caller is held to the same text-only rule the automatic pick is.
+    const wantedTrack = snap.subtitleTracks.find((t) => t.id === wanted) ?? null;
+    const target =
+      wantedTrack && wantedTrack.id !== primaryId && canBeSecondarySub(wantedTrack)
+        ? wantedTrack.id
+        : null;
     if (target === currentId) {
       appliedRef.current = target;
       return;


### PR DESCRIPTION
## Summary

The second subtitle is drawn from mpv's `secondary-sub-text`, which only ever carries text. Put a PGS/VOBSUB/DVB track in that slot and it decodes to nothing — the row shows as active, and no second subtitle appears. Nothing reports why.

Both selection paths could reach one:

| Path | Before |
| --- | --- |
| Automatic (`autoPick`, `use-secondary-sub.ts`) | filtered only the primary track, so a bitmap track could win the language match outright |
| Manual ("2nd" button, `variant-row.tsx`) | rendered for every non-primary row, image tracks included |

The automatic case is the worse of the two: `pickBestTrack` returns the best match for the language, so an image track could shadow a perfectly usable text track further down the list.

## Change

Adds `canBeSecondarySub` beside the existing `isImageSubTrack` in `sub-format.ts`, so the constraint is stated once with the reason attached. The automatic pool filters on it, and the "2nd" button is dropped for rows that cannot fill the slot — reusing the existing `onPickSecondary && ...` conditional, so no new rendering branch.

`useSecondarySub` also gates on the resolved track rather than the id, so an explicit choice arriving from any caller — including `modal://subtitle/secondary` from the overlay window — is held to the same rule.

Image rows keep their existing **Position and size only** tag, so the row still explains itself.

## Commits

- `fix(subtitles):` the change itself — 3 files, +21/−4.
- `style:` formatting. `vp fmt --check` in the Frontend job runs over changed files, and `menu-body.tsx` was already unformatted on `beta-branch`, so touching it at all turns CI red. Split out so the fix stays readable — it is three line-wraps and a trailing newline, no logic.

## Testing

`tsc -b` clean. `vp check` reports the same one warning as the untouched branch, and the same formatting state (`menu-body.tsx` is already unformatted on `beta-branch`, and none of the added lines are what the formatter objects to).

Worth a look from someone with a PGS-bearing remux: pick a bitmap track as the second subtitle before this change and it silently does nothing; after it, the button isn't offered.
