### PR TITLE
Search overlay stays closed after sidebar navigation

### DIFF
--- a/src/lib/search-context.tsx
+++ b/src/lib/search-context.tsx
@@ -14,7 +14,7 @@ import { gatherCatalogAddons, type Addon } from "@/lib/addons";
 import { useAuth } from "@/lib/auth";
 import { useSettings } from "@/lib/settings";
 import { isMagnetInput, isDirectVideoUrl } from "@/lib/torrent/magnet";
-import { useView } from "@/lib/view";
+import { useView, type Frame } from "@/lib/view";
 
 type SearchState = {
   open: boolean;
@@ -450,15 +450,17 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     saveRecent([]);
   }, []);
 
-  const { navDepth } = useView();
+  const { navDepth, rootFrame } = useView();
   const restoreDepth = useRef<number | null>(null);
+  const restoreRoot = useRef<Frame | null>(null);
   const armed = useRef(false);
 
   const closeForNavigation = useCallback(() => {
     restoreDepth.current = navDepth;
+    restoreRoot.current = rootFrame;
     armed.current = false;
     setOpen(false);
-  }, [navDepth]);
+  }, [navDepth, rootFrame]);
 
   useEffect(() => {
     const mark = restoreDepth.current;
@@ -470,13 +472,15 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     if (armed.current && navDepth <= mark) {
       restoreDepth.current = null;
       armed.current = false;
-      setOpen(true);
+      if (rootFrame === restoreRoot.current) setOpen(true);
+      restoreRoot.current = null;
     }
-  }, [navDepth]);
+  }, [navDepth, rootFrame]);
 
   useEffect(() => {
     if (!open) return;
     restoreDepth.current = null;
+    restoreRoot.current = null;
     armed.current = false;
   }, [open]);
 

--- a/src/lib/view.tsx
+++ b/src/lib/view.tsx
@@ -198,6 +198,7 @@ type ViewValue = {
   settingsSectionRequest: { section: SettingsSection | null; nonce: number };
   topKind: Frame["kind"];
   topPath: string;
+  rootFrame: Frame;
   service: StreamingService | null;
   openService: (s: StreamingService | null) => void;
   meta: Meta | null;
@@ -461,6 +462,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const top = stack[stack.length - 1];
+  const rootFrame = stack[0];
 
   const view: View = (() => {
     for (let i = stack.length - 1; i >= 0; i--) {
@@ -1164,6 +1166,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       settingsSectionRequest: sectionReq,
       topKind: top.kind,
       topPath,
+      rootFrame,
       service,
       openService,
       meta,
@@ -1238,6 +1241,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
       view,
       top.kind,
       topPath,
+      rootFrame,
       service,
       meta,
       metaLiveContext,


### PR DESCRIPTION
For #1175. Picking a search result then clicking a sidebar item or the logo no longer reopens the search overlay over the new view. It now only restores when you return to the exact view you searched from with Back.

It tells a Back apart from a sidebar reset by root frame identity: Back keeps the same root frame, while the sidebar and logo build a new root, so a reset to the same kind of view no longer counts as returning. Adds rootFrame to the view context (src/lib/view.tsx) and gates the restore on it (src/lib/search-context.tsx).