### PR TITLE
fix: resolve focused card styling and keyboard navigation issues

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1723,15 +1723,15 @@ html:not([data-input-modality="pointer"]) #root [data-media-card] {
 }
 
 html:not([data-input-modality="pointer"])
-  #root:has([data-focused-card]:is(:focus, [data-tv-focused="true"]))
-  [data-media-card]:not([data-focused-card]:is(:focus, [data-tv-focused="true"])) {
+  #root[data-card-focus-active]
+  [data-media-card]:not([data-tv-focused="true"]) {
   opacity: 0.34;
   filter: brightness(0.68) saturate(0.78) blur(0.7px);
 }
 
 html:not([data-input-modality="pointer"])
-  #root:has([data-focused-card]:is(:focus, [data-tv-focused="true"]))
-  [data-media-card]:is([data-focused-card]:focus, [data-focused-card][data-tv-focused="true"]) {
+  #root[data-card-focus-active]
+  [data-media-card][data-tv-focused="true"] {
   opacity: 1;
   filter: none;
 }

--- a/src/lib/keyboard-navigation.ts
+++ b/src/lib/keyboard-navigation.ts
@@ -554,6 +554,10 @@ function focusElement(el: HTMLElement, scroll: "center" | "nearest" | "none" = "
 
   el.setAttribute("data-tv-focused", "true");
 
+  if (el.hasAttribute("data-focused-card")) {
+    document.getElementById("root")?.setAttribute("data-card-focus-active", "");
+  }
+
   if (isSearchLikeField(el) && activeSearchEditEl !== el) {
     // Navigation focus is not editing mode.
     el.removeAttribute("data-search-editing");
@@ -598,6 +602,10 @@ function clearTvFocusRing(except?: HTMLElement) {
   });
 
   clearSearchVisualFocus();
+
+  if (!except?.hasAttribute("data-focused-card")) {
+    document.getElementById("root")?.removeAttribute("data-card-focus-active");
+  }
 }
 
 function setSearchNavMode(el: HTMLElement) {
@@ -982,12 +990,32 @@ export function useKeyboardNavigation(options: TVNavigationOptions = {}) {
         return;
       }
 
+      const targetIsRange =
+        target instanceof HTMLInputElement &&
+        target.type === "range" &&
+        !target.disabled &&
+        document.activeElement === target;
+
+      const targetIsSelect =
+        target instanceof HTMLSelectElement &&
+        !target.disabled &&
+        document.activeElement === target;
+
+      const dir = getDirection(e);
+
+      if (dir && (targetIsRange || targetIsSelect)) {
+        if (!arrowsRef.current) return;
+        if (targetIsRange && (dir === "left" || dir === "right")) return;
+        e.preventDefault();
+        e.stopPropagation();
+        moveFocus(dir, wrapRef.current);
+        return;
+      }
+
       if (!isNavigatingSearch && !shouldHandleGlobalKeyboardEvent(e)) return;
       if (isLocallyManaged(target)) return;
       if (activeIsSearch && isEditingSearch) return;
       if (isEditable(target) && !isSearchLikeField(target)) return;
-
-      const dir = getDirection(e);
 
       if (dir) {
         if (!arrowsRef.current) return;

--- a/tests/poster-backdrop-expansion.test.ts
+++ b/tests/poster-backdrop-expansion.test.ts
@@ -198,7 +198,7 @@ test("Focused Card is global and independent from card expansion", () => {
   assert.match(hookSource, /focusIntentRef\.current = true/);
   assert.doesNotMatch(hookSource, /row\?\.setFocused|setRowCardFocused/);
   assert.doesNotMatch(rowSource, /focusedCardIndex|deemphasized/);
-  assert.match(cssSource, /#root:has\(\[data-focused-card\]/);
+  assert.match(cssSource, /#root\[data-card-focus-active\]/);
   assert.match(cssSource, /\[data-media-card\]/);
   assert.match(cssSource, /brightness\(0\.68\) saturate\(0\.78\) blur\(0\.7px\)/);
   assert.match(cssSource, /\[data-focused-card\]:is\(:focus-visible, \[data-tv-focused="true"\]\)/);


### PR DESCRIPTION
Two Settings navigation fixes for TV/remote keyboard input:

- Range sliders and <select> no longer trap arrows — Left/Right on a slider still changes the value; any other arrow moves focus out of the field. Enter/Space still opens the select dropdown.


- Faster focused-card dimming — replaced the #root:has(...) CSS selector (which Chromium re-evaluates across the whole DOM on every focus change and made Settings navigation crawl) with a data-card-focus-active attribute toggled by keyboard-navigation.ts on #root. Same visuals, snappier moves.
