### PR TITLE
fix: preserve home hero action hit targets

### DIFF
--- a/src/components/hero-carousel.tsx
+++ b/src/components/hero-carousel.tsx
@@ -105,6 +105,12 @@ export function HeroCarousel({
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
     if (slides.length < 2) return;
+    if (
+      e.target instanceof Element &&
+      e.target.closest("button, a, input, select, textarea, [role='button']")
+    ) {
+      return;
+    }
     widthRef.current = viewportRef.current?.clientWidth ?? 1000;
     downRef.current = true;
     moved.current = false;
@@ -272,7 +278,7 @@ export function HeroCarousel({
               type="button"
               onClick={() => setActive((a) => (a - 1 + slides.length) % slides.length)}
               aria-label={t("Previous")}
-              className="group/hl absolute inset-y-0 start-0 z-30 my-auto flex h-2/3 w-[14%] max-w-[120px] items-center justify-start ps-4"
+              className="group/hl absolute inset-y-0 start-0 z-30 my-auto flex h-14 w-14 items-center justify-center"
             >
               <NavChevron
                 dir="left"
@@ -284,7 +290,7 @@ export function HeroCarousel({
               type="button"
               onClick={() => setActive((a) => (a + 1) % slides.length)}
               aria-label={t("Next")}
-              className="group/hr absolute inset-y-0 end-0 z-30 my-auto flex h-2/3 w-[14%] max-w-[120px] items-center justify-end pe-4"
+              className="group/hr absolute inset-y-0 end-0 z-30 my-auto flex h-14 w-14 items-center justify-center"
             >
               <NavChevron
                 dir="right"

--- a/tests/hero-carousel-hit-target.test.ts
+++ b/tests/hero-carousel-hit-target.test.ts
@@ -1,0 +1,24 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+const carousel = readFileSync(
+  new URL("../src/components/hero-carousel.tsx", import.meta.url),
+  "utf8",
+);
+
+test("hero controls do not start carousel dragging", () => {
+  assert.match(
+    carousel,
+    /e\.target\.closest\("button, a, input, select, textarea, \[role='button'\]"\)/,
+  );
+});
+
+test("carousel arrows keep accessible targets without overlapping hero actions", () => {
+  assert.match(carousel, /start-0 z-30 my-auto flex h-14 w-14 items-center justify-center/);
+  assert.match(carousel, /end-0 z-30 my-auto flex h-14 w-14 items-center justify-center/);
+  assert.doesNotMatch(carousel, /h-2\/3 w-\[14%\] max-w-\[120px\]/);
+});


### PR DESCRIPTION
## Summary

- keep hero action controls out of the carousel drag gesture
- constrain previous and next controls to non-overlapping 56px hit targets
- add regression coverage for the hero action and carousel boundaries

## Why

The carousel used wide invisible navigation regions that overlapped the visible Play button. Its pointer tracking also began when pressing interactive descendants. Clicking parts of Play could therefore activate or drag the carousel instead of opening the selected title.

## Verification

- `pnpm exec vp check src/components/hero-carousel.tsx tests/hero-carousel-hit-target.test.ts`
- `pnpm exec tsc -b --pretty false`
- `node --test tests/hero-carousel-hit-target.test.ts` (2 passed)
- `pnpm tauri:build:linux-system`
- visually checked the updated Play hit area in the Windows Tauri development app

## CI note

The changed-file formatting and lint checks pass. The current beta-branch workflow then fails at Typecheck with Task typecheck not found because the base branch does not define that task; this is pre-existing and outside this PR's two-file scope.

## Platform Impact

The shared frontend interaction was verified on Windows. macOS, Linux, and TV-style input were not manually tested. No native or playback code changed.

## UI Changes

### Before

<img width="1356" height="867" alt="Before: hero carousel navigation overlaps the Play button" src="https://github.com/user-attachments/assets/cf1716b1-a8cb-4b51-b241-e361a4bdef99" />

### After

<img width="691" height="432" alt="After: the full hero Play button is clickable" src="https://github.com/user-attachments/assets/5826db50-2ffc-49e8-82d2-33dbf7902d1e" />

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran TypeScript checking after TypeScript changes.
- [x] No Rust files changed, and the full Tauri build completed successfully.
- [x] I tested the affected interaction on Windows.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
