### PR TITLE
fix(player): prevent paused streams from being auto-skipped

### DIFF
--- a/src/lib/player/stall-wait.ts
+++ b/src/lib/player/stall-wait.ts
@@ -12,3 +12,16 @@ export function stallWaitSec(value: number | undefined): number {
 export function stallWaitMs(value: number | undefined): number {
   return stallWaitSec(value) * 1000;
 }
+
+export function hasPlaybackStartedForStallCheck(params: {
+  status: string;
+  positionSec: number;
+  videoWidth: number;
+  videoHeight: number;
+}): boolean {
+  return (
+    params.status === "paused" ||
+    params.positionSec > 0 ||
+    (params.videoWidth > 0 && params.videoHeight > 0)
+  );
+}

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -13,7 +13,7 @@ import { useQueue, useSleepAtEnd, queueIndexOf, setQueuePlaying } from "@/lib/qu
 import { useSkipSegments, useAdSegments } from "@/lib/skip-intro";
 import { withinAdWindow } from "@/lib/ad-report/window";
 import { isLocalUrl } from "@/lib/player/local-url";
-import { stallWaitMs } from "@/lib/player/stall-wait";
+import { hasPlaybackStartedForStallCheck, stallWaitMs } from "@/lib/player/stall-wait";
 import { useAuth } from "@/lib/auth";
 import { embedFlags } from "./player/player-utils";
 import { useFullscreen } from "./player/hooks/use-fullscreen";
@@ -28,7 +28,7 @@ import { useAutoRetry } from "./player/hooks/use-auto-retry";
 import { useWakeReconnect } from "./player/hooks/use-wake-reconnect";
 import { useEngineStats } from "./player/hooks/use-engine-stats";
 import { useContentAdvisory } from "./player/hooks/use-content-advisory";
-import { setPlaybackDownloaded } from "@/lib/player/playback-clock";
+import { getPlaybackPosition, setPlaybackDownloaded } from "@/lib/player/playback-clock";
 import { isBundledEngineUrl, isLocalEngineUrl } from "@/lib/stremio-server";
 import { usePauseOnInactive } from "./player/hooks/use-pause-on-inactive";
 import { spoilerMaskFor } from "@/lib/spoilers";
@@ -468,12 +468,24 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   });
 
   const autoAdvancedRef = useRef(false);
+  const playbackStartedRef = useRef(false);
   useEffect(() => {
     autoAdvancedRef.current = false;
+    playbackStartedRef.current = false;
   }, [src.url]);
+  if (
+    hasPlaybackStartedForStallCheck({
+      status: snap.status,
+      positionSec: getPlaybackPosition(),
+      videoWidth: snap.videoWidth,
+      videoHeight: snap.videoHeight,
+    })
+  ) {
+    playbackStartedRef.current = true;
+  }
   useEffect(() => {
     if (snap.status !== "error" || autoAdvancedRef.current) return;
-    if (!src.autoFired || hasStarted || src.isLive || inRoom) return;
+    if (!src.autoFired || playbackStartedRef.current || src.isLive || inRoom) return;
     autoAdvancedRef.current = true;
     if (src.streamRef) markStreamDead(src.streamRef, "load-failed", STUB_TTL_MS);
     exitPlayback();
@@ -482,19 +494,29 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
       attempt: (src.attempt ?? 0) + 1,
       resume: src.resume,
     });
-  }, [snap.status, src, hasStarted, inRoom, exitPlayback, openPicker]);
+  }, [snap.status, src, inRoom, exitPlayback, openPicker]);
 
   // Opt-in: advance to the next stream if this pick hasn't started playing within
   // 10s (dead addon / stalled source). First-load only — a hard error is already
   // handled above, and mid-playback buffering is left untouched.
