### PR TITLE
fix(macos): restore Intel builds and initial libmpv rendering

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -23,7 +23,7 @@ jobs:
             target: aarch64-apple-darwin
             bundle: dmg
           - name: macOS-Intel
-            runner: macos-13
+            runner: macos-15-intel
             target: x86_64-apple-darwin
             bundle: dmg
           - name: Linux-x86_64

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/src/mpv_render_mac.rs
+++ b/src-tauri/src/mpv_render_mac.rs
@@ -184,6 +184,7 @@ pub fn install(mpv_ctx: NonNull<mpv_handle>, ns_window_ptr: i64, edr: bool) -> R
             .openGLContext()
             .ok_or_else(|| "openGLContext was nil".to_string())?;
         gl_ctx.makeCurrentContext();
+        let _: () = msg_send![&*gl_ctx, update];
         let opaque_value: i32 = 1;
         let _: () = msg_send![
             &*gl_ctx,
@@ -229,6 +230,7 @@ pub fn install(mpv_ctx: NonNull<mpv_handle>, ns_window_ptr: i64, edr: bool) -> R
             render: Mutex::new(render),
         });
 
+        schedule_redraw();
         eprintln!("[harbor::mpv_mac] installed");
     }
     Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -95,7 +95,8 @@
       }
     },
     "macOS": {
-      "minimumSystemVersion": "11.0"
+      "minimumSystemVersion": "11.0",
+      "entitlements": "Entitlements.plist"
     },
     "windows": {
       "nsis": {


### PR DESCRIPTION
## Summary

* Migrate the Intel macOS GitHub Actions job from the retired `macos-13` runner to `macos-15-intel`.
* Add the macOS entitlements required by the current libmpv/LuaJIT setup.
* Force an initial `NSOpenGLContext` update and libmpv redraw after installing the embedded macOS render view.

## Problem

Harbor could be built for `x86_64-apple-darwin`, but the Intel CI job still used the retired `macos-13` runner.

A locally built Intel application also required:

* `com.apple.security.cs.allow-unsigned-executable-memory`
* `com.apple.security.cs.disable-library-validation`

Without these entitlements, the app either failed library validation or crashed when starting native video playback.

After resolving the startup and playback crash, I found an intermittent macOS rendering issue: video sometimes started with a black picture while audio and subtitles continued normally. Resizing the window immediately made the picture appear.

The runtime log showed that affected sessions reached:

```text
[harbor::mpv_mac] installed
[harbor::mpv_mac] install OK
```

but did not create a `render surface` until the window was resized.

The fix explicitly updates the newly attached OpenGL context and schedules an initial redraw after storing the render context.

## Tested on

* MacBook Pro 13-inch, 2020
* Intel `x86_64`
* Intel Iris Plus Graphics
* 16 GB RAM
* macOS 15.7.7
* Harbor beta `0.9.116`

Build command:

```bash
APPLE_SIGNING_IDENTITY="-" pnpm tauri build --target x86_64-apple-darwin --bundles app
```

Validation performed:

* Release build completed successfully.
* Application launched with the configured entitlements.
* Tested multiple movies and series.
* Tested both fullscreen and windowed playback.
* Video appeared on the first attempt without resizing the window.
* After the fix, every tested player session created a render surface immediately after installation.

Example after the fix:

```text
[harbor::mpv_mac] installed
[harbor::mpv_mac] install OK
[harbor::mpv_mac] render surface 2880x1580 px
```

## Notes

The changes are split into two commits so the CI/entitlements changes and the initial-render fix can be reviewed separately.

The updater endpoint and official signing/notarization configuration are not changed by this PR.
