### PR TITLE
fix(bug): separate TMDB metadata and artwork languages and localize IMDb catalog posters

### DIFF
--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -133,7 +133,18 @@ export function usePosterChain(
       }
     }
     return out;
-  }, [rpdbKey, metaId, altId, metaPoster, animeImdb, animeTvdb, animeTmdb, localized, pending, pinned]);
+  }, [
+    rpdbKey,
+    metaId,
+    altId,
+    metaPoster,
+    animeImdb,
+    animeTvdb,
+    animeTmdb,
+    localized,
+    pending,
+    pinned,
+  ]);
   const sig = candidates.join("|");
   const failedRef = useRef<Set<string>>(new Set());
   const sigRef = useRef(sig);
@@ -245,7 +256,9 @@ export function Poster({
   }, [inView, qMult, ratio]);
   const rawCandidates = [src, ...(fallbacks ?? [])].filter((u): u is string => !!u);
   const candidates =
-    qMult === 0 || targetPx <= 0 ? rawCandidates : rawCandidates.map((u) => sizeImageUrl(u, targetPx));
+    qMult === 0 || targetPx <= 0
+      ? rawCandidates
+      : rawCandidates.map((u) => sizeImageUrl(u, targetPx));
   const sig = candidates.join("|");
   const [idx, setIdx] = useState(0);
   const [loaded, setLoaded] = useState(false);
