### PR TITLE
Fix false slow-load warnings after playback starts

### DIFF
--- a/src/views/player/hooks/use-auto-retry.ts
+++ b/src/views/player/hooks/use-auto-retry.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
-import { getPlaybackBuffered, getPlaybackPosition, usePlaybackFlag } from "@/lib/player/playback-clock";
+import {
+  getPlaybackBuffered,
+  getPlaybackPosition,
+  usePlaybackFlag,
+} from "@/lib/player/playback-clock";
 import { isLocalUrl } from "@/lib/player/local-url";
 import { clearOnePickerCache } from "@/lib/picker-cache";
 import { resolveViaDebrids } from "@/lib/streams/resolve";
@@ -9,8 +13,20 @@ import { buildTranscodedUrl, probeStremioServer } from "@/lib/stremio-server";
 import type { DebridStore } from "@/lib/debrid/types";
 import type { Meta } from "@/lib/cinemeta";
 import type { PlayerSrc, PlayEpisode } from "@/lib/view";
-import { BLACK_SCREEN_GRACE_MS, MAX_AUTORETRY_ATTEMPTS, ROOM_STALL_MS, SLOW_LOAD_MS, STUCK_AUTORETRY_MS } from "../player-utils";
+import {
+  BLACK_SCREEN_GRACE_MS,
+  MAX_AUTORETRY_ATTEMPTS,
+  ROOM_STALL_MS,
+  SLOW_LOAD_MS,
+  STUCK_AUTORETRY_MS,
+} from "../player-utils";
 import { GENUINE_FAILURE_WINDOW_MS, type EngineStats } from "@/lib/torrent/engine-stats";
