### PR TITLE
feat: add localized hero metadata toggle

### DIFF
--- a/src/components/cinema-hero.tsx
+++ b/src/components/cinema-hero.tsx
@@ -9,7 +9,12 @@ import { useSettings } from "@/lib/settings";
 import { useTitleLogo } from "@/lib/title-logo";
 import { useLocalizedOverview } from "@/lib/use-localized-overview";
 import { smartPlayEpisode } from "@/lib/smart-play";
-import { fetchTrailer, prefetchTrailer, trailerSrc, type TrailerInfo } from "@/lib/trailer";
+import {
+  fetchTrailer,
+  prefetchTrailer,
+  trailerSrc,
+  type TrailerInfo,
+} from "@/lib/trailer";
 import { useT } from "@/lib/i18n";
 import { useView } from "@/lib/view";
 import { observe, usePageVisible } from "@/lib/visibility";
@@ -54,8 +59,12 @@ export function CinemaHero({
   }, []);
 
   useEffect(() => {
-    if (paused || dragging || !inViewport || !pageVisible || slides.length < 2) return;
-    const id = setInterval(() => setActive((a) => (a + 1) % slides.length), ROTATE_MS);
+    if (paused || dragging || !inViewport || !pageVisible || slides.length < 2)
+      return;
+    const id = setInterval(
+      () => setActive((a) => (a + 1) % slides.length),
+      ROTATE_MS,
+    );
     return () => clearInterval(id);
   }, [paused, dragging, inViewport, pageVisible, slides.length]);
 
