### PR TITLE
feat: improve download picker feedback and controls

### DIFF
--- a/src/components/download-action-icons.tsx
+++ b/src/components/download-action-icons.tsx
@@ -1,0 +1,30 @@
+import { Pause, Play, X } from "lucide-react";
+
+export function DownloadPauseResumeIcon({ paused, size }: { paused: boolean; size: number }) {
+  return (
+    <span
+      className="download-pause-resume-icon"
+      data-state={paused ? "paused" : "downloading"}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      <Pause
+        size={size}
+        strokeWidth={2.2}
+        data-icon="pause"
+        className="download-pause-resume-glyph"
+      />
+      <Play
+        size={size}
+        strokeWidth={2.2}
+        fill="currentColor"
+        data-icon="resume"
+        className="download-pause-resume-glyph"
+      />
+    </span>
+  );
+}
+
+export function DownloadCancelIcon({ size }: { size: number }) {
+  return <X size={size} strokeWidth={2.2} className="download-cancel-icon" aria-hidden="true" />;
+}

--- a/src/components/downloads-popover.tsx
+++ b/src/components/downloads-popover.tsx
@@ -1,9 +1,13 @@
-import { Download, FolderOpen, Trash2, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Download, FolderOpen, Trash2 } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { DownloadCancelIcon, DownloadPauseResumeIcon } from "@/components/download-action-icons";
+import { HarborLoader } from "@/components/harbor-loader";
 import type { Meta } from "@/lib/cinemeta";
 import {
   cancelDownload,
+  pauseDownload,
   removeDownload,
+  resumeDownload,
   revealDownload,
   useDownloads,
   type DownloadItem,
@@ -19,7 +23,12 @@ export function DownloadsButton() {
   const { openMeta, setView } = useView();
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
-  const activeCount = downloads.filter((d) => d.status === "downloading").length;
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverId = useId();
+  const activeCount = downloads.filter(
+    (d) => d.status === "downloading" || d.status === "paused",
+  ).length;
+  const downloadingCount = downloads.filter((d) => d.status === "downloading").length;
 
   useEffect(() => {
     if (!open) return;
@@ -27,7 +36,10 @@ export function DownloadsButton() {
       if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
     };
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);
@@ -52,11 +64,23 @@ export function DownloadsButton() {
   return (
     <div ref={wrapRef} className="relative">
       <button
+        ref={triggerRef}
+        type="button"
         aria-label={t("Downloads")}
+        aria-expanded={open}
+        aria-controls={popoverId}
         onClick={() => setOpen((v) => !v)}
-        className="harbor-navbtn relative flex h-11 w-11 items-center justify-center rounded-xl bg-elevated/70 text-ink-muted transition-colors duration-150 hover:bg-elevated hover:text-ink"
+        className={`harbor-navbtn relative flex h-11 w-11 items-center justify-center rounded-xl transition-[color,background-color,transform] duration-200 ease-out active:scale-[0.96] motion-reduce:transition-none ${
+          downloadingCount > 0
+            ? "bg-transparent text-accent hover:bg-elevated/50"
+            : "bg-elevated/70 text-ink-muted hover:bg-elevated hover:text-ink"
+        }`}
       >
-        <Download size={17} strokeWidth={1.9} />
+        {downloadingCount > 0 ? (
+          <HarborLoader size="xs" />
+        ) : (
+          <Download size={17} strokeWidth={1.9} />
+        )}
         {activeCount > 0 && (
           <span className="absolute -top-1 -end-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-accent px-1 text-[10px] font-bold leading-none text-canvas">
             {activeCount}
@@ -64,10 +88,16 @@ export function DownloadsButton() {
         )}
       </button>
       {open && (
-        <div className="absolute end-0 top-[calc(100%+8px)] z-50 w-[20rem] overflow-hidden rounded-2xl border border-edge bg-elevated shadow-[0_18px_50px_-15px_rgba(0,0,0,0.7)] animate-popover-in">
+        <div
+          id={popoverId}
+          role="region"
+          aria-label={t("Downloads")}
+          className="absolute end-0 top-[calc(100%+8px)] z-50 w-[20rem] overflow-hidden rounded-2xl border border-edge bg-elevated shadow-[0_18px_50px_-15px_rgba(0,0,0,0.7)] animate-popover-in"
+        >
           <div className="flex items-center justify-between px-4 pb-2 pt-3">
             <span className="text-[13.5px] font-semibold text-ink">{t("Downloads")}</span>
             <button
+              type="button"
               onClick={() => {
                 setOpen(false);
                 setView("downloads");
@@ -88,14 +118,28 @@ export function DownloadsButton() {
   );
 }
 
+function compactEta(d: DownloadItem): string | null {
+  if (d.status !== "downloading" || d.bytesPerSec <= 0 || d.totalBytes == null) return null;
+  const remainingBytes = Math.max(0, d.totalBytes - d.receivedBytes);
+  const seconds = Math.max(1, Math.ceil(remainingBytes / d.bytesPerSec));
+  if (seconds < 60) return `${seconds}s left`;
+  if (seconds < 3600) return `${Math.ceil(seconds / 60)}m left`;
+  const totalMinutes = Math.ceil(seconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h${minutes > 0 ? ` ${minutes}m` : ""} left`;
+}
+
 function DownloadRow({ d, t, onOpen }: { d: DownloadItem; t: T; onOpen: () => void }) {
   const pct = d.totalBytes
     ? Math.min(100, Math.round((d.receivedBytes / d.totalBytes) * 100))
     : Math.round(d.ratio * 100);
-  const downloading = d.status === "downloading";
+  const active = d.status === "downloading" || d.status === "paused";
+  const eta = compactEta(d);
   return (
     <div className="group flex items-center gap-2.5 rounded-xl px-2 py-2 transition-colors hover:bg-raised/50">
       <button
+        type="button"
         onClick={onOpen}
         title={t("Go to show")}
         className="flex min-w-0 flex-1 items-center gap-3 text-start"
@@ -106,12 +150,17 @@ function DownloadRow({ d, t, onOpen }: { d: DownloadItem; t: T; onOpen: () => vo
         <span className="flex min-w-0 flex-1 flex-col gap-1">
           <span className="truncate text-[13px] font-medium text-ink">{d.title}</span>
           {d.subtitle && <span className="truncate text-[11px] text-ink-subtle">{d.subtitle}</span>}
-          {downloading ? (
+          {active ? (
             <span className="mt-0.5 flex items-center gap-2">
               <span className="h-1 flex-1 overflow-hidden rounded-full bg-canvas">
-                <span className="block h-full rounded-full bg-accent transition-[width]" style={{ width: `${pct}%` }} />
+                <span
+                  className="block h-full rounded-full bg-accent transition-[width]"
+                  style={{ width: `${pct}%` }}
+                />
               </span>
-              <span className="shrink-0 text-[10.5px] tabular-nums text-ink-subtle">{pct}%</span>
+              <span className="shrink-0 text-[10.5px] tabular-nums text-ink-subtle">
+                {d.status === "paused" ? t("Paused") : `${pct}%${eta ? ` · ${eta}` : ""}`}
+              </span>
             </span>
           ) : (
             <span
@@ -126,7 +175,7 @@ function DownloadRow({ d, t, onOpen }: { d: DownloadItem; t: T; onOpen: () => vo
               {d.status === "done"
                 ? t("Completed")
                 : d.status === "error"
-                  ? d.error ?? t("Failed")
+                  ? (d.error ?? t("Failed"))
                   : d.status === "interrupted"
                     ? t("Interrupted")
                     : t("Canceled")}
@@ -135,19 +184,31 @@ function DownloadRow({ d, t, onOpen }: { d: DownloadItem; t: T; onOpen: () => vo
         </span>
       </button>
       <div className="flex shrink-0 items-center gap-0.5">
-        {downloading ? (
-          <RowBtn label={t("Cancel")} onClick={() => cancelDownload(d.id)}>
-            <X size={14} strokeWidth={2.2} />
-          </RowBtn>
-        ) : (
+        {active && (
+          <>
+            <RowBtn
+              label={d.status === "paused" ? t("Resume") : t("Pause")}
+              onClick={() => {
+                if (d.status === "paused") void resumeDownload(d.id);
+                else pauseDownload(d.id);
+              }}
+            >
+              <DownloadPauseResumeIcon paused={d.status === "paused"} size={14} />
+            </RowBtn>
+            <RowBtn label={t("Cancel")} onClick={() => cancelDownload(d.id)} cancel>
+              <DownloadCancelIcon size={14} />
+            </RowBtn>
+          </>
+        )}
+        {d.status !== "downloading" && d.status !== "paused" && (
           <>
             {d.status === "done" && (
               <RowBtn label={t("Show in folder")} onClick={() => void revealDownload(d.id)}>
                 <FolderOpen size={14} strokeWidth={2} />
               </RowBtn>
             )}
-            <RowBtn label={t("Remove")} onClick={() => removeDownload(d.id)}>
-              <Trash2 size={14} strokeWidth={2} />
+            <RowBtn label={t("Remove")} onClick={() => removeDownload(d.id)} danger>
+              <Trash2 size={14} strokeWidth={2} className="download-delete-icon" />
             </RowBtn>
           </>
         )}
@@ -159,18 +220,29 @@ function DownloadRow({ d, t, onOpen }: { d: DownloadItem; t: T; onOpen: () => vo
 function RowBtn({
   label,
   onClick,
+  danger = false,
+  cancel = false,
   children,
 }: {
   label: string;
   onClick: () => void;
+  danger?: boolean;
+  cancel?: boolean;
   children: React.ReactNode;
 }) {
   return (
     <button
+      type="button"
       aria-label={label}
       title={label}
       onClick={onClick}
-      className="flex h-7 w-7 items-center justify-center rounded-lg text-ink-subtle opacity-0 transition-all hover:bg-canvas/60 hover:text-ink focus-visible:opacity-100 group-hover:opacity-100"
+      className={`flex h-8 w-8 items-center justify-center rounded-lg transition-[color,background-color,transform] duration-150 active:scale-[0.96] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent ${
+        danger
+          ? "download-delete-trigger text-danger hover:bg-danger/10 hover:text-danger"
+          : cancel
+            ? "download-cancel-trigger text-ink-subtle hover:bg-danger/10 hover:text-danger"
+            : "text-ink-subtle hover:bg-canvas/60 hover:text-ink"
+      }`}
     >
       {children}
     </button>

--- a/src/components/harbor-loader.tsx
+++ b/src/components/harbor-loader.tsx
@@ -5,9 +5,10 @@ import darkBoat from "@/assets/lottie/addons-boat-dark.json";
 import harborBoat from "@/assets/lottie/harbor-loader.json";
 import { prefetchTopAddonLogos, prefetchedTopAddonLogos } from "@/lib/providers/addon-logo-prefetch";
 
-type Size = "sm" | "md" | "lg" | "xl";
+type Size = "xs" | "sm" | "md" | "lg" | "xl";
 
 const SIZE_CLASS: Record<Size, string> = {
+  xs: "h-7 w-7",
   sm: "h-20 w-20",
   md: "h-32 w-32",
   lg: "h-44 w-44",

--- a/src/index.css
+++ b/src/index.css
@@ -710,6 +710,123 @@ main[data-kids="on"]::-webkit-scrollbar-thumb:hover {
   animation: harbor-gear-spin 1.6s var(--ease-out) both;
 }
 
+.download-pause-resume-icon {
+  display: inline-grid;
+  place-items: center;
+}
+
+.download-pause-resume-glyph {
+  grid-area: 1 / 1;
+  transform-box: fill-box;
+  transform-origin: center;
+  transition:
+    opacity 180ms var(--ease-out),
+    transform 180ms var(--ease-out);
+}
+
+.download-pause-resume-icon[data-state="downloading"] [data-icon="pause"],
+.download-pause-resume-icon[data-state="paused"] [data-icon="resume"] {
+  opacity: 1;
+  transform: scale(1) rotate(0deg);
+}
+
+.download-pause-resume-icon[data-state="downloading"] [data-icon="resume"] {
+  opacity: 0;
+  transform: scale(0.62) rotate(-18deg);
+}
+
+.download-pause-resume-icon[data-state="paused"] [data-icon="pause"] {
+  opacity: 0;
+  transform: scale(0.62) rotate(18deg);
+}
+
+.download-cancel-icon {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 140ms var(--ease-out);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .download-cancel-trigger:hover .download-cancel-icon {
+    transform: rotate(8deg);
+  }
+}
+
+.download-cancel-trigger:active .download-cancel-icon {
+  transform: rotate(90deg) scale(0.78);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .download-pause-resume-glyph,
+  .download-cancel-icon {
+    transition: none;
+  }
+}
+
+.source-download-morph-icon {
+  transition:
+    opacity 180ms var(--ease-out),
+    transform 180ms var(--ease-out);
+}
+
+.source-download-morph-icon-check {
+  opacity: 0;
+  transform: scale(0.5);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .source-download-button:hover .source-download-morph-icon-default {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+
+  .source-download-button:hover .source-download-morph-icon-check {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes harbor-source-download-trail {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.source-download-trailing-dot {
+  animation: harbor-source-download-trail 1.5s var(--ease-in-out) infinite;
+  transform-origin: center;
+}
+
+@keyframes harbor-download-delete-shake {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  25% {
+    transform: translateY(-2px) rotate(-10deg);
+  }
+  50% {
+    transform: translateY(0) rotate(10deg);
+  }
+  75% {
+    transform: translateY(-2px) rotate(-10deg);
+  }
+}
+
+.download-delete-icon {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .download-delete-trigger:hover .download-delete-icon {
+    animation: harbor-download-delete-shake 400ms var(--ease-out);
+  }
+}
+
 .harbor-key {
   display: inline-flex;
   transform-origin: 31% 65%;

--- a/src/lib/download/downloads-store.ts
+++ b/src/lib/download/downloads-store.ts
@@ -19,7 +19,7 @@ export type DownloadItem = {
   streamLabel: string | null;
   url: string;
   path: string;
-  status: "downloading" | "done" | "error" | "canceled" | "interrupted";
+  status: "downloading" | "paused" | "done" | "error" | "canceled" | "interrupted";
   receivedBytes: number;
   totalBytes: number | null;
   ratio: number;
@@ -38,6 +38,8 @@ type EnqueueArgs = {
 
 const items = new Map<string, DownloadItem>();
 const handles = new Map<string, DownloadHandle>();
+const completions = new Map<string, Promise<void>>();
+const requestHeaders = new Map<string, Record<string, string>>();
 const speed = new Map<string, { bytes: number; at: number }>();
 const listeners = new Set<() => void>();
 
@@ -68,7 +70,8 @@ function hydrate() {
     if (!Array.isArray(arr)) return;
     for (const d of arr) {
       if (!d || typeof d.id !== "string" || typeof d.path !== "string") continue;
-      const status = d.status === "downloading" ? "interrupted" : d.status;
+      const status =
+        d.status === "downloading" || d.status === "paused" ? "interrupted" : d.status;
       items.set(d.id, { ...d, status, bytesPerSec: 0 });
     }
     snapshot = [...items.values()].sort((a, b) => b.startedAt - a.startedAt);
@@ -93,7 +96,9 @@ function sep(): string {
 async function resolveDir(): Promise<string> {
   try {
     const raw = localStorage.getItem("harbor.settings");
-    const fromSettings = raw ? (JSON.parse(raw) as { downloadDir?: string }).downloadDir?.trim() : "";
+    const fromSettings = raw
+      ? (JSON.parse(raw) as { downloadDir?: string }).downloadDir?.trim()
+      : "";
     if (fromSettings) return fromSettings;
   } catch {
     /* fall through to system default */
@@ -187,49 +192,92 @@ export async function enqueueDownload(args: EnqueueArgs): Promise<string> {
     startedAt: Date.now(),
   };
   items.set(id, item);
-  speed.set(id, { bytes: 0, at: Date.now() });
+  if (headers && Object.keys(headers).length > 0) requestHeaders.set(id, headers);
   rebuild();
 
-  const handle = startDownload(id, url, path, (p) => {
-    const now = Date.now();
-    const s = speed.get(id);
-    let bps = 0;
-    if (s && now - s.at >= 500) {
-      bps = ((p.receivedBytes - s.bytes) / (now - s.at)) * 1000;
-      speed.set(id, { bytes: p.receivedBytes, at: now });
-    }
-    patch(id, {
-      receivedBytes: p.receivedBytes,
-      totalBytes: p.totalBytes,
-      ratio: p.ratio,
-      ...(bps > 0 ? { bytesPerSec: bps } : {}),
-    });
-  }, headers ?? undefined);
-  handles.set(id, handle);
-  handle.promise
-    .then(() => patch(id, { status: "done", ratio: 1, bytesPerSec: 0 }))
-    .catch((e: unknown) => {
-      if (e instanceof Error && e.name === "AbortError") {
-        patch(id, { status: "canceled", bytesPerSec: 0 });
-        return;
-      }
-      patch(id, { status: "error", error: e instanceof Error ? e.message : "Download failed", bytesPerSec: 0 });
-    })
-    .finally(() => {
-      handles.delete(id);
-      speed.delete(id);
-    });
+  beginDownload(id);
   return id;
 }
 
+function beginDownload(id: string): void {
+  const item = items.get(id);
+  if (!item || handles.has(id)) return;
+  speed.set(id, { bytes: item.receivedBytes, at: Date.now() });
+  const handle = startDownload(
+    id,
+    item.url,
+    item.path,
+    (p) => {
+      const now = Date.now();
+      const s = speed.get(id);
+      let bps = 0;
+      if (s && now - s.at >= 500) {
+        bps = ((p.receivedBytes - s.bytes) / (now - s.at)) * 1000;
+        speed.set(id, { bytes: p.receivedBytes, at: now });
+      }
+      patch(id, {
+        receivedBytes: p.receivedBytes,
+        totalBytes: p.totalBytes,
+        ratio: p.ratio,
+        ...(bps > 0 ? { bytesPerSec: bps } : {}),
+      });
+    },
+    requestHeaders.get(id),
+  );
+  handles.set(id, handle);
+  const completion = handle.promise
+    .then(() => patch(id, { status: "done", ratio: 1, bytesPerSec: 0 }))
+    .catch((e: unknown) => {
+      if (e instanceof Error && e.name === "AbortError") {
+        if (items.get(id)?.status === "paused") return;
+        patch(id, { status: "canceled", bytesPerSec: 0 });
+        return;
+      }
+      patch(id, {
+        status: "error",
+        error: e instanceof Error ? e.message : "Download failed",
+        bytesPerSec: 0,
+      });
+    })
+    .finally(() => {
+      if (handles.get(id) === handle) handles.delete(id);
+      if (completions.get(id) === completion) completions.delete(id);
+      speed.delete(id);
+      if (items.get(id)?.status !== "paused") requestHeaders.delete(id);
+    });
+  completions.set(id, completion);
+}
+
 export function cancelDownload(id: string): void {
+  const item = items.get(id);
+  if (!item || (item.status !== "downloading" && item.status !== "paused")) return;
+  patch(id, { status: "canceled", bytesPerSec: 0 });
+  requestHeaders.delete(id);
   handles.get(id)?.abort();
+}
+
+export function pauseDownload(id: string): void {
+  const item = items.get(id);
+  const handle = handles.get(id);
+  if (!item || item.status !== "downloading" || !handle) return;
+  patch(id, { status: "paused", bytesPerSec: 0 });
+  handle.abort();
+}
+
+export async function resumeDownload(id: string): Promise<void> {
+  if (items.get(id)?.status !== "paused") return;
+  await completions.get(id);
+  if (items.get(id)?.status !== "paused" || handles.has(id)) return;
+  patch(id, { status: "downloading", error: null, bytesPerSec: 0 });
+  beginDownload(id);
 }
 
 export function removeDownload(id: string): void {
   const item = items.get(id);
   handles.get(id)?.abort();
   handles.delete(id);
+  completions.delete(id);
+  requestHeaders.delete(id);
   speed.delete(id);
   if (items.delete(id)) rebuild();
   if (item) {
@@ -254,10 +302,14 @@ function subscribe(listener: () => void): () => void {
 }
 
 export function useDownloads(): DownloadItem[] {
-  return useSyncExternalStore(subscribe, () => snapshot, () => snapshot);
+  return useSyncExternalStore(
+    subscribe,
+    () => snapshot,
+    () => snapshot,
+  );
 }
 
 export function useActiveDownloadCount(): number {
   const all = useDownloads();
-  return all.filter((d) => d.status === "downloading").length;
+  return all.filter((d) => d.status === "downloading" || d.status === "paused").length;
 }

--- a/src/views/downloads.tsx
+++ b/src/views/downloads.tsx
@@ -16,11 +16,11 @@ type DownloadGroup =
 type Filter = "all" | "active" | "saved" | "issues";
 
 function statusRank(s: DownloadItem["status"]): number {
-  return s === "downloading" ? 0 : s === "error" ? 1 : s === "done" ? 2 : 3;
+  return s === "downloading" || s === "paused" ? 0 : s === "error" ? 1 : s === "done" ? 2 : 3;
 }
 
 function matchesFilter(d: DownloadItem, f: Filter): boolean {
-  if (f === "active") return d.status === "downloading";
+  if (f === "active") return d.status === "downloading" || d.status === "paused";
   if (f === "saved") return d.status === "done";
   if (f === "issues") return d.status === "error" || d.status === "interrupted";
   return true;
@@ -75,6 +75,7 @@ export function DownloadsView({ active = false }: { active?: boolean }) {
     (sum, d) => (d.status === "downloading" ? sum + d.bytesPerSec : sum),
     0,
   );
+  const paused = items.filter((d) => d.status === "paused").length;
   const savedBytes = items.reduce(
     (sum, d) => (d.status === "done" ? sum + (d.totalBytes ?? d.receivedBytes) : sum),
     0,
@@ -84,7 +85,8 @@ export function DownloadsView({ active = false }: { active?: boolean }) {
       ? "Saved movies and episodes for offline watching"
       : [
           `${items.length} item${items.length === 1 ? "" : "s"}`,
-          counts.active > 0 ? `${counts.active} downloading` : null,
+          counts.active - paused > 0 ? `${counts.active - paused} downloading` : null,
+          paused > 0 ? `${paused} paused` : null,
           totalBps > 0 ? `↓ ${fmtSpeed(totalBps)}` : null,
           savedBytes > 0 ? `${fmtBytes(savedBytes)} saved` : null,
         ]
@@ -115,7 +117,7 @@ export function DownloadsView({ active = false }: { active?: boolean }) {
           <div className="mb-5 flex flex-wrap items-center gap-1.5">
             <FilterTab label="All" count={counts.all} active={effective === "all"} onClick={() => setFilter("all")} />
             {counts.active > 0 && (
-              <FilterTab label="Downloading" count={counts.active} active={effective === "active"} onClick={() => setFilter("active")} />
+              <FilterTab label="Active" count={counts.active} active={effective === "active"} onClick={() => setFilter("active")} />
             )}
             {counts.saved > 0 && (
               <FilterTab label="Saved" count={counts.saved} active={effective === "saved"} onClick={() => setFilter("saved")} />

--- a/src/views/downloads/download-row.tsx
+++ b/src/views/downloads/download-row.tsx
@@ -1,11 +1,14 @@
 import type { ReactNode } from "react";
-import { Check, FolderOpen, Play, Trash2, X } from "lucide-react";
+import { Check, FolderOpen, Play, Trash2 } from "lucide-react";
+import { DownloadCancelIcon, DownloadPauseResumeIcon } from "@/components/download-action-icons";
 import { Poster, usePosterChain } from "@/components/poster";
 import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
 import {
   cancelDownload,
+  pauseDownload,
   removeDownload,
+  resumeDownload,
   revealDownload,
   type DownloadItem,
 } from "@/lib/download/downloads-store";
@@ -22,6 +25,7 @@ export function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?:
   );
   const pct = Math.round(d.ratio * 100);
   const downloading = d.status === "downloading";
+  const active = downloading || d.status === "paused";
   const playLocal = () =>
     openPlayer({
       meta: {
@@ -55,7 +59,7 @@ export function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?:
             <span className="shrink-0 truncate text-[12px] text-ink-subtle">{d.subtitle}</span>
           )}
         </div>
-        {downloading ? (
+        {active ? (
           <>
             <div className="h-1.5 w-full overflow-hidden rounded-full bg-ink/10">
               <div
@@ -64,7 +68,7 @@ export function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?:
               />
             </div>
             <div className="flex flex-wrap items-center gap-x-2 text-[11.5px] tabular-nums text-ink-muted">
-              <span>{pct}%</span>
+              <span>{d.status === "paused" ? "Paused" : `${pct}%`}</span>
               {d.totalBytes != null && (
                 <span className="text-ink-subtle">
                   {fmtBytes(d.receivedBytes)} / {fmtBytes(d.totalBytes)}
@@ -85,7 +89,9 @@ export function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?:
                 </span>
               </>
             )}
-            {d.status === "error" && <span className="text-danger">Failed: {d.error ?? "download error"}</span>}
+            {d.status === "error" && (
+              <span className="text-danger">Failed: {d.error ?? "download error"}</span>
+            )}
             {d.status === "canceled" && <span className="text-ink-subtle">Canceled</span>}
             {d.status === "interrupted" && (
               <span className="text-amber-300/85">Interrupted: re-download to finish</span>
@@ -94,11 +100,23 @@ export function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?:
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1">
-        {downloading ? (
-          <RowBtn label="Cancel download" onClick={() => cancelDownload(d.id)}>
-            <X size={16} strokeWidth={2.2} />
-          </RowBtn>
-        ) : (
+        {active && (
+          <>
+            <RowBtn
+              label={d.status === "paused" ? "Resume download" : "Pause download"}
+              onClick={() => {
+                if (d.status === "paused") void resumeDownload(d.id);
+                else pauseDownload(d.id);
+              }}
+            >
+              <DownloadPauseResumeIcon paused={d.status === "paused"} size={16} />
+            </RowBtn>
+            <RowBtn label="Cancel download" onClick={() => cancelDownload(d.id)} cancel>
+              <DownloadCancelIcon size={16} />
+            </RowBtn>
+          </>
+        )}
+        {!active && (
           <>
             {d.status === "done" && (
               <>
@@ -110,9 +128,7 @@ export function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?:
                 </RowBtn>
               </>
             )}
-            <RowBtn label="Delete download and file" onClick={() => removeDownload(d.id)}>
-              <Trash2 size={16} strokeWidth={2} />
-            </RowBtn>
+            <DeleteButton onClick={() => removeDownload(d.id)} />
           </>
         )}
       </div>
@@ -120,14 +136,43 @@ export function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?:
   );
 }
 
-function RowBtn({ label, onClick, children }: { label: string; onClick: () => void; children: ReactNode }) {
+function DeleteButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Delete download and file"
+      title="Delete download and file"
+      className="download-delete-trigger flex h-9 items-center justify-center gap-2.5 rounded-full border border-danger/10 bg-danger/5 px-4 text-[13px] font-medium tracking-tight text-danger transition-[transform,background-color] duration-150 ease-out hover:scale-[1.02] hover:bg-danger/10 active:scale-[0.96] motion-reduce:transition-none"
+    >
+      <Trash2 size={16} strokeWidth={2} className="download-delete-icon shrink-0" />
+      <span>Delete</span>
+    </button>
+  );
+}
+
+function RowBtn({
+  label,
+  onClick,
+  cancel = false,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  cancel?: boolean;
+  children: ReactNode;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label={label}
       title={label}
-      className="flex h-9 w-9 items-center justify-center rounded-lg text-ink-subtle transition duration-150 hover:bg-ink/10 hover:text-ink active:scale-90"
+      className={`flex h-9 w-9 items-center justify-center rounded-lg transition-[color,background-color,transform] duration-150 active:scale-[0.96] motion-reduce:transition-none ${
+        cancel
+          ? "download-cancel-trigger text-ink-subtle hover:bg-danger/10 hover:text-danger"
+          : "text-ink-subtle hover:bg-ink/10 hover:text-ink"
+      }`}
     >
       {children}
     </button>

--- a/src/views/play-picker.tsx
+++ b/src/views/play-picker.tsx
@@ -47,6 +47,7 @@ import {
   isEngineWarmingError,
   normalizeLangCode,
   orderByAddonNative,
+  streamIdentity,
   streamMatchesLangs,
 } from "./play-picker/picker-utils";
 import { PickerHeader, PickerNav } from "./play-picker/picker-header";
@@ -93,7 +94,7 @@ export function PlayPicker({
   playerActive?: boolean;
 }) {
   const isDownload = intent === "download";
-  const { openPlayer, openSettings, exitPickerToDetail, setView } = useView();
+  const { openPlayer, openSettings, exitPickerToDetail } = useView();
   const backToDetail = () => {
     if (playerActive) void exitWindowFullscreen();
     exitPickerToDetail(meta);
@@ -460,6 +461,7 @@ export function PlayPicker({
     onPlay,
     onCache,
     queuedHash,
+    queuedDownloadKeys,
     debridDown,
     resetDebridDown,
     abortResolve,
@@ -485,7 +487,6 @@ export function PlayPicker({
     claimHost,
     openPlayer: openPlayerGated,
     intent,
-    onDownloadStarted: () => setView("downloads"),
     autoActive,
     autoAttemptIdx,
     autoCandidatesLength: autoCandidates.length,
@@ -852,6 +853,13 @@ export function PlayPicker({
             matchFor={hostMatch ? matchFor : undefined}
             onPlay={playManually}
             download={isDownload}
+            downloadStateFor={(stream) =>
+              resolving?.stream === stream
+                ? "preparing"
+                : queuedDownloadKeys.has(streamIdentity(stream))
+                  ? "queued"
+                  : "idle"
+            }
             isAnime={isAnimeMetaId}
           />
         ) : (

--- a/src/views/play-picker/picker-utils.ts
+++ b/src/views/play-picker/picker-utils.ts
@@ -492,7 +492,7 @@ export function humanError(code: string): string {
   }
 }
 
-function streamIdentity(s: {
+export function streamIdentity(s: {
   addonId: string;
   infoHash?: string;
   fileIdx?: number;

--- a/src/views/play-picker/stremio-layout.tsx
+++ b/src/views/play-picker/stremio-layout.tsx
@@ -21,6 +21,7 @@ export function StremioLayout({
   matchFor,
   onPlay,
   download = false,
+  downloadStateFor,
   isAnime = false,
 }: {
   streams: ScoredStream[];
@@ -32,6 +33,7 @@ export function StremioLayout({
   matchFor?: (s: ScoredStream) => "same" | "close" | null;
   onPlay: (stream: ScoredStream) => void;
   download?: boolean;
+  downloadStateFor?: (stream: ScoredStream) => "idle" | "preparing" | "queued";
   isAnime?: boolean;
 }) {
   const [filter, setFilter] = useState<string>("all");
@@ -197,6 +199,7 @@ export function StremioLayout({
             match={matchFor ? matchFor(s) : null}
             onPlay={() => onPlay(s)}
             download={download}
+            downloadState={downloadStateFor?.(s)}
             isAnime={isAnime}
           />
         ))}

--- a/src/views/play-picker/stremio-row.tsx
+++ b/src/views/play-picker/stremio-row.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownToLine, Play } from "lucide-react";
+import { Check, Download, Play } from "lucide-react";
 import { AddonLogo } from "@/components/addon-logo";
 import { CopyLinkButton, resolveStreamLink } from "@/components/player/copy-link-button";
 import { DubSubPill, streamDubSub } from "@/components/dub-sub-pill";
@@ -15,6 +15,7 @@ export function StremioRow({
   match = null,
   onPlay,
   download = false,
+  downloadState = "idle",
   isAnime = false,
 }: {
   stream: ScoredStream;
@@ -23,6 +24,7 @@ export function StremioRow({
   match?: "same" | "close" | null;
   onPlay: () => void;
   download?: boolean;
+  downloadState?: "idle" | "preparing" | "queued";
   isAnime?: boolean;
 }) {
   const { settings } = useSettings();
@@ -34,6 +36,13 @@ export function StremioRow({
   const badges = settings.showQualityBadge ? streamBadges(stream) : [];
   const dubSub = settings.showDubBadge ? streamDubSub(stream.audioLanguages, isAnime) : null;
   const link = resolveStreamLink(stream);
+  const preparing = download && downloadState === "preparing";
+  const queued = download && downloadState === "queued";
+  const downloadLabel = preparing
+    ? "Preparing download"
+    : queued
+      ? "Added to downloads"
+      : "Download";
   return (
     <div
       className={`flex items-stretch gap-5 rounded-2xl bg-elevated/40 p-5 ring-1 transition-colors ${
@@ -68,25 +77,88 @@ export function StremioRow({
             <EditionChip stream={stream} />
           </div>
         )}
-        {failed && (
-          <p className="text-[13px] font-medium text-danger">Unavailable, try another.</p>
-        )}
+        {failed && <p className="text-[13px] font-medium text-danger">Unavailable, try another.</p>}
       </div>
       <div className="flex shrink-0 items-center gap-2 self-center">
         {link && <CopyLinkButton url={link} size={16} className="h-9 w-9" />}
         <button
-          onClick={onPlay}
-          aria-label={download ? "Download" : "Play"}
-          className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-accent text-canvas shadow-[0_2px_6px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.18)] transition-[transform,box-shadow] duration-150 ease-out hover:shadow-[0_5px_14px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.18)] active:scale-[0.96] active:duration-100"
+          type="button"
+          onClick={() => {
+            if (!preparing && !queued) onPlay();
+          }}
+          aria-disabled={preparing || queued}
+          aria-label={download ? downloadLabel : "Play"}
+          className={
+            download
+              ? `source-download-button flex h-9 min-w-[116px] shrink-0 items-center justify-center gap-2.5 rounded-full border px-5 text-[13px] font-medium tracking-tight transition-[transform,background-color,border-color,color] duration-150 ease-out active:scale-[0.96] active:duration-100 aria-disabled:cursor-default aria-disabled:active:scale-100 motion-reduce:transition-none ${
+                  queued
+                    ? "border-accent/25 bg-accent-soft text-accent"
+                    : "border-ink/[0.06] bg-ink/[0.04] text-ink hover:scale-[1.02] hover:bg-ink/[0.07] aria-disabled:hover:scale-100"
+                }`
+              : "flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-accent text-canvas shadow-[0_2px_6px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.18)] transition-[transform,box-shadow,background-color,color] duration-150 ease-out hover:shadow-[0_5px_14px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.18)] active:scale-[0.96] active:duration-100"
+          }
         >
-          {download ? (
-            <ArrowDownToLine size={25} strokeWidth={2.4} />
+          {preparing ? (
+            <>
+              <TrailingDots />
+              <span>Preparing</span>
+            </>
+          ) : queued ? (
+            <>
+              <Check size={16} strokeWidth={2.5} aria-hidden="true" />
+              <span>Added</span>
+            </>
+          ) : download ? (
+            <>
+              <span className="relative h-4 w-4 shrink-0" aria-hidden="true">
+                <Download
+                  size={16}
+                  strokeWidth={2.2}
+                  className="source-download-morph-icon source-download-morph-icon-default absolute inset-0"
+                />
+                <Check
+                  size={16}
+                  strokeWidth={2.5}
+                  className="source-download-morph-icon source-download-morph-icon-check absolute inset-0"
+                />
+              </span>
+              <span>Download</span>
+            </>
           ) : (
             <Play size={26} fill="currentColor" className="ml-0.5" />
           )}
         </button>
+        {download && (
+          <span className="sr-only" aria-live="polite">
+            {downloadState === "idle" ? "" : downloadLabel}
+          </span>
+        )}
       </div>
     </div>
+  );
+}
+
+const TRAILING_DOTS = [0, 1, 2, 3, 4] as const;
+
+function TrailingDots() {
+  return (
+    <span className="relative h-5 w-5 shrink-0" aria-hidden="true">
+      {TRAILING_DOTS.map((i) => (
+        <span
+          key={i}
+          className="source-download-trailing-dot absolute inset-0"
+          style={{
+            animationDelay: `${i * -0.1}s`,
+            transform: `rotate(${i * 72}deg)`,
+          }}
+        >
+          <span
+            className="absolute left-1/2 top-0 h-1.5 w-1.5 -ml-[3px] rounded-full bg-current"
+            style={{ opacity: 1 - i * 0.16 }}
+          />
+        </span>
+      ))}
+    </span>
   );
 }
 

--- a/src/views/play-picker/use-pick-handler.ts
+++ b/src/views/play-picker/use-pick-handler.ts
@@ -19,7 +19,7 @@ import { buildPlayInvite } from "@/lib/together/build-invite";
 import { type PlayEpisode, type PlayerSrc } from "@/lib/view";
 import { openInAppBrowser, openUrl } from "@/lib/window";
 import { enqueueDownload } from "@/lib/download/downloads-store";
-import { formatStreamQuality, humanError, isDebridFailure } from "./picker-utils";
+import { formatStreamQuality, humanError, isDebridFailure, streamIdentity } from "./picker-utils";
 
 export function usePickHandler({
   meta,
@@ -40,7 +40,6 @@ export function usePickHandler({
   claimHost,
   openPlayer,
   intent,
-  onDownloadStarted,
   autoActive,
   autoAttemptIdx,
   autoCandidatesLength,
@@ -69,7 +68,6 @@ export function usePickHandler({
   claimHost: (fresh: boolean) => void;
   openPlayer: (src: PlayerSrc) => void;
   intent?: "play" | "download";
-  onDownloadStarted?: (label?: string | null) => void;
   autoActive: boolean;
   autoAttemptIdx: number;
   autoCandidatesLength: number;
@@ -81,6 +79,7 @@ export function usePickHandler({
   setResolving: Dispatch<SetStateAction<{ stream: ScoredStream } | null>>;
 }) {
   const [queuedHash, setQueuedHash] = useState<string | null>(null);
+  const [queuedDownloadKeys, setQueuedDownloadKeys] = useState<Set<string>>(() => new Set());
   const [debridDown, setDebridDown] = useState(false);
   const [p2pConfirm, setP2pConfirm] = useState<{ stream: ScoredStream; forceP2p?: boolean } | null>(
     null,
@@ -215,7 +214,7 @@ export function usePickHandler({
           stream.name ||
           stream.addonName ||
           null;
-        void enqueueDownload({
+        await enqueueDownload({
           meta,
           episode,
           streamLabel: label,
@@ -223,8 +222,12 @@ export function usePickHandler({
           headers: r.data.headers,
         });
         opened = true;
+        setQueuedDownloadKeys((prev) => {
+          const next = new Set(prev);
+          next.add(streamIdentity(stream));
+          return next;
+        });
         setResolving(null);
-        onDownloadStarted?.(label);
         return;
       }
       if (inSession && canInvite && inviteSentRef.current == null) {
@@ -402,6 +405,7 @@ export function usePickHandler({
     onPlay,
     onCache,
     queuedHash,
+    queuedDownloadKeys,
     debridDown,
     resetDebridDown,
     abortResolve,

--- a/tests/download-loader.test.ts
+++ b/tests/download-loader.test.ts
@@ -1,0 +1,22 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+const downloadsPopoverSource = readFileSync(
+  new URL("../src/components/downloads-popover.tsx", import.meta.url),
+  "utf8",
+);
+const harborLoaderSource = readFileSync(
+  new URL("../src/components/harbor-loader.tsx", import.meta.url),
+  "utf8",
+);
+
+test("active downloads reuse the shared Harbor loader at compact size", () => {
+  assert.match(downloadsPopoverSource, /import \{ HarborLoader \}/);
+  assert.match(downloadsPopoverSource, /downloadingCount > 0[\s\S]*?<HarborLoader size="xs"/);
+  assert.match(harborLoaderSource, /xs: "h-7 w-7"/);
+  assert.doesNotMatch(downloadsPopoverSource, /DownloadActivityIcon|download-harbor-/);
+});


### PR DESCRIPTION
## Summary

- Keep users on the source-picker page after starting a download.
- Show Preparing and Added states directly on the selected stream.
- Add a compact Downloads popover with progress, ETA, pause/resume, and cancel controls.
- Add matching pause/resume, cancel, and delete controls to the Downloads page.
- Reuse the shared Harbor boat-and-wave loader for the active top-bar download indicator.
- Animate download control-state transitions.

## Why

Starting a download previously moved users away from the source picker and provided limited visual confirmation. Managing active downloads also required navigating to the full Downloads page. The active indicator now uses the same Harbor animation shown while selecting a movie source.

Discord discussion: https://discord.com/channels/1528501875241123901/1532306843316260894

## Verification

- `pnpm exec tsc -b --pretty false`
- Focused `vp check --no-fmt` for all changed frontend and test files
- `pnpm exec node --test tests/download-loader.test.ts`
- `pnpm run build`
- `pnpm tauri:build:linux-system`
- Verified on Windows using the Tauri development build:

https://github.com/user-attachments/assets/907ce461-2d1a-4ee0-8318-2c187ab11925

  - The source picker remains open after selecting Download.
  - The button changes from Preparing to Added.
  - The top download indicator shows the shared Harbor loader while downloading.
  - Pause, resume, cancel, and delete work from the download controls.
  - Progress and estimated time remaining are displayed.

## Platform Impact

Verified on Windows. The changes use shared frontend and download-store code. No Rust or platform-specific source code was changed.

## Checklist

- [x] This pull request targets `beta-branch` and contains no unrelated refactors.
- [x] TypeScript, focused quality checks, the production frontend build, and the full Tauri bundle pass.
- [x] The affected workflow was tested on Windows.
- [x] No secrets, tokens, private information, or personal data are included.