+import {
+  advanceSlowLoadSessionState,
+  hasPlaybackStarted,
+  initialSlowLoadSessionState,
+  shouldArmSlowLoadWarning,
+} from "../slow-load-state";
 
 type OpenPicker = (
   meta: Meta,
@@ -20,7 +36,10 @@ type OpenPicker = (
 
 export type SourceError = { status: number; host: string };
 
-async function probeSourceStatus(url: string, headers?: Record<string, string>): Promise<SourceError> {
+async function probeSourceStatus(
+  url: string,
+  headers?: Record<string, string>,
+): Promise<SourceError> {
   let host = "";
   try {
     host = new URL(url).host;
@@ -28,7 +47,10 @@ async function probeSourceStatus(url: string, headers?: Record<string, string>):
     host = "";
   }
   try {
-    const res = await fetch(url, { method: "GET", headers: { ...(headers ?? {}), Range: "bytes=0-1" } });
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { ...(headers ?? {}), Range: "bytes=0-1" },
+    });
     return { status: res.status, host };
   } catch {
     return { status: 0, host };
@@ -49,7 +71,20 @@ export function useAutoRetry(params: {
   isP2pEngine: boolean;
   engineStats: EngineStats | null;
 }) {
-  const { bridgeRef, src, snap, stremioServerTranscode, instantPlay, inRoom, debrids, selfFrameReadyRef, openPicker, engineFailure, isP2pEngine, engineStats } = params;
+  const {
+    bridgeRef,
+    src,
+    snap,
+    stremioServerTranscode,
+    instantPlay,
+    inRoom,
+    debrids,
+    selfFrameReadyRef,
+    openPicker,
+    engineFailure,
+    isP2pEngine,
+    engineStats,
+  } = params;
   const isLocal = isLocalUrl(src.url);
   const isLive = src.meta.id.startsWith("iptv:");
   const ENGINE_FIRST_FRAME_GRACE_MS = 20_000;
@@ -69,15 +104,38 @@ export function useAutoRetry(params: {
   const hasProgress = usePlaybackFlag(
     () => getPlaybackPosition() > 0.5 || getPlaybackBuffered() > 0.5,
   );
+  const playbackStartedNow = usePlaybackFlag(() =>
+    hasPlaybackStarted({
+      positionSec: getPlaybackPosition(),
+      bufferedSec: getPlaybackBuffered(),
+    }),
+  );
+  const slowLoadSessionRef = useRef(initialSlowLoadSessionState(src.url));
   const [slowLoad, setSlowLoad] = useState(false);
   useEffect(() => {
+    slowLoadSessionRef.current = advanceSlowLoadSessionState(slowLoadSessionRef.current, {
+      sourceUrl: src.url,
+      playbackStartedNow,
+    });
     setSlowLoad(false);
-    if (isLocal) return;
-    const hasMeaningful = snap.durationSec > 0 && hasProgress;
-    if (hasMeaningful) return;
-    const t = window.setTimeout(() => setSlowLoad(true), SLOW_LOAD_MS);
+    const playbackSuspended =
+      snap.status === "paused" || snap.status === "ended" || snap.status === "error";
+    if (
+      !shouldArmSlowLoadWarning({
+        isLocal,
+        playbackStarted: slowLoadSessionRef.current.playbackStarted,
+        playbackSuspended,
+      })
+    )
+      return;
+    const sourceUrl = src.url;
+    const t = window.setTimeout(() => {
+      const session = slowLoadSessionRef.current;
+      if (session.sourceUrl !== sourceUrl || session.playbackStarted) return;
+      setSlowLoad(true);
+    }, SLOW_LOAD_MS);
     return () => window.clearTimeout(t);
-  }, [src.url, snap.durationSec, hasProgress, isLocal]);
+  }, [src.url, playbackStartedNow, isLocal, snap.status]);
 
   const autoRetriedRef = useRef(false);
   const transcodedTriedRef = useRef(false);
@@ -115,17 +173,20 @@ export function useAutoRetry(params: {
     const b = bridgeRef.current;
     if (!b) return;
     const attempt = liveRetryCountRef.current + 1;
-    const timer = window.setTimeout(() => {
-      liveRetryCountRef.current = attempt;
-      console.warn(`[player] live auto-reconnect attempt ${attempt}/${maxAttempts}`);
-      void b.load({
-        url: src.url,
-        subtitles: src.subtitles,
-        notWebReady: src.notWebReady,
-        isLive: true,
-        headers: src.headers,
-      });
-    }, livePlayedRef.current ? 4000 : 1500);
+    const timer = window.setTimeout(
+      () => {
+        liveRetryCountRef.current = attempt;
+        console.warn(`[player] live auto-reconnect attempt ${attempt}/${maxAttempts}`);
+        void b.load({
+          url: src.url,
+          subtitles: src.subtitles,
+          notWebReady: src.notWebReady,
+          isLive: true,
+          headers: src.headers,
+        });
+      },
+      livePlayedRef.current ? 4000 : 1500,
+    );
     return () => window.clearTimeout(timer);
   }, [isLive, snap.errorCode, src.url, src.subtitles, src.notWebReady, bridgeRef]);
 
@@ -162,12 +223,23 @@ export function useAutoRetry(params: {
       openPicker(
         src.meta,
         src.episode,
-        instantPlay || inRoom
-          ? { autoPlay: true, attempt: nextAttempt }
-          : { autoPlay: false },
+        instantPlay || inRoom ? { autoPlay: true, attempt: nextAttempt } : { autoPlay: false },
       );
     },
-    [src.attempt, src.meta, src.episode, openPicker, instantPlay, isLocal, isLive, inRoom, src.url, src.subtitles, src.notWebReady, bridgeRef],
+    [
+      src.attempt,
+      src.meta,
+      src.episode,
+      openPicker,
+      instantPlay,
+      isLocal,
+      isLive,
+      inRoom,
+      src.url,
+      src.subtitles,
+      src.notWebReady,
+      bridgeRef,
+    ],
   );
 
   useEffect(() => {
@@ -178,7 +250,12 @@ export function useAutoRetry(params: {
       return;
     }
     if (getPlaybackPosition() > 5) return;
-    if (isP2pEngine && !engineFailure && Date.now() - urlAtRef.current < ENGINE_FIRST_FRAME_GRACE_MS) return;
+    if (
+      isP2pEngine &&
+      !engineFailure &&
+      Date.now() - urlAtRef.current < ENGINE_FIRST_FRAME_GRACE_MS
+    )
+      return;
     const failoverHash = src.streamRef?.infoHash;
     if (failoverHash && debrids.length > 0 && !debridFailoverTriedRef.current) {
       debridFailoverTriedRef.current = true;
@@ -187,25 +264,36 @@ export function useAutoRetry(params: {
       const hint = src.episode
         ? { season: src.episode.season ?? null, episode: src.episode.episode ?? null }
         : undefined;
-      void resolveViaDebrids(failoverHash, src.streamRef?.fileIdx ?? undefined, cached, debrids, ac.signal, false, {}, hint).then(
-        async (r) => {
-          const b = bridgeRef.current;
-          if (r.ok && b) {
-            let url = r.data.url;
-            if (r.data.headers && Object.keys(r.data.headers).length > 0) {
-              try {
-                url = (await registerStreamProxy(r.data.url, r.data.headers)).url;
-              } catch {
-                /* fall back to the raw debrid url */
-              }
+      void resolveViaDebrids(
+        failoverHash,
+        src.streamRef?.fileIdx ?? undefined,
+        cached,
+        debrids,
+        ac.signal,
+        false,
+        {},
+        hint,
+      ).then(async (r) => {
+        const b = bridgeRef.current;
+        if (r.ok && b) {
+          let url = r.data.url;
+          if (r.data.headers && Object.keys(r.data.headers).length > 0) {
+            try {
+              url = (await registerStreamProxy(r.data.url, r.data.headers)).url;
+            } catch {
+              /* fall back to the raw debrid url */
             }
-            console.warn(`[player] debrid failover via ${r.via}`);
-            void b.load({ url, subtitles: src.subtitles, notWebReady: r.data.notWebReady ?? src.notWebReady });
-          } else {
-            triggerAutoRetry(`playback error "${snap.errorCode}"`);
           }
-        },
-      );
+          console.warn(`[player] debrid failover via ${r.via}`);
+          void b.load({
+            url,
+            subtitles: src.subtitles,
+            notWebReady: r.data.notWebReady ?? src.notWebReady,
+          });
+        } else {
+          triggerAutoRetry(`playback error "${snap.errorCode}"`);
+        }
+      });
       return;
     }
     if (!sameUrlRetriedRef.current) {
@@ -237,7 +325,8 @@ export function useAutoRetry(params: {
         void registerStreamProxy(src.url, src.headers)
           .then((p) => {
             const bb = bridgeRef.current;
-            if (bb) void bb.load({ url: p.url, subtitles: src.subtitles, notWebReady: src.notWebReady });
+            if (bb)
+              void bb.load({ url: p.url, subtitles: src.subtitles, notWebReady: src.notWebReady });
           })
           .catch(() => triggerAutoRetry(`playback error "${snap.errorCode}"`));
         return;
@@ -331,7 +420,9 @@ export function useAutoRetry(params: {
       const graceMs = neverStarted ? 75_000 : 18_000;
       if (now - ref.urlAt < graceMs) return;
       if ((!isP2pEngine || engineFailure) && now - ref.at > graceMs && pos < 5) {
-        triggerAutoRetry(neverStarted ? "source did not start after 75s" : "position frozen for 18s");
+        triggerAutoRetry(
+          neverStarted ? "source did not start after 75s" : "position frozen for 18s",
+        );
       }
     }, 1000);
     return () => window.clearInterval(id);
@@ -359,13 +450,23 @@ export function useAutoRetry(params: {
       noVideoSinceRef.current = Date.now();
       return;
     }
-    const graceMs = isP2pEngine ? Math.max(BLACK_SCREEN_GRACE_MS, ENGINE_FIRST_FRAME_GRACE_MS) : BLACK_SCREEN_GRACE_MS;
+    const graceMs = isP2pEngine
+      ? Math.max(BLACK_SCREEN_GRACE_MS, ENGINE_FIRST_FRAME_GRACE_MS)
+      : BLACK_SCREEN_GRACE_MS;
     if (Date.now() - noVideoSinceRef.current > graceMs) {
       if (!isP2pEngine || engineFailure) {
         triggerAutoRetry("audio plays but no video frames (black screen)");
       }
     }
-  }, [snap.status, snap.videoWidth, snap.videoHeight, triggerAutoRetry, src.url, isP2pEngine, engineFailure]);
+  }, [
+    snap.status,
+    snap.videoWidth,
+    snap.videoHeight,
+    triggerAutoRetry,
+    src.url,
+    isP2pEngine,
+    engineFailure,
+  ]);
 
   useEffect(() => {
     if (snap.status === "ended") return;
@@ -392,7 +493,19 @@ export function useAutoRetry(params: {
       }
     }, ROOM_STALL_MS);
     return () => window.clearTimeout(t);
-  }, [inRoom, isLocal, isLive, snap.status, snap.videoWidth, snap.videoHeight, triggerAutoRetry, src.url, selfFrameReadyRef, isP2pEngine, engineFailure]);
+  }, [
+    inRoom,
+    isLocal,
+    isLive,
+    snap.status,
+    snap.videoWidth,
+    snap.videoHeight,
+    triggerAutoRetry,
+    src.url,
+    selfFrameReadyRef,
+    isP2pEngine,
+    engineFailure,
+  ]);
 
   useEffect(() => {
     if (!isP2pEngine || snap.status === "ended") return;

--- a/src/views/player/slow-load-state.ts
+++ b/src/views/player/slow-load-state.ts
@@ -1,0 +1,34 @@
+const PLAYBACK_STARTED_THRESHOLD_SEC = 0.5;
+
+export type SlowLoadSessionState = {
+  sourceUrl: string;
+  playbackStarted: boolean;
+};
+
+export function hasPlaybackStarted(input: { positionSec: number; bufferedSec: number }): boolean {
+  // Buffered bytes can exist before the player decodes its first frame.
+  return input.positionSec > PLAYBACK_STARTED_THRESHOLD_SEC;
+}
+
+export function initialSlowLoadSessionState(sourceUrl: string): SlowLoadSessionState {
+  return { sourceUrl, playbackStarted: false };
+}
+
+export function advanceSlowLoadSessionState(
+  state: SlowLoadSessionState,
+  input: { sourceUrl: string; playbackStartedNow: boolean },
+): SlowLoadSessionState {
+  if (state.sourceUrl !== input.sourceUrl) {
+    return initialSlowLoadSessionState(input.sourceUrl);
+  }
+  if (state.playbackStarted || !input.playbackStartedNow) return state;
+  return { ...state, playbackStarted: true };
+}
+
+export function shouldArmSlowLoadWarning(input: {
+  isLocal: boolean;
+  playbackStarted: boolean;
+  playbackSuspended: boolean;
+}): boolean {
+  return !input.isLocal && !input.playbackStarted && !input.playbackSuspended;
+}

--- a/tests/slow-load-state.test.ts
+++ b/tests/slow-load-state.test.ts
@@ -1,0 +1,118 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  advanceSlowLoadSessionState,
+  hasPlaybackStarted,
+  initialSlowLoadSessionState,
+  shouldArmSlowLoadWarning,
+} from "../src/views/player/slow-load-state.ts";
+
+const autoRetrySource = readFileSync(
+  new URL("../src/views/player/hooks/use-auto-retry.ts", import.meta.url),
+  "utf8",
+);
+
+test("unknown-duration streams stop the warning after playback advances", () => {
+  const playbackStarted = hasPlaybackStarted({ positionSec: 0.6, bufferedSec: 0 });
+
+  assert.equal(playbackStarted, true);
+  assert.equal(
+    shouldArmSlowLoadWarning({
+      isLocal: false,
+      playbackStarted,
+      playbackSuspended: false,
+    }),
+    false,
+  );
+});
+
+test("remote streams keep the warning armed before playback advances", () => {
+  const playbackStarted = hasPlaybackStarted({ positionSec: 0, bufferedSec: 0 });
+
+  assert.equal(playbackStarted, false);
+  assert.equal(
+    shouldArmSlowLoadWarning({
+      isLocal: false,
+      playbackStarted,
+      playbackSuspended: false,
+    }),
+    true,
+  );
+});
+
+test("prebuffering alone does not count as playback starting", () => {
+  const playbackStarted = hasPlaybackStarted({ positionSec: 0, bufferedSec: 30 });
+
+  assert.equal(playbackStarted, false);
+  assert.equal(
+    shouldArmSlowLoadWarning({
+      isLocal: false,
+      playbackStarted,
+      playbackSuspended: false,
+    }),
+    true,
+  );
+});
+
+test("local streams never arm the warning", () => {
+  assert.equal(
+    shouldArmSlowLoadWarning({
+      isLocal: true,
+      playbackStarted: false,
+      playbackSuspended: false,
+    }),
+    false,
+  );
+});
+
+test("a started source stays started after a seek back to zero", () => {
+  let state = initialSlowLoadSessionState("https://stream.example/one");
+  state = advanceSlowLoadSessionState(state, {
+    sourceUrl: state.sourceUrl,
+    playbackStartedNow: true,
+  });
+  state = advanceSlowLoadSessionState(state, {
+    sourceUrl: state.sourceUrl,
+    playbackStartedNow: false,
+  });
+
+  assert.equal(state.playbackStarted, true);
+});
+
+test("changing sources resets the playback-started latch", () => {
+  let state = initialSlowLoadSessionState("https://stream.example/one");
+  state = advanceSlowLoadSessionState(state, {
+    sourceUrl: state.sourceUrl,
+    playbackStartedNow: true,
+  });
+  state = advanceSlowLoadSessionState(state, {
+    sourceUrl: "https://stream.example/two",
+    playbackStartedNow: true,
+  });
+
+  assert.deepEqual(state, {
+    sourceUrl: "https://stream.example/two",
+    playbackStarted: false,
+  });
+});
+
+test("paused streams do not arm a slow-load warning", () => {
+  assert.equal(
+    shouldArmSlowLoadWarning({
+      isLocal: false,
+      playbackStarted: false,
+      playbackSuspended: true,
+    }),
+    false,
+  );
+});
+
+test("the hook cancels the old timer when playback starts", () => {
+  assert.match(autoRetrySource, /clearTimeout\(t\)/);
+  assert.match(autoRetrySource, /\[src\.url, playbackStartedNow, isLocal, snap\.status\]/);
+  assert.doesNotMatch(autoRetrySource, /snap\.durationSec\s*>\s*0\s*&&\s*hasProgress/);
+});


### PR DESCRIPTION
## Summary

- Treat playback-clock progress as evidence that a stream started even when duration metadata stays unavailable.
- Latch that evidence per source, reset it when the URL changes, and cancel stale warning timers safely.
- Keep the warning armed for prebuffer-only stalls, while suppressing it for local or suspended playback.

## Why

The slow-load pill currently requires both a known duration and progress before it considers playback healthy. Some direct/debrid streams play normally while reporting `durationSec = 0`, so Harbor shows "Stream is taking a while / Probably not cached" after 50 seconds even though playback is smooth.

Fixes #1078.

## Testing

- `node --test tests/slow-load-state.test.ts` — 8 passed
- `pnpm run typecheck` — passed
- `pnpm run check src/views/player/hooks/use-auto-retry.ts src/views/player/slow-load-state.ts tests/slow-load-state.test.ts` — 0 errors; existing warnings remain in `use-auto-retry.ts`
- `pnpm run build` — passed
- `pnpm run i18n:check` — passed
- `pnpm tauri:build:linux-system` — passed and produced the installer
- `pnpm test` — 109 passed, 1 existing unrelated failure in `tests/startup-loader.test.ts` (`main page-load handler must exist`)

## Review note

The repository's pre-commit `vp fmt` hook reformatted the touched `use-auto-retry.ts` file. The behavior change is limited to the slow-load warning section plus the new focused state helper and tests.
