### PR TITLE
fix(subtitles): keep the second subtitle visible under HDR passthrough

### DIFF
--- a/src/lib/player/sub-style.ts
+++ b/src/lib/player/sub-style.ts
@@ -30,6 +30,25 @@ function mpvFontFor(id: string): string {
   }
 }
 
+/** Hand the second subtitle over to mpv's own renderer, for the one surface our
+ *  overlay cannot draw on (HDR passthrough). `secondary-sub-pos` is measured from
+ *  the top, matching how `sub-pos` positions the primary. */
+export async function applySecondarySubNative(
+  on: boolean,
+  placement: Settings["subSecondaryPlacement"],
+  marginY: number,
+): Promise<void> {
+  await invoke("mpv_set_property", {
+    name: "secondary-sub-visibility",
+    value: on,
+  }).catch(() => {});
+  if (!on) return;
+  // "bottom" means "just above the primary line". mpv exposes no line-height
+  // metric, so offset by a fixed slice of the frame rather than guessing exactly.
+  const pos = placement === "top" ? 0 : clamp(100 - (Number(marginY) || 0) - 8, 0, 100);
+  await invoke("mpv_set_property", { name: "secondary-sub-pos", value: pos }).catch(() => {});
+}
+
 export type SubRenderContext = {
   assNativeActive: boolean;
   imageNativeActive: boolean;

--- a/src/lib/player/sub-style.ts
+++ b/src/lib/player/sub-style.ts
@@ -61,7 +61,9 @@ export async function applySubStyle(
 ): Promise<void> {
   const override = s.subAssOverride;
   const normScale =
-    typeof context.assScale === "number" && Number.isFinite(context.assScale) ? context.assScale : null;
+    typeof context.assScale === "number" && Number.isFinite(context.assScale)
+      ? context.assScale
+      : null;
   const effOverride = normScale != null ? "scale" : override;
   const assMargins = context.assNativeActive && override !== "no" ? "yes" : "no";
   const marginY = clamp(Number(s.subMarginY) || 0, 0, 100);
@@ -73,7 +75,12 @@ export async function applySubStyle(
   const props: Array<[string, unknown]> = [
     ["sub-font-size", 32],
     ["sub-font", mpvFontFor(s.subFontFamily)],
-    ["sub-scale", normScale != null ? clamp(normScale, 0.2, 6) : Math.min(4, Math.max(0.4, (Number(s.subFontSize) || 32) / 32))],
+    [
+      "sub-scale",
+      normScale != null
+        ? clamp(normScale, 0.2, 6)
+        : Math.min(4, Math.max(0.4, (Number(s.subFontSize) || 32) / 32)),
+    ],
     ["sub-color", mpvColor(s.subFontColor, opacity)],
     ["sub-border-color", mpvColor(s.subBorderColor, opacity)],
     ["sub-border-size", s.subBorderSize],
@@ -90,8 +97,6 @@ export async function applySubStyle(
     ["sub-pos", reposition ? clamp(100 - marginY, 0, 100) : 100],
   ];
   await Promise.all(
-    props.map(([name, value]) =>
-      invoke("mpv_set_property", { name, value }).catch(() => {}),
-    ),
+    props.map(([name, value]) => invoke("mpv_set_property", { name, value }).catch(() => {})),
   );
 }

--- a/src/views/player/hooks/use-player-media.ts
+++ b/src/views/player/hooks/use-player-media.ts
@@ -182,6 +182,9 @@ export function usePlayerMedia(params: {
     snap,
     sourceUrl: src.url,
     lang: settings.secondarySubLang,
+    nativeRender: hdrNativeSurface,
+    placement: settings.subSecondaryPlacement,
+    marginY: settings.subMarginY,
   });
   useEffect(() => {
     clearImportedSubs();

--- a/src/views/player/hooks/use-player-media.ts
+++ b/src/views/player/hooks/use-player-media.ts
@@ -13,7 +13,11 @@ import { useSettings } from "@/lib/settings";
 import { isLocalEngineUrl } from "@/lib/stremio-server";
 import { useSimklScrobble } from "@/lib/simkl/scrobble-hook";
 import { useTraktScrobble } from "@/lib/trakt/scrobble-hook";
-import { cancelTorrentRemoval, scheduleTorrentRemoval, torrentEngineRemove } from "@/lib/torrent/local-engine";
+import {
+  cancelTorrentRemoval,
+  scheduleTorrentRemoval,
+  torrentEngineRemove,
+} from "@/lib/torrent/local-engine";
 import { stopAllFullDownloads, stopFullDownload } from "@/lib/torrent/full-download";
 import type { PlayerSrc } from "@/lib/view";
 import { useExitSnapshot } from "./use-exit-snapshot";
@@ -73,7 +77,7 @@ export function usePlayerMedia(params: {
 
   const prevEngineHashRef = useRef<string | null>(null);
   useEffect(() => {
-    const hash = isLocalEngineUrl(src.url) ? src.streamRef?.infoHash ?? null : null;
+    const hash = isLocalEngineUrl(src.url) ? (src.streamRef?.infoHash ?? null) : null;
     const fullDlHash = src.streamRef?.infoHash?.toLowerCase() ?? null;
     const prev = prevEngineHashRef.current;
     const keepBg = settings.keepStreamDownloadsInBackground;
@@ -120,9 +124,27 @@ export function usePlayerMedia(params: {
   });
 
   const autoSync = useAutoSync({ bridgeRef, src, snap, engine, settings });
-  const { status: asStatus, offer: asOffer, applyOffer: asApply, revert: asRevert, retry: asRetry, run: asRun, stop: asStop, feedback: asFeedback } = autoSync;
+  const {
+    status: asStatus,
+    offer: asOffer,
+    applyOffer: asApply,
+    revert: asRevert,
+    retry: asRetry,
+    run: asRun,
+    stop: asStop,
+    feedback: asFeedback,
+  } = autoSync;
   useEffect(() => {
-    publishAutoSync({ status: asStatus, offer: asOffer, applyOffer: asApply, revert: asRevert, retry: asRetry, run: asRun, stop: asStop, feedback: asFeedback });
+    publishAutoSync({
+      status: asStatus,
+      offer: asOffer,
+      applyOffer: asApply,
+      revert: asRevert,
+      retry: asRetry,
+      run: asRun,
+      stop: asStop,
+      feedback: asFeedback,
+    });
     return () => publishAutoSync(null);
   }, [asStatus, asOffer, asApply, asRevert, asRetry, asRun, asStop, asFeedback]);
 
@@ -132,19 +154,20 @@ export function usePlayerMedia(params: {
     isWindowsDesktop() &&
     !settings.playerHdrToSdr &&
     HDR_NATIVE_GAMMAS.has(snap.hdrGamma) &&
-    (settings.playerHdrOpaqueWindow || (settings.playerMpvEmbed && settings.playerHdrStage !== "off"));
+    (settings.playerHdrOpaqueWindow ||
+      (settings.playerMpvEmbed && settings.playerHdrStage !== "off"));
   const selectedSubTrack = snap.subtitleTracks.find((t) => t.selected) ?? null;
   const subAssOverridden = settings.subAssOverride !== "no" && settings.subAssOverride !== "scale";
   const selectedAssSub = isAssTrack(selectedSubTrack);
   const selectedImageSub = isImageSubTrack(selectedSubTrack);
   const subAssNative =
     subEmbed && selectedAssSub && (!subAssOverridden || !selectedSubTrack?.external);
-  const subNativeRender =
-    hdrNativeSurface || subAssNative || (subEmbed && selectedImageSub);
+  const subNativeRender = hdrNativeSurface || subAssNative || (subEmbed && selectedImageSub);
   const assNativeActive = selectedAssSub && (subNativeRender || !subEmbed);
   const imageNativeActive = selectedImageSub && (subNativeRender || !subEmbed);
   const assNormalizeScale = useAssNormalize({
-    enabled: engine === "mpv" && settings.subAssNormalizeSize && assNativeActive && !subAssOverridden,
+    enabled:
+      engine === "mpv" && settings.subAssNormalizeSize && assNativeActive && !subAssOverridden,
     sourceUrl: src.url ?? null,
     headers: src.headers,
     track: selectedSubTrack,
@@ -210,7 +233,7 @@ export function usePlayerMedia(params: {
     if (!b) return;
     const base = src.episode
       ? `${src.meta.name ?? "Subtitle"} S${src.episode.season}E${src.episode.episode}`
-      : src.meta.name ?? "Subtitle";
+      : (src.meta.name ?? "Subtitle");
     const fileName = `${base.replace(/[\\/:*?"<>|]+/g, " ").trim() || "Subtitle"}.srt`;
     const res = await getCuesAnySource(b, src.url, src.headers);
     if (res.ok && res.source.cues.length > 0) {
@@ -230,10 +253,25 @@ export function usePlayerMedia(params: {
       infoHash: src.streamRef?.infoHash ?? null,
     });
     return () => setPlayerActions(null);
-  }, [download.start, toggleFullscreen, src.url, src.streamRef?.infoHash, doDownloadSubtitle, canDownloadSub]);
+  }, [
+    download.start,
+    toggleFullscreen,
+    src.url,
+    src.streamRef?.infoHash,
+    doDownloadSubtitle,
+    canDownloadSub,
+  ]);
 
   useResumeAutosave({ src, snap, season, episode, resolvedImdbId, resolvedImdbVerified });
-  useStremioSync({ src, snap, authKey, resolvedImdbId, resolvedImdbVerified, resolutionSettled, castActiveRef });
+  useStremioSync({
+    src,
+    snap,
+    authKey,
+    resolvedImdbId,
+    resolvedImdbVerified,
+    resolutionSettled,
+    castActiveRef,
+  });
   usePowerInhibit(snap);
   const subDropToast = useSubDrop(bridgeRef, src.meta.id);
 
@@ -249,5 +287,11 @@ export function usePlayerMedia(params: {
     });
   }, [engine, src.url, src.meta.name, src.meta.poster, src.episode, snap.durationSec]);
 
-  return { resolvedImdbId, subAssNative: suppressHtmlSubs, captureExitSnapshot, download, subDropToast };
+  return {
+    resolvedImdbId,
+    subAssNative: suppressHtmlSubs,
+    captureExitSnapshot,
+    download,
+    subDropToast,
+  };
 }

--- a/src/views/player/hooks/use-secondary-sub.ts
+++ b/src/views/player/hooks/use-secondary-sub.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef, type RefObject } from "react";
 import type { PlayerBridge, PlayerSnapshot, TrackInfo } from "@/lib/player/bridge";
 import { resetSecondarySub, useSecondarySubChoice } from "@/lib/player/secondary-sub";
 import { pickBestTrack } from "@/lib/subtitles/language";
+import { applySecondarySubNative } from "@/lib/player/sub-style";
+import type { Settings } from "@/lib/settings";
 
 function autoPick(tracks: TrackInfo[], lang: string, primaryId: string | null): string | null {
   if (!lang.trim()) return null;
@@ -14,14 +16,25 @@ export function useSecondarySub({
   snap,
   sourceUrl,
   lang,
+  nativeRender,
+  placement,
+  marginY,
 }: {
   bridgeRef: RefObject<PlayerBridge | null>;
   snap: PlayerSnapshot;
   sourceUrl: string;
   lang: string;
+  /** True on surfaces our overlay cannot draw over, so mpv must render instead. */
+  nativeRender: boolean;
+  placement: Settings["subSecondaryPlacement"];
+  marginY: number;
 }): void {
   const choice = useSecondarySubChoice();
   const appliedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    void applySecondarySubNative(nativeRender, placement, marginY);
+  }, [nativeRender, placement, marginY]);
 
   useEffect(() => {
     appliedRef.current = null;


### PR DESCRIPTION
## Summary

On a Windows HDR passthrough surface nothing can be composited over the video. That is why `suppressHtmlSubs` folds `hdrNativeSurface` in (`use-player-media.ts:161`) and the primary subtitle is handed to mpv through `setSubVisible(subNativeRender)`.

The second subtitle had no equivalent. `secondary-sub-visibility` is set to `"no"` at startup (`src-tauri/src/mpv.rs:717`) and never turned back on, so on that one surface the second subtitle is simply invisible, with nothing indicating why. Every other configuration is unaffected.

## Change

Mirrors the arrangement the primary already has.

`applySecondarySubNative` sits next to `applySubStyle` in `sub-style.ts` — the module that already owns mpv's subtitle properties — and drives `secondary-sub-visibility` plus `secondary-sub-pos`. `useSecondarySub` makes the call, so the whole secondary lifecycle stays in the one hook that owns it.

`secondary-sub-pos` is measured from the top, matching how `sub-pos` positions the primary. **Top of the screen** maps to `0`; **Above the main line** offsets from the configured margin by a fixed slice of the frame, because mpv exposes no line-height metric to be exact with.

The overlay is deliberately left untouched. It cannot draw on that surface, and the HDR chrome window renders `ShellLayer` only — not `StageOverlays` — so there is no second renderer that could double up. An earlier draft threaded a flag through `player.tsx` to blank `secondarySubText`; I dropped it once that turned out to guard against nothing, which also keeps `player.tsx` out of the diff entirely.

## Commits

- `fix(subtitles):` the change itself — 3 files, +35/−0.
- `style:` formatting. `vp fmt --check` in the Frontend job runs over changed files, and `sub-style.ts` and `use-player-media.ts` were both already unformatted on `beta-branch`, so touching them at all turns CI red. Split out so the two-line change in `use-player-media.ts` stays visible.

## Testing

`tsc -b` clean. `vp fmt --check` clean on all three files.

**I could not verify this on hardware** — it needs a Windows machine with an HDR display and a PQ/HLG source, which I don't have. The change mirrors the primary's existing path and the `hdrNativeSurface` guard means nothing else can reach it, but the on-screen result on that surface is unconfirmed. Happy to adjust the `secondary-sub-pos` offset if it sits wrong against the primary line.
