### PR TITLE
fix: keep season pack source across episodes

### DIFF
--- a/src/lib/playback-history.ts
+++ b/src/lib/playback-history.ts
@@ -145,7 +145,10 @@ export type WatchedSet = { ids: Set<string>; titles: Set<string> };
 
 export function watchTitleKey(name: string | null | undefined): string {
   if (!name) return "";
-  return name.toLowerCase().replace(/\(\d{4}\)/g, "").replace(/[^a-z0-9]+/g, "");
+  return name
+    .toLowerCase()
+    .replace(/\(\d{4}\)/g, "")
+    .replace(/[^a-z0-9]+/g, "");
 }
 
 export function recentlyPlayed(): WatchedSet {
@@ -162,7 +165,12 @@ export function recentlyPlayed(): WatchedSet {
   return { ids, titles };
 }
 
-export function playbackEntries(): Array<{ metaId: string; savedAt: number; title?: string; parsedTitle?: string }> {
+export function playbackEntries(): Array<{
+  metaId: string;
+  savedAt: number;
+  title?: string;
+  parsedTitle?: string;
+}> {
   const out: Array<{ metaId: string; savedAt: number; title?: string; parsedTitle?: string }> = [];
   for (const [key, entry] of Object.entries(readAll())) {
     const metaId = key.split("|")[0];
@@ -190,6 +198,7 @@ export function readLastSeriesPlayback(metaId: string): PlaybackEntry | null {
 
 export function streamMatchesSource(
   s: {
+    infoHash?: string | null;
     addonId?: string | null;
     resolution?: string | null;
     source?: string | null;
@@ -197,12 +206,12 @@ export function streamMatchesSource(
   },
   e: PlaybackEntry,
 ): boolean {
+  if (e.infoHash && s.infoHash) {
+    return s.infoHash.toLowerCase() === e.infoHash.toLowerCase();
+  }
   const sBinge = s.behaviorHints?.bingeGroup ?? null;
-  if (e.bingeGroup && sBinge) return sBinge === e.bingeGroup;    
-  return (                                                       
-    !!e.addonId &&
-    s.addonId === e.addonId &&
-    e.resolution === s.resolution &&
-    e.source === s.source
+  if (e.bingeGroup && sBinge) return sBinge === e.bingeGroup;
+  return (
+    !!e.addonId && s.addonId === e.addonId && e.resolution === s.resolution && e.source === s.source
   );
 }

--- a/tests/playback-source-match.test.ts
+++ b/tests/playback-source-match.test.ts
@@ -1,0 +1,47 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { streamMatchesSource } from "../src/lib/playback-history.ts";
+
+test("season-pack episodes match by torrent hash when their file-specific binge groups differ", () => {
+  const entry = {
+    infoHash: "ABCDEF123456",
+    fileIdx: 3,
+    addonId: "comet",
+    resolution: "1080p",
+    source: "BluRay",
+    bingeGroup: "comet|torbox|abcdef123456|3",
+    savedAt: Date.now(),
+  };
+  const nextEpisode = {
+    infoHash: "abcdef123456",
+    fileIdx: 4,
+    addonId: "comet",
+    resolution: "1080p",
+    source: "BluRay",
+    behaviorHints: { bingeGroup: "comet|torbox|abcdef123456|4" },
+  };
+
+  assert.equal(streamMatchesSource(nextEpisode, entry), true);
+});
+
+test("different known torrent hashes do not match through broader source metadata", () => {
+  const entry = {
+    infoHash: "pack-one",
+    addonId: "torrentio",
+    resolution: "1080p",
+    source: "WEB-DL",
+    bingeGroup: "shared-group",
+    savedAt: Date.now(),
+  };
+  const differentRelease = {
+    infoHash: "pack-two",
+    addonId: "torrentio",
+    resolution: "1080p",
+    source: "WEB-DL",
+    behaviorHints: { bingeGroup: "shared-group" },
+  };
+
+  assert.equal(streamMatchesSource(differentRelease, entry), false);
+});


### PR DESCRIPTION
## Summary

- Match season-pack episodes by torrent info hash before comparing file-specific binge groups.
- Keep the existing binge-group and source-metadata fallbacks when a torrent hash is unavailable.
- Add regression coverage for episodes in the same pack and for different releases with otherwise similar metadata.

## Root cause

Some addons include the episode file index in behaviorHints.bingeGroup. That value changes between episode files in the same season pack, so Harbor could reject the locked pack and select a differently ranked source for the next episode.

## User impact

Lock to season server and Keep same source on next episode now recognize different episode files from the same torrent pack while avoiding matches to a different known torrent hash.

## Related report

https://discord.com/channels/1528501875241123901/1532858588110913656

## Validation

- node --test tests/playback-source-match.test.ts
- pnpm exec vp check --no-fmt src/lib/playback-history.ts tests/playback-source-match.test.ts
- pnpm run typecheck
- git diff --check
- pnpm run check reports the existing repository-wide formatting baseline in 1,183 files
- Linux system build could not start in the current Windows environment because cargo is unavailable