-  const hasStartedRef = useRef(hasStarted);
-  hasStartedRef.current = hasStarted;
   const stallSrcRef = useRef(src);
   stallSrcRef.current = src;
   useEffect(() => {
     if (!settings.autoNextStreamOnStall || src.isLive || inRoom) return;
     const timer = window.setTimeout(() => {
-      if (autoAdvancedRef.current || hasStartedRef.current) return;
+      const currentSnap = snapRef.current;
+      if (
+        autoAdvancedRef.current ||
+        playbackStartedRef.current ||
+        hasPlaybackStartedForStallCheck({
+          status: currentSnap.status,
+          positionSec: getPlaybackPosition(),
+          videoWidth: currentSnap.videoWidth,
+          videoHeight: currentSnap.videoHeight,
+        })
+      ) {
+        return;
+      }
       const s = stallSrcRef.current;
       autoAdvancedRef.current = true;
       if (s.streamRef) markStreamDead(s.streamRef, "load-failed", STUB_TTL_MS);

--- a/tests/player-stall-skip.test.ts
+++ b/tests/player-stall-skip.test.ts
@@ -1,0 +1,41 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { hasPlaybackStartedForStallCheck } from "../src/lib/player/stall-wait.ts";
+
+test("paused playback is not treated as a stalled stream", () => {
+  assert.equal(
+    hasPlaybackStartedForStallCheck({
+      status: "paused",
+      positionSec: 0,
+      videoWidth: 0,
+      videoHeight: 0,
+    }),
+    true,
+  );
+});
+
+test("a decoded frame counts as playback before the clock advances", () => {
+  assert.equal(
+    hasPlaybackStartedForStallCheck({
+      status: "loading",
+      positionSec: 0,
+      videoWidth: 1920,
+      videoHeight: 1080,
+    }),
+    true,
+  );
+});
+
+test("a source with no playback evidence remains eligible for stall skipping", () => {
+  assert.equal(
+    hasPlaybackStartedForStallCheck({
+      status: "playing",
+      positionSec: 0,
+      videoWidth: 0,
+      videoHeight: 0,
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

- Track playback evidence independently from Watch Together room state.
- Treat a paused player, a positive playback position, or a decoded video frame as proof that playback started.
- Add regression coverage for paused playback, decoded frames, and genuinely unstarted sources.

Discord report: https://discord.com/channels/1528501875241123901/1530199759615299684

## Why

With **Auto-skip stalled streams** enabled, pausing during the initial wait window could leave the stall detector's `hasStarted` value false. That value represents Watch Together lobby state rather than actual media playback, so the timeout could incorrectly classify a loaded, intentionally paused stream as stalled and advance to another source.

This change gives stall detection its own monotonic playback-started flag. Once the player has paused, advanced its clock, or decoded a frame, the current source is no longer eligible for first-load stall skipping. The same evidence is checked again when the timer fires to avoid acting on stale render state.

## Verification

- `node --test tests/player-stall-skip.test.ts` ? 3 tests passed.
- `pnpm exec tsc -b --pretty false` ? passed.
- `pnpm run build` ? passed.
- `vp check --no-fmt src/lib/player/stall-wait.ts src/views/player.tsx tests/player-stall-skip.test.ts` ? no lint warnings or errors.
- Manual Windows test: paused at 4 seconds, waited approximately 12?15 seconds, confirmed the source remained paused, then resumed playback normally.
- Full formatting reports pre-existing formatting differences elsewhere in `src/views/player.tsx`; those unrelated rewrites are intentionally excluded from this PR.

## Platform Impact

Verified on Windows. The change is platform-independent player-state logic and contains no operating-system-specific code.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files. Scoped lint passed with `--no-fmt`; full formatting is blocked by pre-existing formatting in `src/views/player.tsx`.
- [ ] I ran `vp run typecheck` after TypeScript changes. The repository has no `typecheck` task; the equivalent `pnpm exec tsc -b --pretty false` passed.
- [x] No Rust files changed; Cargo checks are not applicable.
- [x] I tested the affected behavior on Windows.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added tests for the behavior change.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
