### PR TITLE
fix: mirror profile customization toggles in RTL

### DIFF
--- a/src/views/profile/customization/customization-editors.tsx
+++ b/src/views/profile/customization/customization-editors.tsx
@@ -5,7 +5,15 @@ import { FaviconField } from "./favicon-field";
 const inputCls =
   "w-full min-h-11 rounded-[10px] bg-elevated px-3 text-[14px] text-ink outline-none ring-1 ring-edge-soft placeholder:text-ink-subtle focus:ring-edge";
 
-function Row({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+function Row({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
   return (
     <label className="block">
       <div className="mb-1.5 flex items-baseline justify-between">
@@ -31,7 +39,9 @@ export function CustomizationEditors({
       <div className="flex items-center justify-between gap-3 rounded-[10px] bg-elevated px-3 py-2.5 ring-1 ring-edge-soft">
         <div className="min-w-0">
           <div className="text-[13px] font-medium text-ink">Show customization to visitors</div>
-          <div className="text-[12px] text-ink-subtle">Off keeps your font, background, and canvas as a private preview.</div>
+          <div className="text-[12px] text-ink-subtle">
+            Off keeps your font, background, and canvas as a private preview.
+          </div>
         </div>
         <button
           type="button"
@@ -110,7 +120,9 @@ export function CustomizationEditors({
       <div className="flex items-center justify-between gap-3 rounded-[10px] bg-elevated px-3 py-2.5 ring-1 ring-edge-soft">
         <div className="min-w-0">
           <div className="text-[13px] font-medium text-ink">Hide top banner</div>
-          <div className="text-[12px] text-ink-subtle">Let your full page background show without the top cover.</div>
+          <div className="text-[12px] text-ink-subtle">
+            Let your full page background show without the top cover.
+          </div>
         </div>
         <button
           type="button"
@@ -129,7 +141,9 @@ export function CustomizationEditors({
       <div className="flex items-center justify-between gap-3 rounded-[10px] bg-elevated px-3 py-2.5 ring-1 ring-edge-soft">
         <div className="min-w-0">
           <div className="text-[13px] font-medium text-ink">Hide card titles</div>
-          <div className="text-[12px] text-ink-subtle">Drop the About and Custom labels so an embed fills the card cleanly.</div>
+          <div className="text-[12px] text-ink-subtle">
+            Drop the About and Custom labels so an embed fills the card cleanly.
+          </div>
         </div>
         <button
           type="button"

--- a/src/views/profile/customization/customization-editors.tsx
+++ b/src/views/profile/customization/customization-editors.tsx
@@ -42,7 +42,7 @@ export function CustomizationEditors({
           className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors ${form.customEnabled ? "bg-accent" : "bg-edge"}`}
         >
           <span
-            className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${form.customEnabled ? "translate-x-5" : "translate-x-0"}`}
+            className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${form.customEnabled ? "translate-x-5 rtl:-translate-x-5" : "translate-x-0"}`}
           />
         </button>
       </div>
@@ -121,7 +121,7 @@ export function CustomizationEditors({
           className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors ${form.hideTopBanner ? "bg-accent" : "bg-edge"}`}
         >
           <span
-            className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${form.hideTopBanner ? "translate-x-5" : "translate-x-0"}`}
+            className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${form.hideTopBanner ? "translate-x-5 rtl:-translate-x-5" : "translate-x-0"}`}
           />
         </button>
       </div>
@@ -140,7 +140,7 @@ export function CustomizationEditors({
           className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors ${form.hideCardTitles ? "bg-accent" : "bg-edge"}`}
         >
           <span
-            className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${form.hideCardTitles ? "translate-x-5" : "translate-x-0"}`}
+            className={`block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${form.hideCardTitles ? "translate-x-5 rtl:-translate-x-5" : "translate-x-0"}`}
           />
         </button>
       </div>


### PR DESCRIPTION
## Summary

- Mirror the profile customization switch thumb movement in RTL layouts.
- Apply the correction consistently to Show customization to visitors, Hide top banner, and Hide card titles.

## Why

The switch track follows the page direction in Arabic, but its enabled thumb translation was hard-coded toward the physical right. This made the enabled state appear reversed. Harbor's existing RTL switch pattern applies the opposite translation under `rtl`.

## Verification

- Manually verified in Arabic on Windows through `pnpm tauri dev`.
- `npx tsc -b --pretty false` passed.
- `pnpm build` passed with existing Vite chunk warnings.
- `pnpm tauri:build:linux-system` passed on Windows and produced the NSIS bundle.
- `pnpm run check` is unavailable because the repository has no `check` script.
- Scoped `vp check` reports pre-existing formatting in this file; unrelated formatting was deliberately excluded.
- The pre-commit `vp staged` hook is unavailable because `vite.config.ts` has no staged configuration.

## Platform Impact

- Windows: verified manually in Arabic.
- macOS/Linux: direction-only Tailwind classes; not manually tested.
- TV-style input: no input or focus behavior changed.

## UI Changes

**After**

![After - profile customization toggles mirrored correctly in RTL](https://github.com/user-attachments/assets/8d918af0-a7b2-4af8-a693-415fa57092c2)

**Before**

![Before - profile customization toggles reversed in RTL](https://github.com/user-attachments/assets/00ce7d20-f096-4225-b293-78df8b5a5af8)

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes.
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