@@ -112,7 +121,9 @@ export function CinemaHero({
     const distance = offset;
     const threshold = W * SNAP_RATIO;
     const v = velocity.current;
-    const wantNext = (distance < -threshold || v < -FLICK_VELOCITY) && active < slides.length - 1;
+    const wantNext =
+      (distance < -threshold || v < -FLICK_VELOCITY) &&
+      active < slides.length - 1;
     const wantPrev = (distance > threshold || v > FLICK_VELOCITY) && active > 0;
     if (wantNext) setActive(active + 1);
     else if (wantPrev) setActive(active - 1);
@@ -148,7 +159,11 @@ export function CinemaHero({
         onPointerCancel={endDrag}
         onClickCapture={onClickCapture}
         className={`relative h-full w-full overflow-hidden select-none ${
-          slides.length > 1 ? (dragging ? "cursor-grabbing" : "cursor-grab") : ""
+          slides.length > 1
+            ? dragging
+              ? "cursor-grabbing"
+              : "cursor-grab"
+            : ""
         }`}
         style={{ touchAction: "pan-y" }}
       >
@@ -186,7 +201,9 @@ export function CinemaHero({
               onClick={() => setActive(i)}
               aria-label={t("Slide {n}", { n: i + 1 })}
               className={`h-1.5 rounded-full transition-all duration-500 ${
-                i === active ? "w-10 bg-ink" : "w-1.5 bg-ink-muted/55 hover:bg-ink-muted"
+                i === active
+                  ? "w-10 bg-ink"
+                  : "w-1.5 bg-ink-muted/55 hover:bg-ink-muted"
               }`}
             />
           ))}
@@ -223,7 +240,12 @@ function CinemaSlide({
   const [videoReady, setVideoReady] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const pageVisible = usePageVisible();
-  const wantsPlayback = active && !!trailerInfo && pageVisible && inViewport && settings.heroTrailers;
+  const wantsPlayback =
+    active &&
+    !!trailerInfo &&
+    pageVisible &&
+    inViewport &&
+    settings.heroTrailers;
   const bg = upsizeTmdb(meta.background || meta.poster);
 
   useEffect(() => {
@@ -231,9 +253,14 @@ function CinemaSlide({
     let cancelled = false;
     if (!logoResolved) {
       const isTmdb = meta.id.startsWith("tmdb:");
+      const langArg = settings.heroLocalizedMetadata
+        ? meta.originalLanguage
+        : undefined;
       const lookup = isTmdb
-        ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
-        : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
+        ? tmdbLogo(settings.tmdbKey, meta.id, langArg)
+        : fetchMeta(narrowMediaType(meta.type), meta.id).then(
+            (full) => full?.logo,
+          );
       lookup
         .then((url) => {
           if (cancelled) return;
@@ -280,7 +307,13 @@ function CinemaSlide({
   }, [active, meta.id, meta.type, settings.tmdbKey, settings.heroTrailers]);
 
   useEffect(() => {
-    if (!active || !settings.heroTrailers || trailerCandidates.length === 0 || trailerInfo) return;
+    if (
+      !active ||
+      !settings.heroTrailers ||
+      trailerCandidates.length === 0 ||
+      trailerInfo
+    )
+      return;
     let cancelled = false;
     fetchTrailer(trailerCandidates[0], "360p").then((info) => {
       if (!cancelled && info) setTrailerInfo(info);
@@ -316,10 +349,7 @@ function CinemaSlide({
   }, [trailerInfo]);
 
   return (
-    <div
-      aria-hidden={!active}
-      className="relative h-full w-full"
-    >
+    <div aria-hidden={!active} className="relative h-full w-full">
       {bg && (
         <img
           src={bg}
@@ -390,7 +420,11 @@ function CinemaSlide({
           )}
           <div className="mt-2 flex items-center gap-3">
             <button
-              onClick={() => openPicker(meta, smartPlayEpisode(meta), { autoPlay: settings.instantPlay })}
+              onClick={() =>
+                openPicker(meta, smartPlayEpisode(meta), {
+                  autoPlay: settings.instantPlay,
+                })
+              }
               className="flex h-12 items-center gap-2.5 rounded-md bg-ink px-7 text-[14.5px] font-semibold text-canvas shadow-[0_8px_24px_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.5)] transition-transform duration-200 hover:scale-[1.03] active:scale-[0.97]"
             >
               <Play size={17} fill="currentColor" />
@@ -402,7 +436,11 @@ function CinemaSlide({
             >
               <Info size={16} strokeWidth={2} />
               {t("More info")}
-              <ChevronRight size={15} strokeWidth={2} className="dir-icon opacity-65" />
+              <ChevronRight
+                size={15}
+                strokeWidth={2}
+                className="dir-icon opacity-65"
+              />
             </button>
           </div>
         </div>
@@ -444,7 +482,10 @@ function CinemaTitlePlate({
       ) : resolved ? (
         <h2
           className="font-display text-[72px] font-medium leading-[0.95] tracking-tight text-ink"
-          style={{ animation: "harbor-fade-in 420ms cubic-bezier(0.32, 0.72, 0.24, 1) both" }}
+          style={{
+            animation:
+              "harbor-fade-in 420ms cubic-bezier(0.32, 0.72, 0.24, 1) both",
+          }}
         >
           {name}
         </h2>

--- a/src/components/critics-pick.tsx
+++ b/src/components/critics-pick.tsx
@@ -85,7 +85,8 @@ export function CriticsPick({ meta }: { meta: Meta }) {
       return;
     }
     let cancelled = false;
-    tmdbMovieImages(settings.tmdbKey, meta.id)
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
+    tmdbMovieImages(settings.tmdbKey, meta.id, langArg)
       .then((urls) => !cancelled && setStills(urls))
       .catch(() => !cancelled && setStills([]));
     return () => {

--- a/src/components/featured-banner/side-panel.tsx
+++ b/src/components/featured-banner/side-panel.tsx
@@ -31,7 +31,8 @@ export function SidePanel({
       return;
     }
     let cancelled = false;
-    tmdbMovieImages(settings.tmdbKey, meta.id)
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
+    tmdbMovieImages(settings.tmdbKey, meta.id, langArg)
       .then((urls) => {
         if (cancelled) return;
         setStills(urls);

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -161,8 +161,9 @@ export const Hero = memo(function Hero({
     }
     if (!bgResolved) {
       const isTmdb = meta.id.startsWith("tmdb:");
+      const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
       const bg: Promise<string | undefined> = isTmdb
-        ? tmdbMovieImages(settings.tmdbKey, meta.id).then((urls) => urls[0])
+        ? tmdbMovieImages(settings.tmdbKey, meta.id, langArg).then((urls) => urls[0])
         : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.background);
       bg.then((b) => {
         if (cancelled) return;
@@ -416,7 +417,7 @@ export const Hero = memo(function Hero({
             }}
           />
           {description && (
-            <p className="mt-6 line-clamp-3 max-w-xl text-[16px] leading-relaxed text-ink-muted">
+            <p dir="auto" className="mt-6 line-clamp-3 max-w-xl text-[16px] leading-relaxed text-ink-muted">
               {description}
             </p>
           )}

--- a/src/components/peek-hero.tsx
+++ b/src/components/peek-hero.tsx
@@ -207,8 +207,9 @@ function PeekSlide({
     if (logo) return;
     let cancelled = false;
     const isTmdb = meta.id.startsWith("tmdb:");
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
     const lookup = isTmdb
-      ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
+      ? tmdbLogo(settings.tmdbKey, meta.id, langArg)
       : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
     lookup
       .then((url) => {

--- a/src/lib/logo.ts
+++ b/src/lib/logo.ts
@@ -11,7 +11,7 @@ import { fetchTvdbArtwork } from "@/lib/providers/tvdb-proxy";
 import { tmdbAnimeLogo, tmdbIdFromImdb, tmdbImdbId, tmdbLogo } from "@/lib/providers/tmdb";
 import { shouldLocalizePosters } from "@/lib/providers/tmdb/tmdb-image-lang";
 import { getTitleLogo } from "@/lib/title-logo";
-
+import { loadStoredSettings } from "@/lib/settings/load";
 const CACHE_MAX = 1200;
 const cache = new Map<string, string | undefined>();
 const inflight = new Map<string, Promise<string | undefined>>();
@@ -23,10 +23,13 @@ registerEvictable("logo", () => {
   inflight.clear();
 });
 
+
 const isAnimeLogoId = (id: string) => /^(kitsu|mal|anilist|anidb):/.test(id);
 
 function preferTmdbLogo(tmdbKey: string, meta: Meta): boolean {
   if (!tmdbKey || !shouldLocalizePosters()) return false;
+  const settings = loadStoredSettings();
+  if (!settings.heroLocalizedMetadata) return false;
   return meta.id.startsWith("tt") || meta.id.startsWith("tmdb:");
 }
 

--- a/src/lib/providers/tmdb/tmdb-images.ts
+++ b/src/lib/providers/tmdb/tmdb-images.ts
@@ -95,8 +95,8 @@ export async function tmdbDefaultPoster(key: string, metaId: string): Promise<st
   return url;
 }
 
-export async function tmdbMovieImages(key: string, metaId: string): Promise<string[]> {
-  const data = await fetchMovieAssets(key, metaId);
+export async function tmdbMovieImages(key: string, metaId: string, originalLang?: string | null): Promise<string[]> {
+  const data = await fetchMovieAssets(key, metaId, originalLang);
   const seen = new Set<string>();
   const out: string[] = [];
   for (const b of (data?.backdrops ?? []).sort(

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -102,6 +102,7 @@ export const DEFAULT: Settings = {
   heroShadow: 100,
   heroFull: false,
   heroFullQuality: true,
+  heroLocalizedMetadata: true,
   heroFeed: "trending",
   heroTrailers: false,
   heroTrailerAudio: false,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -152,6 +152,7 @@ export type Settings = {
   heroShadow: number;
   heroFull: boolean;
   heroFullQuality: boolean;
+  heroLocalizedMetadata: boolean;
   heroFeed: "trending" | "trakt" | "simkl" | "classic";
   heroTrailers: boolean;
   heroTrailerAudio: boolean;

--- a/src/lib/use-localized-overview.ts
+++ b/src/lib/use-localized-overview.ts
@@ -1,24 +1,38 @@
 import { useEffect, useState } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import { tmdbMetadataOverview } from "@/lib/providers/tmdb/tmdb-lite";
+import { tmdbIdFromImdb } from "@/lib/providers/tmdb/tmdb-imdb-resolve";
 import { useSettings } from "@/lib/settings";
 
 export function useLocalizedOverview(meta: Meta): string | undefined {
   const { settings } = useSettings();
-  const isTmdb = meta.id.startsWith("tmdb:");
-  const [overview, setOverview] = useState<string | undefined>(
-    isTmdb ? undefined : meta.description,
-  );
+  const [overview, setOverview] = useState<string | undefined>(meta.description);
+
   useEffect(() => {
-    if (!isTmdb || !settings.tmdbKey) {
+    if (!settings.tmdbKey || !settings.heroLocalizedMetadata) {
       setOverview(meta.description);
       return;
     }
-    setOverview(undefined);
     let alive = true;
-    void tmdbMetadataOverview(settings.tmdbKey, meta.id).then((o) => {
+    const fetchOverview = async () => {
+      let tmdbId = meta.id;
+      if (tmdbId.startsWith("tt")) {
+        const resolved = await tmdbIdFromImdb(settings.tmdbKey, tmdbId);
+        if (resolved) {
+          tmdbId = resolved;
+        } else {
+          if (alive) setOverview(meta.description);
+          return;
+        }
+      } else if (!tmdbId.startsWith("tmdb:")) {
+        if (alive) setOverview(meta.description);
+        return;
+      }
+      const o = await tmdbMetadataOverview(settings.tmdbKey, tmdbId);
       if (alive) setOverview(o ?? meta.description);
-    });
+    };
+
+    fetchOverview();
     return () => {
       alive = false;
     };

--- a/src/views/kids/kids-hero.tsx
+++ b/src/views/kids/kids-hero.tsx
@@ -72,8 +72,9 @@ function KidsHeroCard({
     if (logo) return;
     let cancelled = false;
     const isTmdb = meta.id.startsWith("tmdb:");
+    const langArg = settings.heroLocalizedMetadata ? meta.originalLanguage : undefined;
     const lookup = isTmdb
-      ? tmdbLogo(settings.tmdbKey, meta.id, meta.originalLanguage)
+      ? tmdbLogo(settings.tmdbKey, meta.id, langArg)
       : fetchMeta(narrowMediaType(meta.type), meta.id).then((full) => full?.logo);
     lookup
       .then((url) => {

--- a/src/views/settings/theme-panel/display-section.tsx
+++ b/src/views/settings/theme-panel/display-section.tsx
@@ -218,6 +218,12 @@ export function DisplaySection() {
           onChange={(v) => update({ heroFullQuality: v })}
         />
         <ToggleRow
+          label={t("Localized hero metadata")}
+          sub={t("Prioritize original language artwork and localized descriptions for the featured title.")}
+          value={settings.heroLocalizedMetadata}
+          onChange={(v) => update({ heroLocalizedMetadata: v })}
+        />
+        <ToggleRow
           label={t("Play trailers in the hero")}
           newId="theme:hero-video"
           sub={t("After a moment on a slide, the featured title's trailer plays muted in the background. Uses more bandwidth.")}


### PR DESCRIPTION
Adds a "Localized hero metadata" toggle in the Home settings that allows users to prioritize original-language backdrops, logos, and localized descriptions for the featured title. When disabled, it falls back to the default English artwork and text.
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/de6a8e83-20ef-422c-ba36-0058291e762d" />
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/dd3c65a7-422a-41f3-bb9d-c3c53329b0d9" />
<img width="759" height="511" alt="image" src="https://github.com/user-attachments/assets/3b779c7b-a99b-45c8-a92a-95785a8166d1" />