### PR TITLE
fix(linux): remove WEBKIT_DISABLE_DMABUF_RENDERER to resolve UI ghosting (issue-1121)

### DIFF
--- a/src-tauri/src/mpv_render_linux.rs
+++ b/src-tauri/src/mpv_render_linux.rs
@@ -223,10 +223,6 @@ pub fn configure_linux_graphics() {
         eprintln!("[harbor::mpv_linux] HARBOR_LINUX_LEGACY_GFX=1: disabling WebKit accelerated compositing (legacy behaviour)");
         std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
     }
-    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
-        eprintln!("[harbor::mpv_linux] setting WEBKIT_DISABLE_DMABUF_RENDERER=1 so WebKitGTK overlays repaint over the mpv render surface");
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-    }
     if !std::path::Path::new("/proc/driver/nvidia/version").exists() {
         return;
     }


### PR DESCRIPTION
## Summary

Removes `WEBKIT_DISABLE_DMABUF_RENDERER=1` from `configure_linux_graphics()` in the Linux MPV graphics setup.

Fixes #1121

## Why

Setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` forces WebKitGTK to bypass the DMABUF renderer, which breaks frame repainting between WebKitGTK UI overlays and the underlying `mpv` rendering surface. On Linux systems (particularly NVIDIA GPU + Wayland setups), this caused severe UI ghosting—leaving old subtitles, seek bar artifacts, and open menus permanently frozen over playback unless the window was resized. Removing this variable allows WebKitGTK to handle compositing properly without leaving ghost artifacts.

## Verification

- Built Harbor locally from source on `beta-branch`.
- Ran video streams via embedded MPV and verified that toggling audio tracks, subtitle overlays, and moving the seek bar no longer leaves ghost images behind.
- Confirmed smooth playback with no system stuttering/GPU compositor conflicts.

## Platform Impact

- **Linux:** Verified on Arch Linux (GNOME 50.3 on Wayland, NVIDIA GTX 1650 Ti / AMD Hybrid GPU setup). Solves ghosting on NVIDIA/Wayland without impacting AMD integrated graphics.
- **Windows / macOS:** None (change is isolated to `configure_linux_graphics()`).

## UI Changes

None (fix relates to rendering compositor behavior; no layout or CSS changes).

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes.
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.