### PR TITLE
fix: select source for season downloads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1573,12 +1573,13 @@ function Shell({ onReady }: { onReady?: () => void }) {
           <div className={layer(pickerTop)}>
             <Suspense fallback={null}>
               <PlayPicker
-                key={`picker-${picker.meta.id}-${picker.episode?.season ?? ""}-${picker.episode?.episode ?? ""}-${picker.attempt ?? 0}-${picker.intent ?? "play"}`}
+                key={`picker-${picker.meta.id}-${picker.episode?.season ?? ""}-${picker.episode?.episode ?? ""}-${picker.attempt ?? 0}-${picker.intent ?? "play"}-${picker.seasonEpisodes?.length ?? 0}`}
                 meta={picker.meta}
                 episode={picker.episode}
                 autoPlay={picker.intent === "download" ? false : picker.autoPlay}
                 attempt={picker.attempt}
                 intent={picker.intent}
+                seasonEpisodes={picker.seasonEpisodes}
                 resume={picker.resume}
                 playerActive={playerActive}
               />

--- a/src/lib/download/season-download.ts
+++ b/src/lib/download/season-download.ts
@@ -1,8 +1,10 @@
 import type { Meta } from "@/lib/cinemeta";
+import type { DebridStore } from "@/lib/debrid/types";
+import { resolveStream } from "@/lib/streams/resolve";
+import type { ScoredStream } from "@/lib/streams/types";
 import type { PlayEpisode } from "@/lib/view";
-import { gatherContext } from "@/lib/auto-download/context";
-import { resolveBestDownload } from "@/lib/auto-download/resolve";
 import { activeDownloadFor, enqueueDownload } from "@/lib/download/downloads-store";
+import { seasonPackFileMatchesEpisode, streamForSeasonPackEpisode } from "./season-pack";
 
 const MAX_CONCURRENT = 2;
 
@@ -31,34 +33,67 @@ export function pendingSeasonEpisodes(metaId: string, episodes: PlayEpisode[]): 
   });
 }
 
