### PR TITLE
Bandwidth setting copy clarifies ranking only

### DIFF
--- a/src/views/settings/player-panel/bandwidth-section.tsx
+++ b/src/views/settings/player-panel/bandwidth-section.tsx
@@ -25,6 +25,7 @@ export function BandwidthInput() {
           <span className="text-[14px] font-medium text-ink">Internet speed</span>
           <span className="text-[12.5px] text-ink-subtle">
             Pick the cap your link can sustain. Run a real speed test if you need a number.
+            This only affects which streams rank higher. It does not limit download speed.
           </span>
         </div>
         <SpeedTestButton />


### PR DESCRIPTION
For #1114. Sub line now says the setting only affects stream ranking and does not limit download speed, since users read it as a throttle. An actual rate limiter in the engine would be a separate change.