### PR TITLE
fix(player): apply picture presets as fixed settings, not cumulative

### DIFF
--- a/src/views/settings/mpv-panel/dials.tsx
+++ b/src/views/settings/mpv-panel/dials.tsx
@@ -53,7 +53,9 @@ export function TweakSlider({
   const active = raw != null && raw !== "" && parseFloat(raw) !== def;
   return (
     <div className={`flex items-center px-1 py-1.5 ${compact ? "gap-2.5" : "gap-4"}`}>
-      <span className={`shrink-0 font-medium text-ink ${compact ? "w-[76px] text-[12.5px]" : "w-36 text-[13.5px]"}`}>
+      <span
+        className={`shrink-0 font-medium text-ink ${compact ? "w-[76px] text-[12.5px]" : "w-36 text-[13.5px]"}`}
+      >
         {label}
       </span>
       <input
@@ -87,7 +89,11 @@ export function TweakSlider({
   );
 }
 
-export const PICTURE_TEMPLATES: Array<{ label: string; sub: string; patch: Record<string, string | null> }> = [
+export const PICTURE_TEMPLATES: Array<{
+  label: string;
+  sub: string;
+  patch: Record<string, string | null>;
+}> = [
   {
     label: "Brighten dark movies",
     sub: "Lifts shadows so the pitch-black scenes are actually watchable.",
@@ -112,6 +118,11 @@ export const PICTURE_TEMPLATES: Array<{ label: string; sub: string; patch: Recor
 
 export const PICTURE_KEYS = ["brightness", "contrast", "saturation", "gamma", "sharpen"];
 
+// Clears every picture dial. Presets spread this first so each one lands on a
+// clean slate: patches only carry the keys they change, so without it applying
+// a preset would merge into whatever the previous preset left behind.
+const PICTURE_RESET: Record<string, null> = Object.fromEntries(PICTURE_KEYS.map((k) => [k, null]));
+
 export function PictureDialsSection() {
   const t = useT();
   const { tweaks, setTweak, applyPatch } = useTweaks();
@@ -119,7 +130,9 @@ export function PictureDialsSection() {
   return (
     <Section
       title={t("Picture adjustments")}
-      subtitle={t("Nudge the image to taste. Start with a one-tap look below, then fine-tune with the dials. Everything resets cleanly, so you can't break anything.")}
+      subtitle={t(
+        "Nudge the image to taste. Start with a one-tap look below, then fine-tune with the dials. Everything resets cleanly, so you can't break anything.",
+      )}
     >
       <div className="flex flex-wrap gap-2">
         {PICTURE_TEMPLATES.map((tpl) => (
@@ -127,7 +140,7 @@ export function PictureDialsSection() {
             key={tpl.label}
             type="button"
             title={t(tpl.sub)}
-            onClick={() => applyPatch(tpl.patch)}
+            onClick={() => applyPatch({ ...PICTURE_RESET, ...tpl.patch })}
             className="rounded-full border border-edge-soft bg-canvas/40 px-3.5 py-1.5 text-[12.5px] font-semibold text-ink-muted transition-colors hover:border-edge hover:text-ink"
           >
             {t(tpl.label)}
@@ -136,7 +149,7 @@ export function PictureDialsSection() {
         {anyActive && (
           <button
             type="button"
-            onClick={() => applyPatch(Object.fromEntries(PICTURE_KEYS.map((k) => [k, null])))}
+            onClick={() => applyPatch(PICTURE_RESET)}
             className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12.5px] font-semibold text-ink-subtle transition-colors hover:text-ink"
           >
             <RotateCcw size={12} strokeWidth={2.4} />
@@ -146,11 +159,57 @@ export function PictureDialsSection() {
       </div>
 
       <div className="mt-1 flex flex-col">
-        <TweakSlider tweaks={tweaks} setTweak={setTweak} mpvKey="brightness" label={t("Brightness")} min={-50} max={50} step={1} def={0} />
-        <TweakSlider tweaks={tweaks} setTweak={setTweak} mpvKey="contrast" label={t("Contrast")} min={-50} max={50} step={1} def={0} />
-        <TweakSlider tweaks={tweaks} setTweak={setTweak} mpvKey="saturation" label={t("Saturation")} min={-50} max={50} step={1} def={0} />
-        <TweakSlider tweaks={tweaks} setTweak={setTweak} mpvKey="gamma" label={t("Gamma (midtones)")} min={-50} max={50} step={1} def={0} />
-        <TweakSlider tweaks={tweaks} setTweak={setTweak} mpvKey="sharpen" label={t("Sharpen")} min={0} max={2} step={0.05} def={0} fmt={(v) => v.toFixed(2)} />
+        <TweakSlider
+          tweaks={tweaks}
+          setTweak={setTweak}
+          mpvKey="brightness"
+          label={t("Brightness")}
+          min={-50}
+          max={50}
+          step={1}
+          def={0}
+        />
+        <TweakSlider
+          tweaks={tweaks}
+          setTweak={setTweak}
+          mpvKey="contrast"
+          label={t("Contrast")}
+          min={-50}
+          max={50}
+          step={1}
+          def={0}
+        />
+        <TweakSlider
+          tweaks={tweaks}
+          setTweak={setTweak}
+          mpvKey="saturation"
+          label={t("Saturation")}
+          min={-50}
+          max={50}
+          step={1}
+          def={0}
+        />
+        <TweakSlider
+          tweaks={tweaks}
+          setTweak={setTweak}
+          mpvKey="gamma"
+          label={t("Gamma (midtones)")}
+          min={-50}
+          max={50}
+          step={1}
+          def={0}
+        />
+        <TweakSlider
+          tweaks={tweaks}
+          setTweak={setTweak}
+          mpvKey="sharpen"
+          label={t("Sharpen")}
+          min={0}
+          max={2}
+          step={0.05}
+          def={0}
+          fmt={(v) => v.toFixed(2)}
+        />
       </div>
     </Section>
   );
@@ -171,7 +230,9 @@ export function ColorHdrSection() {
   return (
     <Section
       title={t("Color & HDR")}
-      subtitle={t("How Harbor squeezes HDR movies onto a normal screen. Auto is right for almost everyone; the curves below just change the look (punchy vs soft). Only matters on HDR sources.")}
+      subtitle={t(
+        "How Harbor squeezes HDR movies onto a normal screen. Auto is right for almost everyone; the curves below just change the look (punchy vs soft). Only matters on HDR sources.",
+      )}
     >
       <div className="flex flex-col gap-1.5">
         <span className="text-[12px] font-semibold uppercase tracking-[0.14em] text-ink-subtle">
@@ -186,7 +247,9 @@ export function ColorHdrSection() {
       </div>
       <ToggleRow
         label={t("Boost SDR video toward HDR")}
-        sub={t("On an HDR display, stretches normal (non-HDR) movies to use the extra brightness range. Leave off on a regular screen; it can look washed out.")}
+        sub={t(
+          "On an HDR display, stretches normal (non-HDR) movies to use the extra brightness range. Leave off on a regular screen; it can look washed out.",
+        )}
         value={tweaks["inverse-tone-mapping"] === "yes"}
         onChange={(on) => setTweak("inverse-tone-mapping", on ? "yes" : null)}
       />


### PR DESCRIPTION
Fixes #1163.

## Problem

Picture adjustment presets stack on top of each other instead of each producing a fixed look.

`applyPatch` merges into the current tweaks:

```ts
const applyPatch = (patch: Record<string, string | null>) => {
  const next = { ...tweaks };          // starts from existing state
  for (const [k, v] of Object.entries(patch)) {
    if (v === null) delete next[k];
    else next[k] = v;
  }
  update({ mpvTweaks: next });
};
```

and each preset's patch only carries the keys it actually changes:

| Preset | Patch | Untouched |
|---|---|---|
| Brighten dark movies | `gamma`, `brightness` | saturation, contrast, sharpen |
| Punchier color | `saturation`, `contrast` | gamma, brightness, sharpen |
| Easy on the eyes | `brightness`, `gamma`, `saturation` | contrast, sharpen |
| Crisp (anime & cartoons) | `sharpen`, `saturation` | brightness, contrast, gamma |

So selecting "Punchier color" and then "Brighten dark movies" leaves saturation, contrast, gamma **and** brightness all applied — a blend of both presets rather than the second one. The result depends on click history, which is what the issue reports.

## Fix

Spread a reset over every picture key before the preset's own patch, so a preset always lands on a clean slate:

```ts
onClick={() => applyPatch({ ...PICTURE_RESET, ...tpl.patch })}
```

Each preset is now reproducible regardless of what was selected before, and the sliders show exactly that preset's values.

`PICTURE_RESET` is the same object the "Reset picture" button was already building inline from `PICTURE_KEYS`, so that call site now shares it instead of duplicating the expression.

## Notes on the diff

The logical change is three lines. The rest is `vp fmt` — the pre-commit hook reformatted the file on stage, and CI runs `vp fmt --check` against changed files, so the file has to be formatted to pass. `dials.tsx` was already non-conformant before this change (it fails `vp check` on a clean checkout), which is why the reformat is larger than expected. No unrelated files were touched.

## Verification

- `pnpm run typecheck` — passes
- `vp fmt --check src/views/settings/mpv-panel/dials.tsx` — clean
- No change to preset values, `PICTURE_TEMPLATES`, or `applyPatch` semantics; only what a preset click passes in