-export async function downloadSeason(meta: Meta, episodes: PlayEpisode[]): Promise<number> {
+export type SeasonDownloadResult = {
+  total: number;
+  queued: number;
+  failed: number;
+};
+
+export async function downloadSeasonFromPack({
+  meta,
+  episodes,
+  stream,
+  streamLabel,
+  debrids,
+  signal,
+}: {
+  meta: Meta;
+  episodes: PlayEpisode[];
+  stream: ScoredStream;
+  streamLabel: string | null;
+  debrids: DebridStore[];
+  signal: AbortSignal;
+}): Promise<SeasonDownloadResult> {
   const targets = pendingSeasonEpisodes(meta.id, episodes);
-  if (targets.length === 0) return 0;
-  const ctx = await gatherContext();
-  const controller = new AbortController();
+  const result: SeasonDownloadResult = { total: targets.length, queued: 0, failed: 0 };
+  if (targets.length === 0 || signal.aborted) return result;
+  const packStream = streamForSeasonPackEpisode(stream);
   const limit = limiter(MAX_CONCURRENT);
-  let queued = 0;
   await Promise.all(
     targets.map((ep) =>
       limit(async () => {
-        const hit = await resolveBestDownload(meta, ep, {
-          allowP2p: true,
-          maxHeight: null,
-          debrids: ctx.debrids,
-          addons: ctx.addons,
-          signal: controller.signal,
-        }).catch(() => null);
-        if (!hit) return;
-        await enqueueDownload({
-          meta,
-          episode: ep,
-          streamLabel: hit.label,
-          url: hit.url,
-          headers: hit.headers ?? null,
-        }).catch(() => {});
-        queued += 1;
+        if (signal.aborted) return;
+        const resolved = await resolveStream(
+          packStream,
+          debrids,
+          signal,
+          true,
+          false,
+          { season: ep.season ?? null, episode: ep.episode ?? null },
+          true,
+        ).catch(() => null);
+        if (!resolved?.ok || signal.aborted) {
+          if (!signal.aborted) result.failed += 1;
+          return;
+        }
+        if (resolved.data.filename && !seasonPackFileMatchesEpisode(resolved.data.filename, ep)) {
+          result.failed += 1;
+          return;
+        }
+        try {
+          await enqueueDownload({
+            meta,
+            episode: ep,
+            streamLabel,
+            url: resolved.data.url,
+            headers: resolved.data.headers ?? null,
+          });
+          result.queued += 1;
+        } catch {
+          result.failed += 1;
+        }
       }),
     ),
   );
-  return queued;
+  return result;
 }

--- a/src/lib/download/season-pack.ts
+++ b/src/lib/download/season-pack.ts
@@ -1,0 +1,50 @@
+import type { ScoredStream } from "../streams/types";
+import { episodeVariantMatch } from "../streams/episode-file.ts";
+import type { PlayEpisode } from "../view";
+
+type SeasonPackCandidate = Pick<ScoredStream, "infoHash" | "season" | "seasonPack">;
+
+export function isDownloadableSeasonPack(
+  stream: SeasonPackCandidate,
+  season?: number | null,
+): boolean {
+  if (!stream.seasonPack || typeof stream.infoHash !== "string" || stream.infoHash.length === 0) {
+    return false;
+  }
+  return season == null || stream.season == null || stream.season === season;
+}
+
+export function downloadableSeasonPacks<T extends SeasonPackCandidate>(
+  streams: T[],
+  season?: number | null,
+): T[] {
+  return streams.filter((stream) => isDownloadableSeasonPack(stream, season));
+}
+
+export function streamForSeasonPackEpisode(stream: ScoredStream): ScoredStream {
+  return {
+    ...stream,
+    url: undefined,
+    externalUrl: undefined,
+    ytId: undefined,
+    nzbUrl: undefined,
+    fileIdx: undefined,
+    size: null,
+    behaviorHints: stream.behaviorHints
+      ? {
+          ...stream.behaviorHints,
+          filename: undefined,
+          fileName: undefined,
+          videoSize: undefined,
+        }
+      : undefined,
+  };
+}
+
+export function seasonPackFileMatchesEpisode(filename: string, episode: PlayEpisode): boolean {
+  return episodeVariantMatch(
+    filename,
+    episode.imdbSeason ?? episode.season ?? null,
+    episode.imdbEpisode ?? episode.episode,
+  );
+}

--- a/src/lib/view.tsx
+++ b/src/lib/view.tsx
@@ -165,6 +165,7 @@ export type Frame =
       autoPlay?: boolean;
       attempt?: number;
       intent?: "play" | "download";
+      seasonEpisodes?: PlayEpisode[];
       resume?: boolean;
     }
   | { kind: "player"; src: PlayerSrc }
@@ -260,12 +261,19 @@ type ViewValue = {
     autoPlay?: boolean;
     attempt?: number;
     intent?: "play" | "download";
+    seasonEpisodes?: PlayEpisode[];
     resume?: boolean;
   } | null;
   openPicker: (
     meta: Meta,
     episode?: PlayEpisode,
-    opts?: { autoPlay?: boolean; attempt?: number; intent?: "play" | "download"; resume?: boolean },
+    opts?: {
+      autoPlay?: boolean;
+      attempt?: number;
+      intent?: "play" | "download";
+      seasonEpisodes?: PlayEpisode[];
+      resume?: boolean;
+    },
   ) => void;
   player: PlayerSrc | null;
   openPlayer: (src: PlayerSrc) => void;
@@ -552,6 +560,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
           autoPlay: top.autoPlay,
           attempt: top.attempt,
           intent: top.intent,
+          seasonEpisodes: top.seasonEpisodes,
           resume: top.resume,
         }
       : null;
@@ -1051,6 +1060,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
         autoPlay?: boolean;
         attempt?: number;
         intent?: "play" | "download";
