### PR TITLE
manga: add manual library refresh button

### DIFF
--- a/src/views/manga/manga-browse.tsx
+++ b/src/views/manga/manga-browse.tsx
@@ -1,8 +1,9 @@
-import { Loader2, Search, Star } from "lucide-react";
+import { Loader2, RefreshCw, Search, Star } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
 import { Poster } from "@/components/poster";
 import {
+  clearMangaCache,
   MANGA_PAGE,
   popularManga,
   popularMangaStream,
@@ -36,6 +37,7 @@ export function MangaBrowse({
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [reloadTick, setReloadTick] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
 
   const offsetRef = useRef(0);
   const seenRef = useRef(new Set<string>());
@@ -63,6 +65,16 @@ export function MangaBrowse({
   );
 
   const reload = useCallback(() => setReloadTick((n) => n + 1), []);
+
+  const handleRefresh = useCallback(() => {
+    clearMangaCache();
+    setRefreshing(true);
+    reload();
+  }, [reload]);
+
+  useEffect(() => {
+    if (status !== "loading") setRefreshing(false);
+  }, [status]);
 
   const sourceRef = useRef(activeMangaSourceId());
   useEffect(
@@ -199,6 +211,16 @@ export function MangaBrowse({
         </div>
         <SourceDropdown onManageSources={onManageSources} />
         <TagDropdown tagId={tagId} onSelect={setTagId} />
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={refreshing}
+          aria-label={t("Refresh library")}
+          title={t("Refresh library")}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-elevated/40 text-ink-subtle ring-1 ring-edge-soft/60 transition-colors hover:bg-elevated/70 hover:text-ink disabled:opacity-50"
+        >
+          <RefreshCw size={15} className={refreshing ? "animate-spin" : undefined} />
+        </button>
       </div>
 
       {status === "loading" ? (


### PR DESCRIPTION
## Summary

Add a manual refresh button to the Manga library view. Clicking it clears the manga cache and re-fetches from the active source (e.g. a connected Suwayomi server) immediately.

## Why

Manga library data is cached for up to 30 minutes before a background refresh is even attempted, and up to 6 hours in the worst case (see POPULAR_DISK / mangaChapters TTLs in src/lib/manga/api.ts). There is currently no manual refresh action anywhere in the Manga UI. This means new chapters on a connected Suwayomi server (e.g. a weekly release) don't show up in Harbor until the entire app is restarted, which clears the in-memory cache. This button lets users force a fresh fetch on demand without restarting.

## Verification

- Ran `pnpm install` and `npx vite build` — build completes with no errors, no TypeScript issues in the changed file.
- Reviewed `clearMangaCache()` in src/lib/manga/api.ts to confirm it clears both the in-memory cache and the disk-backed cache, so the fix covers both the library list and per-manga chapter lists.
- Have not yet run this live in `tauri dev` against a real Suwayomi server end to end — happy to do so if a maintainer wants that confirmed before merge, or if someone else can verify.

## Platform Impact

None expected. Pure frontend (React/TypeScript) change, no platform-specific code touched.

## UI Changes

Added a small circular refresh icon button next to the source/tag filters on the Manga library screen (top toolbar). Spins while refreshing, disabled until the fetch completes or fails. No screenshot yet — can add one if requested.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.