### PR TITLE
Feat: add anime simulcast airing/dub calendar with air times

### DIFF
--- a/src/lib/anilist/airing.ts
+++ b/src/lib/anilist/airing.ts
@@ -1,0 +1,116 @@
+import type { CalendarItem } from "@/lib/calendar";
+import { anilistRequest } from "./client";
+
+const AIRING_QUERY = `query ($start: Int, $end: Int, $page: Int) {
+  Page(page: $page, perPage: 50) {
+    airingSchedules(airingAt_greater: $start, airingAt_lesser: $end, sort: TIME) {
+      airingAt
+      episode
+      media {
+        id
+        idMal
+        type
+        isAdult
+        format
+        title { romaji english }
+        coverImage { extraLarge large }
+        bannerImage
+        averageScore
+        description
+      }
+    }
+  }
+}`;
+
+type AiringMedia = {
+  id: number;
+  idMal: number | null;
+  type: string | null;
+  isAdult: boolean | null;
+  format: string | null;
+  title: { romaji: string | null; english: string | null } | null;
+  coverImage: { extraLarge: string | null; large: string | null } | null;
+  bannerImage: string | null;
+  averageScore: number | null;
+  description: string | null;
+};
+
+type AiringNode = {
+  airingAt: number;
+  episode: number | null;
+  media: AiringMedia | null;
+};
+
+type AiringResponse = { Page: { airingSchedules: AiringNode[] | null } | null };
+
+const MAX_PAGES = 10;
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function toLocalISO(epochSeconds: number): string {
+  const d = new Date(epochSeconds * 1000);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function stripHtml(s: string): string {
+  return s
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export async function fetchAniListAiringCalendar(
+  year: number,
+  month: number,
+): Promise<CalendarItem[]> {
+  const start = Math.floor(new Date(year, month, 1).getTime() / 1000);
+  const end = Math.floor(new Date(year, month + 1, 1).getTime() / 1000);
+  const out: CalendarItem[] = [];
+  const seen = new Set<string>();
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    let data: AiringResponse | null = null;
+    try {
+      data = await anilistRequest<AiringResponse>(
+        AIRING_QUERY,
+        { start, end, page },
+        undefined,
+        true,
+      );
+    } catch {
+      break;
+    }
+    const nodes = data?.Page?.airingSchedules ?? [];
+    for (const node of nodes) {
+      const media = node.media;
+      if (!media) continue;
+      if (media.type !== "ANIME" || media.isAdult) continue;
+      if (media.format === "MOVIE" || node.episode == null) continue;
+      const title = media.title?.english?.trim() || media.title?.romaji?.trim() || "Untitled";
+      const baseId = media.idMal != null ? `mal:${media.idMal}` : `anilist:${media.id}`;
+      const id = `${baseId}:1:${node.episode}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push({
+        id,
+        imdbId: null,
+        type: "tv",
+        name: `${title} S1E${pad(node.episode)}`,
+        poster: media.coverImage?.extraLarge ?? media.coverImage?.large ?? null,
+        background: media.bannerImage ?? null,
+        releaseDate: toLocalISO(node.airingAt),
+        isAnime: true,
+        overview: media.description ? stripHtml(media.description) : "",
+        voteAverage: media.averageScore != null ? media.averageScore / 10 : 0,
+      });
+    }
+    if (nodes.length < 50) break;
+  }
+  out.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
+  return out;
+}

--- a/src/lib/anilist/airing.ts
+++ b/src/lib/anilist/airing.ts
@@ -19,6 +19,9 @@ const AIRING_QUERY = `query ($start: Int, $end: Int, $page: Int) {
         description
       }
     }
+    pageInfo {
+      hasNextPage
+    }
   }
 }`;
 
@@ -41,9 +44,17 @@ type AiringNode = {
   media: AiringMedia | null;
 };
 
-type AiringResponse = { Page: { airingSchedules: AiringNode[] | null } | null };
+type AiringResponse = {
+  Page: {
+    airingSchedules: AiringNode[] | null;
+    pageInfo: { hasNextPage: boolean } | null;
+  } | null;
+};
 
 const MAX_PAGES = 10;
+// Fetches up to this many pages in parallel, then waits for the batch.
+// AniList throttles hard on bursts, so this must stay small.
+const CONCURRENCY = 3;
 
 function pad(n: number): string {
   return String(n).padStart(2, "0");
@@ -71,21 +82,50 @@ export async function fetchAniListAiringCalendar(
 ): Promise<CalendarItem[]> {
   const start = Math.floor(new Date(year, month, 1).getTime() / 1000);
   const end = Math.floor(new Date(year, month + 1, 1).getTime() / 1000);
-  const out: CalendarItem[] = [];
-  const seen = new Set<string>();
-  for (let page = 1; page <= MAX_PAGES; page++) {
-    let data: AiringResponse | null = null;
-    try {
-      data = await anilistRequest<AiringResponse>(
+
+  const pages = new Map<number, readonly AiringNode[]>();
+  let next = 1;
+  let pastLast = false;
+  let inflight = 0;
+  let resolveDone: () => void = () => {};
+  const done = new Promise<void>((r) => {
+    resolveDone = r;
+  });
+
+  const pump = () => {
+    while (!pastLast && next <= MAX_PAGES && inflight < CONCURRENCY) {
+      const page = next++;
+      inflight++;
+      anilistRequest<AiringResponse>(
         AIRING_QUERY,
         { start, end, page },
         undefined,
         true,
-      );
-    } catch {
-      break;
+      )
+        .then((data) => {
+          const nodes = data?.Page?.airingSchedules ?? [];
+          pages.set(page, nodes);
+          const hasNext = data?.Page?.pageInfo?.hasNextPage ?? nodes.length >= 50;
+          if (!hasNext) pastLast = true;
+        })
+        .catch(() => {
+          pastLast = true;
+        })
+        .finally(() => {
+          inflight--;
+          pump();
+          if (inflight === 0) resolveDone();
+        });
     }
-    const nodes = data?.Page?.airingSchedules ?? [];
+  };
+  pump();
+  await done;
+
+  const out: CalendarItem[] = [];
+  const seen = new Set<string>();
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const nodes = pages.get(page);
+    if (!nodes) break;
     for (const node of nodes) {
       const media = node.media;
       if (!media) continue;
@@ -109,7 +149,6 @@ export async function fetchAniListAiringCalendar(
         voteAverage: media.averageScore != null ? media.averageScore / 10 : 0,
       });
     }
-    if (nodes.length < 50) break;
   }
   out.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
   return out;

--- a/src/lib/anilist/airing.ts
+++ b/src/lib/anilist/airing.ts
@@ -68,6 +68,14 @@ function toLocalISO(epochSeconds: number): string {
   return `${y}-${m}-${day}`;
 }
 
+function toLocalTime(epochSeconds: number): string {
+  const d = new Date(epochSeconds * 1000);
+  const hour = d.getHours();
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  const period = hour >= 12 ? "PM" : "AM";
+  return `${hour12}:${pad(d.getMinutes())} ${period}`;
+}
+
 function stripHtml(s: string): string {
   return s
     .replace(/<br\s*\/?>/gi, " ")
@@ -144,6 +152,7 @@ export async function fetchAniListAiringCalendar(
         poster: media.coverImage?.extraLarge ?? media.coverImage?.large ?? null,
         background: media.bannerImage ?? null,
         releaseDate: toLocalISO(node.airingAt),
+        releaseTime: toLocalTime(node.airingAt),
         isAnime: true,
         overview: media.description ? stripHtml(media.description) : "",
         voteAverage: media.averageScore != null ? media.averageScore / 10 : 0,

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -105,6 +105,7 @@ async function mapDubFeedToCalendar(year: number, month: number): Promise<Calend
     if (media.format === "MOVIE" || e.episodeNumber == null) continue;
     const dateISO = e.episodeDate ? toLocalISO(e.episodeDate) : "";
     if (!inMonth(dateISO, year, month)) continue;
+    const time = e.episodeDate ? toLocalTime(e.episodeDate) : "";
     const title =
       media.title?.english?.trim() ||
       media.title?.romaji?.trim() ||
@@ -123,6 +124,7 @@ async function mapDubFeedToCalendar(year: number, month: number): Promise<Calend
       poster: media.coverImage?.extraLarge ?? media.coverImage?.medium ?? null,
       background: media.bannerImage ?? null,
       releaseDate: dateISO,
+      releaseTime: time || undefined,
       isAnime: true,
       overview: "",
       voteAverage: 0,
@@ -139,6 +141,15 @@ function toLocalISO(isoDateTime: string): string {
   const m = pad(d.getMonth() + 1);
   const day = pad(d.getDate());
   return `${y}-${m}-${day}`;
+}
+
+function toLocalTime(isoDateTime: string): string {
+  const d = new Date(isoDateTime);
+  if (Number.isNaN(d.getTime())) return "";
+  const hour = d.getHours();
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  const period = hour >= 12 ? "PM" : "AM";
+  return `${hour12}:${pad(d.getMinutes())} ${period}`;
 }
 
 export async function fetchSimklCalendar(

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -11,6 +11,7 @@ import { fetchWatchlist as fetchSimklWatchlist, fetchWatchingItems } from "./sim
 import { fetchSimklCdnCalendar } from "./simkl/calendar";
 import { isAuthenticated as simklConnected } from "./simkl/session";
 import { fetchAniListAiringCalendar as fetchAniListAiring } from "./anilist/airing";
+import { fetchDubSchedule } from "./providers/anime-dub-sub";
 
 export { fetchLibraryCalendar } from "./calendar-library";
 
@@ -83,6 +84,61 @@ export async function fetchAniListAiringCalendar(
 ): Promise<CalendarItem[]> {
   const cacheKey = `anilist-airing:${year}-${month}`;
   return withCalendarCache(cacheKey, () => fetchAniListAiring(year, month).catch(() => []));
+}
+
+export async function fetchAnimeDubCalendar(
+  year: number,
+  month: number,
+): Promise<CalendarItem[]> {
+  const cacheKey = `anime-dub:${year}-${month}`;
+  return withCalendarCache(cacheKey, () => mapDubFeedToCalendar(year, month).catch(() => []));
+}
+
+async function mapDubFeedToCalendar(year: number, month: number): Promise<CalendarItem[]> {
+  const entries = await fetchDubSchedule();
+  const out: CalendarItem[] = [];
+  const seen = new Set<string>();
+  for (const e of entries) {
+    const media = e?.media?.media;
+    if (!media) continue;
+    if (media.isAdult) continue;
+    if (media.format === "MOVIE" || e.episodeNumber == null) continue;
+    const dateISO = e.episodeDate ? toLocalISO(e.episodeDate) : "";
+    if (!inMonth(dateISO, year, month)) continue;
+    const title =
+      media.title?.english?.trim() ||
+      media.title?.romaji?.trim() ||
+      e.english?.trim() ||
+      e.romaji?.trim() ||
+      "Untitled";
+    const baseId = media.idMal != null ? `mal:${media.idMal}` : `anilist:${media.id}`;
+    const id = `${baseId}:1:${e.episodeNumber}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({
+      id,
+      imdbId: null,
+      type: "tv",
+      name: `${title} S1E${pad(e.episodeNumber)}`,
+      poster: media.coverImage?.extraLarge ?? media.coverImage?.medium ?? null,
+      background: media.bannerImage ?? null,
+      releaseDate: dateISO,
+      isAnime: true,
+      overview: "",
+      voteAverage: 0,
+    });
+  }
+  out.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
+  return out;
+}
+
+function toLocalISO(isoDateTime: string): string {
+  const d = new Date(isoDateTime);
+  if (Number.isNaN(d.getTime())) return "";
+  const y = d.getFullYear();
+  const m = pad(d.getMonth() + 1);
+  const day = pad(d.getDate());
+  return `${y}-${m}-${day}`;
 }
 
 export async function fetchSimklCalendar(

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -10,6 +10,7 @@ import { resolveSavedCalendar, type SavedCandidate } from "./calendar-library";
 import { fetchWatchlist as fetchSimklWatchlist, fetchWatchingItems } from "./simkl/watchlist";
 import { fetchSimklCdnCalendar } from "./simkl/calendar";
 import { isAuthenticated as simklConnected } from "./simkl/session";
+import { fetchAniListAiringCalendar as fetchAniListAiring } from "./anilist/airing";
 
 export { fetchLibraryCalendar } from "./calendar-library";
 
@@ -74,6 +75,14 @@ export async function fetchSimklPremieresCalendar(
 ): Promise<CalendarItem[]> {
   const cacheKey = `simkl-premieres:${year}-${month}`;
   return withCalendarCache(cacheKey, () => fetchSimklCdnCalendar(year, month).catch(() => []));
+}
+
+export async function fetchAniListAiringCalendar(
+  year: number,
+  month: number,
+): Promise<CalendarItem[]> {
+  const cacheKey = `anilist-airing:${year}-${month}`;
+  return withCalendarCache(cacheKey, () => fetchAniListAiring(year, month).catch(() => []));
 }
 
 export async function fetchSimklCalendar(

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -14,6 +14,7 @@ export type CalendarItem = {
   poster: string | null;
   background: string | null;
   releaseDate: string;
+  releaseTime?: string;
   isAnime: boolean;
   overview: string;
   voteAverage: number;

--- a/src/lib/providers/anime-dub-sub.ts
+++ b/src/lib/providers/anime-dub-sub.ts
@@ -8,16 +8,50 @@ let byAnilist: Set<number> | null = null;
 let inflight: Promise<void> | null = null;
 const subs = new Set<() => void>();
 
-type FeedEntry = { media?: { media?: { id?: number | null; idMal?: number | null } } };
+export type DubFeedEntry = {
+  title?: string | null;
+  romaji?: string | null;
+  english?: string | null;
+  episodeDate?: string | null;
+  episodeNumber?: number | null;
+  media?: {
+    media?: {
+      id?: number | null;
+      idMal?: number | null;
+      type?: string | null;
+      format?: string | null;
+      isAdult?: boolean | null;
+      title?: { romaji?: string | null; english?: string | null } | null;
+      coverImage?: { extraLarge?: string | null; medium?: string | null } | null;
+      bannerImage?: string | null;
+    } | null;
+  } | null;
+};
+
+let feedCache: { entries: DubFeedEntry[]; at: number } | null = null;
+const FEED_STALE_MS = 30 * 60 * 1000;
+
+/** Fetch the AniSchedule dub feed, cached briefly. Never rejects. */
+export async function fetchDubSchedule(): Promise<DubFeedEntry[]> {
+  const now = Date.now();
+  if (feedCache && now - feedCache.at < FEED_STALE_MS) return feedCache.entries;
+  try {
+    const res = await safeFetch(FEED_URL);
+    if (!res.ok) return feedCache?.entries ?? [];
+    const arr = (await res.json()) as DubFeedEntry[];
+    feedCache = { entries: arr, at: now };
+    return arr;
+  } catch {
+    return feedCache?.entries ?? [];
+  }
+}
 
 function load(): Promise<void> {
   if (byMal) return Promise.resolve();
   if (inflight) return inflight;
   inflight = (async () => {
     try {
-      const res = await safeFetch(FEED_URL);
-      if (!res.ok) return;
-      const arr = (await res.json()) as FeedEntry[];
+      const arr = await fetchDubSchedule();
       const mal = new Set<number>();
       const ani = new Set<number>();
       for (const e of arr) {

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -533,7 +533,8 @@ export type Settings = {
     | "anticipated"
     | "custom"
     | "simkl"
-    | "simkl-anticipated";
+    | "simkl-anticipated"
+    | "anime";
   simklHomeRailsEnabled: boolean;
   simklUpNextRailEnabled: boolean;
   simklTrendingRailEnabled: boolean;

--- a/src/views/calendar.tsx
+++ b/src/views/calendar.tsx
@@ -46,6 +46,7 @@ export function CalendarView() {
   const [month, setMonth] = useState(today.getMonth());
   const [filter, setFilter] = useState<CalendarFilter>("all");
   const [watchlistOnly, setWatchlistOnly] = useState(false);
+  const [animeDub, setAnimeDub] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   useScrollMemory("calendar", scrollRef);
   const [libraryItems, setLibraryItems] = useState<LibraryItem[]>([]);
@@ -97,6 +98,7 @@ export function CalendarView() {
     settings,
     year,
     month,
+    animeDub,
   });
 
   useEffect(() => {
@@ -170,6 +172,7 @@ export function CalendarView() {
 
   const showAllControls = source === "all";
   const showPremiereFilters = source === "simkl-anticipated";
+  const hideTypeTag = source === "anime";
   const filtersActiveCount = buildActiveCount(settings.customCalendar);
   const filters = settings.hideContent.anime ? FILTERS.filter((f) => f.id !== "anime") : FILTERS;
 
@@ -183,7 +186,14 @@ export function CalendarView() {
   } else if (loading && filtered.length === 0) {
     body = <CalendarSkeleton />;
   } else if (filtered.length === 0) {
-    body = <EmptyState source={source} filter={filter} watchlistOnly={watchlistOnly} />;
+    body = (
+      <EmptyState
+        source={source}
+        filter={filter}
+        watchlistOnly={watchlistOnly}
+        animeDub={animeDub}
+      />
+    );
   } else {
     body = (
       <MonthGrid
@@ -193,6 +203,7 @@ export function CalendarView() {
         weekStartsMonday={settings.weekStartsMonday}
         onOpenItem={openItem}
         onOpenDay={(iso) => setDayModal(iso)}
+        hideTypeTag={hideTypeTag}
       />
     );
   }
@@ -249,6 +260,27 @@ export function CalendarView() {
             traktConnected={traktConnected}
             simklConnected={simklConnected}
           />
+          {source === "anime" && (
+            <div className="flex items-center gap-1 rounded-full border border-edge-soft bg-elevated/30 p-1">
+              {(["sub", "dub"] as const).map((mode) => {
+                const active = animeDub === (mode === "dub");
+                return (
+                  <button
+                    key={mode}
+                    onClick={() => setAnimeDub(mode === "dub")}
+                    aria-pressed={active}
+                    className={`rounded-full px-4 py-1.5 text-[12.5px] font-semibold transition-colors ${
+                      active
+                        ? "bg-ink text-canvas"
+                        : "text-ink-muted hover:bg-raised/60 hover:text-ink"
+                    }`}
+                  >
+                    {t(mode === "sub" ? "Sub" : "Dub")}
+                  </button>
+                );
+              })}
+            </div>
+          )}
           <button
             onClick={() => update({ weekStartsMonday: !settings.weekStartsMonday })}
             className={`rounded-full px-4 py-1.5 text-[12.5px] font-semibold transition-colors ${
@@ -397,6 +429,7 @@ export function CalendarView() {
             setDayModal(null);
             openItem(it);
           }}
+          hideTypeTag={hideTypeTag}
         />
       )}
 

--- a/src/views/calendar.tsx
+++ b/src/views/calendar.tsx
@@ -123,7 +123,10 @@ export function CalendarView() {
     const hideAnime = (list: CalendarItem[]) =>
       settings.hideContent.anime ? list.filter((i) => !i.isAnime) : list;
     if (source !== "all" && source !== "simkl-anticipated") return hideAnime(items);
-    let out = hideAnime(applyCalendarFilter(items, filter));
+    // All upcoming is exclusively movies and TV — anime lives in the dedicated Anime source.
+    const f: CalendarFilter = source === "all" && filter === "anime" ? "all" : filter;
+    let out = hideAnime(applyCalendarFilter(items, f));
+    if (source === "all") out = out.filter((i) => !i.isAnime);
     if (source === "all" && watchlistOnly) {
       out = out.filter((i) => {
         const t = i.type === "tv" ? "tv" : "movie";
@@ -174,7 +177,9 @@ export function CalendarView() {
   const showPremiereFilters = source === "simkl-anticipated";
   const hideTypeTag = source === "anime";
   const filtersActiveCount = buildActiveCount(settings.customCalendar);
-  const filters = settings.hideContent.anime ? FILTERS.filter((f) => f.id !== "anime") : FILTERS;
+  const filters = settings.hideContent.anime || source === "all"
+    ? FILTERS.filter((f) => f.id !== "anime")
+    : FILTERS;
 
   let body: React.ReactNode;
   if (source === "library" && !authKey) {

--- a/src/views/calendar/calendar-chip.tsx
+++ b/src/views/calendar/calendar-chip.tsx
@@ -135,7 +135,10 @@ function ChipTooltip({
             </span>
           )}
           <p className="text-[14px] font-semibold leading-tight text-ink">{item.name}</p>
-          <p className="text-[12px] text-ink-muted">{dateLabel}</p>
+          <p className="text-[12px] text-ink-muted">
+            {dateLabel}
+            {item.releaseTime ? ` · ${item.releaseTime}` : ""}
+          </p>
           {item.voteAverage > 0 && (
             <p className="text-[11.5px] text-ink-muted">
               <span className="text-amber-300">★</span> {item.voteAverage.toFixed(1)}

--- a/src/views/calendar/calendar-chip.tsx
+++ b/src/views/calendar/calendar-chip.tsx
@@ -9,9 +9,11 @@ import { formatDateLong } from "./utils";
 export function CalendarChip({
   item,
   onOpen,
+  hideTypeTag,
 }: {
   item: CalendarItem;
   onOpen: (item: CalendarItem) => void;
+  hideTypeTag: boolean;
 }) {
   const t = useT();
   const { settings } = useSettings();
@@ -52,12 +54,14 @@ export function CalendarChip({
         ) : null}
       </div>
       <span className="flex-1 truncate text-[11.5px] font-medium text-ink">{item.name}</span>
-      <span
-        className={`hidden shrink-0 rounded-sm px-1 py-px text-[9px] font-bold uppercase tracking-[0.12em] xl:inline ${tagClass}`}
-      >
-        {tag}
-      </span>
-      {hovered && <ChipTooltip item={item} anchorRef={ref} />}
+      {!hideTypeTag && (
+        <span
+          className={`hidden shrink-0 rounded-sm px-1 py-px text-[9px] font-bold uppercase tracking-[0.12em] xl:inline ${tagClass}`}
+        >
+          {tag}
+        </span>
+      )}
+      {hovered && <ChipTooltip item={item} anchorRef={ref} hideTypeTag={hideTypeTag} />}
     </button>
   );
 }
@@ -65,9 +69,11 @@ export function CalendarChip({
 function ChipTooltip({
   item,
   anchorRef,
+  hideTypeTag,
 }: {
   item: CalendarItem;
   anchorRef: React.RefObject<HTMLElement | null>;
+  hideTypeTag: boolean;
 }) {
   const t = useT();
   const { settings } = useSettings();
@@ -123,9 +129,11 @@ function ChipTooltip({
           ) : null}
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="text-[10.5px] font-bold uppercase tracking-[0.18em] text-ink-subtle">
-            {tag}
-          </span>
+          {!hideTypeTag && (
+            <span className="text-[10.5px] font-bold uppercase tracking-[0.18em] text-ink-subtle">
+              {tag}
+            </span>
+          )}
           <p className="text-[14px] font-semibold leading-tight text-ink">{item.name}</p>
           <p className="text-[12px] text-ink-muted">{dateLabel}</p>
           {item.voteAverage > 0 && (

--- a/src/views/calendar/day-modal.tsx
+++ b/src/views/calendar/day-modal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { X } from "lucide-react";
+import { Clock, X } from "lucide-react";
 import { Poster, usePosterChain } from "@/components/poster";
 import type { CalendarItem } from "@/lib/calendar";
 import { useT } from "@/lib/i18n";
@@ -124,6 +124,12 @@ function DayModalRow({
           )}
         </div>
         <p className="text-[14px] font-semibold leading-tight text-ink">{item.name}</p>
+        {item.releaseTime && (
+          <p className="text-[11px] font-medium text-ink-subtle">
+            <Clock size={11} className="mr-1 inline text-rose-300" />
+            {item.releaseTime}
+          </p>
+        )}
         {item.overview && (
           <p className="line-clamp-2 text-[12px] leading-relaxed text-ink-muted">{item.overview}</p>
         )}

--- a/src/views/calendar/day-modal.tsx
+++ b/src/views/calendar/day-modal.tsx
@@ -11,11 +11,13 @@ export function DayModal({
   items,
   onClose,
   onOpenItem,
+  hideTypeTag,
 }: {
   dateISO: string;
   items: CalendarItem[];
   onClose: () => void;
   onOpenItem: (item: CalendarItem) => void;
+  hideTypeTag: boolean;
 }) {
   const t = useT();
   useEffect(() => {
@@ -59,7 +61,7 @@ export function DayModal({
         </header>
         <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-3">
           {items.map((item) => (
-            <DayModalRow key={item.id} item={item} onOpen={onOpenItem} />
+            <DayModalRow key={item.id} item={item} onOpen={onOpenItem} hideTypeTag={hideTypeTag} />
           ))}
         </div>
       </div>
@@ -70,9 +72,11 @@ export function DayModal({
 function DayModalRow({
   item,
   onOpen,
+  hideTypeTag,
 }: {
   item: CalendarItem;
   onOpen: (item: CalendarItem) => void;
+  hideTypeTag: boolean;
 }) {
   const t = useT();
   const { settings } = useSettings();
@@ -106,11 +110,13 @@ function DayModalRow({
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex items-center gap-2">
-          <span
-            className={`shrink-0 rounded px-1.5 py-px text-[9.5px] font-bold uppercase tracking-[0.12em] ${tagClass}`}
-          >
-            {tag}
-          </span>
+          {!hideTypeTag && (
+            <span
+              className={`shrink-0 rounded px-1.5 py-px text-[9.5px] font-bold uppercase tracking-[0.12em] ${tagClass}`}
+            >
+              {tag}
+            </span>
+          )}
           {item.voteAverage > 0 && (
             <span className="text-[11px] text-ink-muted">
               <span className="text-amber-300">★</span> {item.voteAverage.toFixed(1)}

--- a/src/views/calendar/empty-states.tsx
+++ b/src/views/calendar/empty-states.tsx
@@ -83,7 +83,9 @@ export function EmptyState({
             ? t("Nothing on Simkl this month")
             : source === "simkl-anticipated"
               ? t("No Simkl premieres this month")
-              : t("Nothing this month");
+              : source === "anime"
+                ? t("Nothing airing this month")
+                : t("Nothing this month");
   const filterKind =
     filter === "movie" ? t("movies") : filter === "tv" ? t("TV") : t("anime");
   const body =
@@ -107,7 +109,11 @@ export function EmptyState({
               ? t(
                   "Simkl lists no new shows or anime premiering this month. Try a different month.",
                 )
-              : watchlistOnly
+              : source === "anime"
+                ? t(
+                    "AniList has no anime episodes scheduled to air this month. Try a different month.",
+                  )
+                : watchlistOnly
             ? t(
                 "Nothing from your library lands this month. Toggle Watchlist off to see all releases.",
               )

--- a/src/views/calendar/empty-states.tsx
+++ b/src/views/calendar/empty-states.tsx
@@ -66,10 +66,12 @@ export function EmptyState({
   source,
   filter,
   watchlistOnly,
+  animeDub,
 }: {
   source: Source;
   filter: CalendarFilter;
   watchlistOnly: boolean;
+  animeDub: boolean;
 }) {
   const t = useT();
   const heading =
@@ -84,7 +86,7 @@ export function EmptyState({
             : source === "simkl-anticipated"
               ? t("No Simkl premieres this month")
               : source === "anime"
-                ? t("Nothing airing this month")
+                ? t(animeDub ? "No dubbed episodes this month" : "Nothing airing this month")
                 : t("Nothing this month");
   const filterKind =
     filter === "movie" ? t("movies") : filter === "tv" ? t("TV") : t("anime");
@@ -111,7 +113,9 @@ export function EmptyState({
                 )
               : source === "anime"
                 ? t(
-                    "AniList has no anime episodes scheduled to air this month. Try a different month.",
+                    animeDub
+                      ? "The dub schedule has no episodes releasing this month. Try a different month."
+                      : "AniList has no anime episodes scheduled to air this month. Try a different month.",
                   )
                 : watchlistOnly
             ? t(

--- a/src/views/calendar/month-grid.tsx
+++ b/src/views/calendar/month-grid.tsx
@@ -11,6 +11,7 @@ export function MonthGrid({
   weekStartsMonday,
   onOpenItem,
   onOpenDay,
+  hideTypeTag,
 }: {
   cells: Cell[];
   grouped: Map<string, CalendarItem[]>;
@@ -18,6 +19,7 @@ export function MonthGrid({
   weekStartsMonday: boolean;
   onOpenItem: (item: CalendarItem) => void;
   onOpenDay: (iso: string) => void;
+  hideTypeTag: boolean;
 }) {
   const t = useT();
   const weekdays = orderedWeekdayNames(weekStartsMonday);
@@ -64,7 +66,12 @@ export function MonthGrid({
               </div>
               <div className="flex min-h-0 flex-col gap-1.5">
                 {events.slice(0, 3).map((item) => (
-                  <CalendarChip key={item.id} item={item} onOpen={onOpenItem} />
+                  <CalendarChip
+                    key={item.id}
+                    item={item}
+                    onOpen={onOpenItem}
+                    hideTypeTag={hideTypeTag}
+                  />
                 ))}
                 {events.length > 3 && (
                   <button

--- a/src/views/calendar/source-switcher.tsx
+++ b/src/views/calendar/source-switcher.tsx
@@ -61,9 +61,9 @@ const OPTIONS: Option[] = [
   },
   {
     id: "anime",
-    label: "Anime airing",
+    label: "Anime",
     icon: () => <Sparkles size={13} strokeWidth={2.2} />,
-    hint: "Anime episodes airing this month, from AniList",
+    hint: "Anime episodes airing this month, sub or dub",
   },
   {
     id: "custom",

--- a/src/views/calendar/source-switcher.tsx
+++ b/src/views/calendar/source-switcher.tsx
@@ -1,4 +1,4 @@
-import { Library, Globe, Star } from "lucide-react";
+import { Library, Globe, Sparkles, Star } from "lucide-react";
 import type { ReactNode } from "react";
 import traktLogo from "@/assets/trakt.svg";
 import simklLogo from "@/assets/simkl.png";
@@ -58,6 +58,12 @@ const OPTIONS: Option[] = [
     label: "Simkl premieres",
     icon: SimklGlyph,
     hint: "New shows and anime premiering this month, from Simkl",
+  },
+  {
+    id: "anime",
+    label: "Anime airing",
+    icon: () => <Sparkles size={13} strokeWidth={2.2} />,
+    hint: "Anime episodes airing this month, from AniList",
   },
   {
     id: "custom",

--- a/src/views/calendar/use-calendar-data.ts
+++ b/src/views/calendar/use-calendar-data.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/calendar";
 import {
   fetchAnticipatedCalendar,
+  fetchAniListAiringCalendar,
   fetchLibraryCalendar,
   fetchSimklCalendar,
   fetchSimklPremieresCalendar,
@@ -86,6 +87,9 @@ export function useCalendarData({
       }
       if (source === "simkl-anticipated") {
         return run(fetchSimklPremieresCalendar(year, month));
+      }
+      if (source === "anime") {
+        return run(fetchAniListAiringCalendar(year, month));
       }
       if (source === "anticipated") {
         return run(fetchAnticipatedCalendar(year, month));

--- a/src/views/calendar/use-calendar-data.ts
+++ b/src/views/calendar/use-calendar-data.ts
@@ -8,6 +8,7 @@ import {
 import {
   fetchAnticipatedCalendar,
   fetchAniListAiringCalendar,
+  fetchAnimeDubCalendar,
   fetchLibraryCalendar,
   fetchSimklCalendar,
   fetchSimklPremieresCalendar,
@@ -24,6 +25,7 @@ type Args = {
   settings: Settings;
   year: number;
   month: number;
+  animeDub: boolean;
 };
 
 export function useCalendarData({
@@ -34,6 +36,7 @@ export function useCalendarData({
   settings,
   year,
   month,
+  animeDub,
 }: Args) {
   const [items, setItems] = useState<CalendarItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -89,7 +92,11 @@ export function useCalendarData({
         return run(fetchSimklPremieresCalendar(year, month));
       }
       if (source === "anime") {
-        return run(fetchAniListAiringCalendar(year, month));
+        return run(
+          animeDub
+            ? fetchAnimeDubCalendar(year, month)
+            : fetchAniListAiringCalendar(year, month),
+        );
       }
       if (source === "anticipated") {
         return run(fetchAnticipatedCalendar(year, month));
@@ -146,6 +153,7 @@ export function useCalendarData({
     settings.customCalendar.includeTraktWatchlist,
     year,
     month,
+    animeDub,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Adds a full anime airing experience to the Calendar across the whole branch:
1. New AniList airing schedule source — a "simulcast" calendar tab that pulls upcoming anime episode airings from AniList (50/page, sub schedule) into the month grid, with posters, backdrops, episode labels, MAL/average scores, and isAnime tagging.
2. Dub schedule with sub/dub toggle — a second anime feed (AniSchedule) curating when dubbed episodes air, with a sub/dub switch in the calendar data layer.
3. Cleaner source layout — the redundant Anime section/pill was removed from "All upcoming" (TMDB), which stays exclusively Movies/TV; anime now lives only in its own tab.
4. Faster loading — AniList airing page fetches were parallelized (bounded concurrency) after a live probe showed ~3× speedup.
5. Air times — each anime episode now shows its air time in 12-hour local format (e.g. 9:00 PM ×²) in the chip tooltip and day-modal rows.

## Why

Anime simulcast watchers need to know when an episode drops, not just the day. TMDB doesn't carry per-episode air times, so this branch adds dedicated anime sources (AniList + dub feed) that do, surfaces the air time in the UI, and keeps "All upcoming" clean by restricting it to Movies/TV. Parallelizing the page fetches made the anime tab load fast enough to be actually usable.

## Verification

- & node_modules\.bin\tsc.cmd --noEmit --pretty false -p tsconfig.json — clean under each change.
- pnpm exec vite build — exit 0; only pre-existing chunk-size / dynamic-import warnings.
- Perf probe on live AniList airing data: serial 3523ms → parallel 1229ms (~2.9× faster) with identical 500-episode result set.
- Reviewed the anime section removal (All upcoming now Movies/TV only) and that sub/dub toggle produces the expected source results.

## Platform Impact

None — all changes are frontend data-shaping and rendering (TypeScript + React + Tailwind). No Rust, config, or platform-specific code touched; playback, hotkeys, and navigation unaffected.

## UI Changes

- Calendar gets anime simulcast contents with sub/dub sourcing and a day-modal/tooltip air-time display.
- "All upcoming" now excludes anime-only entries (pill present only outside its tab).
<img width="2419" height="1187" alt="image" src="https://github.com/user-attachments/assets/df4b9c6b-d962-48d3-9c1b-f950dcc62651" />


## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [ ] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [ ] I removed secrets, tokens, private URLs, and personal data from logs and screenshots. 