### PR TITLE
Use ephemeral stream cache defaults

### DIFF
--- a/src-tauri/src/torrent_engine.rs
+++ b/src-tauri/src/torrent_engine.rs
@@ -57,7 +57,6 @@ fn engine() -> &'static Mutex<EngineState> {
 
 pub const LAN_SERVER_PORT: u16 = 11470;
 
-const CACHE_SWEEP_INITIAL_DELAY_SECS: u64 = 60;
 const CACHE_SWEEP_INTERVAL_SECS: u64 = 30 * 60;
 static CACHE_SWEEP_RUNNING: AtomicBool = AtomicBool::new(false);
 
@@ -85,14 +84,13 @@ fn spawn_cache_sweeper(app: AppHandle) -> CacheSweeper {
     let cancelled = Arc::new(AtomicBool::new(false));
     let cancelled_for_task = cancelled.clone();
     let task = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(CACHE_SWEEP_INITIAL_DELAY_SECS)).await;
         loop {
             if cancelled_for_task.load(Ordering::Acquire) {
                 break;
             }
             let cfg = read_config(&app);
             if let Ok(dir) = engine_dir(&app, &cfg) {
-                let retention = cfg.retention_hours.unwrap_or(24);
+                let retention = cfg.retention_hours.unwrap_or(0);
                 let max_gb = cfg.max_gb.unwrap_or(0);
                 let started = std::time::Instant::now();
                 let cancelled_for_sweep = cancelled_for_task.clone();

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -177,7 +177,7 @@ export const DEFAULT: Settings = {
   torrentsDisabled: false,
   torrentFullDownload: false,
   p2pAutoConsent: false,
-  streamCacheRetentionHours: 24,
+  streamCacheRetentionHours: 0,
   streamCacheMaxGb: 0,
   deleteWatchedDownloads: false,
   streamCacheDir: "",

--- a/tests/stream-cache-defaults.test.ts
+++ b/tests/stream-cache-defaults.test.ts
@@ -1,0 +1,15 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+test("stream cache defaults are ephemeral and swept on startup", () => {
+  const frontendDefaults = readFileSync("src/lib/settings/defaults.ts", "utf8");
+  const engine = readFileSync("src-tauri/src/torrent_engine.rs", "utf8");
+
+  assert.match(frontendDefaults, /streamCacheRetentionHours:\s*0,/);
+  assert.match(engine, /retention_hours\.unwrap_or\(0\)/);
+  assert.doesNotMatch(engine, /CACHE_SWEEP_INITIAL_DELAY_SECS/);
+});


### PR DESCRIPTION
## What changed

- Default new installs to an ephemeral P2P stream cache (`retentionHours = 0`).
- Run the cache sweep immediately when the torrent engine starts instead of waiting 60 seconds.
- Align the native engine fallback with the frontend default.
- Add a regression test covering the defaults and startup sweep behavior.

## Why

P2P playback necessarily writes torrent pieces to disk, but the previous 24-hour default retained those pieces after the player closed. Watching several large titles could therefore consume substantial disk space even when the user never selected Download.

With this change, leaving the player removes the current torrent data through the existing cleanup path. If the app exits unexpectedly, the immediate startup sweep removes stale ephemeral data on the next launch. Explicit downloads remain separate and are not affected. Existing users who selected a retention period keep their stored preference.

## Validation

- `pnpm run typecheck`
- `node --test tests/stream-cache-defaults.test.ts`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Full test suite: 102/103 passed; existing unrelated `tests/startup-loader.test.ts` assertion failed (`main page-load handler must exist`).

Linux bundle build was not available from the Windows development environment.
