### PR TITLE
fix(search): stop the search overlay from ignoring the drag-anywhere setting

### DIFF
--- a/src/components/search/search-overlay.tsx
+++ b/src/components/search/search-overlay.tsx
@@ -97,24 +97,26 @@ export function SearchOverlay() {
     if (e.button !== 0) return;
     const startX = e.clientX;
     const startY = e.clientY;
+    let moved = false;
     let dragStarted = false;
     const onMove = (ev: MouseEvent) => {
       if (dragStarted) return;
       const dx = Math.abs(ev.clientX - startX);
       const dy = Math.abs(ev.clientY - startY);
-      if (dx > 6 || dy > 6) {
-        dragStarted = true;
-        window.removeEventListener("mousemove", onMove);
-        window.removeEventListener("mouseup", onUp);
-        import("@tauri-apps/api/window")
-          .then(({ getCurrentWindow }) => getCurrentWindow().startDragging())
-          .catch(() => {});
-      }
+      if (dx <= 6 && dy <= 6) return;
+      moved = true;
+      if (!settings.dragAnywhere) return;
+      dragStarted = true;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      import("@tauri-apps/api/window")
+        .then(({ getCurrentWindow }) => getCurrentWindow().startDragging())
+        .catch(() => {});
     };
     const onUp = () => {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
-      if (!dragStarted) close();
+      if (!dragStarted && !moved) close();
     };
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
@@ -171,7 +173,7 @@ export function SearchOverlay() {
       <button
         aria-label={t("Close search")}
         onMouseDown={beginDragOrClose}
-        className={`harbor-search-backdrop absolute inset-0 cursor-default ${
+        className={`harbor-search-backdrop no-press absolute inset-0 cursor-default ${
           closing ? "harbor-search-scrim-out" : "harbor-search-scrim-in"
         }`}
       />


### PR DESCRIPTION
## Summary

Fixes the search overlay ignoring Settings -> "Drag the window from anywhere," plus a visual shrink/see-through glitch that appeared when dragging or holding down the overlay's backdrop.

## Why

The overlay's backdrop had its own hand-rolled drag handler that moved the window on any drag gesture, regardless of the `dragAnywhere` setting that gates every other draggable surface in the app (see `useContentDrag` in `lib/window-drag.ts`).

While chasing a visual glitch this produced (the whole blurred backdrop appeared to shrink and show desktop through its edges during a drag), the actual cause turned out to be unrelated to window dragging at all: the backdrop is a `<button>`, and the app has a global base-layer rule (`button:not(.no-press):active { scale: 0.97; }`) that gives every button a tactile press-down effect. Applied to a full-viewport button, holding it down for the duration of a click or drag visibly scales the entire backdrop to 97%, exposing a thin strip of real window edge around all four sides. Confirmed by comparing close-on-mousedown (never visibly active long enough to render) against close-on-mouseup/drag (active for the whole gesture) - only the latter showed it.

## Verification

- Click closes the overlay; drag with `dragAnywhere` ON moves the window (overlay stays open, no shrink); drag with it OFF does nothing (no window move, no close, no shrink).
- `tsc -b --pretty false` — clean.

## Platform Impact

Verified on Windows (where the artifact was reproduced). The `dragAnywhere` setting/logic itself is cross-platform.

## UI Changes

Screenshot of the shrink/see-through artifact (before fix) to be added. ( i lost it ... )

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files. — Not available on `beta-branch` (no `vite-plus` dependency here yet; filed as a separate issue for visibility). Ran `tsc -b --pretty false` instead.
- [x] I ran typecheck after TypeScript changes (via `tsc -b --pretty false`, see note above).
- [x] No Rust changes in this PR.
- [x] Tested on the affected platform (Windows); fix is platform-agnostic.
- [x] No playback, navigation, or hotkey behavior touched.
- [ ] No new tests added — no existing test harness covers window-drag interaction in this repo.
- [x] No secrets, tokens, or personal data included.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>