### PR TITLE
fix(settings): stop overriding saved subtitle provider choices on load

### DIFF
--- a/src/lib/settings/load.ts
+++ b/src/lib/settings/load.ts
@@ -169,8 +169,6 @@ export function loadStoredSettings(rawKey: string = STORAGE_KEY): Settings {
       subProvidersEnabled: {
         ...DEFAULT.subProvidersEnabled,
         ...(parsed.subProvidersEnabled ?? {}),
-        wyzie: false,
-        opensubtitles: true,
       },
       hideContent: {
         ...DEFAULT.hideContent,


### PR DESCRIPTION
Fixes #1074.

## Problem

`loadSettings` spreads the persisted `subProvidersEnabled`, then reassigns two of its keys immediately after:

```ts
subProvidersEnabled: {
  ...DEFAULT.subProvidersEnabled,
  ...(parsed.subProvidersEnabled ?? {}),   // saved value
  wyzie: false,                             // always wins
  opensubtitles: true,                      // always wins
},
```

Object literals apply left to right, so the two literals overwrite whatever came out of the spread. On every load OpenSubtitles is forced on and Wyzie is forced off, which is why disabling OpenSubtitles never survives a restart — it is re-enabled before the UI ever reads it.

## Fix

Drop the two literals so the spread is the last word:

```ts
subProvidersEnabled: {
  ...DEFAULT.subProvidersEnabled,
  ...(parsed.subProvidersEnabled ?? {}),
},
```

Both literals are identical to what is already in `DEFAULT.subProvidersEnabled` (`{ wyzie: false, opensubtitles: true, jimaku: false, addons: true }`), so anyone who has never set these keys is completely unaffected — they still resolve to the same defaults through the spread. The only behaviour that changes is that a *stored* value which differs from the default is now honoured.

## Two things worth flagging

**1. Was the override intentional?** `git log -L` shows both literals have been there since the file was created (`8588d18`, 0.9.6) rather than added later as a kill-switch, which reads more like a leftover from that refactor than a deliberate pin. If `wyzie: false` *is* meant to be a hard kill-switch for a provider that shouldn't run, it would be clearer as a guard at the call site (or by removing it from the type) than as a load-time override that silently discards user state — happy to change this to only drop `opensubtitles` if you'd prefer.

**2. There is no UI for these toggles.** I could not find any component that writes `subProvidersEnabled` — it has a type, a default, this load path, and three read sites, but no write site anywhere in the last 300 commits. So this change makes the setting *persist correctly* without, on its own, giving users a way to change it from the app. Users who reach it via settings import/backup are unblocked; a toggle in the subtitle settings would be the follow-up, and I'm glad to open that as a separate PR if you want it.

I kept this one scoped to the persistence bug since that is what the issue describes and it's correct independently.

## Verification

- `pnpm run typecheck` — passes
- Diff is two deleted lines; no other files touched
