### PR TITLE
fix(dev): stop the in-app updater from hijacking the real install during local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pnpm-debug.log*
 /src-tauri/fonts/*.ttf
 local_docs/
 .diag/
+/src-tauri/tauri.dev.local.json
 
 # This repo is pnpm (see packageManager + CI). npm lockfiles must not be committed.
 package-lock.json

--- a/src/lib/updater/use-update.ts
+++ b/src/lib/updater/use-update.ts
@@ -122,6 +122,11 @@ function betaChannel(): boolean {
 
 export async function checkForUpdate(manual = false): Promise<void> {
   if (!IS_TAURI) return;
+  // The downloaded update package always installs to the real Harbor install
+  // location regardless of this build's identifier, so in dev it would silently
+  // update and relaunch the user's separately installed release build instead
+  // of this one. Never check for updates from a dev build.
+  if (import.meta.env.DEV) return;
   if (
     state.status === "checking" ||
     state.status === "downloading" ||


### PR DESCRIPTION
## Summary

Prevents the in-app updater from ever running inside a `pnpm tauri dev` build, since it can only ever end up silently updating and relaunching a separately installed release build instead of the dev build itself.

## Why

Dev builds share the same Tauri app identifier as the production release build by default. The updater has no awareness of which build triggered it — "Update now" always downloads and runs the real production installer, which always targets the actual Harbor install location on disk. There's no way for that installer to meaningfully "update" a dev build living at `target/debug/harbor.exe`; running the updater there just silently updates the user's separate real install and relaunches that instead, which looks like the dev build vanished.

## Verification

- Ran `pnpm tauri dev`, confirmed the updater no longer checks or shows the update prompt.
- Confirmed `import.meta.env.DEV` is `false` in production builds, so this has zero effect there.
- `tsc -b --pretty false` — clean.

## Platform Impact

Verified on Windows. The fix is gated purely on `import.meta.env.DEV`, so behavior should be identical on macOS/Linux.

## UI Changes

None — dev-only behavior change.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files. — Not available on `beta-branch` (no `vite-plus` dependency here yet; filed as a separate issue for visibility). Ran `tsc -b --pretty false` instead.
- [x] I ran typecheck after TypeScript changes (via `tsc -b --pretty false`, see note above).
- [x] No Rust changes in this PR.
- [x] Tested on the affected platform (Windows); fix is platform-agnostic.
- [x] No playback, navigation, or hotkey behavior touched.
- [ ] No new tests added — no existing test harness covers updater/dev-mode branching in this repo.
- [x] No secrets, tokens, or personal data included.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>