@@ -419,7 +432,10 @@ export function Poster({
           style={
             effect === "off"
               ? { opacity: 1 }
-              : { opacity: loaded ? 1 : 0, transition: hasBase ? "opacity 300ms ease-out" : undefined }
+              : {
+                  opacity: loaded ? 1 : 0,
+                  transition: hasBase ? "opacity 300ms ease-out" : undefined,
+                }
           }
         />
       )}

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -21,11 +21,17 @@ export function useLocalizedPoster(metaId: string): string | undefined {
   const [url, setUrl] = useState<string | undefined>(undefined);
   useEffect(() => {
     setUrl(undefined);
-    if (!settings.tmdbKey || !metaId.startsWith("tmdb:") || !shouldLocalizePosters()) return;
+    const canResolve = metaId.startsWith("tmdb:") || metaId.startsWith("tt");
+    if (!settings.tmdbKey || !canResolve || !shouldLocalizePosters()) return;
     let alive = true;
-    void tmdbLocalizedPoster(settings.tmdbKey, metaId).then((u) => {
-      if (alive && u) setUrl(u);
-    });
+    void (async () => {
+      const tmdbId = metaId.startsWith("tmdb:")
+        ? metaId
+        : await tmdbIdFromImdb(settings.tmdbKey, metaId);
+      if (!tmdbId) return;
+      const localized = await tmdbLocalizedPoster(settings.tmdbKey, tmdbId);
+      if (alive && localized) setUrl(localized);
+    })();
     return () => {
       alive = false;
     };

--- a/src/lib/providers/tmdb/tmdb-client.ts
+++ b/src/lib/providers/tmdb/tmdb-client.ts
@@ -1,6 +1,5 @@
 import { safeFetch } from "@/lib/safe-fetch";
 import { createRequestScheduler } from "@/lib/request-scheduler";
-import { imageRequestLang } from "./tmdb-image-lang";
 
 export const TMDB = "https://api.themoviedb.org/3";
 export const IMG = "https://image.tmdb.org/t/p";
@@ -98,7 +97,7 @@ export async function get<T>(
   if (!key) return null;
   const url = new URL(`${TMDB}/${path}`);
   url.searchParams.set("api_key", key);
-  const lang = effectiveTmdbLanguage() || imageRequestLang();
+  const lang = effectiveTmdbLanguage();
   if (lang && !params.language) url.searchParams.set("language", lang);
   for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   const target = url.toString();

--- a/src/lib/providers/tmdb/tmdb-client.ts
+++ b/src/lib/providers/tmdb/tmdb-client.ts
@@ -26,9 +26,13 @@ function logTmdbFailure(path: string, status: number, body: string): void {
   if (now - lastFailureLogged < 1000) return;
   lastFailureLogged = now;
   if (status === 401) {
-    console.warn(`[tmdb] 401 unauthorized on ${path} — TMDB key invalid or revoked. ${body.slice(0, 200)}`);
+    console.warn(
+      `[tmdb] 401 unauthorized on ${path} — TMDB key invalid or revoked. ${body.slice(0, 200)}`,
+    );
   } else if (status === 429) {
-    console.warn(`[tmdb] 429 rate-limited on ${path} — TMDB throttling this IP/key. ${body.slice(0, 200)}`);
+    console.warn(
+      `[tmdb] 429 rate-limited on ${path} — TMDB throttling this IP/key. ${body.slice(0, 200)}`,
+    );
   } else if (status === 404) {
     console.warn(`[tmdb] 404 not found on ${path} — TMDB does not have this resource.`);
   } else {
@@ -106,7 +110,8 @@ export async function get<T>(
       const backoffMs = Math.min(2000, 250 * 2 ** attempt);
       const { status, data } = await tmdbRequests.schedule(target, async () => {
         const result = await fetchTmdbOnce<T>(target, path);
-        if (result.status === 429 || (result.status >= 500 && result.status < 600)) tmdbRequests.pauseFor(backoffMs);
+        if (result.status === 429 || (result.status >= 500 && result.status < 600))
+          tmdbRequests.pauseFor(backoffMs);
         return result;
       });
       if (status === 429 || (status >= 500 && status < 600)) {

--- a/tests/tmdb-language-separation.test.ts
+++ b/tests/tmdb-language-separation.test.ts
@@ -1,0 +1,29 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+const clientSource = readFileSync(
+  new URL("../src/lib/providers/tmdb/tmdb-client.ts", import.meta.url),
+  "utf8",
+);
+const detailsSource = readFileSync(
+  new URL("../src/lib/providers/tmdb/tmdb-details.ts", import.meta.url),
+  "utf8",
+);
+const imagesSource = readFileSync(
+  new URL("../src/lib/providers/tmdb/tmdb-images.ts", import.meta.url),
+  "utf8",
+);
+test("TMDB metadata requests never fall back to the artwork language", () => {
+  assert.match(clientSource, /const lang = effectiveTmdbLanguage\(\);/);
+  assert.doesNotMatch(clientSource, /imageRequestLang/);
+  assert.match(clientSource, /if \(lang && !params\.language\)/);
+});
+
+test("TMDB artwork requests keep their independent language preference", () => {
+  assert.match(detailsSource, /include_image_language: imageLangParam\(\)/);
+  assert.match(imagesSource, /include_image_language: imageLangParam\(originalLang\)/);
+});

--- a/tests/tmdb-language-separation.test.ts
+++ b/tests/tmdb-language-separation.test.ts
@@ -17,6 +17,10 @@ const imagesSource = readFileSync(
   new URL("../src/lib/providers/tmdb/tmdb-images.ts", import.meta.url),
   "utf8",
 );
+const posterSource = readFileSync(
+  new URL("../src/components/poster.tsx", import.meta.url),
+  "utf8",
+);
 test("TMDB metadata requests never fall back to the artwork language", () => {
   assert.match(clientSource, /const lang = effectiveTmdbLanguage\(\);/);
   assert.doesNotMatch(clientSource, /imageRequestLang/);
@@ -26,4 +30,10 @@ test("TMDB metadata requests never fall back to the artwork language", () => {
 test("TMDB artwork requests keep their independent language preference", () => {
   assert.match(detailsSource, /include_image_language: imageLangParam\(\)/);
   assert.match(imagesSource, /include_image_language: imageLangParam\(originalLang\)/);
+});
+
+test("IMDb-based catalogs resolve through TMDB before selecting localized posters", () => {
+  assert.match(posterSource, /metaId\.startsWith\("tmdb:"\) \|\| metaId\.startsWith\("tt"\)/);
+  assert.match(posterSource, /await tmdbIdFromImdb\(settings\.tmdbKey, metaId\)/);
+  assert.match(posterSource, /tmdbLocalizedPoster\(settings\.tmdbKey, tmdbId\)/);
 });

--- a/tests/tmdb-language-separation.test.ts
+++ b/tests/tmdb-language-separation.test.ts
@@ -17,10 +17,7 @@ const imagesSource = readFileSync(
   new URL("../src/lib/providers/tmdb/tmdb-images.ts", import.meta.url),
   "utf8",
 );
-const posterSource = readFileSync(
-  new URL("../src/components/poster.tsx", import.meta.url),
-  "utf8",
-);
+const posterSource = readFileSync(new URL("../src/components/poster.tsx", import.meta.url), "utf8");
 test("TMDB metadata requests never fall back to the artwork language", () => {
   assert.match(clientSource, /const lang = effectiveTmdbLanguage\(\);/);
   assert.doesNotMatch(clientSource, /imageRequestLang/);


### PR DESCRIPTION
## Summary

This PR fixes two language-related bugs:

- The selected image language could affect TMDB titles and metadata. Metadata requests now use only the configured metadata language, while image language is limited to posters and backdrops.
- Localized posters did not work for catalogs using IMDb IDs, such as Letterboxd. IMDb IDs are now resolved to TMDB IDs before requesting localized artwork.

For example, selecting English metadata and Arabic images now keeps titles and descriptions in English while using Arabic posters when available.

Regression tests were added to ensure metadata and artwork languages remain independent and IMDb-based catalogs receive the correct localized posters.