### PR TITLE
feat(manga): improve and enhance Manga workflows and remote controls

### DIFF
--- a/src/lib/manga-downloads.ts
+++ b/src/lib/manga-downloads.ts
@@ -1,13 +1,22 @@
 import { useEffect, useState } from "react";
 import { chapterPages } from "@/lib/manga/api";
 
-export type MangaDownloadStatus = "idle" | "downloading" | "done" | "error";
+export type MangaDownloadStatus = "idle" | "downloading" | "paused" | "done" | "error";
 
 export type MangaDownloadRec = {
   status: MangaDownloadStatus;
   done: number;
   total: number;
   files: string[];
+};
+
+export type MangaDownloadBatchStatus = "idle" | "downloading" | "paused" | "done" | "error";
+
+export type MangaDownloadBatchRec = {
+  status: MangaDownloadBatchStatus;
+  done: number;
+  total: number;
+  failed: number;
 };
 
 export type MangaDownloadInfo = {
@@ -44,7 +53,17 @@ const MANIFEST_KEY = "harbor.manga.downloads.v1";
 const META_KEY = "harbor.manga.downloads.meta.v1";
 const DIR_KEY = "harbor.manga.downloads.dir.v1";
 const runtime = new Map<string, MangaDownloadRec>();
+const batchRuntime = new Map<string, MangaDownloadBatchRec>();
 const listeners = new Set<(changed?: string) => void>();
+
+type BatchControl = {
+  paused: boolean;
+  currentChapterId?: string;
+  waiters: Set<() => void>;
+  promise?: Promise<void>;
+};
+
+const batchControls = new Map<string, BatchControl>();
 
 function notify(changed?: string): void {
   for (const l of listeners) l(changed);
@@ -195,6 +214,54 @@ export function mangaDownloadStatus(chapterId: string): MangaDownloadRec {
   return recOf(chapterId);
 }
 
+function batchRecOf(mangaId: string): MangaDownloadBatchRec {
+  return batchRuntime.get(mangaId) ?? { status: "idle", done: 0, total: 0, failed: 0 };
+}
+
+function setBatchRec(mangaId: string, patch: Partial<MangaDownloadBatchRec>): void {
+  batchRuntime.set(mangaId, { ...batchRecOf(mangaId), ...patch });
+  notify(`batch:${mangaId}`);
+}
+
+export function mangaDownloadBatchStatus(mangaId: string): MangaDownloadBatchRec {
+  return batchRecOf(mangaId);
+}
+
+function setChapterPaused(chapterId: string | undefined, paused: boolean): void {
+  if (!chapterId) return;
+  const rec = recOf(chapterId);
+  if (paused && rec.status === "downloading") {
+    runtime.set(chapterId, { ...rec, status: "paused" });
+    notify(chapterId);
+  } else if (!paused && rec.status === "paused") {
+    runtime.set(chapterId, { ...rec, status: "downloading" });
+    notify(chapterId);
+  }
+}
+
+export function pauseMangaDownloadBatch(mangaId: string): void {
+  const control = batchControls.get(mangaId);
+  if (!control || batchRecOf(mangaId).status !== "downloading") return;
+  control.paused = true;
+  setChapterPaused(control.currentChapterId, true);
+  setBatchRec(mangaId, { status: "paused" });
+}
+
+export function resumeMangaDownloadBatch(mangaId: string): void {
+  const control = batchControls.get(mangaId);
+  if (!control || batchRecOf(mangaId).status !== "paused") return;
+  control.paused = false;
+  setChapterPaused(control.currentChapterId, false);
+  setBatchRec(mangaId, { status: "downloading" });
+  for (const resolve of control.waiters) resolve();
+  control.waiters.clear();
+}
+
+function waitForBatch(control?: BatchControl): Promise<void> {
+  if (!control?.paused) return Promise.resolve();
+  return new Promise((resolve) => control.waiters.add(resolve));
+}
+
 export async function downloadedPages(chapterId: string): Promise<string[] | null> {
   const files = readManifest()[chapterId];
   if (!files?.length) return null;
@@ -216,13 +283,16 @@ const IMG_HEADERS = {
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
 };
 
-export async function downloadChapter(
+async function downloadChapterWithControl(
   mangaId: string,
   chapterId: string,
   info?: MangaDownloadInfo,
-): Promise<void> {
+  batchControl?: BatchControl,
+): Promise<boolean> {
   const cur = recOf(chapterId);
-  if (cur.status === "downloading" || cur.status === "done") return;
+  if (cur.status === "downloading" || cur.status === "paused" || cur.status === "done") {
+    return cur.status === "done";
+  }
 
   const setRec = (patch: Partial<MangaDownloadRec>) => {
     runtime.set(chapterId, { ...recOf(chapterId), ...patch });
@@ -230,11 +300,17 @@ export async function downloadChapter(
   };
 
   try {
-    setRec({ status: "downloading", done: 0, total: 0, files: [] });
+    setRec({
+      status: batchControl?.paused ? "paused" : "downloading",
+      done: 0,
+      total: 0,
+      files: [],
+    });
+    await waitForBatch(batchControl);
     const urls = (await chapterPages(chapterId)).filter((u) => /^https?:/i.test(u));
     if (!urls.length) {
       setRec({ status: "error" });
-      return;
+      return false;
     }
     setRec({ total: urls.length });
 
@@ -260,7 +336,9 @@ export async function downloadChapter(
 
     const files: string[] = [];
     for (let i = 0; i < urls.length; i++) {
+      await waitForBatch(batchControl);
       const bytes = await fetchBytes(urls[i]);
+      await waitForBatch(batchControl);
       const path = await join(dir, `${String(i + 1).padStart(4, "0")}.${extOf(urls[i])}`);
       await writeFile(path, bytes);
       files.push(path);
@@ -280,21 +358,56 @@ export async function downloadChapter(
     };
     writeMeta(meta);
     setRec({ status: "done", files });
+    return true;
   } catch (e) {
     console.error("[manga-download] chapter failed", chapterId, e);
     setRec({ status: "error" });
+    return false;
   }
+}
+
+export function downloadChapter(
+  mangaId: string,
+  chapterId: string,
+  info?: MangaDownloadInfo,
+): Promise<boolean> {
+  return downloadChapterWithControl(mangaId, chapterId, info);
 }
 
 export async function downloadAllChapters(
   mangaId: string,
   items: Array<{ chapterId: string; info?: MangaDownloadInfo }>,
 ): Promise<void> {
-  for (const it of items) {
-    const rec = recOf(it.chapterId);
-    if (rec.status === "done" || rec.status === "downloading") continue;
-    await downloadChapter(mangaId, it.chapterId, it.info);
-  }
+  const running = batchControls.get(mangaId);
+  if (running?.promise) return running.promise;
+
+  const pending = items.filter((item) => {
+    const status = recOf(item.chapterId).status;
+    return status !== "done" && status !== "downloading" && status !== "paused";
+  });
+  const control: BatchControl = { paused: false, waiters: new Set() };
+  batchControls.set(mangaId, control);
+  setBatchRec(mangaId, { status: "downloading", done: 0, total: pending.length, failed: 0 });
+
+  const job = (async () => {
+    let done = 0;
+    let failed = 0;
+    for (const item of pending) {
+      await waitForBatch(control);
+      control.currentChapterId = item.chapterId;
+      const ok = await downloadChapterWithControl(mangaId, item.chapterId, item.info, control);
+      if (ok) done += 1;
+      else failed += 1;
+      setBatchRec(mangaId, { done, failed });
+    }
+    setBatchRec(mangaId, { status: failed > 0 ? "error" : "done", done, failed });
+  })().finally(() => {
+    control.currentChapterId = undefined;
+    control.promise = undefined;
+  });
+
+  control.promise = job;
+  return job;
 }
 
 async function removeChapterDir(firstFile: string): Promise<void> {
@@ -333,5 +446,17 @@ export function useMangaDownload(chapterId: string): MangaDownloadRec {
     sync();
     return subscribeMangaDownloads(sync);
   }, [chapterId]);
+  return rec;
+}
+
+export function useMangaDownloadBatch(mangaId: string): MangaDownloadBatchRec {
+  const [rec, setRec] = useState<MangaDownloadBatchRec>(() => mangaDownloadBatchStatus(mangaId));
+  useEffect(() => {
+    const sync = (changed?: string) => {
+      if (!changed || changed === `batch:${mangaId}`) setRec(mangaDownloadBatchStatus(mangaId));
+    };
+    sync();
+    return subscribeMangaDownloads(sync);
+  }, [mangaId]);
   return rec;
 }

--- a/src/lib/manga-favorites.tsx
+++ b/src/lib/manga-favorites.tsx
@@ -1,11 +1,28 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useProfiles } from "./profiles";
 import { persistCritical } from "./storage-recovery";
+import { setMangaInLibrary } from "./manga/api";
 
 export type MangaFavEntry = { id: string; title: string; cover?: string; addedAt: number };
 
 const PREFIX = "harbor.mangafav.v1.";
 const keyFor = (pid: string) => PREFIX + pid;
+const librarySync = new Map<string, Promise<void>>();
+
+function syncLibrary(id: string, inLibrary: boolean): void {
+  const pending = librarySync.get(id) ?? Promise.resolve();
+  const next = pending
+    .catch(() => {})
+    .then(async () => {
+      await setMangaInLibrary(id, inLibrary);
+    });
+  librarySync.set(id, next);
+  void next
+    .catch((error) => console.warn("[manga-favorites] Suwayomi library sync failed", error))
+    .finally(() => {
+      if (librarySync.get(id) === next) librarySync.delete(id);
+    });
+}
 
 function readMap(key: string): Map<string, MangaFavEntry> {
   const map = new Map<string, MangaFavEntry>();
@@ -60,6 +77,7 @@ export function MangaFavoritesProvider({ children }: { children: ReactNode }) {
         const next = new Map(items);
         if (next.has(input.id)) {
           next.delete(input.id);
+          syncLibrary(input.id, false);
         } else {
           next.set(input.id, {
             id: input.id,
@@ -67,6 +85,7 @@ export function MangaFavoritesProvider({ children }: { children: ReactNode }) {
             cover: input.cover,
             addedAt: Date.now(),
           });
+          syncLibrary(input.id, true);
         }
         writeMap(keyFor(pid), next);
         setItems(next);

--- a/src/lib/manga/api.ts
+++ b/src/lib/manga/api.ts
@@ -5,7 +5,13 @@ import {
   aggregateSubProviders,
   ensureMangaSources,
 } from "./sources";
-import { ownSourceChapters, routeById, streamAll, streamAggregateChapters } from "./sources/aggregate";
+import {
+  ownSourceChapters,
+  routeById,
+  streamAll,
+  streamAggregateChapters,
+} from "./sources/aggregate";
+import { suwayomiSourcesRevision } from "./sources/suwayomi/source-events";
 import type { MangaChapter, MangaProvider, MangaSummary } from "./types";
 
 export {
@@ -197,6 +203,20 @@ export function searchManga(query: string, offset = 0, tagId?: string) {
   );
 }
 
+export function searchMangaEverywhere(query: string) {
+  const revision = suwayomiSourcesRevision();
+  return cached(
+    "searchAll",
+    `${revision}|${query}`,
+    5 * MIN,
+    (p) => p.searchAll?.(query) ?? p.search(query, 0),
+    {
+      tries: 1,
+      timeout: 30_000,
+    },
+  );
+}
+
 type Chunk = (items: MangaSummary[]) => void;
 
 async function streamOrCall(
@@ -259,7 +279,11 @@ export function popularMangaStream(offset: number, tagId: string | undefined, on
     `${offset}|${tag}`,
     5 * MIN,
     (p) => p.popular(offset, tagId),
-    { tries: 3, timeout: 10_000, disk: offset === 0 ? { key: `pop|${tag}`, ...POPULAR_DISK } : undefined },
+    {
+      tries: 3,
+      timeout: 10_000,
+      disk: offset === 0 ? { key: `pop|${tag}`, ...POPULAR_DISK } : undefined,
+    },
     onChunk,
   );
 }
@@ -336,8 +360,25 @@ export function chapterPages(chapterId: string) {
 }
 
 export function mangaTags() {
-  return cached("tags", "", 30 * MIN, (p) => (p.tags ? p.tags() : Promise.resolve([])), {
-    tries: 1,
-    disk: { key: "tags", ...TAGS_DISK },
-  });
+  const revision = suwayomiSourcesRevision();
+  return cached(
+    "tags",
+    String(revision),
+    30 * MIN,
+    (p) => (p.tags ? p.tags() : Promise.resolve([])),
+    {
+      tries: 1,
+      disk: { key: `tags|${revision}`, ...TAGS_DISK },
+    },
+  );
+}
+
+export async function setMangaInLibrary(id: string, inLibrary: boolean): Promise<boolean> {
+  await ensureMangaSources();
+  const routed = routeById(id);
+  const provider = routed?.provider ?? activeMangaProvider();
+  const mangaId = routed?.orig ?? id;
+  if (!provider.setLibrary) return false;
+  await provider.setLibrary(mangaId, inLibrary);
+  return true;
 }

--- a/src/lib/manga/sources/aggregate.ts
+++ b/src/lib/manga/sources/aggregate.ts
@@ -14,9 +14,9 @@ const EMPTY_PROVIDER: MangaProvider = {
   pageUrls: async () => [],
 };
 
-function withTimeout<T>(p: Promise<T>, fallback: T): Promise<T> {
+function withTimeout<T>(p: Promise<T>, fallback: T, timeout = SOURCE_TIMEOUT): Promise<T> {
   return new Promise((resolve) => {
-    const t = setTimeout(() => resolve(fallback), SOURCE_TIMEOUT);
+    const t = setTimeout(() => resolve(fallback), timeout);
     p.then(
       (v) => {
         clearTimeout(t);
@@ -56,12 +56,14 @@ export function routeById(id: string): { provider: MangaProvider; orig: string }
 
 async function mergeLists(
   fn: (p: MangaProvider) => Promise<MangaSummary[]>,
+  timeout = SOURCE_TIMEOUT,
 ): Promise<MangaSummary[]> {
   const lists = await Promise.all(
     aggregateSubProviders().map((p) =>
       withTimeout(
         fn(p).then((l) => l.map((m) => ({ ...m, id: prefixId(p.id, m.id) }))),
         [] as MangaSummary[],
+        timeout,
       ).catch(() => [] as MangaSummary[]),
     ),
   );
@@ -124,7 +126,10 @@ export async function streamAggregateChapters(
     ...others.map((p) =>
       withTimeout(
         (async () => {
-          const hit = pickSameTitle(await p.search(title as string, 0).catch(() => []), title as string);
+          const hit = pickSameTitle(
+            await p.search(title as string, 0).catch(() => []),
+            title as string,
+          );
           if (!hit) return;
           const labeled = labelChapters(await p.chapters(hit.id).catch(() => []), p);
           if (labeled.length) onChunk(labeled);
@@ -157,6 +162,38 @@ function pickSameTitle(hits: MangaSummary[], title: string): MangaSummary | null
   );
 }
 
+async function mergeSearchLists(query: string): Promise<MangaSummary[]> {
+  const providers = aggregateSubProviders();
+  if (!providers.length) return [];
+
+  const lists = new Map<number, MangaSummary[]>();
+  let releaseExact: () => void = () => {};
+  const exact = new Promise<void>((resolve) => {
+    releaseExact = resolve;
+  });
+  let exactFound = false;
+
+  const requests = providers.map((provider, index) =>
+    withTimeout(
+      (provider.searchAll?.(query) ?? provider.search(query, 0)).then((items) =>
+        items.map((item) => ({ ...item, id: prefixId(provider.id, item.id) })),
+      ),
+      [] as MangaSummary[],
+      30_000,
+    ).then((items) => {
+      lists.set(index, items);
+      if (!exactFound && pickSameTitle(items, query)) {
+        exactFound = true;
+        releaseExact();
+      }
+    }),
+  );
+
+  const all = Promise.all(requests).then(() => undefined);
+  await Promise.race([all, exact]);
+  return [...lists.entries()].sort(([a], [b]) => a - b).flatMap(([, items]) => items);
+}
+
 export async function ownSourceChapters(id: string): Promise<MangaChapter[]> {
   const { source, orig } = parseId(id);
   const ownP = subById(source);
@@ -168,9 +205,12 @@ export const aggregateProvider: MangaProvider = {
   name: "All Sources",
   popular: (offset, tagId) => mergeLists((p) => p.popular(offset, tagId)),
   search: (query, offset, tagId) => mergeLists((p) => p.search(query, offset, tagId)),
+  searchAll: mergeSearchLists,
   detail: async (id) => {
     const { source, orig } = parseId(id);
-    const d = await subById(source).detail(orig).catch(() => null);
+    const d = await subById(source)
+      .detail(orig)
+      .catch(() => null);
     return d ? { ...d, id } : null;
   },
   chapters: async (id) => {
@@ -193,13 +233,18 @@ export const aggregateProvider: MangaProvider = {
           [] as MangaChapter[],
         ),
       ),
-
     );
     return [...ownChs, ...extra.flat()];
   },
   pageUrls: async (chapterId) => {
     const { source, orig } = parseId(chapterId);
-    return subById(source).pageUrls(orig).catch(() => []);
+    return subById(source)
+      .pageUrls(orig)
+      .catch(() => []);
+  },
+  setLibrary: async (id, inLibrary) => {
+    const { source, orig } = parseId(id);
+    await subById(source).setLibrary?.(orig, inLibrary);
   },
   tags: () => aggregateSubProviders()[0]?.tags?.() ?? Promise.resolve([]),
 };

--- a/src/lib/manga/sources/suwayomi/api.ts
+++ b/src/lib/manga/sources/suwayomi/api.ts
@@ -3,6 +3,7 @@ import { imageUrl, mapManga, type SuwayomiExtension, type SuwayomiSource } from 
 import {
   configClient,
   configServer,
+  clearLoadedSources,
   loadSources,
   pickTransport,
   withTransportFallback,
@@ -35,6 +36,7 @@ import {
   type ExtensionRepo,
 } from "./graphql";
 import { normalizeExtensionRepoUrl } from "./base-url";
+import { notifySuwayomiSourcesChanged } from "./source-events";
 
 export type { ExtensionRepo } from "./graphql";
 
@@ -133,9 +135,9 @@ export async function sourceSearch(
 
 export async function listExtensions(config: ServerConfig): Promise<SuwayomiExtension[]> {
   const client = configClient(config);
-  return (await pickTransport(client)) === "rest"
-    ? restExtensions(client)
-    : gqlExtensions(client);
+  return withTransportFallback(client, (transport) =>
+    transport === "rest" ? restExtensions(client) : gqlExtensions(client),
+  );
 }
 
 async function mutateExtension(
@@ -145,11 +147,12 @@ async function mutateExtension(
   graphql: (c: ReturnType<typeof configClient>, p: string) => Promise<boolean>,
 ): Promise<void> {
   const client = configClient(config);
-  const ok =
-    (await pickTransport(client)) === "rest"
-      ? await rest(client, pkgName)
-      : await graphql(client, pkgName);
-  if (!ok) throw new Error("suwayomi extension action failed");
+  await withTransportFallback(client, async (transport) => {
+    const ok = transport === "rest" ? await rest(client, pkgName) : await graphql(client, pkgName);
+    if (!ok) throw new Error("suwayomi extension action failed");
+  });
+  clearLoadedSources(client.server.base);
+  notifySuwayomiSourcesChanged(client.server.base);
 }
 
 export function installExtension(config: ServerConfig, pkgName: string): Promise<void> {

--- a/src/lib/manga/sources/suwayomi/graphql.ts
+++ b/src/lib/manga/sources/suwayomi/graphql.ts
@@ -10,7 +10,11 @@ import type { RestChapter, RestPage } from "./rest";
 
 const GQL = "/api/graphql";
 
-async function gql(client: SuwayomiClient, query: string, variables?: Record<string, unknown>): Promise<any | null> {
+async function gql(
+  client: SuwayomiClient,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<any | null> {
   const res = await client.postJson(GQL, { query, variables: variables ?? {} });
   if (!res) return null;
   return res.data ?? null;
@@ -37,7 +41,10 @@ export async function gqlAbout(
   const data = await gql(client, "query { aboutServer { name version } }");
   const v = data?.aboutServer;
   if (!v) return null;
-  return { name: v.name ? String(v.name) : undefined, version: v.version ? String(v.version) : undefined };
+  return {
+    name: v.name ? String(v.name) : undefined,
+    version: v.version ? String(v.version) : undefined,
+  };
 }
 
 export async function gqlSources(client: SuwayomiClient): Promise<SuwayomiSource[]> {
@@ -126,7 +133,9 @@ function mapGqlChapters(chapters: any[]): RestChapter[] {
         pageCount: Number.isFinite(pc) && pc >= 0 ? pc : 0,
         downloaded: !!ch.isDownloaded,
         isRead: ch.isRead === true,
-        lastPageRead: Number.isFinite(Number(ch.lastPageRead)) ? Number(ch.lastPageRead) : undefined,
+        lastPageRead: Number.isFinite(Number(ch.lastPageRead))
+          ? Number(ch.lastPageRead)
+          : undefined,
       };
     });
 }
@@ -179,6 +188,21 @@ export async function gqlLibrary(client: SuwayomiClient): Promise<any[]> {
   return Array.isArray(nodes) ? nodes : [];
 }
 
+export async function gqlSetMangaInLibrary(
+  client: SuwayomiClient,
+  mangaId: string,
+  inLibrary: boolean,
+): Promise<boolean> {
+  if (!isDigits(mangaId)) return false;
+  const q = `mutation($id: Int!, $inLibrary: Boolean!) {
+    updateManga(input: { id: $id, patch: { inLibrary: $inLibrary } }) {
+      manga { id }
+    }
+  }`;
+  const data = await gql(client, q, { id: Number(mangaId), inLibrary });
+  return data?.updateManga?.manga?.id != null;
+}
+
 export async function gqlExtensions(client: SuwayomiClient): Promise<SuwayomiExtension[]> {
   const data = await gql(
     client,
@@ -186,6 +210,7 @@ export async function gqlExtensions(client: SuwayomiClient): Promise<SuwayomiExt
       pkgName apkName name lang iconUrl versionName isInstalled hasUpdate isObsolete isNsfw repo
     } } }`,
   );
+  if (data == null) throw new Error("suwayomi_graphql_error");
   const nodes = data?.extensions?.nodes;
   if (!Array.isArray(nodes)) return [];
   return nodes
@@ -221,7 +246,9 @@ async function updateExtension(
     }
   }`;
   const data = await gql(client, q, { id: pkgName });
-  return !!data?.updateExtension?.extension;
+  const extension = data?.updateExtension?.extension;
+  if (!extension) return false;
+  return patch === "uninstall" ? extension.isInstalled === false : extension.isInstalled === true;
 }
 
 export function gqlInstallExtension(client: SuwayomiClient, pkgName: string): Promise<boolean> {
@@ -251,7 +278,10 @@ export async function gqlListExtensionRepos(client: SuwayomiClient): Promise<Ext
     }));
 }
 
-export async function gqlAddExtensionRepo(client: SuwayomiClient, indexUrl: string): Promise<boolean> {
+export async function gqlAddExtensionRepo(
+  client: SuwayomiClient,
+  indexUrl: string,
+): Promise<boolean> {
   const q = `mutation($url: String!) {
     addExtensionStore(input: { indexUrl: $url }) { extensionStore { indexUrl } }
   }`;
@@ -259,7 +289,10 @@ export async function gqlAddExtensionRepo(client: SuwayomiClient, indexUrl: stri
   return !!data?.addExtensionStore?.extensionStore;
 }
 
-export async function gqlRemoveExtensionRepo(client: SuwayomiClient, indexUrl: string): Promise<boolean> {
+export async function gqlRemoveExtensionRepo(
+  client: SuwayomiClient,
+  indexUrl: string,
+): Promise<boolean> {
   const q = `mutation($url: String!) {
     removeExtensionStore(input: { indexUrl: $url }) { clientMutationId }
   }`;

--- a/src/lib/manga/sources/suwayomi/model.ts
+++ b/src/lib/manga/sources/suwayomi/model.ts
@@ -39,6 +39,7 @@ export type SuwayomiClient = {
   server: SuwayomiServer;
   getJson(path: string): Promise<any | null>;
   getOk(path: string): Promise<boolean>;
+  deleteOk(path: string): Promise<boolean>;
   postJson(path: string, body: unknown): Promise<any | null>;
   probeStatus(path: string): Promise<number | null>;
 };
@@ -110,12 +111,25 @@ export function makeClient(server: SuwayomiServer, gapMs = 150): SuwayomiClient 
         }
       });
     },
+    deleteOk(path) {
+      return throttle(async () => {
+        try {
+          const res = await safeFetch(server.base + path, {
+            method: "DELETE",
+            headers,
+          });
+          return res.ok;
+        } catch {
+          return false;
+        }
+      });
+    },
     postJson(path, body) {
       return throttle(async () => {
         try {
           const res = await safeFetch(server.base + path, {
             method: "POST",
-            headers: { ...(headers ?? {}), "content-type": "application/json" },
+            headers: { ...headers, "content-type": "application/json" },
             body: JSON.stringify(body),
           });
           if (!res.ok) return null;

--- a/src/lib/manga/sources/suwayomi/provider.ts
+++ b/src/lib/manga/sources/suwayomi/provider.ts
@@ -18,11 +18,34 @@ import {
   restMangaFull,
   restPageUrls,
   restSearch,
+  restSetMangaInLibrary,
   type RestChapter,
 } from "./rest";
-import { gqlBrowse, gqlChapters, gqlLibrary, gqlManga, gqlPageUrls } from "./graphql";
+import {
+  gqlBrowse,
+  gqlChapters,
+  gqlLibrary,
+  gqlManga,
+  gqlPageUrls,
+  gqlSetMangaInLibrary,
+} from "./graphql";
 import { loadSources, pickTransport, sourceLang, withTransportFallback } from "./transport";
 import { registerServerPageHeaders } from "@/lib/manga/plugins/adapter";
+
+const SEARCH_ALL_CONCURRENCY = 4;
+
+function normalizedTitle(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function isStrongSearchMatch(item: MangaSummary, query: string): boolean {
+  const key = normalizedTitle(query);
+  if (!key) return false;
+  return [item.title, item.altTitle]
+    .filter((title): title is string => !!title)
+    .map(normalizedTitle)
+    .some((title) => title === key || title.startsWith(key) || key.startsWith(title));
+}
 
 function mapChapters(
   sourceId: string,
@@ -57,19 +80,22 @@ export function makeSuwayomiProvider(baseUrl: string, basicAuth?: string): Manga
     kind: BrowseKind,
     offset: number,
     query: string,
+    requestClient = client,
   ): Promise<MangaSummary[]> {
     const key = cursorKey(server.base, sourceId, kind, query);
     const page = nextPage(key, offset);
     if (page < 0) return [];
-    const res = await withTransportFallback(client, (t) =>
+    const res = await withTransportFallback(requestClient, (t) =>
       t === "rest"
         ? kind === "search"
-          ? restSearch(client, sourceId, query, page)
-          : restBrowse(client, sourceId, kind, page)
-        : gqlBrowse(client, sourceId, kind, page, kind === "search" ? query : undefined),
+          ? restSearch(requestClient, sourceId, query, page)
+          : restBrowse(requestClient, sourceId, kind, page)
+        : gqlBrowse(requestClient, sourceId, kind, page, kind === "search" ? query : undefined),
     );
     recordPage(key, res.items.length, res.hasNextPage, page);
-    return res.items.map((m) => mapManga(server, sourceId, m)).filter((m): m is MangaSummary => !!m);
+    return res.items
+      .map((m) => mapManga(server, sourceId, m))
+      .filter((m): m is MangaSummary => !!m);
   }
 
   async function library(): Promise<MangaSummary[]> {
@@ -93,6 +119,42 @@ export function makeSuwayomiProvider(baseUrl: string, basicAuth?: string): Manga
     if (offset > 0) return [];
     const lower = q.toLowerCase();
     return (await library()).filter((m) => m.title.toLowerCase().includes(lower));
+  }
+
+  async function searchAll(query: string): Promise<MangaSummary[]> {
+    const q = query.trim();
+    if (!q) return [];
+    const sources = await loadSources(client, await pickTransport(client));
+    if (!sources.length) return [];
+
+    const unique = new Map<string, MangaSummary>();
+    let nextSource = 0;
+    let exactFound = false;
+    let releaseExact: () => void = () => {};
+    const exact = new Promise<void>((resolve) => {
+      releaseExact = resolve;
+    });
+
+    const worker = async () => {
+      while (!exactFound) {
+        const source = sources[nextSource++];
+        if (!source) return;
+        const requestClient = makeClient(server, 0);
+        const items = await browse(source.id, "search", 0, q, requestClient).catch(() => []);
+        for (const item of items) unique.set(item.id, item);
+        if (items.some((item) => isStrongSearchMatch(item, q))) {
+          exactFound = true;
+          releaseExact();
+        }
+      }
+    };
+
+    const workers = Array.from({ length: Math.min(SEARCH_ALL_CONCURRENCY, sources.length) }, () =>
+      worker(),
+    );
+    const all = Promise.all(workers).then(() => undefined);
+    await Promise.race([all, exact]);
+    return [...unique.values()];
   }
 
   async function detail(id: string): Promise<MangaSummary | null> {
@@ -156,7 +218,30 @@ export function makeSuwayomiProvider(baseUrl: string, basicAuth?: string): Manga
     }));
   }
 
-  return { id: "suwayomi", name: "My Server", popular, search, detail, chapters, pageUrls, tags };
+  async function setLibrary(id: string, inLibrary: boolean): Promise<void> {
+    const parsed = decodeMangaId(id);
+    if (!parsed) return;
+    await withTransportFallback(client, async (t) => {
+      const ok =
+        t === "rest"
+          ? await restSetMangaInLibrary(client, parsed.mangaId, inLibrary)
+          : await gqlSetMangaInLibrary(client, parsed.mangaId, inLibrary);
+      if (!ok) throw new Error("suwayomi_library_update_failed");
+    });
+  }
+
+  return {
+    id: "suwayomi",
+    name: "My Server",
+    popular,
+    search,
+    searchAll,
+    detail,
+    chapters,
+    pageUrls,
+    tags,
+    setLibrary,
+  };
 }
 
 export * from "./api";

--- a/src/lib/manga/sources/suwayomi/rest.ts
+++ b/src/lib/manga/sources/suwayomi/rest.ts
@@ -120,6 +120,15 @@ export async function restLibrary(client: SuwayomiClient): Promise<any[]> {
   return merged;
 }
 
+export function restSetMangaInLibrary(
+  client: SuwayomiClient,
+  mangaId: string,
+  inLibrary: boolean,
+): Promise<boolean> {
+  const path = `/api/v1/manga/${mangaId}/library`;
+  return inLibrary ? client.getOk(path) : client.deleteOk(path);
+}
+
 export async function restMangaFull(client: SuwayomiClient, mangaId: string): Promise<any | null> {
   const full = await client.getJson(`/api/v1/manga/${mangaId}/full`);
   if (full) return full;
@@ -128,7 +137,10 @@ export async function restMangaFull(client: SuwayomiClient, mangaId: string): Pr
   return basic;
 }
 
-export async function restChapters(client: SuwayomiClient, mangaId: string): Promise<RestChapter[]> {
+export async function restChapters(
+  client: SuwayomiClient,
+  mangaId: string,
+): Promise<RestChapter[]> {
   const list = await client.getJson(`/api/v1/manga/${mangaId}/chapters`);
   if (list == null) throw new Error("suwayomi_rest_error");
   if (!Array.isArray(list)) return [];
@@ -145,7 +157,9 @@ export async function restChapters(client: SuwayomiClient, mangaId: string): Pro
         pageCount: Number.isFinite(Number(ch.pageCount)) ? Number(ch.pageCount) : 0,
         downloaded: !!ch.downloaded,
         isRead: ch.read === true,
-        lastPageRead: Number.isFinite(Number(ch.lastPageRead)) ? Number(ch.lastPageRead) : undefined,
+        lastPageRead: Number.isFinite(Number(ch.lastPageRead))
+          ? Number(ch.lastPageRead)
+          : undefined,
       };
     });
 }
@@ -166,6 +180,7 @@ export async function restPageUrls(
 
 export async function restExtensions(client: SuwayomiClient): Promise<SuwayomiExtension[]> {
   const res = await client.getJson("/api/v1/extension/list");
+  if (res == null) throw new Error("suwayomi_rest_error");
   if (!Array.isArray(res)) return [];
   return res
     .filter((e) => e?.pkgName)
@@ -185,13 +200,13 @@ export async function restExtensions(client: SuwayomiClient): Promise<SuwayomiEx
 }
 
 export function restInstallExtension(client: SuwayomiClient, pkgName: string): Promise<boolean> {
-  return client.getOk(`/api/v1/extension/install/${pkgName}`);
+  return client.getOk(`/api/v1/extension/install/${encodeURIComponent(pkgName)}`);
 }
 
 export function restUninstallExtension(client: SuwayomiClient, pkgName: string): Promise<boolean> {
-  return client.getOk(`/api/v1/extension/uninstall/${pkgName}`);
+  return client.getOk(`/api/v1/extension/uninstall/${encodeURIComponent(pkgName)}`);
 }
 
 export function restUpdateExtension(client: SuwayomiClient, pkgName: string): Promise<boolean> {
-  return client.getOk(`/api/v1/extension/update/${pkgName}`);
+  return client.getOk(`/api/v1/extension/update/${encodeURIComponent(pkgName)}`);
 }

--- a/src/lib/manga/sources/suwayomi/source-events.ts
+++ b/src/lib/manga/sources/suwayomi/source-events.ts
@@ -1,0 +1,33 @@
+const REVISION_KEY = "harbor.manga.suwayomi-sources-revision.v1";
+
+const listeners = new Set<(base: string) => void>();
+
+function storedRevision(): number {
+  try {
+    const value = Number(localStorage.getItem(REVISION_KEY));
+    return Number.isFinite(value) && value >= 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+let revision = storedRevision();
+
+export function suwayomiSourcesRevision(): number {
+  return Math.max(revision, storedRevision());
+}
+
+export function notifySuwayomiSourcesChanged(base: string): void {
+  revision = suwayomiSourcesRevision() + 1;
+  try {
+    localStorage.setItem(REVISION_KEY, String(revision));
+  } catch {
+    /* in-memory revision still invalidates this session */
+  }
+  for (const listener of listeners) listener(base);
+}
+
+export function subscribeSuwayomiSourcesChanged(listener: (base: string) => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/src/lib/manga/sources/suwayomi/transport.ts
+++ b/src/lib/manga/sources/suwayomi/transport.ts
@@ -31,6 +31,10 @@ export function configClient(config: ServerConfig): SuwayomiClient {
 const transportCache = new Map<string, Promise<Transport>>();
 const sourceCache = new Map<string, Map<string, SuwayomiSource>>();
 
+export function clearLoadedSources(base: string): void {
+  sourceCache.delete(base.replace(/\/+$/, ""));
+}
+
 export function pickTransport(client: SuwayomiClient): Promise<Transport> {
   const base = client.server.base;
   const cached = transportCache.get(base);

--- a/src/lib/manga/types.ts
+++ b/src/lib/manga/types.ts
@@ -20,6 +20,8 @@ export type MangaProvider = {
   chapters(id: string): Promise<MangaChapter[]>;
   pageUrls(chapterId: string): Promise<string[]>;
   tags?(): Promise<MangaTag[]>;
+  searchAll?(query: string): Promise<MangaSummary[]>;
+  setLibrary?(id: string, inLibrary: boolean): Promise<void>;
 };
 
 export function mangaThrottle(gapMs: number): <T>(task: () => Promise<T>) => Promise<T> {

--- a/src/views/manga/manga-browse/filters.tsx
+++ b/src/views/manga/manga-browse/filters.tsx
@@ -11,6 +11,7 @@ import {
   subscribeMangaSources,
   type MangaSource,
 } from "@/lib/manga/sources";
+import { subscribeSuwayomiSourcesChanged } from "@/lib/manga/sources/suwayomi/source-events";
 
 export const FAVORITES = "__favorites__";
 
@@ -128,13 +129,18 @@ export function TagDropdown({
 
   useEffect(() => {
     let alive = true;
-    mangaTags()
-      .then((list) => {
-        if (alive) setTags(list);
-      })
-      .catch(() => {});
+    const load = () => {
+      mangaTags()
+        .then((list) => {
+          if (alive) setTags(list);
+        })
+        .catch(() => {});
+    };
+    load();
+    const unsubscribe = subscribeSuwayomiSourcesChanged(load);
     return () => {
       alive = false;
+      unsubscribe();
     };
   }, []);
 
@@ -178,7 +184,11 @@ export function TagDropdown({
               {tagId === FAVORITES && <Check size={14} className="text-accent" />}
             </button>
             <div className="my-1 border-t border-edge-soft/60" />
-            <TagRow label={t("All tags")} active={!tagId} onClick={() => (onSelect(""), setOpen(false))} />
+            <TagRow
+              label={t("All tags")}
+              active={!tagId}
+              onClick={() => (onSelect(""), setOpen(false))}
+            />
             {shown.map((t) => (
               <TagRow
                 key={t.id}

--- a/src/views/manga/manga-detail/chapter-list.tsx
+++ b/src/views/manga/manga-detail/chapter-list.tsx
@@ -8,6 +8,8 @@ import {
   LayoutGrid,
   List,
   Loader2,
+  Pause,
+  Play,
   Search,
   Server,
   Tv,
@@ -19,7 +21,10 @@ import { useMangaProgressEntry, type MangaProgressEntry } from "@/lib/manga-prog
 import {
   downloadAllChapters,
   downloadChapter,
+  pauseMangaDownloadBatch,
+  resumeMangaDownloadBatch,
   useMangaDownload,
+  useMangaDownloadBatch,
   type MangaDownloadInfo,
 } from "@/lib/manga-downloads";
 import { listMangaSources, sourceIconUrl } from "@/lib/manga/sources";
@@ -150,7 +155,11 @@ function ChapterMeta({ chapter }: { chapter: MangaChapter }) {
   return (
     <span className="flex min-w-0 items-center gap-1.5 text-[12.5px] text-ink-subtle">
       {chapter.group && <span className="truncate">{chapter.group}</span>}
-      {chapter.group && rel && <span aria-hidden className="text-ink-subtle/50">·</span>}
+      {chapter.group && rel && (
+        <span aria-hidden className="text-ink-subtle/50">
+          ·
+        </span>
+      )}
       {rel && <span className="shrink-0">{rel}</span>}
     </span>
   );
@@ -178,7 +187,9 @@ function chapterSourceId(id: string): string {
 function isCurrentChapter(progress: MangaProgressEntry | undefined, c: MangaChapter): boolean {
   if (!progress) return false;
   if (progress.chapterId === c.id) return true;
-  return progress.chapterNumber != null && c.chapter != null && progress.chapterNumber === c.chapter;
+  return (
+    progress.chapterNumber != null && c.chapter != null && progress.chapterNumber === c.chapter
+  );
 }
 
 function ChapterDownloadButton({
@@ -201,6 +212,14 @@ function ChapterDownloadButton({
     return (
       <span className="flex shrink-0 items-center gap-1 text-[11px] font-semibold tabular-nums text-ink-subtle">
         <Loader2 size={14} className="animate-spin" />
+        {rec.total ? `${rec.done}/${rec.total}` : null}
+      </span>
+    );
+  }
+  if (rec.status === "paused") {
+    return (
+      <span className="flex shrink-0 items-center gap-1 text-[11px] font-semibold tabular-nums text-ink-subtle">
+        <Pause size={14} />
         {rec.total ? `${rec.done}/${rec.total}` : null}
       </span>
     );
@@ -302,13 +321,22 @@ function SourceFilterDropdown({
       >
         <SourceIcon iconUrl={active?.iconUrl} />
         <span>{active ? active.name : t("All sources")}</span>
-        <ChevronDown size={16} className={`text-ink-subtle transition-transform ${open ? "rotate-180" : ""}`} />
+        <ChevronDown
+          size={16}
+          className={`text-ink-subtle transition-transform ${open ? "rotate-180" : ""}`}
+        />
       </button>
       {open && (
         <div className="absolute right-0 z-30 mt-2 max-h-80 w-56 overflow-y-auto rounded-xl border border-edge-soft bg-elevated py-1.5 shadow-[0_18px_44px_rgba(0,0,0,0.45)]">
           <SourceRow label={t("All sources")} active={!selected} onClick={() => onSelect("")} />
           {options.map((o) => (
-            <SourceRow key={o.id} label={o.name} iconUrl={o.iconUrl} active={o.id === selected} onClick={() => onSelect(o.id)} />
+            <SourceRow
+              key={o.id}
+              label={o.name}
+              iconUrl={o.iconUrl}
+              active={o.id === selected}
+              onClick={() => onSelect(o.id)}
+            />
           ))}
         </div>
       )}
@@ -358,7 +386,7 @@ export function ChapterList({
   const [view, setView] = useState<ChapterView>(readView);
   const [range, setRange] = useState<number | null>(null);
   const [sourceFilter, setSourceFilter] = useState("");
-  const [dlAll, setDlAll] = useState(false);
+  const batch = useMangaDownloadBatch(mangaId ?? "");
 
   useEffect(() => {
     localStorage.setItem(VIEW_KEY, view);
@@ -385,7 +413,8 @@ export function ChapterList({
   }, [sourceOptions, sourceFilter]);
 
   const scoped = useMemo(
-    () => (sourceFilter ? chapters.filter((c) => chapterSourceId(c.id) === sourceFilter) : chapters),
+    () =>
+      sourceFilter ? chapters.filter((c) => chapterSourceId(c.id) === sourceFilter) : chapters,
     [chapters, sourceFilter],
   );
 
@@ -459,7 +488,9 @@ export function ChapterList({
             </p>
           ) : (
             <p className="text-[15px] text-ink-muted">
-              {t("No chapters available in {lang} from this source.", { lang: languageName(selectedLang) })}
+              {t("No chapters available in {lang} from this source.", {
+                lang: languageName(selectedLang),
+              })}
             </p>
           )}
         </div>
@@ -482,7 +513,12 @@ export function ChapterList({
         </div>
         <div className="flex flex-wrap items-center gap-3">
           <div className="flex h-11 items-center gap-1 rounded-xl border border-edge-soft bg-surface/60 p-1">
-            {([["list", List], ["grid", LayoutGrid]] as const).map(([v, Icon]) => (
+            {(
+              [
+                ["list", List],
+                ["grid", LayoutGrid],
+              ] as const
+            ).map(([v, Icon]) => (
               <button
                 key={v}
                 type="button"
@@ -513,29 +549,51 @@ export function ChapterList({
           {mangaId && ascending.length > 0 && (
             <button
               type="button"
-              disabled={dlAll}
-              onClick={async () => {
-                setDlAll(true);
-                try {
-                  await downloadAllChapters(
-                    mangaId,
-                    ascending.map((c) => ({
-                      chapterId: c.id,
-                      info: { title: mangaTitle, cover: mangaCover, chapter: c.chapter },
-                    })),
-                  );
-                } finally {
-                  setDlAll(false);
+              onClick={() => {
+                if (batch.status === "downloading") {
+                  pauseMangaDownloadBatch(mangaId);
+                  return;
                 }
+                if (batch.status === "paused") {
+                  resumeMangaDownloadBatch(mangaId);
+                  return;
+                }
+                void downloadAllChapters(
+                  mangaId,
+                  ascending.map((c) => ({
+                    chapterId: c.id,
+                    info: { title: mangaTitle, cover: mangaCover, chapter: c.chapter },
+                  })),
+                );
               }}
-              className="flex h-11 items-center gap-2 rounded-xl border border-edge-soft bg-surface/60 px-3.5 text-[13px] font-medium text-ink-muted transition-colors hover:text-ink disabled:opacity-60"
+              aria-label={
+                batch.status === "downloading"
+                  ? t("Pause downloads")
+                  : batch.status === "paused"
+                    ? t("Resume downloads")
+                    : t("Download all")
+              }
+              className="flex h-11 items-center gap-2 rounded-xl border border-edge-soft bg-surface/60 px-3.5 text-[13px] font-medium text-ink-muted transition-[color,background-color,transform] hover:bg-elevated/60 hover:text-ink active:scale-[0.96] motion-reduce:active:scale-100"
             >
-              {dlAll ? (
-                <Loader2 size={16} className="animate-spin motion-reduce:animate-none" />
+              {batch.status === "downloading" ? (
+                <Pause size={16} />
+              ) : batch.status === "paused" ? (
+                <Play size={16} />
               ) : (
                 <Download size={16} />
               )}
-              {dlAll ? t("Downloading...") : t("Download all")}
+              {batch.status === "downloading"
+                ? t("Pause downloads")
+                : batch.status === "paused"
+                  ? t("Resume downloads")
+                  : batch.status === "error"
+                    ? t("Retry downloads")
+                    : t("Download all")}
+              {(batch.status === "downloading" || batch.status === "paused") && batch.total > 0 && (
+                <span className="tabular-nums text-ink-subtle">
+                  {batch.done}/{batch.total}
+                </span>
+              )}
             </button>
           )}
           {sourceOptions.length > 1 && (
@@ -571,7 +629,9 @@ export function ChapterList({
             type="button"
             onClick={() => setRange(null)}
             className={`h-9 rounded-lg px-3.5 text-[13px] font-medium tabular-nums transition-colors ${
-              range == null ? "bg-accent text-canvas" : "bg-elevated/50 text-ink-muted hover:text-ink"
+              range == null
+                ? "bg-accent text-canvas"
+                : "bg-elevated/50 text-ink-muted hover:text-ink"
             }`}
           >
             {t("All")}
@@ -582,7 +642,9 @@ export function ChapterList({
               type="button"
               onClick={() => setRange(r.b)}
               className={`h-9 rounded-lg px-3.5 text-[13px] font-medium tabular-nums transition-colors ${
-                range === r.b ? "bg-accent text-canvas" : "bg-elevated/50 text-ink-muted hover:text-ink"
+                range === r.b
+                  ? "bg-accent text-canvas"
+                  : "bg-elevated/50 text-ink-muted hover:text-ink"
               }`}
             >
               {r.hi}-{r.lo}
@@ -603,7 +665,12 @@ export function ChapterList({
               <button
                 key={c.id}
                 type="button"
-                onClick={() => onRead(ascending, ascending.findIndex((x) => x.id === c.id))}
+                onClick={() =>
+                  onRead(
+                    ascending,
+                    ascending.findIndex((x) => x.id === c.id),
+                  )
+                }
                 className={`group flex min-h-[64px] w-full items-center justify-between gap-4 border-b border-edge-soft/60 px-5 py-3.5 text-start transition-colors last:border-b-0 hover:bg-elevated/40 ${
                   cur ? "bg-accent/5" : ""
                 }`}
@@ -652,7 +719,12 @@ export function ChapterList({
               <button
                 key={c.id}
                 type="button"
-                onClick={() => onRead(ascending, ascending.findIndex((x) => x.id === c.id))}
+                onClick={() =>
+                  onRead(
+                    ascending,
+                    ascending.findIndex((x) => x.id === c.id),
+                  )
+                }
                 className={`group flex min-h-[64px] flex-col justify-between gap-2 rounded-xl border bg-surface/60 px-4 py-3.5 text-start transition-colors hover:bg-elevated/60 ${
                   cur ? "border-accent/70" : "border-edge-soft hover:border-edge"
                 }`}

--- a/src/views/manga/manga-sources-panel/suwayomi/browse-results.tsx
+++ b/src/views/manga/manga-sources-panel/suwayomi/browse-results.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, ChevronLeft, Loader2, RefreshCw, Search, SearchX } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { ServerConfig, SuwayomiSource } from "@/lib/manga/sources/suwayomi/provider";
 import type { MangaSummary } from "@/lib/manga/types";
 import { useT } from "@/lib/i18n";
@@ -7,13 +7,25 @@ import { CARD, INPUT } from "../shared";
 import { MangaGrid, MangaGridSkeleton } from "./manga-grid";
 import { useSourceFeed, type FeedMode } from "./use-source-feed";
 
-function ModeTab({ active, onClick, children }: { active: boolean; onClick: () => void; children: string }) {
+type BrowseSort = "popular" | "latest" | "alphabetical";
+
+function ModeTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: string;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
       className={`h-9 rounded-lg px-4 text-[13.5px] font-semibold transition-all active:scale-[0.97] motion-reduce:active:scale-100 ${
-        active ? "bg-accent text-canvas" : "bg-raised text-ink-muted ring-1 ring-edge-soft hover:text-ink"
+        active
+          ? "bg-accent text-canvas"
+          : "bg-raised text-ink-muted ring-1 ring-edge-soft hover:text-ink"
       }`}
     >
       {children}
@@ -33,10 +45,18 @@ export function BrowseResults({
   onOpen?: (item: MangaSummary) => void;
 }) {
   const t = useT();
-  const [mode, setMode] = useState<FeedMode>("popular");
+  const [sort, setSort] = useState<BrowseSort>("popular");
   const [draft, setDraft] = useState("");
   const [query, setQuery] = useState("");
+  const mode: FeedMode = sort === "latest" ? "latest" : "popular";
   const feed = useSourceFeed(config, source.id, mode, query);
+  const items = useMemo(
+    () =>
+      sort === "alphabetical"
+        ? [...feed.items].sort((a, b) => a.title.localeCompare(b.title))
+        : feed.items,
+    [feed.items, sort],
+  );
 
   const submit = () => setQuery(draft.trim());
   const clear = () => {
@@ -59,7 +79,10 @@ export function BrowseResults({
       </div>
 
       <div className="relative">
-        <Search size={17} className="pointer-events-none absolute start-4 top-1/2 -translate-y-1/2 text-ink-subtle" />
+        <Search
+          size={17}
+          className="pointer-events-none absolute start-4 top-1/2 -translate-y-1/2 text-ink-subtle"
+        />
         <input
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
@@ -82,21 +105,26 @@ export function BrowseResults({
 
       {!query && (
         <div className="flex gap-2">
-          <ModeTab active={mode === "popular"} onClick={() => setMode("popular")}>
+          <ModeTab active={sort === "popular"} onClick={() => setSort("popular")}>
             {t("Popular")}
           </ModeTab>
           {source.supportsLatest && (
-            <ModeTab active={mode === "latest"} onClick={() => setMode("latest")}>
+            <ModeTab active={sort === "latest"} onClick={() => setSort("latest")}>
               {t("Latest")}
             </ModeTab>
           )}
+          <ModeTab active={sort === "alphabetical"} onClick={() => setSort("alphabetical")}>
+            {t("A-Z")}
+          </ModeTab>
         </div>
       )}
 
       {feed.state === "loading" ? (
         <MangaGridSkeleton />
       ) : feed.state === "error" ? (
-        <div className={`flex flex-col items-center justify-center gap-3 py-12 text-ink-muted ${CARD}`}>
+        <div
+          className={`flex flex-col items-center justify-center gap-3 py-12 text-ink-muted ${CARD}`}
+        >
           <div className="flex items-center gap-2">
             <AlertCircle size={16} className="text-danger" />
             <span className="text-[13.5px]">{t("Could not load results")}</span>
@@ -110,14 +138,16 @@ export function BrowseResults({
             {t("Retry")}
           </button>
         </div>
-      ) : feed.items.length === 0 ? (
-        <div className={`flex flex-col items-center gap-2 py-12 text-center text-ink-muted ${CARD}`}>
+      ) : items.length === 0 ? (
+        <div
+          className={`flex flex-col items-center gap-2 py-12 text-center text-ink-muted ${CARD}`}
+        >
           <SearchX size={20} className="text-ink-subtle" />
           <span className="text-[13.5px]">{t("Nothing found here")}</span>
         </div>
       ) : (
         <>
-          <MangaGrid items={feed.items} onOpen={onOpen} />
+          <MangaGrid items={items} onOpen={onOpen} />
           {feed.loadMoreFailed && (
             <p className="text-center text-[12.5px] font-medium text-danger">
               {t("Could not load results")}

--- a/src/views/manga/manga-sources-panel/suwayomi/extensions-manager.tsx
+++ b/src/views/manga/manga-sources-panel/suwayomi/extensions-manager.tsx
@@ -1,6 +1,10 @@
-import { AlertCircle, Blocks, Loader2, RefreshCw, Search } from "lucide-react";
+import { AlertCircle, Blocks, ChevronDown, Loader2, RefreshCw, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { listExtensions, type ServerConfig, type SuwayomiExtension } from "@/lib/manga/sources/suwayomi/provider";
+import {
+  listExtensions,
+  type ServerConfig,
+  type SuwayomiExtension,
+} from "@/lib/manga/sources/suwayomi/provider";
 import { languageName } from "@/lib/manga/types";
 import { useT } from "@/lib/i18n";
 import { CARD, INPUT } from "../shared";
@@ -23,23 +27,57 @@ function Group({
   config,
   items,
   onChanged,
+  collapsible = false,
+  expanded = true,
+  onExpandedChange,
+  contentId,
 }: {
   label: string;
   count: number;
   config: ServerConfig;
   items: SuwayomiExtension[];
   onChanged: () => void;
+  collapsible?: boolean;
+  expanded?: boolean;
+  onExpandedChange?: () => void;
+  contentId?: string;
 }) {
   if (items.length === 0) return null;
   return (
     <div className="flex flex-col gap-2">
-      <p className="px-1 text-[12px] font-bold uppercase tracking-[0.12em] text-ink-subtle">
-        {label} · {count}
-      </p>
-      <div className={`divide-y divide-edge-soft overflow-hidden ${CARD}`}>
-        {items.map((ext) => (
-          <ExtensionRow key={ext.pkgName} config={config} ext={ext} onChanged={onChanged} />
-        ))}
+      {collapsible ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-controls={contentId}
+          onClick={onExpandedChange}
+          className="group flex min-h-10 w-full items-center justify-between rounded-xl px-2 text-start text-ink-subtle transition-colors hover:bg-raised/60 hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        >
+          <span className="text-[12px] font-bold uppercase tracking-[0.12em]">
+            {label} · {count}
+          </span>
+          <span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-raised/70 ring-1 ring-edge-soft transition-colors group-hover:bg-elevated">
+            <ChevronDown
+              aria-hidden="true"
+              size={16}
+              className={`transition-transform duration-150 motion-reduce:transition-none ${expanded ? "rotate-180" : ""}`}
+            />
+          </span>
+        </button>
+      ) : (
+        <p className="px-1 text-[12px] font-bold uppercase tracking-[0.12em] text-ink-subtle">
+          {label} · {count}
+        </p>
+      )}
+      <div
+        id={contentId}
+        hidden={collapsible && !expanded}
+        className={`divide-y divide-edge-soft overflow-hidden ${CARD}`}
+      >
+        {(!collapsible || expanded) &&
+          items.map((ext) => (
+            <ExtensionRow key={ext.pkgName} config={config} ext={ext} onChanged={onChanged} />
+          ))}
       </div>
     </div>
   );
@@ -50,6 +88,7 @@ export function ExtensionsManager({ config }: { config: ServerConfig }) {
   const [load, setLoad] = useState<Load>({ state: "loading", items: [] });
   const [query, setQuery] = useState("");
   const [reload, setReload] = useState(0);
+  const [availableExpanded, setAvailableExpanded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -66,7 +105,10 @@ export function ExtensionsManager({ config }: { config: ServerConfig }) {
     };
   }, [config.baseUrl, config.auth?.username, config.auth?.password, reload]);
 
-  const filtered = useMemo(() => load.items.filter((e) => matches(e, query.trim())), [load.items, query]);
+  const filtered = useMemo(
+    () => load.items.filter((e) => matches(e, query.trim())),
+    [load.items, query],
+  );
   const installed = filtered.filter((e) => e.installed);
   const updatable = installed.filter((e) => e.hasUpdate);
   const available = filtered.filter((e) => !e.installed);
@@ -76,7 +118,9 @@ export function ExtensionsManager({ config }: { config: ServerConfig }) {
       <ExtensionRepos config={config} onChanged={() => setReload((n) => n + 1)} />
 
       <div className="flex items-center justify-between gap-3 px-1">
-        <p className="text-[12.5px] font-bold uppercase tracking-[0.12em] text-ink-subtle">{t("Extensions")}</p>
+        <p className="text-[12.5px] font-bold uppercase tracking-[0.12em] text-ink-subtle">
+          {t("Extensions")}
+        </p>
         <button
           type="button"
           onClick={() => setReload((n) => n + 1)}
@@ -88,10 +132,16 @@ export function ExtensionsManager({ config }: { config: ServerConfig }) {
       </div>
 
       <div className="relative">
-        <Search size={17} className="pointer-events-none absolute start-4 top-1/2 -translate-y-1/2 text-ink-subtle" />
+        <Search
+          size={17}
+          className="pointer-events-none absolute start-4 top-1/2 -translate-y-1/2 text-ink-subtle"
+        />
         <input
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            if (e.target.value.trim()) setAvailableExpanded(true);
+          }}
           placeholder={t("Search extensions")}
           autoCapitalize="off"
           spellCheck={false}
@@ -110,7 +160,9 @@ export function ExtensionsManager({ config }: { config: ServerConfig }) {
           <span className="text-[13.5px]">{t("Loading extensions...")}</span>
         </div>
       ) : filtered.length === 0 ? (
-        <div className={`flex flex-col items-center gap-2 py-10 text-center text-ink-muted ${CARD}`}>
+        <div
+          className={`flex flex-col items-center gap-2 py-10 text-center text-ink-muted ${CARD}`}
+        >
           <Blocks size={20} className="text-ink-subtle" />
           <span className="text-[13.5px]">
             {query ? t("No extensions match your search") : t("This server lists no extensions")}
@@ -138,6 +190,10 @@ export function ExtensionsManager({ config }: { config: ServerConfig }) {
             config={config}
             items={available}
             onChanged={() => setReload((n) => n + 1)}
+            collapsible
+            expanded={availableExpanded}
+            onExpandedChange={() => setAvailableExpanded((open) => !open)}
+            contentId="suwayomi-available-extensions"
           />
         </>
       )}

--- a/src/views/manga/manga-sources-panel/suwayomi/source-picker.tsx
+++ b/src/views/manga/manga-sources-panel/suwayomi/source-picker.tsx
@@ -1,8 +1,13 @@
 import { AlertCircle, ChevronRight, Compass, Loader2, RefreshCw, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { listSources, type ServerConfig, type SuwayomiSource } from "@/lib/manga/sources/suwayomi/provider";
+import {
+  listSources,
+  type ServerConfig,
+  type SuwayomiSource,
+} from "@/lib/manga/sources/suwayomi/provider";
 import { languageName } from "@/lib/manga/types";
 import { useT } from "@/lib/i18n";
+import { subscribeSuwayomiSourcesChanged } from "@/lib/manga/sources/suwayomi/source-events";
 import { CARD, INPUT } from "../shared";
 import { initials } from "./types";
 
@@ -32,6 +37,8 @@ export function SourcePicker({
   const [query, setQuery] = useState("");
   const [reload, setReload] = useState(0);
 
+  useEffect(() => subscribeSuwayomiSourcesChanged(() => setReload((n) => n + 1)), []);
+
   useEffect(() => {
     let cancelled = false;
     setState("loading");
@@ -60,7 +67,9 @@ export function SourcePicker({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3 px-1">
-        <p className="text-[12.5px] font-bold uppercase tracking-[0.12em] text-ink-subtle">{t("Browse sources")}</p>
+        <p className="text-[12.5px] font-bold uppercase tracking-[0.12em] text-ink-subtle">
+          {t("Browse sources")}
+        </p>
         <button
           type="button"
           onClick={() => setReload((n) => n + 1)}
@@ -72,7 +81,10 @@ export function SourcePicker({
       </div>
 
       <div className="relative">
-        <Search size={17} className="pointer-events-none absolute start-4 top-1/2 -translate-y-1/2 text-ink-subtle" />
+        <Search
+          size={17}
+          className="pointer-events-none absolute start-4 top-1/2 -translate-y-1/2 text-ink-subtle"
+        />
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
@@ -94,10 +106,14 @@ export function SourcePicker({
           <span className="text-[13.5px]">{t("Could not load sources")}</span>
         </div>
       ) : filtered.length === 0 ? (
-        <div className={`flex flex-col items-center gap-2 py-10 text-center text-ink-muted ${CARD}`}>
+        <div
+          className={`flex flex-col items-center gap-2 py-10 text-center text-ink-muted ${CARD}`}
+        >
           <Compass size={20} className="text-ink-subtle" />
           <span className="text-[13.5px]">
-            {query ? t("No sources match your filter") : t("Install an extension above to get sources")}
+            {query
+              ? t("No sources match your filter")
+              : t("Install an extension above to get sources")}
           </span>
         </div>
       ) : (
@@ -119,7 +135,9 @@ export function SourcePicker({
                     </span>
                   )}
                 </div>
-                <span className="truncate text-[12.5px] text-ink-muted">{languageName(s.lang)}</span>
+                <span className="truncate text-[12.5px] text-ink-muted">
+                  {languageName(s.lang)}
+                </span>
               </div>
               <ChevronRight size={18} className="shrink-0 text-ink-subtle" />
             </button>

--- a/src/views/manga/manga-universes.tsx
+++ b/src/views/manga/manga-universes.tsx
@@ -1,11 +1,11 @@
-import { ChevronLeft, ChevronRight, Users } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 import { usePageVisible } from "@/lib/visibility";
 import { useT } from "@/lib/i18n";
 import { mangaBackdrop } from "@/lib/manga/backdrop";
 import { topCharacterImage } from "@/lib/manga/character";
 import { universeLogo } from "@/lib/manga/universe-logo";
-import { searchManga } from "@/lib/manga/api";
+import { searchMangaEverywhere } from "@/lib/manga/api";
 import { MANGA_UNIVERSES, type MangaUniverse } from "@/lib/manga/universes";
 
 const AMES = '"QR Ames Beta", var(--font-display), serif';
@@ -58,7 +58,15 @@ function useUniverseLogo(query: string, baked?: string): string | null {
   return baked ?? url;
 }
 
-function BannerLayer({ name, backdrop, active }: { name: string; backdrop?: string; active: boolean }) {
+function BannerLayer({
+  name,
+  backdrop,
+  active,
+}: {
+  name: string;
+  backdrop?: string;
+  active: boolean;
+}) {
   const [seen, setSeen] = useState(active);
   useEffect(() => {
     if (active) setSeen(true);
@@ -122,7 +130,9 @@ export function UniversesCta({ onClick }: { onClick: () => void }) {
       </span>
       <div className="relative flex min-w-0 flex-1 flex-col">
         <span className="text-[15.5px] font-semibold text-ink">{t("Universes")}</span>
-        <span className="truncate text-[13px] text-ink-muted">{t("One Piece, Naruto and more worlds")}</span>
+        <span className="truncate text-[13px] text-ink-muted">
+          {t("One Piece, Naruto and more worlds")}
+        </span>
       </div>
       <ChevronRight
         size={22}
@@ -132,14 +142,26 @@ export function UniversesCta({ onClick }: { onClick: () => void }) {
   );
 }
 
-function UniverseCard({ universe, onSelect }: { universe: MangaUniverse; onSelect: () => void }) {
+function UniverseCard({
+  universe,
+  onSelect,
+  loading,
+  disabled,
+}: {
+  universe: MangaUniverse;
+  onSelect: () => void;
+  loading: boolean;
+  disabled: boolean;
+}) {
   const art = useBackdrop(universe.query, universe.backdrop);
   const logo = useUniverseLogo(universe.noLogo ? "" : universe.query, universe.logo);
   return (
     <button
       type="button"
       onClick={onSelect}
-      className="group relative aspect-[16/10] overflow-hidden rounded-2xl ring-1 ring-edge-soft transition-shadow duration-200 [clip-path:inset(0_round_1rem)] hover:ring-edge active:scale-[0.98]"
+      disabled={disabled}
+      aria-busy={loading}
+      className="group relative aspect-[16/10] overflow-hidden rounded-2xl ring-1 ring-edge-soft transition-[box-shadow,opacity,transform] duration-200 [clip-path:inset(0_round_1rem)] hover:ring-edge active:scale-[0.96] disabled:cursor-wait disabled:opacity-70 motion-reduce:active:scale-100"
     >
       <div className="absolute inset-0" style={{ background: NEUTRAL }} />
       {art && (
@@ -163,6 +185,11 @@ function UniverseCard({ universe, onSelect }: { universe: MangaUniverse; onSelec
           style={{ fontFamily: AMES }}
         >
           {universe.name}
+        </span>
+      )}
+      {loading && (
+        <span className="absolute end-3 top-3 grid h-8 w-8 place-items-center rounded-full bg-black/55 text-white ring-1 ring-white/15 backdrop-blur-sm">
+          <Loader2 size={15} className="animate-spin motion-reduce:animate-none" />
         </span>
       )}
     </button>
@@ -204,10 +231,17 @@ export function MangaUniverses({
   onBack: () => void;
 }) {
   const t = useT();
+  const [selecting, setSelecting] = useState<string | null>(null);
   const select = async (u: MangaUniverse) => {
-    const results = await searchManga(u.query, 0).catch(() => []);
-    const found = pickBestMatch(results, u.query, u.name);
-    if (found) onOpen(found.id);
+    if (selecting) return;
+    setSelecting(u.id);
+    try {
+      const results = await searchMangaEverywhere(u.query).catch(() => []);
+      const found = pickBestMatch(results, u.query, u.name);
+      if (found) onOpen(found.id);
+    } finally {
+      setSelecting(null);
+    }
   };
   return (
     <div className="animate-fade-in flex flex-col gap-6">
@@ -220,14 +254,25 @@ export function MangaUniverses({
         {t("Back")}
       </button>
       <div className="flex flex-col gap-1.5">
-        <h1 className="text-[34px] font-medium tracking-tight text-ink" style={{ fontFamily: AMES }}>
+        <h1
+          className="text-[34px] font-medium tracking-tight text-ink"
+          style={{ fontFamily: AMES }}
+        >
           {t("Universes")}
         </h1>
-        <p className="text-[15px] text-ink-muted">{t("Pick a world and dive into everything in it.")}</p>
+        <p className="text-[15px] text-ink-muted">
+          {t("Pick a world and dive into everything in it.")}
+        </p>
       </div>
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
         {MANGA_UNIVERSES.map((u) => (
-          <UniverseCard key={u.id} universe={u} onSelect={() => void select(u)} />
+          <UniverseCard
+            key={u.id}
+            universe={u}
+            onSelect={() => void select(u)}
+            loading={selecting === u.id}
+            disabled={selecting !== null}
+          />
         ))}
       </div>
     </div>

--- a/src/views/mobile/manga-remote/manga-remote.tsx
+++ b/src/views/mobile/manga-remote/manga-remote.tsx
@@ -1,5 +1,15 @@
 import { lazy, Suspense, useRef, useState } from "react";
-import { Bookmark, BookOpen, ChevronDown, ChevronsLeft, ChevronsRight, Minus, Monitor, Plus, X } from "lucide-react";
+import {
+  Bookmark,
+  BookOpen,
+  ChevronDown,
+  ChevronsLeft,
+  ChevronsRight,
+  Minus,
+  Monitor,
+  Plus,
+  X,
+} from "lucide-react";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
 import { useMobileRemote } from "../mobile-remote";
 import { RendererSheet } from "../renderer-sheet";
@@ -10,11 +20,23 @@ import { useOptimisticPage } from "./use-optimistic-page";
 import { useHistoryBackGuard } from "./use-history-guard";
 import { clampZoom, ZOOM_MAX, ZOOM_MIN, type TurnDir } from "./gesture-math";
 
-const ChapterNavigator = lazy(() => import("./chapter-navigator").then((m) => ({ default: m.ChapterNavigator })));
-const PageJumpSheet = lazy(() => import("./page-jump-sheet").then((m) => ({ default: m.PageJumpSheet })));
-const BookmarksSheet = lazy(() => import("./bookmarks-sheet").then((m) => ({ default: m.BookmarksSheet })));
+const ChapterNavigator = lazy(() =>
+  import("./chapter-navigator").then((m) => ({ default: m.ChapterNavigator })),
+);
+const PageJumpSheet = lazy(() =>
+  import("./page-jump-sheet").then((m) => ({ default: m.PageJumpSheet })),
+);
+const BookmarksSheet = lazy(() =>
+  import("./bookmarks-sheet").then((m) => ({ default: m.BookmarksSheet })),
+);
 
-export function MangaRemote({ standalone = false, onReadHere }: { standalone?: boolean; onReadHere?: () => void }) {
+export function MangaRemote({
+  standalone = false,
+  onReadHere,
+}: {
+  standalone?: boolean;
+  onReadHere?: () => void;
+}) {
   const { connected, snapshot, sendCommand } = useMobileRemote();
   const reduce = useReducedMotion();
   const m = snapshot.manga;
@@ -31,7 +53,12 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
   useHistoryBackGuard(true);
 
   const count = m?.pageCount ?? 0;
-  const { displayPage, advance } = useOptimisticPage(m?.pageIndex ?? 0, count, m?.chapterId ?? "", m?.seq ?? 0);
+  const { displayPage, advance } = useOptimisticPage(
+    m?.pageIndex ?? 0,
+    count,
+    m?.chapterId ?? "",
+    m?.seq ?? 0,
+  );
 
   if (!m || !m.open) return <MangaRemoteEmpty variant="closed" />;
 
@@ -55,7 +82,8 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
     else if (!sent) flash("Reconnecting to your computer");
   };
   const zoomAbs = (z: number) => sendCommand({ action: "mangaSetZoom", zoom: clampZoom(z) });
-  const zoomStep = (dir: "in" | "out") => sendCommand({ action: dir === "in" ? "mangaZoomIn" : "mangaZoomOut" });
+  const zoomStep = (dir: "in" | "out") =>
+    sendCommand({ action: dir === "in" ? "mangaZoomIn" : "mangaZoomOut" });
   const pan = (dx: number, dy: number) => sendCommand({ action: "mangaPan", dx, dy });
 
   const chromeCls = `${reduce ? "" : "transition-opacity duration-200 "}${chromeHidden ? "pointer-events-none opacity-0" : "opacity-100"}`;
@@ -89,7 +117,11 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
             onClick={() => setDeviceOpen(true)}
             className="flex min-w-0 items-center gap-1.5 rounded-full px-2 py-1 transition-opacity active:opacity-60"
           >
-            <Monitor size={15} strokeWidth={2.2} className={connected ? "text-ink" : "text-ink-subtle"} />
+            <Monitor
+              size={15}
+              strokeWidth={2.2}
+              className={connected ? "text-ink" : "text-ink-subtle"}
+            />
             <span className="truncate text-[13px] font-semibold text-ink">
               {connected ? snapshot.target.label || "Your computer" : "Reconnecting"}
             </span>
@@ -139,8 +171,14 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
           }}
         />
 
-        <div className={`flex items-center justify-center gap-2 px-4 ${chromeCls} ${zoomEngaged ? "pointer-events-none opacity-0" : ""}`}>
-          <DockButton label="Previous chapter" disabled={!m.hasPrev} onPress={() => sendCommand({ action: "mangaJumpChapter", index: m.chapterIndex - 1 })}>
+        <div
+          className={`flex items-center justify-center gap-2 px-4 ${chromeCls} ${zoomEngaged ? "pointer-events-none opacity-0" : ""}`}
+        >
+          <DockButton
+            label="Previous chapter"
+            disabled={!m.hasPrev}
+            onPress={() => sendCommand({ action: "mangaJumpChapter", index: m.chapterIndex - 1 })}
+          >
             <ChevronsLeft size={24} strokeWidth={2.2} />
           </DockButton>
           {m.canZoom && (
@@ -166,7 +204,11 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
               <Plus size={22} strokeWidth={2.4} />
             </DockButton>
           )}
-          <DockButton label="Next chapter" disabled={!m.hasNext} onPress={() => sendCommand({ action: "mangaJumpChapter", index: m.chapterIndex + 1 })}>
+          <DockButton
+            label="Next chapter"
+            disabled={!m.hasNext}
+            onPress={() => sendCommand({ action: "mangaJumpChapter", index: m.chapterIndex + 1 })}
+          >
             <ChevronsRight size={24} strokeWidth={2.2} />
           </DockButton>
         </div>
@@ -175,7 +217,6 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
           zoom={m.zoom}
           min={ZOOM_MIN}
           max={ZOOM_MAX}
-          rtl={m.rtl}
           canZoom={m.canZoom}
           onZoom={zoomAbs}
           onPan={pan}
@@ -199,7 +240,9 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
           className="pointer-events-none fixed inset-x-0 z-[60] flex justify-center px-4"
           style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
         >
-          <span className="rounded-full bg-danger/90 px-4 py-2 text-[13px] font-semibold text-white backdrop-blur-xl">{hint}</span>
+          <span className="rounded-full bg-danger/90 px-4 py-2 text-[13px] font-semibold text-white backdrop-blur-xl">
+            {hint}
+          </span>
         </div>
       )}
 
@@ -215,8 +258,12 @@ export function MangaRemote({ standalone = false, onReadHere }: { standalone?: b
             }}
           />
         )}
-        {pageJumpOpen && <PageJumpSheet open={pageJumpOpen} onClose={() => setPageJumpOpen(false)} />}
-        {bookmarksOpen && <BookmarksSheet open={bookmarksOpen} onClose={() => setBookmarksOpen(false)} />}
+        {pageJumpOpen && (
+          <PageJumpSheet open={pageJumpOpen} onClose={() => setPageJumpOpen(false)} />
+        )}
+        {bookmarksOpen && (
+          <BookmarksSheet open={bookmarksOpen} onClose={() => setBookmarksOpen(false)} />
+        )}
       </Suspense>
     </>
   );

--- a/src/views/mobile/manga-remote/zoom-joystick.tsx
+++ b/src/views/mobile/manga-remote/zoom-joystick.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, X, ZoomIn, ZoomOut } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
 
 const PAD = 176;
@@ -43,7 +51,6 @@ export function ZoomJoystick({
   zoom,
   min,
   max,
-  rtl,
   canZoom,
   onZoom,
   onPan,
@@ -53,7 +60,6 @@ export function ZoomJoystick({
   zoom: number;
   min: number;
   max: number;
-  rtl: boolean;
   canZoom: boolean;
   onZoom: (zoom: number) => void;
   onPan: (dx: number, dy: number) => void;
@@ -68,8 +74,8 @@ export function ZoomJoystick({
   const [pct, setPct] = useState(() => Math.round(zoom * 100));
 
   const padRef = useRef<HTMLDivElement>(null);
-  const propsRef = useRef({ zoom, min, max, rtl, onZoom, onPan });
-  propsRef.current = { zoom, min, max, rtl, onZoom, onPan };
+  const propsRef = useRef({ zoom, min, max, onZoom, onPan });
+  propsRef.current = { zoom, min, max, onZoom, onPan };
 
   const rafRef = useRef(0);
   const tickRef = useRef((_now: number) => {});
@@ -109,7 +115,7 @@ export function ZoomJoystick({
   const tick = (now: number) => {
     const dt = Math.min(0.05, (now - lastTRef.current) / 1000);
     lastTRef.current = now;
-    const { rtl: rl, onPan: emitPan } = propsRef.current;
+    const { onPan: emitPan } = propsRef.current;
 
     if (phaseRef.current === "drag") {
       const off = offRef.current;
@@ -118,7 +124,7 @@ export function ZoomJoystick({
       const px = shape(nx);
       const py = shape(ny);
       if (px !== 0 || py !== 0) {
-        panRemXRef.current += px * (rl ? -1 : 1) * PAN_SPEED * dt;
+        panRemXRef.current += px * PAN_SPEED * dt;
         panRemYRef.current += py * PAN_SPEED * dt;
         const wx = Math.trunc(panRemXRef.current);
         const wy = Math.trunc(panRemYRef.current);
@@ -235,7 +241,10 @@ export function ZoomJoystick({
     phaseRef.current = "idle";
     if (cancel) return;
     const held = performance.now() - startRef.current.t;
-    const moved = Math.hypot(lastRef.current.x - startRef.current.x, lastRef.current.y - startRef.current.y);
+    const moved = Math.hypot(
+      lastRef.current.x - startRef.current.x,
+      lastRef.current.y - startRef.current.y,
+    );
     if (held <= TAP_MS && moved <= TAP_SLOP) disengage();
   };
 
@@ -282,10 +291,7 @@ export function ZoomJoystick({
   if (!canZoom) return null;
 
   return (
-    <div
-      className="absolute end-4 z-40 flex flex-col items-end"
-      style={{ bottom: bottomOffset }}
-    >
+    <div className="absolute end-4 z-40 flex flex-col items-end" style={{ bottom: bottomOffset }}>
       {!engaged && (
         <button
           type="button"
@@ -294,7 +300,9 @@ export function ZoomJoystick({
           className="flex h-14 w-14 touch-none select-none flex-col items-center justify-center rounded-full bg-elevated/80 text-ink shadow-[0_10px_28px_-14px_rgba(0,0,0,0.65)] ring-1 ring-edge-soft/50 backdrop-blur-xl transition-transform duration-100 active:scale-90"
         >
           <ZoomIn size={20} strokeWidth={2.2} />
-          <span className="mt-0.5 text-[10.5px] font-semibold leading-none tabular-nums text-ink-subtle">{pct}%</span>
+          <span className="mt-0.5 text-[10.5px] font-semibold leading-none tabular-nums text-ink-subtle">
+            {pct}%
+          </span>
         </button>
       )}
 
@@ -347,14 +355,36 @@ export function ZoomJoystick({
             style={{ width: PAD, height: PAD }}
           >
             <div className="pointer-events-none absolute inset-3 rounded-full ring-1 ring-edge-soft/25" />
-            <ChevronUp aria-hidden size={16} strokeWidth={2.2} className="pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 text-ink-subtle/55" />
-            <ChevronDown aria-hidden size={16} strokeWidth={2.2} className="pointer-events-none absolute bottom-3 left-1/2 -translate-x-1/2 text-ink-subtle/55" />
-            <ChevronLeft aria-hidden size={16} strokeWidth={2.2} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-subtle/55" />
-            <ChevronRight aria-hidden size={16} strokeWidth={2.2} className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-ink-subtle/55" />
+            <ChevronUp
+              aria-hidden
+              size={16}
+              strokeWidth={2.2}
+              className="pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 text-ink-subtle/55"
+            />
+            <ChevronDown
+              aria-hidden
+              size={16}
+              strokeWidth={2.2}
+              className="pointer-events-none absolute bottom-3 left-1/2 -translate-x-1/2 text-ink-subtle/55"
+            />
+            <ChevronLeft
+              aria-hidden
+              size={16}
+              strokeWidth={2.2}
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-subtle/55"
+            />
+            <ChevronRight
+              aria-hidden
+              size={16}
+              strokeWidth={2.2}
+              className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-ink-subtle/55"
+            />
 
             <div
               className={`pointer-events-none grid place-items-center rounded-full shadow-[0_8px_20px_-8px_rgba(0,0,0,0.7)] ${
-                active ? "bg-elevated ring-2 ring-accent/70" : "bg-elevated/95 ring-1 ring-edge-soft/60"
+                active
+                  ? "bg-elevated ring-2 ring-accent/70"
+                  : "bg-elevated/95 ring-1 ring-edge-soft/60"
               } ${reduce ? "" : "transition-[background-color,box-shadow] duration-150"}`}
               style={{
                 width: NUB,

--- a/tests/manga-suwayomi-workflow.test.ts
+++ b/tests/manga-suwayomi-workflow.test.ts
@@ -1,0 +1,75 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+test("extension changes invalidate tags and refresh installed sources", () => {
+  const api = source("../src/lib/manga/sources/suwayomi/api.ts");
+  const graphql = source("../src/lib/manga/sources/suwayomi/graphql.ts");
+  const tags = source("../src/lib/manga/api.ts");
+  const picker = source("../src/views/manga/manga-sources-panel/suwayomi/source-picker.tsx");
+  assert.match(api, /notifySuwayomiSourcesChanged\(client\.server\.base\)/);
+  assert.match(api, /withTransportFallback\(client, async \(transport\)/);
+  assert.match(graphql, /patch === "uninstall" \? extension\.isInstalled === false/);
+  assert.match(tags, /suwayomiSourcesRevision\(\)/);
+  assert.match(picker, /subscribeSuwayomiSourcesChanged/);
+});
+
+test("manga phone joystick uses direct horizontal and vertical pan directions", () => {
+  const joystick = source("../src/views/mobile/manga-remote/zoom-joystick.tsx");
+  assert.match(joystick, /panRemXRef\.current \+= px \* PAN_SPEED \* dt/);
+  assert.match(joystick, /panRemYRef\.current \+= py \* PAN_SPEED \* dt/);
+  assert.doesNotMatch(joystick, /rl \? -1 : 1/);
+});
+
+test("available extensions are collapsed until opened or searched", () => {
+  const manager = source("../src/views/manga/manga-sources-panel/suwayomi/extensions-manager.tsx");
+  assert.match(manager, /useState\(false\)/);
+  assert.match(manager, /aria-expanded=\{expanded\}/);
+  assert.match(manager, /hidden=\{collapsible && !expanded\}/);
+  assert.match(manager, /if \(e\.target\.value\.trim\(\)\) setAvailableExpanded\(true\)/);
+});
+
+test("universe matching searches installed sources instead of only the library", () => {
+  const provider = source("../src/lib/manga/sources/suwayomi/provider.ts");
+  const aggregate = source("../src/lib/manga/sources/aggregate.ts");
+  const universes = source("../src/views/manga/manga-universes.tsx");
+  assert.match(provider, /SEARCH_ALL_CONCURRENCY = 4/);
+  assert.match(provider, /makeClient\(server, 0\)/);
+  assert.match(provider, /Promise\.race\(\[all, exact\]\)/);
+  assert.match(aggregate, /searchAll: mergeSearchLists/);
+  assert.match(universes, /searchMangaEverywhere\(u\.query\)/);
+});
+
+test("Harbor favorites mirror the Suwayomi library state", () => {
+  const favorites = source("../src/lib/manga-favorites.tsx");
+  const rest = source("../src/lib/manga/sources/suwayomi/rest.ts");
+  const graphql = source("../src/lib/manga/sources/suwayomi/graphql.ts");
+  assert.match(favorites, /syncLibrary\(input\.id, true\)/);
+  assert.match(rest, /\/api\/v1\/manga\/\$\{mangaId\}\/library/);
+  assert.match(
+    graphql,
+    /updateManga\(input: \{ id: \$id, patch: \{ inLibrary: \$inLibrary \} \}\)/,
+  );
+});
+
+test("chapter batches expose pause and resume controls", () => {
+  const downloads = source("../src/lib/manga-downloads.ts");
+  const chapters = source("../src/views/manga/manga-detail/chapter-list.tsx");
+  assert.match(downloads, /export function pauseMangaDownloadBatch/);
+  assert.match(downloads, /await waitForBatch\(batchControl\)/);
+  assert.match(chapters, /t\("Pause downloads"\)/);
+  assert.match(chapters, /t\("Resume downloads"\)/);
+});
+
+test("Suwayomi browse results include alphabetical ordering", () => {
+  const browse = source("../src/views/manga/manga-sources-panel/suwayomi/browse-results.tsx");
+  assert.match(browse, /type BrowseSort = "popular" \| "latest" \| "alphabetical"/);
+  assert.match(browse, /a\.title\.localeCompare\(b\.title\)/);
+});


### PR DESCRIPTION
## Summary

- refresh Suwayomi sources and All Tags immediately after extension changes
- make extension install, update, and uninstall work across REST and GraphQL server variants
- add pause and resume controls for Manga chapter batch downloads
- add Popular, Latest, and A-Z sorting for Suwayomi source results
- search installed Suwayomi sources when matching Manga universes instead of limiting matches to the library
- mirror Harbor Manga favorites to the Suwayomi library
- collapse the large Available extensions list by default
- correct the Manga phone controller's left and right pan direction

## Root causes

Harbor cached Suwayomi sources independently from extension mutations, selected one API transport without mutation fallback, searched only the Suwayomi library for universe matches, and applied an extra RTL multiplier to the phone controller's horizontal pan axis.

## User impact

Installed extensions now appear consistently in Manga source tags, removed extensions disappear without restarting, Manga can be discovered across installed sources, batch downloads can be paused and resumed, and phone controller panning follows the direction of the joystick.

## Related Discord threads

- https://discord.com/channels/1528501875241123901/1528755783783682168
- https://discord.com/channels/1528501875241123901/1531894098116476960
- https://discord.com/channels/1528501875241123901/1531685117666525364

## Validation

- `pnpm exec vp check --fix` and `pnpm exec vp check` on all changed files
- `pnpm exec tsc -b --pretty false`
- `node --test tests/manga-suwayomi-workflow.test.ts` (7 passed)
- `pnpm tauri:build:linux-system`
- `git diff --check`

The repository-wide formatter still reports the existing line-ending baseline in untouched files; every file in this PR passes the scoped check.