### PR TITLE
fix(macos): stop audio device enumeration from crashing on hotplug

### DIFF
--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use libmpv2::events::{Event, EventContext, PropertyData};
@@ -276,6 +276,34 @@ fn read_audio_devices(mpv: &Mpv) -> Vec<AudioDevice> {
     out
 }
 
+/// Long-lived mpv context used only to enumerate audio devices.
+///
+/// Reading `audio-device-list` makes mpv call `create_hotplug()`, which on
+/// macOS registers `hotplug_cb` against `kAudioObjectSystemObject` with the
+/// `struct ao *` as the listener context. CoreAudio delivers those
+/// notifications on its own serial dispatch queue, and
+/// `AudioObjectRemovePropertyListener` does not drain callbacks that are
+/// already in flight. Creating a throwaway `Mpv` here and dropping it at the
+/// end of the call therefore frees the `ao` out from under a callback that
+/// CoreAudio may already have queued, and `hotplug_cb`'s first statement is
+/// `MP_VERBOSE(ao, ...)` -> `mp_msg(ao->log, ...)` on freed memory.
+///
+/// Keeping a single context alive for the process lifetime means the listener
+/// is registered once and its context outlives every notification, so the
+/// race cannot be lost. The context is idle and holds no audio output.
+static DEVICE_PROBE_MPV: OnceLock<Result<Arc<Mpv>, String>> = OnceLock::new();
+
+fn device_probe_mpv() -> Result<Arc<Mpv>, String> {
+    DEVICE_PROBE_MPV
+        .get_or_init(|| {
+            force_c_numeric_locale();
+            Mpv::new()
+                .map(Arc::new)
+                .map_err(|e| format!("mpv init: {}", e))
+        })
+        .clone()
+}
+
 #[tauri::command]
 pub async fn mpv_audio_devices(state: State<'_, MpvState>) -> Result<Vec<AudioDevice>, String> {
     let existing = {
@@ -285,8 +313,7 @@ pub async fn mpv_audio_devices(state: State<'_, MpvState>) -> Result<Vec<AudioDe
     if let Some(mpv) = existing {
         return Ok(read_audio_devices(&mpv));
     }
-    force_c_numeric_locale();
-    let mpv = Mpv::new().map_err(|e| format!("mpv init: {}", e))?;
+    let mpv = device_probe_mpv()?;
     Ok(read_audio_devices(&mpv))
 }
 


### PR DESCRIPTION
## Summary

Fixes a use-after-free that crashes Harbor on macOS (`EXC_BAD_ACCESS` / `SIGSEGV`) when audio devices change while the app is running.

`mpv_audio_devices` creates a throwaway `Mpv`, reads `audio-device-list`, and drops it at the end of the call. Reading that property makes mpv register a **global CoreAudio property listener** whose context pointer is the `struct ao *` owned by that context. Dropping the context frees the `ao`, but CoreAudio can still have a notification in flight — and the callback's first statement dereferences it.

## Root cause

The chain, verified against mpv's source:

1. `read_audio_devices()` reads `audio-device-list`.
2. `mp_property_audio_devices()` in mpv's `player/command.c` calls `create_hotplug(mpctx)` unconditionally, which lazily creates `cmd->hotplug` via `ao_hotplug_create()`.
3. On macOS that reaches `hotplug_init()` → `register_hotplug_cb()` in `audio/out/ao_coreaudio.c`, which calls `AudioObjectAddPropertyListener(kAudioObjectSystemObject, &addr, hotplug_cb, (void *)ao)`.
4. `cmd->hotplug` is destroyed only in `command_uninit` (`ao_hotplug_destroy(ctx->hotplug)`), i.e. **when the mpv context dies**. So the listener's lifetime is exactly the mpv context's lifetime.
5. Dropping the throwaway `Mpv` unregisters and frees the `ao`. But `AudioObjectRemovePropertyListener` does not drain callbacks CoreAudio has already dispatched onto its own serial queue.
6. `hotplug_cb` then runs against freed memory, and its first statement is:

```c
static OSStatus hotplug_cb(AudioObjectID id, ..., void *ctx)
{
    struct ao *ao = ctx;
    struct priv *p = ao->priv;
    MP_VERBOSE(ao, "Handling potential hotplug event...\n");   // mp_msg(ao->log, ...)
```

`MP_VERBOSE(ao, ...)` expands to `mp_msg(ao->log, ...)`, so a freed `ao` means `ao->log` is garbage.

## Evidence

Two crashes on macOS 27.0, Harbor 0.9.21, arm64. Identical frames, **different** faulting addresses — the signature of freed-then-reused memory rather than a plain null bug:

```
libmpv.2.dylib   mp_msg_va
libmpv.2.dylib   mp_msg
libmpv.2.dylib   hotplug_cb
CoreAudio        HALObject::PropertiesChanged(...)
CoreAudio        HALSystem::AudioObjectsPublishedAndDied(...)
CoreAudio        HALC_ProxyNotifications::CallListener(...)
libdispatch      _dispatch_client_callout
libdispatch      _dispatch_lane_serial_drain
libdispatch      _dispatch_workloop_worker_thread
```

- Crash A: `KERN_INVALID_ADDRESS at 0x0000000000000000`
- Crash B: `KERN_INVALID_ADDRESS at 0x...` — *"possible pointer authentication failure"*

The `libdispatch` frames confirm the callback is being delivered on CoreAudio's own serial queue, which is why unregistering does not prevent it.

## Why it shows up in practice

The window is small, so it needs frequent audio-device churn to be hit. Anything that republishes the CoreAudio device list repeatedly will do it — on the machine where this was diagnosed, an iPhone Continuity audio device was flapping in and out of availability roughly 4 times a minute, producing ~700 device-list notifications over 3 hours. Bluetooth headphones reconnecting, docks, virtual audio devices (Teams/Loopback/aggregate devices), and display audio all produce the same notifications.

The race is armed every time the **Settings → Quality** panel mounts, since `AudioOutputRow` calls `listMpvAudioDevices()` in a `useEffect` on mount.

Introduced alongside the audio output device picker in v0.9.20.

## The fix

Use a single process-lifetime mpv context for device enumeration instead of creating and destroying one per call. The hotplug listener is then registered once and its context outlives every notification, so the race cannot be lost. The context is idle and holds no audio output.

The live player context is still preferred when one exists, so this only affects the "no player running" path.

This is a Harbor-side fix for what is ultimately an upstream mpv lifetime bug (`AudioObjectRemovePropertyListener` is not synchronized against in-flight dispatch-queue callbacks). Not creating and destroying short-lived contexts avoids it entirely and is worth doing regardless of whether upstream changes.

## Testing

- `cargo check --manifest-path src-tauri/Cargo.toml` passes.
- Verified the other two `Mpv::new()` call sites (`mpv_probe`, `supports_vapoursynth_filter`) never read `audio-device-list`, so they do not register the CoreAudio listener and are unaffected.
- No change to the `mpv_audio_devices` command signature or its frontend contract.
