### PR TITLE
Fix subtitle addon lookup for local and downloaded files

### DIFF
--- a/src/lib/download/downloads-store.ts
+++ b/src/lib/download/downloads-store.ts
@@ -4,6 +4,7 @@ import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { useSyncExternalStore } from "react";
 import type { Meta } from "@/lib/cinemeta";
 import type { PlayEpisode } from "@/lib/view";
+import type { DownloadPlaybackContext } from "./playback-context";
 import { buildDefaultFilename, sanitizeName } from "./filename";
 import { startDownload, type DownloadHandle } from "./video-download";
 import { isWindowsDesktop } from "@/lib/platform";
@@ -17,6 +18,7 @@ export type DownloadItem = {
   season: number | null;
   episode: number | null;
   streamLabel: string | null;
+  playback?: DownloadPlaybackContext;
   url: string;
   path: string;
   status: "downloading" | "done" | "error" | "canceled" | "interrupted";
@@ -32,6 +34,7 @@ type EnqueueArgs = {
   meta: Meta;
   episode?: PlayEpisode;
   streamLabel?: string | null;
+  playback?: DownloadPlaybackContext;
   url: string;
   headers?: Record<string, string> | null;
 };
@@ -93,7 +96,9 @@ function sep(): string {
 async function resolveDir(): Promise<string> {
   try {
     const raw = localStorage.getItem("harbor.settings");
-    const fromSettings = raw ? (JSON.parse(raw) as { downloadDir?: string }).downloadDir?.trim() : "";
+    const fromSettings = raw
+      ? (JSON.parse(raw) as { downloadDir?: string }).downloadDir?.trim()
+      : "";
     if (fromSettings) return fromSettings;
   } catch {
     /* fall through to system default */
@@ -149,7 +154,7 @@ export function activeDownloadFor(
 }
 
 export async function enqueueDownload(args: EnqueueArgs): Promise<string> {
-  const { meta, episode, streamLabel, url, headers } = args;
+  const { meta, episode, streamLabel, playback, url, headers } = args;
   let dir = await resolveDir();
   try {
     const raw = localStorage.getItem("harbor.settings");
@@ -176,6 +181,7 @@ export async function enqueueDownload(args: EnqueueArgs): Promise<string> {
     season: episode?.season ?? null,
     episode: episode?.episode ?? null,
     streamLabel: streamLabel ?? null,
+    playback,
     url,
     path,
     status: "downloading",
@@ -190,21 +196,27 @@ export async function enqueueDownload(args: EnqueueArgs): Promise<string> {
   speed.set(id, { bytes: 0, at: Date.now() });
   rebuild();
 
-  const handle = startDownload(id, url, path, (p) => {
-    const now = Date.now();
-    const s = speed.get(id);
-    let bps = 0;
-    if (s && now - s.at >= 500) {
-      bps = ((p.receivedBytes - s.bytes) / (now - s.at)) * 1000;
-      speed.set(id, { bytes: p.receivedBytes, at: now });
-    }
-    patch(id, {
-      receivedBytes: p.receivedBytes,
-      totalBytes: p.totalBytes,
-      ratio: p.ratio,
-      ...(bps > 0 ? { bytesPerSec: bps } : {}),
-    });
-  }, headers ?? undefined);
+  const handle = startDownload(
+    id,
+    url,
+    path,
+    (p) => {
+      const now = Date.now();
+      const s = speed.get(id);
+      let bps = 0;
+      if (s && now - s.at >= 500) {
+        bps = ((p.receivedBytes - s.bytes) / (now - s.at)) * 1000;
+        speed.set(id, { bytes: p.receivedBytes, at: now });
+      }
+      patch(id, {
+        receivedBytes: p.receivedBytes,
+        totalBytes: p.totalBytes,
+        ratio: p.ratio,
+        ...(bps > 0 ? { bytesPerSec: bps } : {}),
+      });
+    },
+    headers ?? undefined,
+  );
   handles.set(id, handle);
   handle.promise
     .then(() => patch(id, { status: "done", ratio: 1, bytesPerSec: 0 }))
@@ -213,7 +225,11 @@ export async function enqueueDownload(args: EnqueueArgs): Promise<string> {
         patch(id, { status: "canceled", bytesPerSec: 0 });
         return;
       }
-      patch(id, { status: "error", error: e instanceof Error ? e.message : "Download failed", bytesPerSec: 0 });
+      patch(id, {
+        status: "error",
+        error: e instanceof Error ? e.message : "Download failed",
+        bytesPerSec: 0,
+      });
     })
     .finally(() => {
       handles.delete(id);
@@ -254,7 +270,11 @@ function subscribe(listener: () => void): () => void {
 }
 
 export function useDownloads(): DownloadItem[] {
-  return useSyncExternalStore(subscribe, () => snapshot, () => snapshot);
+  return useSyncExternalStore(
+    subscribe,
+    () => snapshot,
+    () => snapshot,
+  );
 }
 
 export function useActiveDownloadCount(): number {

--- a/src/lib/download/playback-context.ts
+++ b/src/lib/download/playback-context.ts
@@ -1,0 +1,39 @@
+import type { PlayEpisode, PlayerSrc, PlayerSubtitleHints } from "@/lib/view";
+
+export type DownloadPlaybackContext = {
+  imdbId?: string;
+  imdbIdVerified?: boolean;
+  episode?: PlayEpisode;
+  subtitleHints?: PlayerSubtitleHints;
+};
+
+export function snapshotDownloadPlaybackContext(
+  context: DownloadPlaybackContext,
+): DownloadPlaybackContext {
+  const verifiedImdbId =
+    context.imdbIdVerified === true && /^tt\d+$/.test(context.imdbId ?? "")
+      ? context.imdbId
+      : undefined;
+  return {
+    ...(verifiedImdbId ? { imdbId: verifiedImdbId, imdbIdVerified: true } : {}),
+    ...(context.episode ? { episode: { ...context.episode } } : {}),
+    ...(context.subtitleHints ? { subtitleHints: { ...context.subtitleHints } } : {}),
+  };
+}
+
+export function downloadPlaybackFields(
+  context: DownloadPlaybackContext | undefined,
+  season: number | null,
+  episode: number | null,
+  path?: string,
+): Pick<PlayerSrc, "imdbId" | "imdbIdVerified" | "episode" | "subtitleHints"> {
+  const filename = path?.split(/[\\/]/).pop()?.trim();
+  return {
+    imdbId: context?.imdbId,
+    imdbIdVerified: context?.imdbIdVerified === true,
+    episode:
+      context?.episode ?? (season != null && episode != null ? { season, episode } : undefined),
+    subtitleHints:
+      context?.subtitleHints ?? (filename ? { filename, release: filename } : undefined),
+  };
+}

--- a/src/lib/local-library/player-src.ts
+++ b/src/lib/local-library/player-src.ts
@@ -10,21 +10,33 @@ export function episodeLabel(e: LocalEntry): string | null {
 
 export function localPlayerSrc(entry: LocalEntry): PlayerSrc {
   const epLabel = episodeLabel(entry);
+  const imdbId = /^tt\d+$/.test(entry.imdbId ?? "") ? (entry.imdbId ?? undefined) : undefined;
   return {
     meta: {
-      id: entry.imdbId ?? `local:${entry.id}`,
+      id: imdbId ?? `local:${entry.id}`,
       type: entry.type === "show" ? "series" : "movie",
       name: entry.title,
       poster: entry.poster ?? undefined,
       releaseInfo: entry.year ? String(entry.year) : undefined,
     },
-    imdbId: entry.imdbId ?? undefined,
+    imdbId,
+    imdbIdVerified: !!imdbId,
+    tmdbId: entry.tmdbId ?? undefined,
     episode: epLabel
-      ? { season: entry.season as number, episode: entry.episode as number, imdbId: entry.imdbId ?? undefined }
+      ? {
+          season: entry.season as number,
+          episode: entry.episode as number,
+          imdbId,
+        }
       : undefined,
     url: entry.path,
     title: entry.title,
     subtitle: epLabel ?? (entry.year ? String(entry.year) : entry.filename),
     notWebReady: true,
+    subtitleHints: {
+      filename: entry.filename,
+      release: entry.filename,
+      resolution: entry.resolution ?? null,
+    },
   };
 }

--- a/src/lib/subtitles/addon-routing.ts
+++ b/src/lib/subtitles/addon-routing.ts
@@ -1,0 +1,30 @@
+export type SubtitleIdQuery = {
+  imdbId?: string;
+  stremioId?: string;
+  season?: number;
+  episode?: number;
+};
+
+export function subtitleContentIds(query: SubtitleIdQuery): string[] {
+  const rawImdb = query.imdbId?.trim();
+  const imdbId = rawImdb ? (rawImdb.startsWith("tt") ? rawImdb : `tt${rawImdb}`) : "";
+  const candidates = [imdbId, query.stremioId?.trim() ?? ""].filter(Boolean);
+  const isEpisode = query.season != null && query.episode != null;
+  return [...new Set(candidates)].map((base) =>
+    isEpisode && !/:\d+:\d+$/.test(base) ? `${base}:${query.season}:${query.episode}` : base,
+  );
+}
+
+export function routeSubtitleAddonIds<T>(
+  addons: T[],
+  query: SubtitleIdQuery,
+  accepts: (addon: T, id: string) => boolean,
+): { ids: string[]; matches: Array<{ addon: T; id: string }> } {
+  const ids = subtitleContentIds(query);
+  const matches: Array<{ addon: T; id: string }> = [];
+  for (const addon of addons) {
+    const id = ids.find((candidate) => accepts(addon, candidate));
+    if (id) matches.push({ addon, id });
+  }
+  return { ids, matches };
+}

--- a/src/lib/subtitles/player-hints.ts
+++ b/src/lib/subtitles/player-hints.ts
@@ -1,0 +1,40 @@
+import type { PlayerSrc, PlayerStreamRef, PlayerSubtitleHints } from "@/lib/view";
+
+export function trustedPlayerImdbId(
+  src: Pick<PlayerSrc, "imdbId" | "imdbIdVerified" | "meta">,
+): string | undefined {
+  if (src.imdbIdVerified === true && /^tt\d+$/.test(src.imdbId ?? "")) return src.imdbId;
+  return /^tt\d+$/.test(src.meta.id) ? src.meta.id : undefined;
+}
+
+export function playerSubtitleMetadataId(src: Pick<PlayerSrc, "meta" | "tmdbId">): string {
+  if (src.tmdbId == null) return src.meta.id;
+  const kind = src.meta.type === "series" ? "tv" : "movie";
+  return `tmdb:${kind}:${src.tmdbId}`;
+}
+
+export function subtitleHintsFromStreamRef(
+  streamRef: PlayerStreamRef | undefined,
+): PlayerSubtitleHints | undefined {
+  if (!streamRef) return undefined;
+  return {
+    filename: streamRef.parsedTitle ?? streamRef.title ?? undefined,
+    release: streamRef.title ?? streamRef.parsedTitle ?? null,
+    source: streamRef.source ?? null,
+    resolution: streamRef.resolution ?? null,
+    size: streamRef.size ?? null,
+  };
+}
+
+export function resolvePlayerSubtitleHints(
+  src: Pick<PlayerSrc, "streamRef" | "subtitleHints">,
+): PlayerSubtitleHints {
+  const fallback = subtitleHintsFromStreamRef(src.streamRef);
+  return {
+    filename: src.subtitleHints?.filename ?? fallback?.filename,
+    release: src.subtitleHints?.release ?? fallback?.release,
+    source: src.subtitleHints?.source ?? fallback?.source,
+    resolution: src.subtitleHints?.resolution ?? fallback?.resolution,
+    size: src.subtitleHints?.size ?? fallback?.size,
+  };
+}

--- a/src/lib/subtitles/providers/addons.ts
+++ b/src/lib/subtitles/providers/addons.ts
@@ -1,6 +1,7 @@
 import { addonAccepts, type Addon } from "@/lib/addons";
 import { safeFetch } from "@/lib/safe-fetch";
 import { dlog } from "@/lib/debug";
+import { routeSubtitleAddonIds } from "../addon-routing";
 import type { SubResult, SubSearchQuery } from "../types";
 import { normalizeLang } from "../language";
 
@@ -16,18 +17,6 @@ function transportBase(transportUrl: string): string {
   return transportUrl.replace(/\/manifest\.json$/i, "").replace(/\/$/, "");
 }
 
-function contentId(q: SubSearchQuery): string | null {
-  const base =
-    q.stremioId?.trim() ||
-    (q.imdbId ? (q.imdbId.startsWith("tt") ? q.imdbId : `tt${q.imdbId}`) : "");
-  if (!base) return null;
-  const isEpisode = q.season != null && q.episode != null;
-  if (isEpisode && !/:\d+:\d+$/.test(base)) {
-    return `${base}:${q.season}:${q.episode}`;
-  }
-  return base;
-}
-
 function extraSegment(q: SubSearchQuery): string {
   const parts: string[] = [];
   if (q.videoHash) parts.push(`videoHash=${encodeURIComponent(q.videoHash)}`);
@@ -36,7 +25,12 @@ function extraSegment(q: SubSearchQuery): string {
   return parts.length > 0 ? `/${parts.join("&")}` : "";
 }
 
-async function callOne(addon: Addon, type: string, id: string, extra: string): Promise<RawAddonSub[]> {
+async function callOne(
+  addon: Addon,
+  type: string,
+  id: string,
+  extra: string,
+): Promise<RawAddonSub[]> {
   const base = transportBase(addon.transportUrl);
   const url = `${base}/subtitles/${type}/${id}${extra}.json`;
   dlog(`[addons] Fetching from ${addon.manifest.name}: ${url}`);
@@ -56,40 +50,40 @@ async function callOne(addon: Addon, type: string, id: string, extra: string): P
   }
 }
 
-export async function searchAddons(
-  addons: Addon[],
-  q: SubSearchQuery,
-): Promise<SubResult[]> {
+export async function searchAddons(addons: Addon[], q: SubSearchQuery): Promise<SubResult[]> {
   dlog(`[addons] searchAddons called with ${addons.length} addons`);
 
-  const id = contentId(q);
-  if (!id) {
-    dlog('[addons] No content ID, returning empty');
+  const type = q.type ?? (q.season != null && q.episode != null ? "series" : "movie");
+  const { ids, matches: subAddons } = routeSubtitleAddonIds(addons, q, (addon, id) =>
+    addonAccepts(addon, "subtitles", type, id),
+  );
+  if (ids.length === 0) {
+    dlog("[addons] No content ID, returning empty");
     return [];
   }
 
-  const type = q.type ?? (q.season != null && q.episode != null ? "series" : "movie");
-  dlog(`[addons] Content ID: ${id}, Type: ${type}`);
+  dlog(`[addons] Content IDs: ${ids.join(", ")}, Type: ${type}`);
 
-  const subAddons = addons.filter((a) => {
-    const accepts = addonAccepts(a, "subtitles", type, id);
-    if (!accepts) {
-      dlog(`[addons] ${a.manifest.name} does NOT accept ${type}/${id}`);
+  const accepted = new Set(subAddons.map(({ addon }) => addon));
+  for (const addon of addons) {
+    if (!accepted.has(addon)) {
+      dlog(`[addons] ${addon.manifest.name} does NOT accept ${type}/${ids.join(" or ")}`);
     }
-    return accepts;
-  });
+  }
   dlog(`[addons] === Filtered subtitle addons: ${subAddons.length} of ${addons.length} ===`);
   if (subAddons.length > 0) {
-    dlog(`[addons] Accepting addons: ${subAddons.map(a => a.manifest.name).join(', ')}`);
+    dlog(
+      `[addons] Accepting addons: ${subAddons.map(({ addon }) => addon.manifest.name).join(", ")}`,
+    );
   }
   if (subAddons.length === 0) {
-    dlog('[addons] No subtitle addons accept this content');
+    dlog("[addons] No subtitle addons accept this content");
     return [];
   }
 
   const extra = extraSegment(q);
   const settled = await Promise.all(
-    subAddons.map(async (addon) => {
+    subAddons.map(async ({ addon, id }) => {
       const result = await callOne(addon, type, id, extra);
       dlog(`[addons] ${addon.manifest.name}: ${result.length} subtitles`);
       return result;
@@ -98,14 +92,14 @@ export async function searchAddons(
 
   const out: SubResult[] = [];
   settled.forEach((subs, i) => {
-    const addonName = subAddons[i].manifest.name;
+    const addonName = subAddons[i].addon.manifest.name;
     for (let idx = 0; idx < subs.length; idx++) {
       const s = subs[idx];
       if (!s.url) continue;
       // Include addon name and index to ensure unique IDs across different addons
       const uniqueId = s.id
-        ? `${addonName.toLowerCase().replace(/[^a-z0-9]/g, '-')}-${s.id}`
-        : `${addonName.toLowerCase().replace(/[^a-z0-9]/g, '-')}-${idx}`;
+        ? `${addonName.toLowerCase().replace(/[^a-z0-9]/g, "-")}-${s.id}`
+        : `${addonName.toLowerCase().replace(/[^a-z0-9]/g, "-")}-${idx}`;
       out.push({
         id: uniqueId,
         url: s.url,
@@ -120,4 +114,3 @@ export async function searchAddons(
   dlog(`[addons] Total addon results: ${out.length}`);
   return out;
 }
-

--- a/src/lib/view.tsx
+++ b/src/lib/view.tsx
@@ -53,10 +53,19 @@ export type PlayEpisode = {
   runtime?: number;
 };
 
+export type PlayerSubtitleHints = {
+  filename?: string;
+  release?: string | null;
+  source?: string | null;
+  resolution?: string | null;
+  size?: number | null;
+};
+
 export type PlayerSrc = {
   meta: Meta;
   imdbId?: string;
   imdbIdVerified?: boolean;
+  tmdbId?: number;
   episode?: PlayEpisode;
   url: string;
   title: string;
@@ -68,6 +77,7 @@ export type PlayerSrc = {
   autoFired?: boolean;
   resume?: boolean;
   startFromZero?: boolean;
+  subtitleHints?: PlayerSubtitleHints;
   streamRef?: PlayerStreamRef;
   liveProgram?: string;
   isLive?: boolean;

--- a/src/views/downloads.tsx
+++ b/src/views/downloads.tsx
@@ -11,6 +11,7 @@ import {
   useDownloads,
   type DownloadItem,
 } from "@/lib/download/downloads-store";
+import { downloadPlaybackFields } from "@/lib/download/playback-context";
 
 function fmtBytes(n: number | null): string {
   if (n == null || n <= 0) return "";
@@ -131,7 +132,8 @@ function EmptyState() {
       <div className="flex flex-col gap-1.5">
         <p className="text-[15px] font-semibold text-ink">No downloads yet</p>
         <p className="max-w-[340px] text-[13.5px] leading-relaxed text-ink-muted">
-          Open any movie or show, hover an episode, and click the download icon. Pick the exact source you want and it saves here for offline watching.
+          Open any movie or show, hover an episode, and click the download icon. Pick the exact
+          source you want and it saves here for offline watching.
         </p>
       </div>
     </div>
@@ -140,7 +142,12 @@ function EmptyState() {
 
 function ShowGroup({ group }: { group: Extract<DownloadGroup, { kind: "show" }> }) {
   const { settings } = useSettings();
-  const poster = usePosterChain(settings.rpdbKey, group.metaId, group.poster ?? undefined, "series");
+  const poster = usePosterChain(
+    settings.rpdbKey,
+    group.metaId,
+    group.poster ?? undefined,
+    "series",
+  );
   const episodes = useMemo(
     () =>
       [...group.items].sort(
@@ -186,7 +193,8 @@ function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?: boolea
   );
   const pct = Math.round(d.ratio * 100);
   const downloading = d.status === "downloading";
-  const playLocal = () =>
+  const playLocal = () => {
+    const playback = downloadPlaybackFields(d.playback, d.season, d.episode, d.path);
     openPlayer({
       meta: {
         id: d.metaId,
@@ -198,11 +206,9 @@ function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?: boolea
       title: d.title,
       subtitle: d.subtitle ?? undefined,
       notWebReady: true,
-      episode:
-        d.season != null && d.episode != null
-          ? { season: d.season, episode: d.episode }
-          : undefined,
+      ...playback,
     });
+  };
   return (
     <li className="group flex items-center gap-4 rounded-2xl border border-edge-soft bg-elevated/40 p-3 transition-colors hover:bg-elevated/70">
       <div
@@ -249,7 +255,9 @@ function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?: boolea
                 </span>
               </>
             )}
-            {d.status === "error" && <span className="text-danger">Failed: {d.error ?? "download error"}</span>}
+            {d.status === "error" && (
+              <span className="text-danger">Failed: {d.error ?? "download error"}</span>
+            )}
             {d.status === "canceled" && <span className="text-ink-subtle">Canceled</span>}
             {d.status === "interrupted" && (
               <span className="text-amber-300/85">Interrupted: re-download to finish</span>
@@ -284,7 +292,15 @@ function DownloadRow({ d, compact = false }: { d: DownloadItem; compact?: boolea
   );
 }
 
-function RowBtn({ label, onClick, children }: { label: string; onClick: () => void; children: ReactNode }) {
+function RowBtn({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
   return (
     <button
       type="button"

--- a/src/views/play-picker/hooks/use-subtitle-choices.ts
+++ b/src/views/play-picker/hooks/use-subtitle-choices.ts
@@ -4,6 +4,11 @@ import type { Addon } from "@/lib/addons";
 import { gatherSubtitleAddons } from "@/lib/subtitles/addon-source";
 import { languageName } from "@/lib/subtitles/language";
 import { searchSubtitles } from "@/lib/subtitles/search";
+import {
+  playerSubtitleMetadataId,
+  resolvePlayerSubtitleHints,
+  trustedPlayerImdbId,
+} from "@/lib/subtitles/player-hints";
 import type { SubResult } from "@/lib/subtitles/types";
 import { useSettings } from "@/lib/settings";
 import type { PlayerSrc } from "@/lib/view";
@@ -33,7 +38,7 @@ export function useSubtitleChoices(src: PlayerSrc) {
   const preferredLangs = useMemo(() => {
     const primary = settings.preferredSubLangs?.length
       ? settings.preferredSubLangs
-      : settings.preferredLanguages ?? [];
+      : (settings.preferredLanguages ?? []);
     const base = primary.length > 0 ? primary : ["English"];
     return isAnimeSrc(src) ? base : base.filter((l) => !isJapanese(l));
   }, [settings.preferredSubLangs, settings.preferredLanguages, src.meta.id]);
@@ -52,15 +57,16 @@ export function useSubtitleChoices(src: PlayerSrc) {
       }
       const enabled = settings.subProvidersEnabled ?? {};
       try {
+        const subtitleHints = resolvePlayerSubtitleHints(src);
         const r = await searchSubtitles(
           {
-            imdbId: src.imdbId ?? (src.meta.id?.startsWith("tt") ? src.meta.id : undefined),
-            stremioId: src.meta.id,
+            imdbId: trustedPlayerImdbId(src),
+            stremioId: playerSubtitleMetadataId(src),
             type: src.meta.type === "series" ? "series" : "movie",
             season: src.episode?.season,
             episode: src.episode?.episode,
             langs: preferredLangs,
-            filename: src.streamRef?.parsedTitle ?? src.streamRef?.title ?? undefined,
+            filename: subtitleHints.filename,
           },
           {
             providers: {
@@ -71,9 +77,9 @@ export function useSubtitleChoices(src: PlayerSrc) {
             addons,
             preferredLangs,
             streamHints: {
-              release: src.streamRef?.title ?? src.streamRef?.parsedTitle ?? null,
-              source: src.streamRef?.source ?? null,
-              resolution: src.streamRef?.resolution ?? null,
+              release: subtitleHints.release,
+              source: subtitleHints.source,
+              resolution: subtitleHints.resolution,
             },
           },
         );

--- a/src/views/play-picker/use-pick-handler.ts
+++ b/src/views/play-picker/use-pick-handler.ts
@@ -19,6 +19,8 @@ import { buildPlayInvite } from "@/lib/together/build-invite";
 import { type PlayEpisode, type PlayerSrc } from "@/lib/view";
 import { openInAppBrowser, openUrl } from "@/lib/window";
 import { enqueueDownload } from "@/lib/download/downloads-store";
+import { snapshotDownloadPlaybackContext } from "@/lib/download/playback-context";
+import { subtitleHintsFromStreamRef } from "@/lib/subtitles/player-hints";
 import { formatStreamQuality, humanError, isDebridFailure } from "./picker-utils";
 
 export function usePickHandler({
@@ -80,7 +82,9 @@ export function usePickHandler({
 }) {
   const [queuedHash, setQueuedHash] = useState<string | null>(null);
   const [debridDown, setDebridDown] = useState(false);
-  const [p2pConfirm, setP2pConfirm] = useState<{ stream: ScoredStream; forceP2p?: boolean } | null>(null);
+  const [p2pConfirm, setP2pConfirm] = useState<{ stream: ScoredStream; forceP2p?: boolean } | null>(
+    null,
+  );
   const debridFailStreakRef = useRef(0);
   const resolveAcRef = useRef<AbortController | null>(null);
   const autoPickRef = useRef(false);
@@ -121,7 +125,9 @@ export function usePickHandler({
     resolveAcRef.current = ac;
     let opened = false;
     try {
-      const hint = episode ? { season: episode.season ?? null, episode: episode.episode ?? null } : undefined;
+      const hint = episode
+        ? { season: episode.season ?? null, episode: episode.episode ?? null }
+        : undefined;
       const r = await resolveStream(stream, debrids, ac.signal, userCommitted, forceP2p, hint);
       if (ac.signal.aborted) return;
       if (!r.ok) {
@@ -158,7 +164,8 @@ export function usePickHandler({
         } catch (e) {
           setFailedStreams((prev) => new Set(prev).add(stream));
           const willRetry = autoActive && autoAttemptIdx + 1 < autoCandidatesLength;
-          if (!willRetry) setResolveError("Could not start the local stream proxy. Pick another stream.");
+          if (!willRetry)
+            setResolveError("Could not start the local stream proxy. Pick another stream.");
           advanceAuto();
           return;
         }
@@ -185,10 +192,28 @@ export function usePickHandler({
         const willRetry = autoActive && autoAttemptIdx + 1 < autoCandidatesLength;
         advanceAuto();
         if (!willRetry && !autoActive) {
-          setResolveError("This source isn't ready on your debrid yet. Try it again in a moment or pick another.");
+          setResolveError(
+            "This source isn't ready on your debrid yet. Try it again in a moment or pick another.",
+          );
         }
         return;
       }
+      const streamRef = {
+        infoHash: stream.infoHash ?? null,
+        fileIdx: r.data.fileIdx ?? stream.fileIdx ?? null,
+        addonId: stream.addonId ?? null,
+        title: stream.title ?? null,
+        parsedTitle: stream.parsedTitle ?? null,
+        resolution: stream.resolution ?? null,
+        quality: formatStreamQuality(stream),
+        releaseGroup: stream.releaseGroupNormalized ?? null,
+        source: stream.source ?? null,
+        bingeGroup: stream.behaviorHints?.bingeGroup ?? null,
+        size: stream.size ?? null,
+        cachedSlugs: Object.entries(stream.cached ?? {})
+          .filter(([, v]) => v === true)
+          .map(([k]) => k),
+      };
       if (intent === "download") {
         const label =
           [stream.resolution, stream.source].filter(Boolean).join(" ") ||
@@ -197,7 +222,19 @@ export function usePickHandler({
           stream.name ||
           stream.addonName ||
           null;
-        void enqueueDownload({ meta, episode, streamLabel: label, url: r.data.url, headers: r.data.headers });
+        void enqueueDownload({
+          meta,
+          episode,
+          streamLabel: label,
+          playback: snapshotDownloadPlaybackContext({
+            imdbId: imdbId ?? undefined,
+            imdbIdVerified: imdbIdVerified === true,
+            episode,
+            subtitleHints: subtitleHintsFromStreamRef(streamRef),
+          }),
+          url: r.data.url,
+          headers: r.data.headers,
+        });
         opened = true;
         setResolving(null);
         onDownloadStarted?.(label);
@@ -223,22 +260,7 @@ export function usePickHandler({
         attempt: attempt ?? 0,
         autoFired: autoPickRef.current,
         resume: !!resume,
-        streamRef: {
-          infoHash: stream.infoHash ?? null,
-          fileIdx: r.data.fileIdx ?? stream.fileIdx ?? null,
-          addonId: stream.addonId ?? null,
-          title: stream.title ?? null,
-          parsedTitle: stream.parsedTitle ?? null,
-          resolution: stream.resolution ?? null,
-          quality: formatStreamQuality(stream),
-          releaseGroup: stream.releaseGroupNormalized ?? null,
-          source: stream.source ?? null,
-          bingeGroup: stream.behaviorHints?.bingeGroup ?? null,
-          size: stream.size ?? null,
-          cachedSlugs: Object.entries(stream.cached ?? {})
-            .filter(([, v]) => v === true)
-            .map(([k]) => k),
-        },
+        streamRef,
       });
       opened = true;
       sameSourceRetryRef.current = 0;
@@ -363,5 +385,15 @@ export function usePickHandler({
     sameSourceRetryRef.current = 0;
   };
 
-  return { onPlay, onCache, queuedHash, debridDown, resetDebridDown, abortResolve, p2pConfirm, confirmP2p, cancelP2p };
+  return {
+    onPlay,
+    onCache,
+    queuedHash,
+    debridDown,
+    resetDebridDown,
+    abortResolve,
+    p2pConfirm,
+    confirmP2p,
+    cancelP2p,
+  };
 }

--- a/src/views/player/hooks/use-track-autoload.ts
+++ b/src/views/player/hooks/use-track-autoload.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
 import { langScore, pickBestTrack } from "@/lib/subtitles/language";
 import { searchSubtitles } from "@/lib/subtitles/search";
+import { playerSubtitleMetadataId, resolvePlayerSubtitleHints } from "@/lib/subtitles/player-hints";
 import { readPlayerPrefs, type PerShowPrefs } from "@/lib/player-prefs";
 import { tmdbImdbId } from "@/lib/providers/tmdb";
 import type { Addon } from "@/lib/addons";
@@ -41,7 +42,7 @@ export function useTrackAutoload(params: {
       setResolutionSettled(true);
       return;
     }
-    const raw = src.meta.id ?? "";
+    const raw = playerSubtitleMetadataId(src);
     if (raw.startsWith("tt")) {
       setResolvedImdbId(raw);
       setResolvedImdbVerified(true);
@@ -66,7 +67,7 @@ export function useTrackAutoload(params: {
     return () => {
       cancelled = true;
     };
-  }, [src.imdbId, src.imdbIdVerified, src.meta.id, settings.tmdbKey]);
+  }, [src.imdbId, src.imdbIdVerified, src.meta.id, src.meta.type, src.tmdbId, settings.tmdbKey]);
 
   const [userAddonsState, setUserAddonsState] = useState<{
     authKey: string | null;
@@ -112,19 +113,20 @@ export function useTrackAutoload(params: {
         episode: src.episode?.episode,
         langs,
       });
+      const subtitleHints = resolvePlayerSubtitleHints(src);
       const { videoHash, videoSize } = settings.subtitleAutoSync ? await resolveVideoHash(src) : {};
       if (videoHash) console.info(`[subs/autoload] moviehash ${videoHash} (${videoSize})`);
       const results = await searchSubtitles(
         {
           imdbId: searchImdbId,
-          stremioId: src.meta.id,
+          stremioId: playerSubtitleMetadataId(src),
           type: src.meta.type === "series" ? "series" : "movie",
           season: src.episode?.season,
           episode: src.episode?.episode,
           langs,
           videoHash,
           videoSize,
-          filename: src.streamRef?.parsedTitle ?? src.streamRef?.title ?? undefined,
+          filename: subtitleHints.filename,
         },
         {
           providers: {
@@ -135,9 +137,9 @@ export function useTrackAutoload(params: {
           addons: readyAddons ?? [],
           preferredLangs: langs,
           streamHints: {
-            release: src.streamRef?.title ?? src.streamRef?.parsedTitle ?? null,
-            source: src.streamRef?.source ?? null,
-            resolution: src.streamRef?.resolution ?? null,
+            release: subtitleHints.release,
+            source: subtitleHints.source,
+            resolution: subtitleHints.resolution,
           },
         },
       );
@@ -364,7 +366,7 @@ async function resolveVideoHash(
       invoke<{ hash: string; size: number }>("compute_moviehash", {
         url: src.url,
         headers: src.headers,
-        size: src.streamRef?.size ?? undefined,
+        size: resolvePlayerSubtitleHints(src).size ?? undefined,
       }),
       1800,
     );

--- a/tests/download-subtitle-context.test.ts
+++ b/tests/download-subtitle-context.test.ts
@@ -1,0 +1,129 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  downloadPlaybackFields,
+  snapshotDownloadPlaybackContext,
+} from "../src/lib/download/playback-context.ts";
+import { localPlayerSrc } from "../src/lib/local-library/player-src.ts";
+import {
+  playerSubtitleMetadataId,
+  subtitleHintsFromStreamRef,
+  trustedPlayerImdbId,
+} from "../src/lib/subtitles/player-hints.ts";
+
+test("download playback keeps verified content and release metadata for subtitle providers", () => {
+  const episode = { season: 1, episode: 3, imdbSeason: 2, imdbEpisode: 8 };
+  const streamRef = {
+    infoHash: "0123456789abcdef",
+    title: "Show.S02E08.1080p.WEB-DL.mkv",
+    parsedTitle: "Show S02E08",
+    resolution: "1080p",
+    releaseGroup: "GROUP",
+    source: "WEB-DL",
+    size: 1_234_567,
+  };
+  const subtitleHints = subtitleHintsFromStreamRef(streamRef);
+  const context = snapshotDownloadPlaybackContext({
+    imdbId: "tt1234567",
+    imdbIdVerified: true,
+    episode,
+    subtitleHints,
+  });
+
+  episode.imdbEpisode = 99;
+  streamRef.title = "changed";
+  if (subtitleHints) subtitleHints.filename = "changed";
+
+  assert.equal(context.imdbId, "tt1234567");
+  assert.equal(context.imdbIdVerified, true);
+  assert.equal(context.episode?.imdbEpisode, 8);
+  assert.equal(context.subtitleHints?.filename, "Show S02E08");
+  assert.equal(context.subtitleHints?.release, "Show.S02E08.1080p.WEB-DL.mkv");
+  assert.equal(context.subtitleHints?.source, "WEB-DL");
+  assert.equal(context.subtitleHints?.size, 1_234_567);
+
+  const restored = downloadPlaybackFields(
+    JSON.parse(JSON.stringify(context)) as typeof context,
+    null,
+    null,
+  );
+  assert.equal(restored.imdbId, "tt1234567");
+  assert.equal(restored.episode?.imdbEpisode, 8);
+  assert.equal(restored.subtitleHints?.filename, "Show S02E08");
+  assert.equal("streamRef" in restored, false);
+});
+
+test("download playback does not trust fallback IMDb guesses", () => {
+  const context = snapshotDownloadPlaybackContext({
+    imdbId: "tt7654321",
+    imdbIdVerified: false,
+  });
+
+  assert.equal(context.imdbId, undefined);
+  assert.equal(context.imdbIdVerified, undefined);
+  assert.equal(
+    trustedPlayerImdbId({
+      meta: { id: "tmdb:movie:42", type: "movie", name: "Movie" },
+      imdbId: "tt7654321",
+      imdbIdVerified: false,
+    }),
+    undefined,
+  );
+  assert.equal(
+    trustedPlayerImdbId({
+      meta: { id: "tt1111111", type: "movie", name: "Movie" },
+      imdbId: undefined,
+      imdbIdVerified: undefined,
+    }),
+    "tt1111111",
+  );
+});
+
+test("older download records still rebuild their episode context", () => {
+  const playback = downloadPlaybackFields(undefined, 4, 11, "C:\\Downloads\\Show.S04E11.1080p.mkv");
+  assert.deepEqual(playback.episode, { season: 4, episode: 11 });
+  assert.equal(playback.imdbId, undefined);
+  assert.equal(playback.imdbIdVerified, false);
+  assert.equal(playback.subtitleHints?.filename, "Show.S04E11.1080p.mkv");
+});
+
+test("scanned local files expose verified IMDb and filename hints", () => {
+  const src = localPlayerSrc({
+    id: "local-1",
+    path: "C:/Media/Movie.2025.2160p.mkv",
+    filename: "Movie.2025.2160p.mkv",
+    title: "Movie",
+    year: 2025,
+    type: "movie",
+    resolution: "2160p",
+    imdbId: "tt7654321",
+    addedAt: 1,
+  });
+
+  assert.equal(src.imdbId, "tt7654321");
+  assert.equal(src.imdbIdVerified, true);
+  assert.equal(src.subtitleHints?.filename, "Movie.2025.2160p.mkv");
+  assert.equal(src.subtitleHints?.resolution, "2160p");
+  assert.equal(src.streamRef, undefined);
+});
+
+test("TMDB-only local files keep stable resume and subtitle lookup IDs", () => {
+  const src = localPlayerSrc({
+    id: "local-2",
+    path: "C:/Media/Movie.mkv",
+    filename: "Movie.mkv",
+    title: "Movie",
+    year: null,
+    type: "movie",
+    tmdbId: 42,
+    addedAt: 1,
+  });
+
+  assert.equal(src.meta.id, "local:local-2");
+  assert.equal(src.tmdbId, 42);
+  assert.equal(playerSubtitleMetadataId(src), "tmdb:movie:42");
+  assert.equal(src.imdbId, undefined);
+  assert.equal(src.imdbIdVerified, false);
+});

--- a/tests/subtitle-addon-id.test.ts
+++ b/tests/subtitle-addon-id.test.ts
@@ -1,0 +1,42 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { routeSubtitleAddonIds } from "../src/lib/subtitles/addon-routing.ts";
+
+test("subtitle addons receive the first content ID each manifest supports", () => {
+  const addons = [
+    { name: "IMDb subtitles", prefix: "tt" },
+    { name: "TMDB subtitles", prefix: "tmdb:" },
+  ];
+  const routed = routeSubtitleAddonIds(
+    addons,
+    {
+      imdbId: "tt1234567",
+      stremioId: "tmdb:tv:123",
+      season: 1,
+      episode: 3,
+    },
+    (addon, id) => id.startsWith(addon.prefix),
+  );
+
+  assert.deepEqual(routed.ids, ["tt1234567:1:3", "tmdb:tv:123:1:3"]);
+  assert.deepEqual(
+    routed.matches.map(({ addon, id }) => [addon.name, id]),
+    [
+      ["IMDb subtitles", "tt1234567:1:3"],
+      ["TMDB subtitles", "tmdb:tv:123:1:3"],
+    ],
+  );
+});
+
+test("subtitle addon routing deduplicates identical IMDb and Stremio IDs", () => {
+  const routed = routeSubtitleAddonIds(
+    [{ prefix: "tt" }],
+    { imdbId: "tt7654321", stremioId: "tt7654321" },
+    (addon, id) => id.startsWith(addon.prefix),
+  );
+
+  assert.deepEqual(routed.ids, ["tt7654321"]);
+  assert.equal(routed.matches[0]?.id, "tt7654321");
+});


### PR DESCRIPTION
## Summary

- Persist verified IMDb IDs, full episode context, and release/filename hints when a download is queued.
- Restore that context when playing downloaded or scanned local files, without treating local paths as remembered online stream sources.
- Route each subtitle addon to the first content ID its manifest accepts: verified IMDb first, then the original Stremio or TMDB ID.
- Keep older download records readable, with season/episode and filename fallbacks.

## Why

Downloaded playback previously retained only the original metadata ID and basic season/episode numbers. Subtitle addons that accept IMDb IDs could therefore reject TMDB or Kitsu downloads even when Harbor had already resolved a verified IMDb ID. Local files also lacked consistent release hints for subtitle matching.

This keeps subtitle lookup metadata separate from playback-history source identity, so enabling addon subtitles does not replace a user's remembered online stream with a local file path.

Fixes #1167

## Verification

- `node --test tests/download-subtitle-context.test.ts tests/subtitle-addon-id.test.ts tests/subtitle-autoload.test.ts` — 12 passed.
- `pnpm run typecheck` — passed.
- `pnpm run build` — passed.
- `pnpm run i18n:check` — passed.
- `pnpm exec vp check <13 changed files>` — 0 errors; all changed files correctly formatted. Existing React hook/compiler warnings remain in legacy touched files.
- `pnpm test` — 108 passed; one unrelated existing Windows failure in `tests/startup-loader.test.ts` (`main page-load handler must exist`).
- `pnpm tauri:build:linux-system` — attempted on Windows; timed out after 10 minutes. No Rust or platform-specific playback code changed.

## Platform Impact

TypeScript-only metadata persistence and subtitle search routing. Verified on Windows. No UI, native player, navigation, hotkey, or Rust changes. Linux full-binary verification remains for CI.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes. (No Rust changes.)
- [x] I tested affected platforms when the change is platform-specific. (Not platform-specific; verified on Windows.)
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
