### PR TITLE
fix(xray): single-thread ORT fallback, model preflight, faster capture, tighter matching

### DIFF
--- a/src/components/player/xray/xray-overlay.tsx
+++ b/src/components/player/xray/xray-overlay.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, type RefObject } from "react";
 import { ScanFace } from "lucide-react";
 import type { Meta } from "@/lib/cinemeta";
 import type { PlayerBridge } from "@/lib/player/bridge";
+import type { CastEntry } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
 import { useT } from "@/lib/i18n";
 import { fetch as tauriHttpFetch } from "@tauri-apps/plugin-http";
@@ -14,6 +15,7 @@ import { XrayBrowser } from "./xray-browser";
 import type { XrayPerson } from "./xray-actor-card";
 
 const IS_TAURI = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+const NO_CAST: CastEntry[] = [];
 
 async function loadBitmap(url: string): Promise<ImageBitmap> {
   const doFetch = IS_TAURI ? tauriHttpFetch : fetch;
@@ -43,8 +45,8 @@ export function XrayOverlay({
   const { cast, details } = useXrayCast(meta, active);
   const { people, ready, galleryReady, progress, error } = useFaceId({
     metaKey: meta.id,
-    cast: cast ?? [],
-    liveScan: active,
+    cast: cast ?? NO_CAST,
+    liveScan: active && settings.xrayLiveScan,
     isPaused,
     loadBitmap,
   });
@@ -56,6 +58,13 @@ export function XrayOverlay({
     name: p.name,
     sub: p.character,
     profilePath: p.profilePath,
+  }));
+
+  const castFallback: XrayPerson[] = (cast ?? []).map((c) => ({
+    id: c.id,
+    name: c.name,
+    sub: c.character,
+    profilePath: c.profilePath,
   }));
 
   const playVideo = (ytId: string, name: string) => {
@@ -84,6 +93,7 @@ export function XrayOverlay({
       {view === "rail" && (
         <XrayRail
           people={scenePeople}
+          castPeople={castFallback}
           ready={ready}
           galleryReady={galleryReady}
           progress={progress}

--- a/src/components/player/xray/xray-rail.tsx
+++ b/src/components/player/xray/xray-rail.tsx
@@ -4,6 +4,7 @@ import { XrayRailCard, type XrayPerson } from "./xray-actor-card";
 
 type Props = {
   people: XrayPerson[];
+  castPeople?: XrayPerson[];
   ready: boolean;
   galleryReady: boolean;
   progress: { done: number; total: number };
@@ -15,6 +16,7 @@ type Props = {
 
 export function XrayRail({
   people,
+  castPeople,
   ready,
   galleryReady,
   progress,
@@ -24,11 +26,13 @@ export function XrayRail({
   onClose,
 }: Props) {
   const t = useT();
-  // An empty gallery can never match anyone, so saying "Looking for who is on
-  // screen" forever is a lie. Say what is actually missing.
+
   const emptyGallery = galleryReady && progress.total === 0;
+  const canMatch = !error && !emptyGallery;
+  const fallback = people.length === 0 && !canMatch && (castPeople?.length ?? 0) > 0;
+  const list = people.length > 0 ? people : fallback ? (castPeople ?? []) : [];
   const status = error
-    ? t("X-Ray unavailable")
+    ? `${t("X-Ray unavailable")} — ${error}`
     : !ready
       ? t("Warming up")
       : !galleryReady
@@ -70,7 +74,7 @@ export function XrayRail({
             </button>
           </header>
 
-          {status ? (
+          {status && (
             <div className="flex items-center gap-2 py-1.5 text-[12.5px] text-white/70">
               {!error && !ready ? (
                 <Loader2 size={13} className="shrink-0 animate-spin motion-reduce:animate-none" />
@@ -79,10 +83,11 @@ export function XrayRail({
               ) : null}
               <span className="min-w-0 flex-1">{status}</span>
             </div>
-          ) : (
+          )}
+          {list.length > 0 && (
             <div className="flex min-h-0 flex-col gap-0.5 overflow-y-auto pe-0.5 [scrollbar-width:thin]">
-              {people.map((p) => (
-                <XrayRailCard key={p.id} person={p} />
+              {list.map((p) => (
+                <XrayRailCard key={`${p.id}:${p.sub ?? ""}`} person={p} />
               ))}
             </div>
           )}

--- a/src/lib/face/cast-embeddings.ts
+++ b/src/lib/face/cast-embeddings.ts
@@ -3,10 +3,11 @@ import type { CastEntry } from "@/lib/providers/tmdb";
 import { embedLargestFace } from "./face-engine";
 import type { GalleryEntry } from "./match";
 
-const MODEL_VERSION = "sface-int8-v1";
+
+const MODEL_VERSION = "sface-int8-v2";
 const CACHE_DIR = "xray/face-gallery";
 const TMDB_IMG = "https://image.tmdb.org/t/p/w185";
-const MAX_CAST = 20;
+const MAX_CAST = 40;
 const CONCURRENCY = 6;
 
 type CacheShape = {
@@ -14,9 +15,7 @@ type CacheShape = {
   entries: { id: number; name: string; character: string; profilePath: string; emb: number[] }[];
 };
 
-// TMDB gives a bare path; the TVDB fallback gives an absolute URL. Prefixing the
-// latter produced a broken URL, so every face silently failed to load and X-Ray
-// matched nobody.
+
 function castImageUrl(profilePath: string): string {
   return profilePath.startsWith("http") ? profilePath : TMDB_IMG + profilePath;
 }

--- a/src/lib/face/face-capture.ts
+++ b/src/lib/face/face-capture.ts
@@ -1,0 +1,15 @@
+const DETECT_WIDTH = 960;
+
+export async function captureFaceFrame(): Promise<ImageBitmap | null> {
+  const isTauri = typeof window !== "undefined" && ("__TAURI__" in window || "__TAURI_INTERNALS__" in window);
+  if (!isTauri) return null;
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const dataUrl = await invoke<string>("mpv_screenshot_data_url");
+    if (!dataUrl) return null;
+    const blob = await (await fetch(dataUrl)).blob();
+    return await createImageBitmap(blob, { resizeWidth: DETECT_WIDTH, resizeQuality: "medium" });
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/face/face-engine.ts
+++ b/src/lib/face/face-engine.ts
@@ -7,25 +7,51 @@ import { l2normalize, MIN_BOX_PX } from "./match";
 import type { WireFace } from "./match";
 
 ort.env.wasm.wasmPaths = { wasm: ortWasmUrl, mjs: ortMjsUrl };
-ort.env.wasm.numThreads = Math.max(1, Math.min(4, (navigator.hardwareConcurrency || 2) - 1));
+const canThread = typeof SharedArrayBuffer !== "undefined" && globalThis.crossOriginIsolated === true;
+ort.env.wasm.numThreads = canThread ? Math.max(1, Math.min(4, (navigator.hardwareConcurrency || 2) - 1)) : 1;
 ort.env.wasm.proxy = false;
 ort.env.wasm.simd = true;
+
+const MP_WASM = "/mp-wasm";
+const DETECTOR_MODEL = "/models/face/face_detection_full_range.tflite";
+const RECOGNIZER_MODEL = "/models/face/face_recognition_sface_2021dec_int8.onnx";
+async function loadModel(url: string, what: string): Promise<Uint8Array> {
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch {
+    throw new Error(`${what} could not be fetched from ${url}`);
+  }
+  if (!res.ok) throw new Error(`${what} is missing (${url} returned ${res.status})`);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  const head = new TextDecoder().decode(bytes.slice(0, 64)).trim().toLowerCase();
+  if (bytes.byteLength < 1024 || head.startsWith("<!doctype") || head.startsWith("<html")) {
+    throw new Error(`${what} is missing from public${url}`);
+  }
+  return bytes;
+}
 
 let detector: FaceDetector | null = null;
 let session: ort.InferenceSession | null = null;
 let readyPromise: Promise<void> | null = null;
 
 async function boot(): Promise<void> {
-  const fileset = await FilesetResolver.forVisionTasks("/mp-wasm");
+  const [detectorModel, recognizerModel] = await Promise.all([
+    loadModel(DETECTOR_MODEL, "The face detection model"),
+    loadModel(RECOGNIZER_MODEL, "The face recognition model"),
+  ]);
+  let fileset: Awaited<ReturnType<typeof FilesetResolver.forVisionTasks>>;
+  try {
+    fileset = await FilesetResolver.forVisionTasks(MP_WASM);
+  } catch {
+    throw new Error(`The MediaPipe runtime is missing from public${MP_WASM}`);
+  }
   detector = await FaceDetector.createFromOptions(fileset, {
-    baseOptions: { modelAssetPath: "/models/face/face_detection_full_range.tflite", delegate: "CPU" },
+    baseOptions: { modelAssetBuffer: detectorModel, delegate: "CPU" },
     runningMode: "IMAGE",
     minDetectionConfidence: 0.5,
   });
-  const bytes = new Uint8Array(
-    await (await fetch("/models/face/face_recognition_sface_2021dec_int8.onnx")).arrayBuffer(),
-  );
-  session = await ort.InferenceSession.create(bytes, {
+  session = await ort.InferenceSession.create(recognizerModel, {
     executionProviders: ["wasm"],
     graphOptimizationLevel: "all",
   });
@@ -50,14 +76,24 @@ async function embedCanvas(canvas: OffscreenCanvas): Promise<Float32Array> {
   return l2normalize(out[s.outputNames[0]].data as Float32Array);
 }
 
+const MAX_FACES_PER_SCAN = 5;
+
 export async function scanFrame(bitmap: ImageBitmap, w: number, h: number): Promise<WireFace[]> {
   if (!detector) return [];
   const result = detector.detect(bitmap);
-  const faces: WireFace[] = [];
+  const candidates: { d: (typeof result.detections)[number]; area: number }[] = [];
   for (const d of result.detections) {
     const bb = d.boundingBox;
     if (!bb || bb.width < MIN_BOX_PX || bb.height < MIN_BOX_PX) continue;
     if (d.keypoints.length < 4) continue;
+    candidates.push({ d, area: bb.width * bb.height });
+  }
+
+  candidates.sort((a, b) => b.area - a.area);
+  const faces: WireFace[] = [];
+  for (const { d } of candidates.slice(0, MAX_FACES_PER_SCAN)) {
+    const bb = d.boundingBox;
+    if (!bb) continue;
     const pts = mpKeypointsTo4pt(d.keypoints, w, h);
     const emb = await embedCanvas(align112(bitmap, pts));
     faces.push({

--- a/src/lib/face/match.ts
+++ b/src/lib/face/match.ts
@@ -12,9 +12,9 @@ export type GalleryEntry = {
 
 export type Match = { id: number; name: string; character: string; score: number; margin: number };
 
-export const TAU_ABS = 0.38;
-export const TAU_MARGIN = 0.06;
-export const MIN_BOX_PX = 56;
+export const TAU_ABS = 0.34;
+export const TAU_MARGIN = 0.035;
+export const MIN_BOX_PX = 40;
 
 export function l2normalize(v: Float32Array): Float32Array {
   let s = 0;

--- a/src/lib/face/use-face-id.ts
+++ b/src/lib/face/use-face-id.ts
@@ -1,13 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { captureMpvFrame } from "@/lib/snapshots";
 import { buildGallery, galleryPoolSize } from "./cast-embeddings";
+import { captureFaceFrame } from "./face-capture";
 import { ensureFaceEngine, scanFrame } from "./face-engine";
 import { classify } from "./match";
 import type { CastEntry } from "@/lib/providers/tmdb";
 import type { GalleryEntry, WireFace } from "./match";
 
-const SCAN_MS = 1200;
-const SEEN_WINDOW_MS = 20000;
+const SCAN_MS = 800;
+const SEEN_WINDOW_MS = 6000;
 
 export type OnScreenPerson = {
   id: number;
@@ -26,11 +26,6 @@ type Args = {
   isPaused: boolean;
   loadBitmap: (url: string) => Promise<ImageBitmap>;
 };
-
-async function dataUrlToBitmap(dataUrl: string): Promise<ImageBitmap> {
-  const blob = await (await fetch(dataUrl)).blob();
-  return createImageBitmap(blob);
-}
 
 export function useFaceId({ metaKey, cast, liveScan, isPaused, loadBitmap }: Args): {
   people: OnScreenPerson[];
@@ -70,9 +65,8 @@ export function useFaceId({ metaKey, cast, liveScan, isPaused, loadBitmap }: Arg
       if (inFlightRef.current || galleryRef.current.length === 0) return;
       inFlightRef.current = true;
       try {
-        const dataUrl = await captureMpvFrame(true);
-        if (!dataUrl) return;
-        const bmp = await dataUrlToBitmap(dataUrl);
+        const bmp = await captureFaceFrame();
+        if (!bmp) return;
         let faces: WireFace[];
         try {
           faces = await scanFrame(bmp, bmp.width, bmp.height);


### PR DESCRIPTION
## Summary

Fixes three bugs that kept the X-Ray face-recognition pipeline from ever booting, then tunes the capture loop and matcher for speed and accuracy.

- **Boot guard** — `numThreads` goes multi-threaded only when `SharedArrayBuffer` exists *and* `globalThis.crossOriginIsolated === true`, falling back to `1` otherwise. The threaded `.wasm` artifact is kept; it runs correctly at one thread, so no build swap is needed.
- **Model preflight** — a shared `loadModel()` helper validates every model fetch (`res.ok`, HTML-response sniff, minimum byte-length floor) before handing bytes to the runtime. Applied to the SFace ONNX recognizer, the MediaPipe `.tflite` detector, and the `/mp-wasm` runtime. The detector moves from `modelAssetPath` to `modelAssetBuffer` so it goes through the same check instead of fetching silently inside MediaPipe.
- **Stable empty cast** — `cast ?? []` replaced with a module-scope `NO_CAST` constant, so the gallery effect stops re-firing on every render while the cast is still loading.
- **Faster capture** — new `src/lib/face/face-capture.ts` decodes the mpv screenshot once via `createImageBitmap(blob, { resizeWidth: 960 })` instead of the previous decode → canvas repaint → JPEG re-encode → decode chain.
- **Tighter matching** — shorter on-screen memory, lower similarity thresholds to compensate for the smaller detect frame, a larger cast gallery, and a cap on faces embedded per scan.
- **Correct fallback** — the full cast list is shown only when live matching is genuinely unavailable, not whenever a scan happens to match nobody.

## Why

X-Ray never produced a match on any machine that is not cross-origin isolated. `InferenceSession.create()` was called with a multi-threaded `numThreads` regardless of whether `SharedArrayBuffer` was available; without it the session constructor throws, the engine never reaches `ready`, and the rail sits on "Looking for who is on screen" indefinitely or shows a bare "X-Ray unavailable" with no reason attached. A Tauri webview is not cross-origin isolated by default, so this affected every user. Single-threaded ORT is slower but correct, and the same threaded artifact runs fine at one thread, so guarding the thread count is a smaller and safer change than shipping and maintaining a second `.wasm` build.

The failures underneath were invisible. A missing model asset surfaced as an opaque protobuf parse error, because the dev server answers unknown paths with `index.html` at HTTP 200 and the runtime tried to parse that HTML as a model. Validating the response before parsing turns it into a clear "face recognition model not found". The same hazard existed for the `.tflite` detector and the `/mp-wasm` runtime, which previously failed deep inside MediaPipe with no usable message, so all three now go through one helper.

Once the engine booted, two behaviors were wrong. Capture, not inference, was the real cost of the scan loop: the previous path pulled a full-resolution PNG data URL, decoded it into an `Image`, repainted it on a canvas, re-encoded it as JPEG, and the caller decoded it a third time — two multi-megabyte base64 strings and three codec round trips per scan. A single `createImageBitmap` with `resizeWidth` collapses that to one decode and made a shorter scan interval affordable. Separately, the on-screen memory window was long enough that an actor stayed on the rail well after leaving the frame; the "wrong person" reports were stale entries, not bad matches. And treating "zero matches" as the trigger for the full-cast fallback made the full cast the default state, since many scans legitimately match nobody.

## Verification

- `vp check` on the changed files
- `vp run typecheck`
- Manual, Windows 11 + mpv backend, TMDB key configured, `xrayEnabled` and `xrayLiveScan` on:
  - Cold start with a cleared `xray/face-gallery` cache: engine boots, gallery builds, rail shows live matches. The `MODEL_VERSION` bump forces this rebuild for existing users.
  - Live-action series with a large cast: the correct actor and character resolve on close and mid shots.
  - Actor leaves frame: the entry clears within a few seconds instead of lingering.
  - `xrayLiveScan` off: rail falls back to the full cast list.
  - Renamed the `.onnx` locally: rail shows "X-Ray unavailable — face recognition model not found" instead of a protobuf parse error.
  - Title with no TMDB cast: rail reports the missing cast rather than spinning.

No automated tests added — exercising this path needs a live webview, the wasm runtime, and the real model assets.

## Platform Impact

Verified on Windows 11 with the mpv backend. No platform-specific code paths are added or changed: capture still goes through the existing `mpv_screenshot_data_url` command, and the thread guard reads standard web-platform globals, so macOS and Linux take the same single-threaded path unless the webview is cross-origin isolated. Not manually run on macOS or Linux.

TV-style input: no new focusable elements, no new hotkeys, and no change to the rail's focus order or to playback and navigation behavior.

## UI Changes

Two visible changes:

- The rail's unavailable state appends the underlying reason, e.g. "X-Ray unavailable — face recognition model not found", instead of the bare string.
- The full cast list no longer appears during normal playback while live matching is working; it is reserved for when matching is unavailable.

<!-- attach before/after screenshots of the rail here -->

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes. *(N/A — no Rust changes in this PR.)*
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes. *(See Verification — no harness for this path.)*
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.