+        seasonEpisodes?: PlayEpisode[];
         resume?: boolean;
       },
     ) => {
@@ -1069,7 +1079,8 @@ export function ViewProvider({ children }: { children: ReactNode }) {
           t.kind === "picker" &&
           t.meta.id === m.id &&
           (t.attempt ?? 0) === (opts?.attempt ?? 0) &&
-          (t.intent ?? "play") === (opts?.intent ?? "play")
+          (t.intent ?? "play") === (opts?.intent ?? "play") &&
+          Boolean(t.seasonEpisodes?.length) === Boolean(opts?.seasonEpisodes?.length)
         ) {
           return cur;
         }
@@ -1080,6 +1091,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
           autoPlay: opts?.autoPlay,
           attempt: opts?.attempt,
           intent: opts?.intent,
+          seasonEpisodes: opts?.seasonEpisodes,
           resume: opts?.resume,
         });
       });

--- a/src/views/detail/episode-downloads-menu.tsx
+++ b/src/views/detail/episode-downloads-menu.tsx
@@ -1,10 +1,10 @@
-import { ArrowDownToLine, CalendarClock, Check, Download, Loader2, SlidersHorizontal } from "lucide-react";
+import { ArrowDownToLine, CalendarClock, Check, Download, SlidersHorizontal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Meta } from "@/lib/cinemeta";
 import type { PlayEpisode } from "@/lib/view";
 import { toggleAutoDownload, useIsAutoDownloaded } from "@/lib/auto-download";
-import { downloadSeason, pendingSeasonEpisodes } from "@/lib/download/season-download";
+import { pendingSeasonEpisodes } from "@/lib/download/season-download";
 import { useDownloads } from "@/lib/download/downloads-store";
 import { useView } from "@/lib/view";
 import { HoverTooltip } from "@/components/hover-tooltip";
