### PR TITLE
fix(core): stop misparsing sizes that use comma or space separators

### DIFF
--- a/harbor-core/src/parser.rs
+++ b/harbor-core/src/parser.rs
@@ -165,8 +165,20 @@ static TORRENTIO_NOISE_SUFFIX_RX: Lazy<Regex> = Lazy::new(|| {
 static CONTAINER_RX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)\.(mkv|mp4|m4v|avi|webm|mov|ts|wmv)\b").unwrap());
 
-static SIZE_RX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)(\d+(?:\.\d+)?)\s*(GB|MB|TB|GiB|MiB|TiB)\b").unwrap());
+// Groups: 1 = integer part (may carry `,`/space thousands separators),
+// 2 = fractional digits, 3 = unit.
+//
+// The leading `(?:^|[^\d.,])` is a consuming boundary (the regex crate has no
+// lookbehind). Without it the pattern happily matched the tail of a longer
+// number, so "2,75 GB" parsed as 75 GB. A fraction is capped at two digits so
+// a three-digit group is read as a thousands separator instead: "1,500 MB" is
+// 1500 MB, while "1,5 GB" is 1.5 GB.
+static SIZE_RX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)(?:^|[^\d.,])(\d{1,3}(?:[ ,]\d{3})+|\d+)(?:[.,](\d{1,2}))?\s*(GB|MB|TB|GiB|MiB|TiB)\b",
+    )
+    .unwrap()
+});
 
 static SEEDERS_RX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?i)(?:\x{1F465}|\x{1F464}|S:|seeds?:?|\bS\s*=\s*)\s*(\d+)").unwrap()
@@ -1259,8 +1271,14 @@ fn parse_size(text: &str, hint: Option<u64>) -> Option<u64> {
         }
     }
     let c = SIZE_RX.captures(text)?;
-    let n: f64 = c.get(1)?.as_str().parse().ok()?;
-    let unit = c.get(2)?.as_str().to_lowercase();
+    let int_part = c.get(1)?.as_str();
+    let mut digits: String = int_part.chars().filter(char::is_ascii_digit).collect();
+    if let Some(frac) = c.get(2) {
+        digits.push('.');
+        digits.push_str(frac.as_str());
+    }
+    let n: f64 = digits.parse().ok()?;
+    let unit = c.get(3)?.as_str().to_lowercase();
     let bytes = if unit.starts_with('t') {
         n * (1024f64.powi(4))
     } else if unit.starts_with('g') {
@@ -1775,5 +1793,48 @@ mod tests {
         s.behavior_hints = Some(json!({ "videoSize": 5_000_000_000_u64 }));
         let p = parse_stream(s);
         assert_eq!(p.size, Some(5_000_000_000));
+    }
+
+    fn gb(v: f64) -> Option<u64> {
+        Some((v * 1024.0 * 1024.0 * 1024.0).round() as u64)
+    }
+
+    fn mb(v: f64) -> Option<u64> {
+        Some((v * 1024.0 * 1024.0).round() as u64)
+    }
+
+    #[test]
+    fn size_parses_dot_decimals() {
+        assert_eq!(parse_size("1.5 GB", None), gb(1.5));
+        assert_eq!(parse_size("3.2GB", None), gb(3.2));
+        assert_eq!(parse_size("700 MB", None), mb(700.0));
+    }
+
+    #[test]
+    fn size_parses_comma_decimals() {
+        // The pattern used to match the tail of a longer number, so the leading
+        // digits were dropped and "2,75 GB" came back as 75 GB.
+        assert_eq!(parse_size("2,75 GB", None), gb(2.75));
+        assert_eq!(parse_size("1,5 GB", None), gb(1.5));
+        assert_eq!(parse_size("12,4 GB", None), gb(12.4));
+    }
+
+    #[test]
+    fn size_parses_grouped_thousands() {
+        assert_eq!(parse_size("1,500 MB", None), mb(1500.0));
+        assert_eq!(parse_size("1 500 MB", None), mb(1500.0));
+        assert_eq!(parse_size("1,234.56 GB", None), gb(1234.56));
+    }
+
+    #[test]
+    fn size_reads_from_surrounding_text() {
+        assert_eq!(parse_size("Size: 2.75 GB | 40 seeds", None), gb(2.75));
+        assert_eq!(parse_size("\u{1F4BE} 4.7 GiB", None), gb(4.7));
+    }
+
+    #[test]
+    fn size_hint_takes_precedence() {
+        assert_eq!(parse_size("2,75 GB", Some(123)), Some(123));
+        assert_eq!(parse_size("2,75 GB", Some(0)), gb(2.75));
     }
 }


### PR DESCRIPTION
## Problem

`SIZE_RX` only accepted `.` as a decimal separator and had no left boundary:

```rust
r"(?i)(\d+(?:\.\d+)?)\s*(GB|MB|TB|GiB|MiB|TiB)\b"
```

On a comma-formatted size the leading digits fail to match, the scan advances, and the **tail** matches as a whole number. The result is a silently wrong value, not a missing one:

| Input | Parsed as | Error |
|---|---|---|
| `2,75 GB` | **75 GB** | 27× too large |
| `1,5 GB` | 5 GB | 3.3× too large |
| `12,4 GB` | 4 GB | 3× too small |
| `1 500 MB` | 500 MB | 3× too small |

Size feeds `scoring`, so a misparsed size can change which stream gets picked — a 75 GB phantom outranks or gets filtered differently from the real 2.75 GB file.

## Fix

Anchor the match on a non-digit boundary so a fragment of a longer number can never match, and accept `,` as a decimal separator:

```rust
r"(?i)(?:^|[^\d.,])(\d{1,3}(?:[ ,]\d{3})+|\d+)(?:[.,](\d{1,2}))?\s*(GB|MB|TB|GiB|MiB|TiB)\b"
```

A group of exactly three digits is read as a thousands separator rather than a fraction, which keeps both conventions working:

- `1,500 MB` → 1500 MB (grouped thousands)
- `1,5 GB` → 1.5 GB (decimal comma)
- `1,234.56 GB` → 1234.56 GB (both)

The `regex` crate has no lookbehind, so the boundary is a consuming `(?:^|[^\d.,])` prefix; capture groups shift by one and `parse_size` reassembles the number from the integer group (separators stripped) plus the optional fraction.

## Tests

Five new tests in `parser::tests` covering dot decimals, comma decimals, grouped thousands, sizes embedded in surrounding text, and `hint` precedence.

I verified they actually catch the bug by reverting the implementation and re-running — three fail against the original, with `2,75 GB` returning `80530636800` (75 GB) instead of `2952790016` (2.75 GB). The dot-decimal and surrounding-text tests pass either way and serve as regression guards.

## Verification

- `cargo test --manifest-path harbor-core/Cargo.toml` — 61 passed, 0 failed
- `cargo check --manifest-path harbor-core/Cargo.toml` — clean
- `cargo fmt --check` — no objections to the added lines (the crate has pre-existing rustfmt diffs in `lib.rs` and `parser.rs`; I left those alone)

`parse_size` is private and its signature is unchanged, so there is no API surface change.

## Scope note

I have not confirmed how often real addons emit comma-formatted sizes — this was found by reading the parser, not from a bug report. But the current behaviour is indefensible when it does happen, and failing toward the correct value (or `None`) is strictly better than reporting 75 GB for a 2.75 GB file.
