### PR TITLE
fix(mal): handle absolute pagination URLs

### DIFF
--- a/src/lib/mal/client.ts
+++ b/src/lib/mal/client.ts
@@ -1,6 +1,7 @@
 import { MAL_API_BASE } from "./config";
 import { getSession } from "./session";
 import { ensureRefreshed } from "./auth";
+import { resolveMalRequestUrl } from "./url";
 
 export class MalApiError extends Error {
   constructor(
@@ -30,7 +31,9 @@ export async function malRequest<T>(
   if (token) headers["Authorization"] = `Bearer ${token}`;
   if (options.body) headers["Content-Type"] = "application/x-www-form-urlencoded";
 
-  let res = await tauriFetch(`${MAL_API_BASE}${path}`, {
+  const requestUrl = resolveMalRequestUrl(MAL_API_BASE, path);
+
+  let res = await tauriFetch(requestUrl, {
     method: options.method ?? "GET",
     headers,
     body: options.body?.toString(),
@@ -40,7 +43,7 @@ export async function malRequest<T>(
     const refreshed = await ensureRefreshed();
     if (refreshed) {
       headers["Authorization"] = `Bearer ${refreshed.accessToken}`;
-      res = await tauriFetch(`${MAL_API_BASE}${path}`, {
+      res = await tauriFetch(requestUrl, {
         method: options.method ?? "GET",
         headers,
         body: options.body?.toString(),

--- a/src/lib/mal/url.ts
+++ b/src/lib/mal/url.ts
@@ -1,0 +1,3 @@
+export function resolveMalRequestUrl(base: string, path: string): string {
+  return path.startsWith(base) ? path : `${base}${path}`;
+}

--- a/tests/mal-pagination.test.ts
+++ b/tests/mal-pagination.test.ts
@@ -1,0 +1,19 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { MAL_API_BASE } from "../src/lib/mal/config.ts";
+import { resolveMalRequestUrl } from "../src/lib/mal/url.ts";
+
+test("keeps absolute MyAnimeList pagination URLs intact", () => {
+  const nextPage = `${MAL_API_BASE}/users/@me/animelist?offset=1000&limit=1000`;
+
+  assert.equal(resolveMalRequestUrl(MAL_API_BASE, nextPage), nextPage);
+});
+
+test("prefixes relative MyAnimeList API paths", () => {
+  assert.equal(
+    resolveMalRequestUrl(MAL_API_BASE, "/users/@me/animelist?limit=1000"),
+    `${MAL_API_BASE}/users/@me/animelist?limit=1000`,
+  );
+});


### PR DESCRIPTION
## Summary

- Preserve absolute URLs returned by MyAnimeList pagination while continuing to prefix Harbor's relative MAL API paths.
- Reuse the resolved URL when retrying after an OAuth token refresh.
- Add regression coverage for both absolute pagination URLs and relative request paths.

## Why

MyAnimeList returns `paging.next` as an absolute URL. Harbor forwards that cursor to `malRequest`, which previously prepended `MAL_API_BASE` unconditionally. On the second page, this produced a malformed double-prefixed URL and prevented libraries over 1,000 entries from loading completely.

Resolving the request URL once keeps the existing behavior for Harbor-authored relative paths and passes MAL's absolute pagination cursor through unchanged.

## Verification

- `pnpm exec vp check src/lib/mal/client.ts src/lib/mal/url.ts tests/mal-pagination.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `node --test tests/mal-pagination.test.ts` — 2 passed
- `pnpm test` — 89 passed, 1 failed due to the existing `startup-loader.test.ts` assertion `main page-load handler must exist`
- `node --test tests/startup-loader.test.ts` on untouched `origin/main` — reproduces the same existing failure

## Platform Impact

None. This is platform-neutral MAL request URL handling; the production frontend build was verified on Windows.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes. (Not applicable; no Rust changes.)
- [x] I tested affected platforms when the change is platform-specific. (Not platform-specific.)
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.