### PR TITLE
feat: add localized hero metadata toggle

### DIFF
--- a/src/components/cinema-hero.tsx
+++ b/src/components/cinema-hero.tsx
@@ -231,8 +231,9 @@ function CinemaSlide({
     let cancelled = false;
     if (!logoResolved) {
       const isTmdb = meta.id.startsWith("tmdb:");
+      const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
       const lookup = isTmdb
-        ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
+        ? tmdbLogo(settings.tmdbKey, meta.id, langArg)
         : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
       lookup
         .then((url) => {

--- a/src/components/critics-pick.tsx
+++ b/src/components/critics-pick.tsx
@@ -85,7 +85,8 @@ export function CriticsPick({ meta }: { meta: Meta }) {
       return;
     }
     let cancelled = false;
-    tmdbMovieImages(settings.tmdbKey, meta.id)
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
+    tmdbMovieImages(settings.tmdbKey, meta.id, langArg)
       .then((urls) => !cancelled && setStills(urls))
       .catch(() => !cancelled && setStills([]));
     return () => {

--- a/src/components/featured-banner/side-panel.tsx
+++ b/src/components/featured-banner/side-panel.tsx
@@ -31,7 +31,8 @@ export function SidePanel({
       return;
     }
     let cancelled = false;
-    tmdbMovieImages(settings.tmdbKey, meta.id)
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
+    tmdbMovieImages(settings.tmdbKey, meta.id, langArg)
       .then((urls) => {
         if (cancelled) return;
         setStills(urls);

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -161,8 +161,9 @@ export const Hero = memo(function Hero({
     }
     if (!bgResolved) {
       const isTmdb = meta.id.startsWith("tmdb:");
+      const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
       const bg: Promise<string | undefined> = isTmdb
-        ? tmdbMovieImages(settings.tmdbKey, meta.id).then((urls) => urls[0])
+        ? tmdbMovieImages(settings.tmdbKey, meta.id, langArg).then((urls) => urls[0])
         : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.background);
       bg.then((b) => {
         if (cancelled) return;
@@ -416,7 +417,7 @@ export const Hero = memo(function Hero({
             }}
           />
           {description && (
-            <p className="mt-6 line-clamp-3 max-w-xl text-[16px] leading-relaxed text-ink-muted">
+            <p dir="auto" className="mt-6 line-clamp-3 max-w-xl text-[16px] leading-relaxed text-ink-muted">
               {description}
             </p>
           )}

--- a/src/components/peek-hero.tsx
+++ b/src/components/peek-hero.tsx
@@ -207,8 +207,9 @@ function PeekSlide({
     if (logo) return;
     let cancelled = false;
     const isTmdb = meta.id.startsWith("tmdb:");
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
     const lookup = isTmdb
-      ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
+      ? tmdbLogo(settings.tmdbKey, meta.id, langArg)
       : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
     lookup
       .then((url) => {

--- a/src/lib/logo.ts
+++ b/src/lib/logo.ts
@@ -23,10 +23,14 @@ registerEvictable("logo", () => {
   inflight.clear();
 });
 
+import { loadStoredSettings } from "@/lib/settings/load";
+
 const isAnimeLogoId = (id: string) => /^(kitsu|mal|anilist|anidb):/.test(id);
 
 function preferTmdbLogo(tmdbKey: string, meta: Meta): boolean {
   if (!tmdbKey || !shouldLocalizePosters()) return false;
+  const settings = loadStoredSettings();
+  if (!settings.heroLocalizedMetadata) return false;
   return meta.id.startsWith("tt") || meta.id.startsWith("tmdb:");
 }
 

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -102,6 +102,7 @@ export const DEFAULT: Settings = {
   heroShadow: 100,
   heroFull: false,
   heroFullQuality: true,
+  heroLocalizedMetadata: true,
   heroFeed: "trending",
   heroTrailers: false,
   heroTrailerAudio: false,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -152,6 +152,7 @@ export type Settings = {
   heroShadow: number;
   heroFull: boolean;
   heroFullQuality: boolean;
+  heroLocalizedMetadata: boolean;
   heroFeed: "trending" | "trakt" | "simkl" | "classic";
   heroTrailers: boolean;
   heroTrailerAudio: boolean;

--- a/src/lib/use-localized-overview.ts
+++ b/src/lib/use-localized-overview.ts
@@ -1,24 +1,38 @@
 import { useEffect, useState } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import { tmdbMetadataOverview } from "@/lib/providers/tmdb/tmdb-lite";
+import { tmdbIdFromImdb } from "@/lib/providers/tmdb/tmdb-imdb-resolve";
 import { useSettings } from "@/lib/settings";
 
 export function useLocalizedOverview(meta: Meta): string | undefined {
   const { settings } = useSettings();
-  const isTmdb = meta.id.startsWith("tmdb:");
-  const [overview, setOverview] = useState<string | undefined>(
-    isTmdb ? undefined : meta.description,
-  );
+  const [overview, setOverview] = useState<string | undefined>(meta.description);
+
   useEffect(() => {
-    if (!isTmdb || !settings.tmdbKey) {
+    if (!settings.tmdbKey || !settings.heroLocalizedMetadata) {
       setOverview(meta.description);
       return;
     }
-    setOverview(undefined);
     let alive = true;
-    void tmdbMetadataOverview(settings.tmdbKey, meta.id).then((o) => {
+    const fetchOverview = async () => {
+      let tmdbId = meta.id;
+      if (tmdbId.startsWith("tt")) {
+        const resolved = await tmdbIdFromImdb(settings.tmdbKey, tmdbId);
+        if (resolved) {
+          tmdbId = resolved;
+        } else {
+          if (alive) setOverview(meta.description);
+          return;
+        }
+      } else if (!tmdbId.startsWith("tmdb:")) {
+        if (alive) setOverview(meta.description);
+        return;
+      }
+      const o = await tmdbMetadataOverview(settings.tmdbKey, tmdbId);
       if (alive) setOverview(o ?? meta.description);
-    });
+    };
+
+    fetchOverview();
     return () => {
       alive = false;
     };

--- a/src/views/kids/kids-hero.tsx
+++ b/src/views/kids/kids-hero.tsx
@@ -72,8 +72,9 @@ function KidsHeroCard({
     if (logo) return;
     let cancelled = false;
     const isTmdb = meta.id.startsWith("tmdb:");
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
     const lookup = isTmdb
-      ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
+      ? tmdbLogo(settings.tmdbKey, meta.id, langArg)
       : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
     lookup
       .then((url) => {

--- a/src/views/settings/theme-panel/display-section.tsx
+++ b/src/views/settings/theme-panel/display-section.tsx
@@ -218,6 +218,12 @@ export function DisplaySection() {
           onChange={(v) => update({ heroFullQuality: v })}
         />
         <ToggleRow
+          label={t("Localized hero metadata")}
+          sub={t("Prioritize original language artwork and localized descriptions for the featured title.")}
+          value={settings.heroLocalizedMetadata}
+          onChange={(v) => update({ heroLocalizedMetadata: v })}
+        />
+        <ToggleRow
           label={t("Play trailers in the hero")}
           newId="theme:hero-video"
           sub={t("After a moment on a slide, the featured title's trailer plays muted in the background. Uses more bandwidth.")}


### PR DESCRIPTION
Adds a "Localized hero metadata" toggle in the Home settings that allows users to prioritize original-language backdrops, logos, and localized descriptions for the featured title. When disabled, it falls back to the default English artwork and text.
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/de6a8e83-20ef-422c-ba36-0058291e762d" />
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/dd3c65a7-422a-41f3-bb9d-c3c53329b0d9" />
<img width="759" height="511" alt="image" src="https://github.com/user-attachments/assets/3b779c7b-a99b-45c8-a92a-95785a8166d1" />
