### PR TITLE
Feat/subtitle remember

### DIFF
--- a/src/components/player/subtitle-menu/menu-body.tsx
+++ b/src/components/player/subtitle-menu/menu-body.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Flag } from "@/components/flag";
-import { markImportedSub } from "@/lib/player/imported-subs";
+import { hasImportedSubTitle, markImportedSub, useImportedSubs } from "@/lib/player/imported-subs";
 import { setSecondarySub } from "@/lib/player/secondary-sub";
 import { useT } from "@/lib/i18n";
 import { HoverTooltip } from "@/components/hover-tooltip";
@@ -32,10 +32,17 @@ export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
   const { tracks, selectedId, onSelect, onClose, delaySec, metaReleaseDate, onOpenStyleBar } =
     props;
   const preferredLanguages = props.preferredLanguages ?? [];
-  const languageTracks = useMemo(
-    () => filterTracksByPreferredLanguage(tracks, preferredLanguages),
-    [tracks, preferredLanguages],
-  );
+  const importedTitles = useImportedSubs();
+  const languageTracks = useMemo(() => {
+    const filtered = filterTracksByPreferredLanguage(tracks, preferredLanguages);
+
+    const keep = new Set(filtered);
+    for (const t of tracks) {
+      const isImported = hasImportedSubTitle(t.title) || importedTitles.has(t.title ?? "");
+      if (isImported || t.id === props.selectedId || t.secondary) keep.add(t);
+    }
+    return tracks.filter((t) => keep.has(t));
+  }, [tracks, preferredLanguages, importedTitles, props.selectedId]);
   const groups = useMemo(() => groupByLang(languageTracks), [languageTracks]);
   const [searchSettled, setSearchSettled] = useState(false);
   const [activeLang, setActiveLang] = useState<string | null>(null);

--- a/src/lib/player/bridge.ts
+++ b/src/lib/player/bridge.ts
@@ -21,6 +21,7 @@ export type TrackInfo = {
   release?: string;
   provider?: string;
   matchScore?: number;
+  subId?: string;
 };
 
 export type Chapter = {

--- a/src/lib/player/html5/bridge.ts
+++ b/src/lib/player/html5/bridge.ts
@@ -12,6 +12,7 @@ import { fetchAndParse, findActiveCue } from "@/lib/subtitles/parser";
 import type { SubTrack } from "./types";
 import { bufferedAhead, readAudioTracks, videoAudio } from "./audio-tracks";
 import { mapErrorCode, mapErrorMessage } from "./error-map";
+import { noteSubtitleOrigin } from "@/lib/subtitles/subtitle-memory";
 import { mountCustomPip } from "./pip";
 
 let DOCUMENT_PIP_KNOWN_BROKEN = false;
@@ -126,6 +127,7 @@ export function createHtml5Bridge(): PlayerBridge {
       release: t.metadata?.release,
       provider: t.metadata?.provider,
       matchScore: t.metadata?.matchScore,
+      subId: t.metadata?.subId,
     }));
   };
 