@@ -12,13 +12,13 @@ import { useT } from "@/lib/i18n";
 
 export function EpisodeDownloadsMenu({ meta, episodes }: { meta: Meta; episodes: PlayEpisode[] }) {
   const t = useT();
-  const { setView } = useView();
+  const { openPicker, setView } = useView();
   useDownloads();
   const autoOn = useIsAutoDownloaded(meta.id);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
-  const [busy, setBusy] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
-  const pending = pendingSeasonEpisodes(meta.id, episodes).length;
+  const pendingEpisodes = pendingSeasonEpisodes(meta.id, episodes);
+  const pending = pendingEpisodes.length;
 
   useEffect(() => {
     if (!menu) return;
@@ -45,12 +45,14 @@ export function EpisodeDownloadsMenu({ meta, episodes }: { meta: Meta; episodes:
     });
   };
 
-  const startSeason = async () => {
+  const startSeason = () => {
     setMenu(null);
-    if (busy || pending === 0) return;
-    setBusy(true);
-    await downloadSeason(meta, episodes).catch(() => {});
-    setBusy(false);
+    const firstEpisode = pendingEpisodes[0];
+    if (!firstEpisode) return;
+    openPicker(meta, firstEpisode, {
+      intent: "download",
+      seasonEpisodes: pendingEpisodes,
+    });
   };
 
   return (
@@ -72,11 +74,7 @@ export function EpisodeDownloadsMenu({ meta, episodes }: { meta: Meta; episodes:
               : "border-edge-soft bg-canvas/60 text-ink-muted hover:border-edge hover:text-ink"
           }`}
         >
-          {busy ? (
-            <Loader2 size={16} className="animate-spin" />
-          ) : (
-            <ArrowDownToLine size={16} strokeWidth={2} />
-          )}
+          <ArrowDownToLine size={16} strokeWidth={2} />
         </button>
       </HoverTooltip>
       {menu &&
@@ -91,16 +89,24 @@ export function EpisodeDownloadsMenu({ meta, episodes }: { meta: Meta; episodes:
               icon={<Download size={15} strokeWidth={2} />}
               label={pending > 0 ? t("Download this season") : t("Season saved offline")}
               sub={pending > 0 ? t("{n} episodes", { n: pending }) : undefined}
-              disabled={pending === 0 || busy}
+              disabled={pending === 0}
               onClick={startSeason}
             />
             <div className="my-1 h-px bg-edge-soft" />
             <MenuItem
               icon={
-                autoOn ? <Check size={15} strokeWidth={2.4} /> : <CalendarClock size={15} strokeWidth={2} />
+                autoOn ? (
+                  <Check size={15} strokeWidth={2.4} />
+                ) : (
+                  <CalendarClock size={15} strokeWidth={2} />
+                )
               }
               label={t("Auto-download new episodes")}
-              sub={autoOn ? t("On. New episodes grab themselves.") : t("Grab each new episode as it airs")}
+              sub={
+                autoOn
+                  ? t("On. New episodes grab themselves.")
+                  : t("Grab each new episode as it airs")
+              }
               active={autoOn}
               onClick={() => {
                 toggleAutoDownload(meta);
@@ -150,7 +156,9 @@ function MenuItem({
     >
       <span className={`mt-0.5 ${active ? "text-accent" : "text-ink-muted"}`}>{icon}</span>
       <span className="flex min-w-0 flex-col">
-        <span className={`text-[13px] font-medium ${active ? "text-accent" : "text-ink"}`}>{label}</span>
+        <span className={`text-[13px] font-medium ${active ? "text-accent" : "text-ink"}`}>
+          {label}
+        </span>
         {sub && <span className="text-[11.5px] leading-snug text-ink-subtle">{sub}</span>}
       </span>
     </button>

--- a/src/views/play-picker.tsx
+++ b/src/views/play-picker.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowUp, ChevronLeft, Filter, Loader2, RefreshCw, X } from "lucide-react";
+import { ArrowUp, ChevronLeft, Filter, Loader2, PackageX, RefreshCw, X } from "lucide-react";
 import { useT } from "@/lib/i18n";
 import { resolveAddonLogo } from "@/components/addon-logo";
 import { torrentEngineStatus } from "@/lib/torrent/local-engine";
@@ -69,6 +69,7 @@ import { usePipelineResult } from "./play-picker/use-pipeline-result";
 import { useStreamIds } from "./play-picker/use-stream-ids";
 import { findLocalEpisodeVersions, findLocalMovieVersions } from "@/lib/local-library/versions";
 import { localPlayerSrc } from "@/lib/local-library/player-src";
+import { downloadableSeasonPacks } from "@/lib/download/season-pack";
 import { LocalStreamList } from "./play-picker/local-stream-card";
 import { SubtitleSelectStep } from "./play-picker/subtitle-select-step";
 
@@ -82,6 +83,7 @@ export function PlayPicker({
   autoPlay,
   attempt,
   intent,
+  seasonEpisodes,
   resume,
   playerActive,
 }: {
@@ -90,10 +92,13 @@ export function PlayPicker({
   autoPlay?: boolean;
   attempt?: number;
   intent?: "play" | "download";
+  seasonEpisodes?: PlayEpisode[];
   resume?: boolean;
   playerActive?: boolean;
 }) {
+  const t = useT();
   const isDownload = intent === "download";
+  const isSeasonDownload = isDownload && (seasonEpisodes?.length ?? 0) > 0;
   const { openPlayer, openSettings, exitPickerToDetail } = useView();
   const backToDetail = () => {
     if (playerActive) void exitWindowFullscreen();
@@ -259,7 +264,13 @@ export function PlayPicker({
 
   const filteredPicker = useMemo(() => {
     if (!result) return null;
-    let all = result.picker.all;
+    const candidatePool = isSeasonDownload
+      ? downloadableSeasonPacks(
+          result.picker.all,
+          /^(kitsu|mal|anilist|anidb):/.test(meta.id) ? null : (episode?.season ?? null),
+        )
+      : result.picker.all;
+    let all = candidatePool;
     if (settings.streamMode === "addons") {
       const addonsOnly = all.filter((s) => !isP2pStream(s));
       if (addonsOnly.length > 0) all = addonsOnly;
@@ -282,9 +293,9 @@ export function PlayPicker({
       if (matched.length > 0) all = matched;
       else fellBack = true;
     }
-    if (all.length === 0 && result.picker.all.length > 0) {
-      all = result.picker.all;
-      allRaw = result.picker.all;
+    if (all.length === 0 && candidatePool.length > 0) {
+      all = candidatePool;
+      allRaw = candidatePool;
       fellBack = true;
     }
     const cachedFirst = all.slice().sort((a, b) => (isCached(b) ? 1 : 0) - (isCached(a) ? 1 : 0));
@@ -312,6 +323,9 @@ export function PlayPicker({
     hostMatch,
     activeStreamFilter,
     settings.streamMode,
+    isSeasonDownload,
+    meta.id,
+    episode?.season,
   ]);
 
   const anyAddonRanked = useMemo(() => (addons ?? []).some((a) => isAddonRanked(a)), [addons]);
@@ -487,6 +501,7 @@ export function PlayPicker({
     claimHost,
     openPlayer: openPlayerGated,
     intent,
+    seasonEpisodes,
     autoActive,
     autoAttemptIdx,
     autoCandidatesLength: autoCandidates.length,
@@ -604,6 +619,7 @@ export function PlayPicker({
   const noResults =
     addonsSettled && !!streamIds && streamIds.length > 0 && allCount === 0 && debrids.length > 0;
   const terminalEmpty = noStreamIds || noDebrids || noResults;
+  const seasonPackEmpty = isSeasonDownload && addonsSettled && allCount === 0;
   const [stubBanner, setStubBanner] = useState<string | null>(null);
   useEffect(() => {
     const ev = consumeRecentStubEvent(8000);
@@ -757,7 +773,11 @@ export function PlayPicker({
 
         {isDownload && (
           <div className="rounded-2xl border border-edge-soft bg-elevated/60 px-5 py-3.5 text-[13.5px] text-ink-muted">
-            Choose a source to save offline. You can track progress on the Downloads page.
+            {isSeasonDownload
+              ? t(
+                  "Choose one season package. Harbor will match and download every available episode from it.",
+                )
+              : t("Choose a source to save offline. You can track progress on the Downloads page.")}
           </div>
         )}
 
@@ -808,26 +828,38 @@ export function PlayPicker({
           </div>
         )}
 
-        <PickerEmptyLadder
-          meta={meta}
-          result={result}
-          addonsSettled={addonsSettled}
-          pipelineDone={pipelineDone}
-          streamIds={streamIds}
-          debridCount={debrids.length}
-          addonCount={addons?.length ?? 0}
-          allCount={allCount}
-          rawCount={rawCount}
-          strictMode={strictMode}
-          forceShowAll={forceShowAll}
-          onOpenLibrarySettings={() => openSettings("library")}
-          onOpenStreamingSettings={() => openSettings("streaming")}
-          onShowAll={() => setForceShowAll(true)}
-          onSearchWider={() => {
-            if (strictMode) setStrictMode(false);
-            else setForceShowAll(true);
-          }}
-        />
+        {seasonPackEmpty ? (
+          <SeasonPackEmptyState
+            season={episode?.season ?? null}
+            rawCount={rawCount}
+            refreshing={loading}
+            onRefresh={refresh}
+            onOpenSettings={() => openSettings("streaming")}
+          />
+        ) : (
+          !isSeasonDownload && (
+            <PickerEmptyLadder
+              meta={meta}
+              result={result}
+              addonsSettled={addonsSettled}
+              pipelineDone={pipelineDone}
+              streamIds={streamIds}
+              debridCount={debrids.length}
+              addonCount={addons?.length ?? 0}
+              allCount={allCount}
+              rawCount={rawCount}
+              strictMode={strictMode}
+              forceShowAll={forceShowAll}
+              onOpenLibrarySettings={() => openSettings("library")}
+              onOpenStreamingSettings={() => openSettings("streaming")}
+              onShowAll={() => setForceShowAll(true)}
+              onSearchWider={() => {
+                if (strictMode) setStrictMode(false);
+                else setForceShowAll(true);
+              }}
+            />
+          )
+        )}
 
         {debrids.length > 0 && filteredPicker && filteredPicker.all.length > 0 && <CachedTip />}
 
@@ -960,6 +992,70 @@ export function PlayPicker({
           />
         )}
     </main>
+  );
+}
+
+function SeasonPackEmptyState({
+  season,
+  rawCount,
+  refreshing,
+  onRefresh,
+  onOpenSettings,
+}: {
+  season: number | null;
+  rawCount: number;
+  refreshing: boolean;
+  onRefresh: () => void;
+  onOpenSettings: () => void;
+}) {
+  const t = useT();
+  const seasonLabel = season == null ? t("this season") : t("Season {n}", { n: season });
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-[24px] border border-edge-soft/70 bg-canvas/80 px-9 py-11"
+    >
+      <div className="flex flex-col items-center gap-5 text-center">
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-elevated text-ink-muted ring-1 ring-edge-soft">
+          <PackageX size={22} strokeWidth={1.8} aria-hidden />
+        </span>
+        <div className="flex max-w-lg flex-col gap-2">
+          <h2 className="font-display text-[30px] leading-tight text-ink">
+            {t("No season package found")}
+          </h2>
+          <p className="text-[13.5px] leading-relaxed text-ink-muted">
+            {rawCount > 0
+              ? t(
+                  "Harbor found episode sources, but none was a downloadable package for {season}. Try another addon or refresh the sources.",
+                  { season: seasonLabel },
+                )
+              : t(
+                  "None of your addons returned a downloadable package for {season}. Refresh the sources or check your source settings.",
+                  { season: seasonLabel },
+                )}
+          </p>
+        </div>
+        <div className="flex flex-wrap justify-center gap-2.5">
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            className="inline-flex h-10 items-center gap-2 rounded-full bg-ink px-5 text-[13px] font-semibold text-canvas transition-transform hover:scale-[1.02] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-55 motion-reduce:transition-none motion-reduce:hover:scale-100"
+          >
+            <RefreshCw size={14} className={refreshing ? "animate-spin" : ""} aria-hidden />
+            {t("Refresh sources")}
+          </button>
+          <button
+            type="button"
+            onClick={onOpenSettings}
+            className="h-10 rounded-full border border-edge-soft bg-elevated px-5 text-[13px] font-semibold text-ink-muted transition-colors hover:border-edge hover:text-ink"
+          >
+            {t("Source settings")}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/views/play-picker/use-pick-handler.ts
+++ b/src/views/play-picker/use-pick-handler.ts
@@ -19,6 +19,9 @@ import { buildPlayInvite } from "@/lib/together/build-invite";
 import { type PlayEpisode, type PlayerSrc } from "@/lib/view";
 import { openInAppBrowser, openUrl } from "@/lib/window";
 import { enqueueDownload } from "@/lib/download/downloads-store";
+import { downloadSeasonFromPack } from "@/lib/download/season-download";
+import { isDownloadableSeasonPack } from "@/lib/download/season-pack";
+import { useT } from "@/lib/i18n";
 import { formatStreamQuality, humanError, isDebridFailure, streamIdentity } from "./picker-utils";
 
 export function usePickHandler({
@@ -40,6 +43,7 @@ export function usePickHandler({
   claimHost,
   openPlayer,
   intent,
+  seasonEpisodes,
   autoActive,
   autoAttemptIdx,
   autoCandidatesLength,
@@ -68,6 +72,7 @@ export function usePickHandler({
   claimHost: (fresh: boolean) => void;
   openPlayer: (src: PlayerSrc) => void;
   intent?: "play" | "download";
+  seasonEpisodes?: PlayEpisode[];
   autoActive: boolean;
   autoAttemptIdx: number;
   autoCandidatesLength: number;
@@ -78,6 +83,7 @@ export function usePickHandler({
   setResolveError: (msg: string | null) => void;
   setResolving: Dispatch<SetStateAction<{ stream: ScoredStream } | null>>;
 }) {
+  const t = useT();
   const [queuedHash, setQueuedHash] = useState<string | null>(null);
   const [queuedDownloadKeys, setQueuedDownloadKeys] = useState<Set<string>>(() => new Set());
   const [debridDown, setDebridDown] = useState(false);
@@ -124,6 +130,58 @@ export function usePickHandler({
     resolveAcRef.current = ac;
     let opened = false;
     try {
+      if (intent === "download" && seasonEpisodes && seasonEpisodes.length > 0) {
+        if (!isDownloadableSeasonPack(stream)) {
+          setFailedStreams((prev) => new Set(prev).add(stream));
+          setResolveError(
+            t("This source is not a downloadable season package. Pick another package."),
+          );
+          return;
+        }
+        const label =
+          [stream.resolution, stream.source].filter(Boolean).join(" ") ||
+          stream.parsedTitle ||
+          stream.title ||
+          stream.name ||
+          stream.addonName ||
+          null;
+        const batch = await downloadSeasonFromPack({
+          meta,
+          episodes: seasonEpisodes,
+          stream,
+          streamLabel: label,
+          debrids,
+          signal: ac.signal,
+        });
+        if (ac.signal.aborted) return;
+        if (batch.total === 0) {
+          opened = true;
+          setQueuedDownloadKeys((prev) => new Set(prev).add(streamIdentity(stream)));
+          setResolving(null);
+          return;
+        }
+        if (batch.queued === 0) {
+          setFailedStreams((prev) => new Set(prev).add(stream));
+          setResolveError(
+            t(
+              "No downloadable episode files were found in this season package. Pick another package.",
+            ),
+          );
+          return;
+        }
+        opened = true;
+        setQueuedDownloadKeys((prev) => new Set(prev).add(streamIdentity(stream)));
+        setResolving(null);
+        if (batch.failed > 0) {
+          setResolveError(
+            t(
+              "Queued {queued} of {total} episodes. Harbor could not match every episode in this package.",
+              { queued: batch.queued, total: batch.total },
+            ),
+          );
+        }
+        return;
+      }
       const hint = episode
         ? { season: episode.season ?? null, episode: episode.episode ?? null }
         : undefined;

--- a/tests/season-download.test.ts
+++ b/tests/season-download.test.ts
@@ -1,0 +1,79 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  downloadableSeasonPacks,
+  isDownloadableSeasonPack,
+  seasonPackFileMatchesEpisode,
+  streamForSeasonPackEpisode,
+} from "../src/lib/download/season-pack.ts";
+
+test("season download picker only shows torrent season packages", () => {
+  const packageWithHash = {
+    seasonPack: true,
+    season: 2,
+    infoHash: "abc123",
+    name: "Season pack",
+  };
+  const wrongSeason = {
+    seasonPack: true,
+    season: 3,
+    infoHash: "ghi789",
+    name: "Wrong season",
+  };
+  const packageWithoutHash = {
+    seasonPack: true,
+    season: 2,
+    name: "Direct episode source",
+  };
+  const singleEpisode = {
+    seasonPack: false,
+    season: 2,
+    infoHash: "def456",
+    name: "Single episode",
+  };
+
+  assert.equal(isDownloadableSeasonPack(packageWithHash), true);
+  assert.equal(isDownloadableSeasonPack(packageWithoutHash), false);
+  assert.equal(isDownloadableSeasonPack(singleEpisode), false);
+  assert.equal(isDownloadableSeasonPack(wrongSeason, 2), false);
+  assert.deepEqual(
+    downloadableSeasonPacks([packageWithHash, wrongSeason, packageWithoutHash, singleEpisode], 2),
+    [packageWithHash],
+  );
+});
+
+test("each episode resolves from the selected package instead of its first direct file", () => {
+  const source = {
+    seasonPack: true,
+    infoHash: "abc123",
+    url: "https://example.test/episode-1.mkv",
+    externalUrl: "https://example.test/page",
+    ytId: "video",
+    nzbUrl: "https://example.test/file.nzb",
+    fileIdx: 4,
+    size: 20_000_000_000,
+    behaviorHints: { filename: "Show.S02E01.mkv", videoSize: 2_000_000_000 },
+  } as Parameters<typeof streamForSeasonPackEpisode>[0];
+
+  const resolved = streamForSeasonPackEpisode(source);
+
+  assert.equal(resolved.infoHash, "abc123");
+  assert.equal(resolved.seasonPack, true);
+  assert.equal(resolved.url, undefined);
+  assert.equal(resolved.externalUrl, undefined);
+  assert.equal(resolved.ytId, undefined);
+  assert.equal(resolved.nzbUrl, undefined);
+  assert.equal(resolved.fileIdx, undefined);
+  assert.equal(resolved.size, null);
+  assert.equal(resolved.behaviorHints?.filename, undefined);
+  assert.equal(resolved.behaviorHints?.videoSize, undefined);
+  assert.equal(source.fileIdx, 4);
+});
+
+test("a fallback file from the package cannot be queued for the wrong episode", () => {
+  const episode = { season: 2, episode: 4 };
+  assert.equal(seasonPackFileMatchesEpisode("Show.Name.S02E04.1080p.mkv", episode), true);
+  assert.equal(seasonPackFileMatchesEpisode("Show.Name.S02E01.1080p.mkv", episode), false);
+});


### PR DESCRIPTION
## Summary

- Route **Download this season** through the source picker instead of automatically choosing separate sources.
- Show only hash-backed packages that match the active season.
- Resolve every pending episode from the package the user selected.
- Reject mismatched fallback files and report partial or empty package results clearly.
- Add regression coverage for package filtering, per-episode resolution, and wrong-file rejection.

## Why

The season download action previously began immediately and selected sources automatically for each episode. Users could not choose a release, and failures did not explain when no season package was available.

This keeps the existing action explicit: the user chooses one package, then Harbor queues the available episodes from that package.

## Verification

- `vp check` on all eight changed files: passed with zero errors. Two warnings are pre-existing on untouched lines.
- `npx tsc -b --pretty false`: passed.
- `npx tsx --test tests/season-download.test.ts`: passed, 3/3.
- `npx tsx --test tests/*.test.ts`: 218/222 passed. The four failures are existing beta-branch failures in untouched activity, subtitle autosync, player-buffer-policy, and RTX HDR tests.
- `pnpm build`: passed.
- `pnpm tauri:build:linux-system`: passed and produced the 0.9.116 NSIS installer.
- Manual Windows test: confirmed that **Download this season** opens the picker and queues the selected package.

## Platform Impact

- Windows: manually verified.
- Linux and macOS: not runtime-tested.
- No Rust or platform-specific native code changed.
- Normal playback and single-episode downloads retain their existing paths.

## UI Changes

The existing season download action now opens the source picker. The picker explains that one package will be used for the season and shows a dedicated **No season package found** state when applicable.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `npx tsc -b --pretty false` after TypeScript changes. The repository has no `vp run typecheck` task.
- [x] No Rust files changed, so Cargo checks are not applicable.
- [x] I tested the affected flow on Windows.
- [x] I preserved normal playback, single-episode downloads, navigation, and configured hotkey behavior.
- [x] I added regression tests for the behavior change.
- [x] The diff contains no secrets, tokens, private URLs, personal data, or unrelated files.
