### PR TITLE
fix: Save button stays active with no changes, poisoned-mutex panic risk

### DIFF
--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -2326,11 +2326,13 @@ fn position_embedded_mpv_child(app: &AppHandle, css: MpvGeometry) -> Result<(), 
             }
         }
         let new_rect = (first, x, y, w, h);
-        let prev_rect = {
-            let mut guard = MPV_POS_LAST_RECT.lock().unwrap();
-            let prev = *guard;
-            *guard = Some(new_rect);
-            prev
+        let prev_rect = match MPV_POS_LAST_RECT.lock() {
+            Ok(mut guard) => {
+                let prev = *guard;
+                *guard = Some(new_rect);
+                prev
+            }
+            Err(_) => None,
         };
         let first_position = prev_rect.map(|r| r.0) != Some(first);
         let rect_unchanged = prev_rect == Some(new_rect);

--- a/src/views/profile/customization/customization-panel.tsx
+++ b/src/views/profile/customization/customization-panel.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Check, Eye } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { socialPost } from "@/lib/social/client";
 import type { CustomizationInput, ProfileSummary } from "../profile-types";
 import { CustomizePreview } from "./customize-preview";
@@ -30,10 +30,12 @@ export function CustomizationPanel({
     hideTopBanner: summary.hideTopBanner ?? false,
     hideCardTitles: summary.hideCardTitles ?? false,
   });
+  const initialForm = useRef(form);
   const [mode, setMode] = useState<"edit" | "preview">("edit");
   const [previewMounted, setPreviewMounted] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isDirty = JSON.stringify(form) !== JSON.stringify(initialForm.current);
 
   const set = <K extends keyof CustomizationInput>(k: K, v: CustomizationInput[K]) =>
     setForm((f) => ({ ...f, [k]: v }));
@@ -119,13 +121,15 @@ export function CustomizationPanel({
             >
               Cancel
             </button>
-            <button
-              onClick={() => void save()}
-              disabled={saving}
-              className="inline-flex min-h-11 items-center gap-2 rounded-[10px] bg-accent px-5 text-[14px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-40"
-            >
-              <Check size={18} /> {saving ? "Saving" : "Save"}
-            </button>
+            {(isDirty || saving) && (
+              <button
+                onClick={() => void save()}
+                disabled={saving}
+                className="inline-flex min-h-11 items-center gap-2 rounded-[10px] bg-accent px-5 text-[14px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-40"
+              >
+                <Check size={18} /> {saving ? "Saving" : "Save"}
+              </button>
+            )}
           </div>
         </div>
 

--- a/src/views/profile/profile-settings.tsx
+++ b/src/views/profile/profile-settings.tsx
@@ -94,6 +94,8 @@ export function ProfileSettings({
     friendsVisibility: summary.friendsVisibility ?? "everyone",
     private: summary.private ?? false,
   });
+  const initialForm = useRef(form);
+  const isDirty = JSON.stringify(form) !== JSON.stringify(initialForm.current);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pickingLists, setPickingLists] = useState(false);
@@ -188,13 +190,15 @@ export function ProfileSettings({
             >
               Cancel
             </button>
-            <button
-              onClick={() => void save()}
-              disabled={saving}
-              className="inline-flex min-h-11 items-center gap-2 rounded-[10px] bg-accent px-5 text-[14px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-40"
-            >
-              <Check size={18} /> {saving ? "Saving" : "Save"}
-            </button>
+            {(isDirty || saving) && (
+              <button
+                onClick={() => void save()}
+                disabled={saving}
+                className="inline-flex min-h-11 items-center gap-2 rounded-[10px] bg-accent px-5 text-[14px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:opacity-40"
+              >
+                <Check size={18} /> {saving ? "Saving" : "Save"}
+              </button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- "Save" button on the **Edit profile** screen (and the "Customize profile" CSS/HTML sub-panel) stayed active/clickable even when nothing had changed. It's now hidden unless the form actually differs from the loaded profile. Reported by a community user.
- `mpv.rs`: `position_embedded_mpv_child` used `MPV_POS_LAST_RECT.lock().unwrap()`, inconsistent with the poison-safe `if let Ok(...)` pattern already used for the same static at two other call sites in the file. Replaced with the same safe pattern.

Full write-up of each fix (problem, root cause, fix) is in `docs/fixes.md`.

## Test plan
- [x] `cargo check` passes clean
- [x] `tsc -b --pretty false` passes clean
- [ ] Manually verify: open Edit profile / Customize profile with no changes — Save button should not appear; make a change — it should appear and save correctly