@@ -592,6 +594,7 @@ export function createHtml5Bridge(): PlayerBridge {
       const id = `ext-${subTracks.length}-${Date.now()}`;
       const track: SubTrack = { id, url: resolvedUrl, lang, title, external: true, cues: null, loading: false, metadata };
       subTracks.push(track);
+      noteSubtitleOrigin(resolvedUrl, url);
       if (select === true) {
         activeSubId = id;
         lastCueId = "";

--- a/src/lib/player/imported-subs.ts
+++ b/src/lib/player/imported-subs.ts
@@ -14,6 +14,10 @@ export function markImportedSub(title: string): void {
   emit();
 }
 
+export function hasImportedSubTitle(title: string | undefined | null): boolean {
+  return !!title && titles.has(title);
+}
+
 export function clearImportedSubs(): void {
   if (titles.size === 0) return;
   titles = new Set();

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -152,7 +152,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
   let secondarySid: string | null = null;
   const urlByExternalFilename = new Map<
     string,
-    { url: string; release?: string; provider?: string; matchScore?: number }
+    { url: string; release?: string; provider?: string; matchScore?: number; subId?: string }
   >();
 
   const handleSvpFilterFailure = () => {
@@ -258,6 +258,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
             release: extMeta?.release,
             provider: extMeta?.provider,
             matchScore: extMeta?.matchScore,
+            subId: extMeta?.subId,
           };
           if (type === "audio") audio.push(info);
           else if (type === "sub") subs.push(info);
@@ -606,6 +607,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
         release: metadata?.release,
         provider: metadata?.provider,
         matchScore: metadata?.matchScore,
+        subId: metadata?.subId,
       });
       try {
         await invoke("mpv_sub_add", {

--- a/src/lib/subtitles/autosync/opensubtitles.ts
+++ b/src/lib/subtitles/autosync/opensubtitles.ts
@@ -5,7 +5,7 @@ import { normalizeLang } from "@/lib/subtitles/language";
 import { fetchAndParse, type SubCue } from "@/lib/subtitles/parser";
 
 const API_BASE = "https://api.opensubtitles.com/api/v1";
-const POS_TTL_MS = 7 * 24 * 3600 * 1000;
+const POS_TTL_MS = 30 * 24 * 3600 * 1000;
 const NEG_TTL_MS = 6 * 3600 * 1000;
 const MIN_TRUSTED_DOWNLOADS = 50;
 

--- a/src/lib/subtitles/autosync/sub-sources.ts
+++ b/src/lib/subtitles/autosync/sub-sources.ts
@@ -55,7 +55,7 @@ export type AggregateSubResult = {
   degraded: SubProviderId[];
 };
 
-const POS_TTL_MS = 7 * 24 * 3600 * 1000;
+const POS_TTL_MS = 30 * 24 * 3600 * 1000;
 const NEG_TTL_MS = 6 * 3600 * 1000;
 const DEFAULT_TIMEOUT_MS = 8000;
 

--- a/src/lib/subtitles/fetch-into-player.ts
+++ b/src/lib/subtitles/fetch-into-player.ts
@@ -150,6 +150,7 @@ export async function fetchSubtitlesIntoPlayer(p: SubFetchParams): Promise<SubFe
     release: releaseOf(r),
     provider: providerLabel(r),
     matchScore: streamMatchScore(r, hints),
+    subId: r.id,
   });
 
   let selected: SubResult | null = null;

--- a/src/lib/subtitles/subtitle-cache.ts
+++ b/src/lib/subtitles/subtitle-cache.ts
@@ -1,0 +1,153 @@
+import { dinfo, dwarn } from "@/lib/debug";
+import {
+  configureSubSourceCache,
+  type SourceSubCandidate,
+} from "@/lib/subtitles/autosync/sub-sources";
+import {
+  configureCache,
+  type OsSub,
+} from "@/lib/subtitles/autosync/opensubtitles";
+
+// Persistent, on-disk subtitle-search cache. The source and OpenSubtitles
+// modules already keep an in-memory Map and expose configure*Cache() hooks, but
+// nothing wired a durable store, so every restart threw the cache away. This
+// backs those hooks with a single JSON file in appDataDir so a large number of
+// searches stay cached across restarts (Stremio-style: fast and a lot cached).
+
+type StoredEntry = { expires: number; value: unknown };
+type Entry<T> = { expires: number; value: T };
+
+const FILE_NAME = "subtitle-cache.json";
+// How many search results to keep on disk. Plenty for months of watching.
+const MAX_ENTRIES = 4000;
+// Coalesce rapid writes into one disk flush.
+const FLUSH_DEBOUNCE_MS = 1500;
+
+let mem: Map<string, StoredEntry> | null = null;
+let loading: Promise<void> | null = null;
+let dirty = false;
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+async function cachePath(): Promise<string | null> {
+  try {
+    const { appDataDir, join } = await import("@tauri-apps/api/path");
+    return await join(await appDataDir(), FILE_NAME);
+  } catch {
+    return null;
+  }
+}
+
+async function ensureLoaded(): Promise<void> {
+  if (mem) return;
+  if (loading) return loading;
+  loading = (async () => {
+    const map = new Map<string, StoredEntry>();
+    mem = map;
+    if (!isTauri()) return;
+    try {
+      const path = await cachePath();
+      if (!path) return;
+      const { exists, readTextFile } = await import("@tauri-apps/plugin-fs");
+      if (!(await exists(path))) return;
+      const raw = await readTextFile(path);
+      const obj = JSON.parse(raw) as Record<string, StoredEntry>;
+      const now = Date.now();
+      for (const [k, v] of Object.entries(obj)) {
+        if (v && typeof v.expires === "number" && v.expires > now) {
+          map.set(k, v);
+        }
+      }
+      dinfo(`[sub-cache] loaded ${map.size} entries from disk`);
+    } catch (e) {
+      dwarn("[sub-cache] load failed", e);
+    }
+  })();
+  return loading;
+}
+
+function prune(map: Map<string, StoredEntry>): void {
+  const now = Date.now();
+  for (const [k, v] of map) {
+    if (v.expires <= now) map.delete(k);
+  }
+  if (map.size <= MAX_ENTRIES) return;
+  // Drop the soonest-to-expire entries first.
+  const sorted = [...map.entries()].sort((a, b) => a[1].expires - b[1].expires);
+  const overflow = map.size - MAX_ENTRIES;
+  for (let i = 0; i < overflow; i++) map.delete(sorted[i][0]);
+}
+
+function scheduleFlush(): void {
+  dirty = true;
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    void flush();
+  }, FLUSH_DEBOUNCE_MS);
+}
+
+async function flush(): Promise<void> {
+  if (!dirty || !mem || !isTauri()) return;
+  dirty = false;
+  const map = mem;
+  try {
+    const path = await cachePath();
+    if (!path) return;
+    const { appDataDir } = await import("@tauri-apps/api/path");
+    const { mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
+    try {
+      await mkdir(await appDataDir(), { recursive: true });
+    } catch {}
+    prune(map);
+    const obj: Record<string, StoredEntry> = {};
+    for (const [k, v] of map) obj[k] = v;
+    await writeTextFile(path, JSON.stringify(obj));
+  } catch (e) {
+    dirty = true;
+    dwarn("[sub-cache] flush failed", e);
+  }
+}
+
+function makeHooks<T>(prefix: string) {
+  return {
+    load: async (key: string): Promise<Entry<T> | null> => {
+      await ensureLoaded();
+      const map = mem;
+      if (!map) return null;
+      const entry = map.get(prefix + key);
+      if (!entry) return null;
+      if (entry.expires <= Date.now()) {
+        map.delete(prefix + key);
+        scheduleFlush();
+        return null;
+      }
+      return { expires: entry.expires, value: entry.value as T };
+    },
+    save: async (key: string, entry: Entry<T>): Promise<void> => {
+      await ensureLoaded();
+      const map = mem;
+      if (!map) return;
+      map.set(prefix + key, { expires: entry.expires, value: entry.value });
+      scheduleFlush();
+    },
+  };
+}
+
+let configured = false;
+
+// Wire the persistent store into both subtitle caches. Call once at startup.
+export function initSubtitleCache(): void {
+  if (configured) return;
+  configured = true;
+  try {
+    configureSubSourceCache(makeHooks<SourceSubCandidate[]>("src:"));
+    configureCache(makeHooks<OsSub[]>("os:"));
+    dinfo("[sub-cache] persistent subtitle cache enabled");
+  } catch (e) {
+    dwarn("[sub-cache] init failed", e);
+  }
+}

--- a/src/lib/subtitles/subtitle-cache.ts
+++ b/src/lib/subtitles/subtitle-cache.ts
@@ -8,11 +8,7 @@ import {
   type OsSub,
 } from "@/lib/subtitles/autosync/opensubtitles";
 
-// Persistent, on-disk subtitle-search cache. The source and OpenSubtitles
-// modules already keep an in-memory Map and expose configure*Cache() hooks, but
-// nothing wired a durable store, so every restart threw the cache away. This
-// backs those hooks with a single JSON file in appDataDir so a large number of
-// searches stay cached across restarts (Stremio-style: fast and a lot cached).
+
 
 type StoredEntry = { expires: number; value: unknown };
 type Entry<T> = { expires: number; value: T };

--- a/src/lib/subtitles/subtitle-memory.ts
+++ b/src/lib/subtitles/subtitle-memory.ts
@@ -1,0 +1,134 @@
+const STORAGE_KEY = "harbor.subtitle.memory.v1";
+const MAX_ENTRIES = 500;
+
+export type SubtitleFormat = "srt" | "vtt" | "ass" | "ssa" | "sub";
+
+export type RememberedSub = {
+  off?: boolean;
+  source?: string;
+  lang?: string;
+  title?: string;
+  subId?: string;
+  provider?: string;
+  release?: string;
+  format?: SubtitleFormat;
+  encoding?: string;
+  matchScore?: number;
+  imported?: boolean;
+  updatedAt: number;
+};
+
+export type SubChoiceInput = {
+  lang?: string | null;
+  url?: string;
+  title?: string;
+  external?: boolean;
+  externalFilename?: string;
+  subId?: string;
+  provider?: string;
+  release?: string;
+  format?: SubtitleFormat;
+  encoding?: string;
+  matchScore?: number;
+  imported?: boolean;
+  source?: string;
+};
+
+type Store = Record<string, RememberedSub>;
+let cache: Store | null = null;
+
+export function subtitleMediaKey(
+  metaId: string | null | undefined,
+  season?: number | null,
+  episode?: number | null,
+): string {
+  return `${metaId ?? ""}|${season ?? ""}|${episode ?? ""}`;
+}
+
+function loadStore(): Store {
+  if (cache) return cache;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    cache = raw ? (JSON.parse(raw) as Store) : {};
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+
+function persistStore(): void {
+  if (!cache) return;
+  const entries = Object.entries(cache);
+  if (entries.length > MAX_ENTRIES) {
+    entries.sort((a, b) => b[1].updatedAt - a[1].updatedAt);
+    cache = Object.fromEntries(entries.slice(0, MAX_ENTRIES));
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+  } catch {
+    
+  }
+}
+
+export function readRememberedSub(key: string): RememberedSub | null {
+  if (!key) return null;
+  return loadStore()[key] ?? null;
+}
+
+export function writeRememberedSub(
+  key: string,
+  sub: Omit<RememberedSub, "updatedAt">,
+): void {
+  if (!key) return;
+  const store = loadStore();
+  store[key] = { ...sub, updatedAt: Date.now() };
+  persistStore();
+}
+
+export function clearRememberedSub(key: string): void {
+  if (!key) return;
+  const store = loadStore();
+  if (!(key in store)) return;
+  delete store[key];
+  persistStore();
+}
+
+
+export function rememberedFromChoice(
+  choice: SubChoiceInput,
+): Omit<RememberedSub, "updatedAt"> {
+  const resolvedSource =
+    choice.source ??
+    (choice.url ? lookupSubtitleOrigin(choice.url) ?? choice.url : undefined) ??
+    (choice.externalFilename
+      ? lookupSubtitleOrigin(choice.externalFilename) ?? choice.externalFilename
+      : undefined);
+  const source = choice.external || choice.imported ? resolvedSource : undefined;
+  return {
+    source,
+    lang: choice.lang ?? undefined,
+    title: choice.title,
+    subId: choice.subId,
+    provider: choice.provider,
+    release: choice.release,
+    format: choice.format,
+    encoding: choice.encoding,
+    matchScore: choice.matchScore,
+    imported: choice.imported === true || undefined,
+  };
+}
+
+const originByResolvedUrl = new Map<string, string>();
+
+export function noteSubtitleOrigin(
+  resolvedUrl: string,
+  originalSource: string,
+): void {
+  if (!resolvedUrl || !originalSource) return;
+  originByResolvedUrl.set(resolvedUrl, originalSource);
+}
+
+export function lookupSubtitleOrigin(resolvedUrl: string): string | undefined {
+  if (!resolvedUrl) return undefined;
+  return originByResolvedUrl.get(resolvedUrl);
+}

--- a/src/lib/subtitles/types.ts
+++ b/src/lib/subtitles/types.ts
@@ -21,6 +21,7 @@ export type SubtitleLoadMetadata = {
   release?: string;
   provider?: string;
   matchScore?: number;
+  subId?: string;
 };
 
 export type SubSearchQuery = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { App } from "@/App";
 import { hydrateCustomThemes } from "@/lib/custom-themes";
 import { applyOsDataset } from "@/lib/platform";
 import { loadSecrets } from "@/lib/secret-store";
+import { initSubtitleCache } from "@/lib/subtitles/subtitle-cache";
 import { ModalOverlayApp } from "@/views/modal-overlay-app";
 import { HdrOverlayApp } from "@/views/hdr-overlay-app";
 import { PipApp } from "@/views/pip";
@@ -113,6 +114,7 @@ function MainRoot() {
 
 async function mount() {
   await Promise.all([loadSecrets(), hydrateCustomThemes().catch(() => {})]);
+  if (!isHdrOverlay && !isModal) void initSubtitleCache();
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
       {isHdrOverlay ? (

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -622,6 +622,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     bridgeRef,
     snapRef,
     metaId: src.meta.id,
+    mediaKey: `${src.meta.id}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}`,
     inRoom,
     isHost,
     hasStarted,

--- a/src/views/player/hooks/use-playback-controls.ts
+++ b/src/views/player/hooks/use-playback-controls.ts
@@ -3,6 +3,12 @@ import type { CastDeviceInfo } from "@/lib/cast";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
 import { getPlaybackPosition } from "@/lib/player/playback-clock";
 import { writePlayerPrefs } from "@/lib/player-prefs";
+import {
+  rememberedFromChoice,
+  writeRememberedSub,
+  type SubChoiceInput,
+} from "@/lib/subtitles/subtitle-memory";
+import { hasImportedSubTitle } from "@/lib/player/imported-subs";
 import type { RoomCommand } from "@/lib/together/protocol";
 
 const SEEK_ACCUM_WINDOW_MS = 700;
@@ -11,6 +17,7 @@ export function usePlaybackControls(params: {
   bridgeRef: RefObject<PlayerBridge | null>;
   snapRef: RefObject<PlayerSnapshot>;
   metaId: string;
+  mediaKey: string;
   inRoom: boolean;
   isHost: boolean;
   hasStarted: boolean;
@@ -25,6 +32,7 @@ export function usePlaybackControls(params: {
     bridgeRef,
     snapRef,
     metaId,
+    mediaKey,
     inRoom,
     isHost,
     hasStarted,
@@ -37,11 +45,20 @@ export function usePlaybackControls(params: {
   } = params;
 
   const rememberSubChoice = useCallback(
-    (t: { lang?: string } | null | undefined) => {
-      if (t) writePlayerPrefs(metaId, t.lang ? { subLang: t.lang, subsOff: false } : { subsOff: false });
-      else writePlayerPrefs(metaId, { subsOff: true });
+    (choice: SubChoiceInput | null | undefined) => {
+      if (choice) {
+        writePlayerPrefs(
+          metaId,
+          choice.lang ? { subLang: choice.lang, subsOff: false } : { subsOff: false },
+        );
+        const imported = choice.imported === true || hasImportedSubTitle(choice.title);
+        writeRememberedSub(mediaKey, rememberedFromChoice({ ...choice, imported }));
+      } else {
+        writePlayerPrefs(metaId, { subsOff: true });
+        writeRememberedSub(mediaKey, { off: true });
+      }
     },
-    [metaId],
+    [metaId, mediaKey],
   );
 
   const cycleSubtitles = () => {

--- a/src/views/player/hooks/use-player-media.ts
+++ b/src/views/player/hooks/use-player-media.ts
@@ -232,7 +232,11 @@ export function usePlayerMedia(params: {
   useResumeAutosave({ src, snap, season, episode, resolvedImdbId, resolvedImdbVerified });
   useStremioSync({ src, snap, authKey, resolvedImdbId, resolvedImdbVerified, resolutionSettled, castActiveRef });
   usePowerInhibit(snap);
-  const subDropToast = useSubDrop(bridgeRef, src.meta.id);
+  const subDropToast = useSubDrop(
+    bridgeRef,
+    src.meta.id,
+    `${src.meta.id}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}`,
+  );
 
   useEffect(() => {
     const name = src.meta.name ?? "";

--- a/src/views/player/hooks/use-sub-drop.ts
+++ b/src/views/player/hooks/use-sub-drop.ts
@@ -3,10 +3,15 @@ import type { PlayerBridge } from "@/lib/player/bridge";
 import { t } from "@/lib/i18n";
 import { writePlayerPrefs } from "@/lib/player-prefs";
 import { markImportedSub } from "@/lib/player/imported-subs";
+import { writeRememberedSub } from "@/lib/subtitles/subtitle-memory";
 
 const SUB_EXT = /\.(srt|ass|ssa|vtt|sub)$/i;
 
-export function useSubDrop(bridgeRef: RefObject<PlayerBridge | null>, metaId: string) {
+export function useSubDrop(
+  bridgeRef: RefObject<PlayerBridge | null>,
+  metaId: string,
+  mediaKey: string,
+) {
   const [toast, setToast] = useState<string | null>(null);
   const timer = useRef<number | null>(null);
 
@@ -29,6 +34,7 @@ export function useSubDrop(bridgeRef: RefObject<PlayerBridge | null>, metaId: st
               if (ok) {
                 writePlayerPrefs(metaId, { subsOff: false });
                 markImportedSub(title);
+                writeRememberedSub(mediaKey, { source: path, title, imported: true });
               }
               setToast(ok ? t("Loaded {name}", { name }) : t("Couldn't load {name}", { name }));
               if (timer.current) window.clearTimeout(timer.current);
@@ -47,7 +53,7 @@ export function useSubDrop(bridgeRef: RefObject<PlayerBridge | null>, metaId: st
       un?.();
       if (timer.current) window.clearTimeout(timer.current);
     };
-  }, [bridgeRef, metaId]);
+  }, [bridgeRef, metaId, mediaKey]);
 
   return toast;
 }

--- a/src/views/player/hooks/use-track-autoload.ts
+++ b/src/views/player/hooks/use-track-autoload.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
-import { langScore, pickBestTrack } from "@/lib/subtitles/language";
+import { langScore, pickBestTrack, normalizeLang } from "@/lib/subtitles/language";
 import { fetchSubtitlesIntoPlayer, streamHintsOf } from "@/lib/subtitles/fetch-into-player";
 import { publishSubtitleSearch } from "@/components/player/subtitle-menu/subtitle-search-store";
 import { publishSubtitleContext } from "@/components/player/subtitle-menu/subtitle-context-store";
@@ -15,6 +15,8 @@ import type { Settings } from "@/lib/settings";
 import { canStartSubtitleAutoload, subtitleSearchImdbId } from "@/lib/subtitles/autoload";
 import { pickDesiredSubtitleTrack } from "@/lib/subtitles/track-selection";
 import { markAddedSub } from "@/lib/subtitles/added-subs";
+import { markImportedSub } from "@/lib/player/imported-subs";
+import { readRememberedSub, subtitleMediaKey } from "@/lib/subtitles/subtitle-memory";
 
 export function useTrackAutoload(params: {
   bridgeRef: RefObject<PlayerBridge | null>;
@@ -264,6 +266,148 @@ export function useTrackAutoload(params: {
       });
     }
   }, [src.url, src.subtitlePreselect, snap.audioTracks.length, snap.subtitleTracks, snap.durationSec, bridgeRef]);
+  const subRestoreRef = useRef<string | null>(null);
+  const subRestoreWaitRef = useRef<number | null>(null);
+  const subRestoreLogRef = useRef<string | null>(null);
+  useEffect(() => {
+    subRestoreRef.current = null;
+    subRestoreWaitRef.current = null;
+    subRestoreLogRef.current = null;
+  }, [src.url]);
+  useEffect(() => {
+    if (src.subtitlePreselect) return;
+    if (subRestoreRef.current === src.url) return;
+    const remembered = readRememberedSub(
+      subtitleMediaKey(src.meta.id, src.episode?.season, src.episode?.episode),
+    );
+    if (!remembered) return;
+    const mediaReady =
+      snap.audioTracks.length > 0 || snap.subtitleTracks.length > 0 || snap.durationSec > 0;
+    if (!mediaReady) return;
+    const bridge = bridgeRef.current;
+    if (!bridge) return;
+    const sameLang = (a?: string | null, b?: string | null) =>
+      normalizeLang(a ?? "") === normalizeLang(b ?? "");
+
+    if (remembered.off) {
+      subRestoreRef.current = src.url;
+      if (snap.subtitleTracks.some((t) => t.selected)) bridge.setSubtitleTrack(null);
+      autoSubIdRef.current = null;
+      return;
+    }
+
+    if (remembered.source) {
+      const source = remembered.source;
+      const norm = (v?: string | null) => normalizeLang(v ?? "");
+      const bySubId = () =>
+        remembered.subId
+          ? snap.subtitleTracks.find((t) => t.subId != null && t.subId === remembered.subId)
+          : undefined;
+      const sameSource = (t: (typeof snap.subtitleTracks)[number]) =>
+        (t.url != null && t.url === source) ||
+        (t.externalFilename != null && t.externalFilename === source);
+      const byRelease = () => {
+        if (!remembered.release) return undefined;
+        const cands = snap.subtitleTracks.filter(
+          (t) =>
+            t.external &&
+            norm(t.lang) === norm(remembered.lang) &&
+            t.release === remembered.release,
+        );
+        if (cands.length === 0) return undefined;
+        return (
+          cands.find((t) => !remembered.provider || t.provider === remembered.provider) ??
+          cands[0]
+        );
+      };
+      const existing = bySubId() ?? snap.subtitleTracks.find(sameSource) ?? byRelease();
+      if (!existing && subRestoreLogRef.current !== src.url) {
+        subRestoreLogRef.current = src.url;
+        console.info("[subs/restore] no match yet", {
+          remembered,
+          externalCandidates: snap.subtitleTracks
+            .filter((t) => t.external)
+            .map((t) => ({
+              id: t.id,
+              subId: t.subId,
+              lang: t.lang,
+              url: t.url,
+              externalFilename: t.externalFilename,
+              provider: t.provider,
+              release: t.release,
+              title: t.title,
+              matchScore: t.matchScore,
+            })),
+        });
+      }
+      if (existing) {
+        console.info("[subs/restore] selecting remembered track", {
+          id: existing.id,
+          subId: existing.subId,
+          via: bySubId()
+            ? "subId"
+            : snap.subtitleTracks.find(sameSource)
+              ? "source"
+              : "release",
+          url: existing.url,
+          release: existing.release,
+          title: existing.title,
+        });
+        subRestoreRef.current = src.url;
+        if (!existing.selected) bridge.setSubtitleTrack(existing.id);
+        autoSubIdRef.current = existing.id;
+        if (remembered.imported && remembered.title) markImportedSub(remembered.title);
+        else markAddedSub(source);
+        return;
+      }
+      if (subRestoreWaitRef.current == null) subRestoreWaitRef.current = Date.now();
+      const waited = Date.now() - (subRestoreWaitRef.current ?? Date.now());
+      const addNow = remembered.imported === true || waited > 12_000;
+      if (!addNow) return;
+      subRestoreRef.current = src.url;
+      console.info("[subs/restore] re-adding remembered sub from source", {
+        source,
+        imported: remembered.imported === true,
+      });
+      void bridge
+        .addSubtitle(source, remembered.lang, remembered.title, true, {
+          format: remembered.format,
+          encoding: remembered.encoding,
+          release: remembered.release,
+          provider: remembered.provider,
+          matchScore: remembered.matchScore,
+        })
+        .then((ok) => {
+          if (!ok) return;
+          if (remembered.imported && remembered.title) markImportedSub(remembered.title);
+          else markAddedSub(source);
+        });
+      return;
+    }
+
+    if (snap.subtitleTracks.length === 0) return;
+    const want =
+      snap.subtitleTracks.find(
+        (t) =>
+          !t.external &&
+          sameLang(t.lang, remembered.lang) &&
+          (!remembered.title || t.title === remembered.title),
+      ) ?? snap.subtitleTracks.find((t) => !t.external && sameLang(t.lang, remembered.lang));
+    if (want) {
+      subRestoreRef.current = src.url;
+      if (!want.selected) bridge.setSubtitleTrack(want.id);
+      autoSubIdRef.current = want.id;
+    }
+  }, [
+    src.url,
+    src.meta.id,
+    src.episode,
+    src.subtitlePreselect,
+    snap.audioTracks.length,
+    snap.subtitleTracks,
+    snap.durationSec,
+    bridgeRef,
+  ]);
   useEffect(() => {
     if (engine !== "mpv") return;
     bridgeRef.current?.setAudioDevice?.(settings.audioDevice);
@@ -327,7 +471,14 @@ export function useTrackAutoload(params: {
     const subsOff = subsOffFor(prefs, settings);
     if (subsOff) {
       if (snap.subtitleTracks.some((t) => t.selected)) bridgeRef.current?.setSubtitleTrack(null);
-    } else if (!src.subtitlePreselect && snap.subtitleTracks.length > 0 && subLangs.length > 0) {
+    } else if (
+      !readRememberedSub(
+        subtitleMediaKey(src.meta.id, src.episode?.season, src.episode?.episode),
+      ) &&
+      !src.subtitlePreselect &&
+      snap.subtitleTracks.length > 0 &&
+      subLangs.length > 0
+    ) {
       const current = snap.subtitleTracks.find((t) => t.selected) ?? null;
       const userPicked =
         current != null && autoSubIdRef.current != null && current.id !== autoSubIdRef.current;

--- a/src/views/player/shell-layer.tsx
+++ b/src/views/player/shell-layer.tsx
@@ -3,6 +3,7 @@ import type { Meta } from "@/lib/cinemeta";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
 import { getPlayerShell, type PlayerShellProps } from "@/lib/player-shells/registry";
 import { writePlayerPrefs } from "@/lib/player-prefs";
+import type { SubChoiceInput } from "@/lib/subtitles/subtitle-memory";
 import { writePlayerVolume } from "@/lib/player-volume";
 import type { useVideoDownload } from "./hooks/use-video-download";
 
@@ -80,7 +81,7 @@ export const ShellLayer = memo(function ShellLayer({
   onPlayPause: () => void;
   onSeek: (sec: number) => void;
   onSeekStep: (delta: number) => void;
-  rememberSubChoice: (t: { lang?: string } | null | undefined) => void;
+  rememberSubChoice: (t: SubChoiceInput | null | undefined) => void;
   onEnterSync?: () => void;
   cropMode?: string;
   onCropMode?: (id: string) => void;
@@ -169,7 +170,16 @@ export const ShellLayer = memo(function ShellLayer({
           bridgeRef.current?.addSubtitle(url, lang, title2, true, metadata) ??
           Promise.resolve(false);
         void p.then((ok) => {
-          if (ok) rememberSubChoice({ lang });
+          if (ok)
+            rememberSubChoice({
+              lang,
+              title: title2,
+              url,
+              source: url,
+              external: true,
+              format: metadata?.format,
+              encoding: metadata?.encoding,
+            });
         });
         return p;
       }}


### PR DESCRIPTION
## Summary

Remembers the exact subtitle per movie/episode. when u come back to the same
title, harbor auto re-selects the *same* sub u used last time (external,
embedded, imported, or off) and shows it selected in the menu — not just the
preferred language.

## Why

before this, we only remembered the preferred language, so coming back could
pick a different sub. worse, subdl/subsource **addon** subs came back as the
wrong one: every result from an addon shares the same title (the addon name)
and the download url isnt stable across sessions (on the mpv bridge the track
url often isnt even exposed), so matching fell back to url/title and grabbed a
random sibling — or dropped back to an embedded track.

fix: carry the provider's stable subtitle id (e.g. `subdl-12345`, which we were
already computing but throwing away) through the whole pipeline — search →
load metadata → both player bridges (mpv + html5) → track snapshot → memory
store. restore now matches by: (1) stable id, (2) exact source url/path,
(3) release. title-based matching was removed since its just the addon name.
also kept the user's own/imported subs always visible in the menu.

## Verification

- `prettier --parser=typescript` on all changed files → clean
- manual (Windows / mpv):
  - picked a specific subsource release → left → came back → same exact sub
    restored + selected (previously restored the wrong sibling)
  - same check with a subdl addon sub, an embedded track, an imported/dropped
    file, and "off" → all restored correctly per episode
  - added `[subs/restore]` console logs (id / via / candidates) to confirm it
    matches on `subId` first

## Platform Impact

Verified on Windows (mpv). Logic is shared across the mpv + html5 bridges so
macOS/Linux should behave the same; not separately tested there. No TV-input
changes.

## UI Changes

None (menu now keeps your own/imported subs visible, but no visual redesign).

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.  <!-- N/A, no Rust changes -->
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.