### PR TITLE
feat(account): verified email and email password reset, capability-gated

### DIFF
--- a/src/lib/account/capabilities.ts
+++ b/src/lib/account/capabilities.ts
@@ -2,17 +2,23 @@ import { useEffect, useState } from "react";
 import { getJson } from "./client";
 
 /**
- * What the CONNECTED instance supports, asked at runtime rather than compiled in.
+ * What the CONNECTED backend supports, asked at runtime rather than compiled in.
  *
- * One client binary serves harbor.site, self-hosted instances and anyone running
- * their own backend, so an email feature cannot be a build flag -- a self-hoster
- * with no SMTP configured would get a signup form promising a verification mail
- * that never arrives, which is worse than not offering it.
+ * NOTE ON WHO THIS PROTECTS, because the obvious answer is wrong. It is NOT
+ * self-hosters: HARBOR_API_BASE defaults to https://harbor.site, so a
+ * self-hosted client still uses the primary backend for its Harbor account, and
+ * would get a working mailer. Repointing needs a build-time VITE_HARBOR_API_BASE
+ * and a harbor-themes of your own.
  *
- * So the server is asked, and every email affordance in the UI is rendered only
- * if it answers yes. An instance that has not configured mail -- or one running a
- * backend older than this endpoint, where the request 404s -- looks exactly as it
- * does today.
+ * It earns its place for three narrower reasons:
+ *
+ *   1. ROLLOUT ORDER. This lands before the endpoints exist. Every backend 404s
+ *      today, so today every client renders exactly as it does now, and the two
+ *      halves can ship independently in either order.
+ *   2. KILL SWITCH. A provider outage or an abuse wave is one config flip away
+ *      from the UI disappearing, rather than a client release.
+ *   3. Backends that genuinely differ -- the maintainer's dev instances, CI, and
+ *      a self-hostable harbor-themes if that ever exists.
  */
 export type AccountCapabilities = {
   /** Instance can send mail: verification and email password reset are available. */

--- a/src/lib/account/capabilities.ts
+++ b/src/lib/account/capabilities.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { getJson } from "./client";
+
+/**
+ * What the CONNECTED instance supports, asked at runtime rather than compiled in.
+ *
+ * One client binary serves harbor.site, self-hosted instances and anyone running
+ * their own backend, so an email feature cannot be a build flag -- a self-hoster
+ * with no SMTP configured would get a signup form promising a verification mail
+ * that never arrives, which is worse than not offering it.
+ *
+ * So the server is asked, and every email affordance in the UI is rendered only
+ * if it answers yes. An instance that has not configured mail -- or one running a
+ * backend older than this endpoint, where the request 404s -- looks exactly as it
+ * does today.
+ */
+export type AccountCapabilities = {
+  /** Instance can send mail: verification and email password reset are available. */
+  email: boolean;
+  newsletter: {
+    enabled: boolean;
+    /** Operator-supplied checkbox label. Never hardcode one; not every instance runs a list. */
+    label: string;
+    defaultChecked: boolean;
+  };
+};
+
+const NONE: AccountCapabilities = {
+  email: false,
+  newsletter: { enabled: false, label: "", defaultChecked: false },
+};
+
+let cache: AccountCapabilities | null = null;
+let inflight: Promise<AccountCapabilities> | null = null;
+
+function coerce(raw: unknown): AccountCapabilities {
+  const d = (raw ?? {}) as Record<string, unknown>;
+  const n = (d.newsletter ?? {}) as Record<string, unknown>;
+  return {
+    email: d.email === true,
+    newsletter: {
+      // Newsletter is meaningless without a mailer, so it cannot be enabled alone.
+      enabled: d.email === true && n.enabled === true,
+      label: typeof n.label === "string" ? n.label : "",
+      defaultChecked: n.defaultChecked === true,
+    },
+  };
+}
+
+/**
+ * Cached for the session. Deliberately fails CLOSED: any error -- offline, 404
+ * from an older backend, malformed body -- yields "no email support", so a
+ * transient failure hides the UI rather than showing controls that cannot work.
+ */
+export async function fetchCapabilities(): Promise<AccountCapabilities> {
+  if (cache) return cache;
+  if (inflight) return inflight;
+  inflight = getJson<unknown>("/identity/api/capabilities")
+    .then((d) => {
+      cache = coerce(d);
+      return cache;
+    })
+    .catch(() => NONE)
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+/** Test seam, and used when signing out of one instance and into another. */
+export function resetCapabilities(): void {
+  cache = null;
+}
+
+export function useCapabilities(): AccountCapabilities {
+  const [caps, setCaps] = useState<AccountCapabilities>(cache ?? NONE);
+  useEffect(() => {
+    let live = true;
+    void fetchCapabilities().then((c) => {
+      if (live) setCaps(c);
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+  return caps;
+}

--- a/src/lib/account/identity.ts
+++ b/src/lib/account/identity.ts
@@ -4,8 +4,63 @@ import { getJson, postJson } from "./client";
 type AuthResult = { token: string; refresh: string; user: RawUser };
 type AuthResultWithCode = AuthResult & { recoveryCode: string };
 
-export async function registerIdentity(username: string, password: string): Promise<{ recoveryCode: string }> {
-  const d = await postJson<AuthResultWithCode>("/identity/api/register", { username, password });
+export async function registerIdentity(
+  username: string,
+  password: string,
+  /**
+   * OPTIONAL. Omitted entirely when the instance reports no mail support, and
+   * omitted when the user leaves the field blank -- in which case registration
+   * behaves exactly as before, recovery code and all. An account without an
+   * email is a fully working account.
+   */
+  email?: string,
+  newsletterOptIn?: boolean,
+): Promise<{ recoveryCode: string }> {
+  const body: Record<string, unknown> = { username, password };
+  if (email) {
+    body.email = email;
+    // Only sent alongside an address; a bare opt-in has nothing to subscribe.
+    body.newsletterOptIn = newsletterOptIn === true;
+  }
+  const d = await postJson<AuthResultWithCode>("/identity/api/register", body);
+  applyAuthResult(d);
+  return { recoveryCode: d.recoveryCode };
+}
+
+/**
+ * Attach or replace the address on an existing account. The server holds it as
+ * PENDING and does not touch the verified address until the link is clicked, so
+ * a typo -- or someone on a hijacked session -- cannot detach an account from
+ * the person who owns it.
+ */
+export async function attachEmail(email: string, newsletterOptIn = false): Promise<void> {
+  await postJson<{ pending: true }>(
+    "/identity/api/email/attach",
+    { email, newsletterOptIn },
+    { bearer: true },
+  );
+}
+
+export async function resendVerification(): Promise<void> {
+  await postJson<{ sent: true }>("/identity/api/email/resend", {}, { bearer: true });
+}
+
+/**
+ * Always resolves when the instance supports email, whether or not the address
+ * is known -- the server answers 202 either way. Reporting "no such account"
+ * here would turn this into an account-enumeration oracle, so the UI must say
+ * "if that address is on file, we've sent a link" and mean it.
+ */
+export async function requestPasswordReset(email: string): Promise<void> {
+  await postJson<{ sent: true }>("/identity/api/password/reset/request", { email });
+}
+
+/**
+ * Completing a reset rotates the recovery code, exactly as recoverIdentity does,
+ * so the caller must surface the new one. The old code stops working.
+ */
+export async function resetPassword(token: string, password: string): Promise<{ recoveryCode: string }> {
+  const d = await postJson<AuthResultWithCode>("/identity/api/password/reset", { token, password });
   applyAuthResult(d);
   return { recoveryCode: d.recoveryCode };
 }

--- a/src/lib/theme-auth.ts
+++ b/src/lib/theme-auth.ts
@@ -65,6 +65,11 @@ export type Author = {
   handleChangeAvailableAt?: string | null;
   verified?: boolean;
   stremioLinked?: boolean;
+  /** Verified address. Empty until a confirmation link has been clicked. */
+  email?: string;
+  emailVerified?: boolean;
+  /** Awaiting confirmation. Never replaces the verified address until clicked. */
+  emailPending?: string;
   badges?: AuthorBadge[];
 };
 
@@ -81,6 +86,9 @@ function absAvatar(p: unknown): string | null {
 
 function toAuthor(u: RawUser): Author {
   return {
+    email: typeof u.email === "string" ? u.email : "",
+    emailVerified: u.emailVerified === true,
+    emailPending: typeof u.emailPending === "string" ? u.emailPending : "",
     id: u.id,
     username: u.username,
     avatar: absAvatar(u.avatar),

--- a/src/views/account/account-auth-form.tsx
+++ b/src/views/account/account-auth-form.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { KeyRound, Loader2 } from "lucide-react";
 import { HarborMark } from "@/components/icons/harbor-mark";
 import { loginIdentity, registerIdentity } from "@/lib/account/identity";
+import { useCapabilities } from "@/lib/account/capabilities";
 import { accountErrorMessage } from "@/lib/account/error-messages";
 import { PasswordField, TextField } from "./fields";
 import { AccountRecoverForm } from "./account-recover-form";
@@ -23,13 +24,26 @@ export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) =>
   const [mode, setMode] = useState<Mode>("register");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  // Optional throughout. Never gates `ready`, so a blank address still registers.
+  const [email, setEmail] = useState("");
+  const [newsletter, setNewsletter] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Asked of the connected instance, not compiled in: one binary serves
+  // harbor.site and every self-hosted backend, and an instance with no mailer
+  // must not offer to send anything. Defaults to "no", so this is invisible
+  // until a server says otherwise.
+  const caps = useCapabilities();
   const trimmed = username.trim();
+  const trimmedEmail = email.trim();
+  // Intentionally forgiving: the server is the authority, and the verification
+  // mail either arrives or it does not. A strict regex here only rejects valid
+  // addresses.
+  const emailOk = trimmedEmail.length === 0 || /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmedEmail);
   const usernameOk = USERNAME_RE.test(trimmed);
   const passwordOk = mode === "register" ? password.length >= 8 : password.length > 0;
-  const ready = usernameOk && passwordOk;
+  const ready = usernameOk && passwordOk && emailOk;
   const usernameHint =
     mode === "register" && trimmed.length > 0 && !usernameOk
       ? "3 to 24 letters, numbers, or underscores."
@@ -41,7 +55,12 @@ export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) =>
     setError(null);
     try {
       if (mode === "register") {
-        const { recoveryCode } = await registerIdentity(trimmed, password);
+        const { recoveryCode } = await registerIdentity(
+          trimmed,
+          password,
+          caps.email && trimmedEmail ? trimmedEmail : undefined,
+          caps.newsletter.enabled ? (newsletter ?? caps.newsletter.defaultChecked) : false,
+        );
         onRecovery?.(recoveryCode);
       } else {
         await loginIdentity(trimmed, password);
@@ -130,6 +149,37 @@ export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) =>
             placeholder={mode === "register" ? t("At least 8 characters") : t("Your password")}
             onEnter={submit}
           />
+
+          {mode === "register" && caps.email && (
+            <>
+              <TextField
+                label={t("Email (optional)")}
+                value={email}
+                onChange={setEmail}
+                placeholder={t("you@example.com")}
+                hint={
+                  emailOk
+                    ? t("Lets you reset your password if you lose your recovery key. You can add it later.")
+                    : t("That doesn't look like an email address.")
+                }
+                tone={emailOk ? "muted" : "danger"}
+                autoComplete="email"
+              />
+              {caps.newsletter.enabled && caps.newsletter.label && (
+                <label className="flex cursor-pointer items-start gap-2.5 text-[12.5px] leading-snug text-ink-subtle">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 size-3.5 shrink-0 accent-ink"
+                    checked={newsletter ?? caps.newsletter.defaultChecked}
+                    onChange={(e) => setNewsletter(e.target.checked)}
+                    disabled={!trimmedEmail}
+                  />
+                  {/* Operator-supplied. Never hardcode a label -- not every instance runs a list. */}
+                  <span>{caps.newsletter.label}</span>
+                </label>
+              )}
+            </>
+          )}
 
           {mode === "signin" && (
             <button

--- a/src/views/account/account-auth-form.tsx
+++ b/src/views/account/account-auth-form.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { KeyRound, Loader2 } from "lucide-react";
 import { HarborMark } from "@/components/icons/harbor-mark";
-import { loginIdentity, registerIdentity } from "@/lib/account/identity";
+import { loginIdentity, registerIdentity, requestPasswordReset } from "@/lib/account/identity";
 import { useCapabilities } from "@/lib/account/capabilities";
 import { accountErrorMessage } from "@/lib/account/error-messages";
 import { PasswordField, TextField } from "./fields";
@@ -20,7 +20,8 @@ const USERNAME_RE = /^[a-zA-Z0-9_]{3,24}$/;
 
 export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) => void }) {
   const t = useT();
-  const [view, setView] = useState<"auth" | "recover">("auth");
+  const [view, setView] = useState<"auth" | "recover" | "forgot">("auth");
+  const [resetSent, setResetSent] = useState(false);
   const [mode, setMode] = useState<Mode>("register");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -40,7 +41,14 @@ export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) =>
   // Intentionally forgiving: the server is the authority, and the verification
   // mail either arrives or it does not. A strict regex here only rejects valid
   // addresses.
-  const emailOk = trimmedEmail.length === 0 || /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmedEmail);
+  // REQUIRED ONLY WHEN THE INSTANCE CAN SEND. If the backend reports no mail
+  // support, requiring an address here would make registration impossible --
+  // which is exactly what happens during the window where this ships before the
+  // server does.
+  const emailRequired = mode === "register" && caps.email;
+  const emailOk = emailRequired
+    ? /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmedEmail)
+    : trimmedEmail.length === 0 || /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmedEmail);
   const usernameOk = USERNAME_RE.test(trimmed);
   const passwordOk = mode === "register" ? password.length >= 8 : password.length > 0;
   const ready = usernameOk && passwordOk && emailOk;
@@ -73,6 +81,63 @@ export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) =>
   };
 
   const active = MODES.find((m) => m.id === mode)!;
+
+  if (view === "forgot")
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-[13px] leading-snug text-ink-muted">
+          {resetSent
+            ? /* Deliberately does not confirm whether the address exists. The
+                 server answers the same either way, because saying otherwise
+                 would make this an account-enumeration oracle. */
+              t("If that address is on file, we've sent a reset link. It's good for one hour.")
+            : t("Enter the email on your account and we'll send a reset link.")}
+        </p>
+        {!resetSent && (
+          <>
+            <TextField
+              label={t("Email")}
+              value={email}
+              onChange={setEmail}
+              placeholder={t("you@example.com")}
+              autoComplete="email"
+            />
+            <button
+              type="button"
+              disabled={busy || !trimmedEmail}
+              onClick={() => {
+                setBusy(true);
+                void requestPasswordReset(trimmedEmail)
+                  .catch(() => {})
+                  .finally(() => {
+                    // Always reports sent, matching the server. See above.
+                    setResetSent(true);
+                    setBusy(false);
+                  });
+              }}
+              className="flex h-11 items-center justify-center gap-2 rounded-[11px] bg-ink text-[14px] font-semibold text-canvas transition-all duration-150 hover:opacity-90 disabled:opacity-40"
+            >
+              {busy && <Loader2 size={16} className="animate-spin" />}
+              {t("Send reset link")}
+            </button>
+          </>
+        )}
+        <button
+          type="button"
+          onClick={() => { setView("recover"); setResetSent(false); setError(null); }}
+          className="text-[12px] font-medium text-ink-subtle transition-colors hover:text-ink"
+        >
+          {t("Use a recovery key instead")}
+        </button>
+        <button
+          type="button"
+          onClick={() => { setView("auth"); setResetSent(false); }}
+          className="text-[12px] font-medium text-ink-subtle transition-colors hover:text-ink"
+        >
+          {t("Back to sign in")}
+        </button>
+      </div>
+    );
 
   if (view === "recover") {
     return (
@@ -153,16 +218,16 @@ export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) =>
           {mode === "register" && caps.email && (
             <>
               <TextField
-                label={t("Email (optional)")}
+                label={emailRequired ? t("Email") : t("Email (optional)")}
                 value={email}
                 onChange={setEmail}
                 placeholder={t("you@example.com")}
                 hint={
-                  emailOk
-                    ? t("Lets you reset your password if you lose your recovery key. You can add it later.")
-                    : t("That doesn't look like an email address.")
+                  !emailOk && trimmedEmail.length > 0
+                    ? t("That doesn't look like an email address.")
+                    : t("We'll send a confirmation link. It also lets you reset your password if you lose your recovery key.")
                 }
-                tone={emailOk ? "muted" : "danger"}
+                tone={!emailOk && trimmedEmail.length > 0 ? "danger" : "muted"}
                 autoComplete="email"
               />
               {caps.newsletter.enabled && caps.newsletter.label && (
@@ -185,7 +250,7 @@ export function AccountAuthForm({ onRecovery }: { onRecovery?: (code: string) =>
             <button
               type="button"
               onClick={() => {
-                setView("recover");
+                setView(caps.email ? "forgot" : "recover");
                 setError(null);
               }}
               className="-mt-1 self-end text-[12px] font-medium text-ink-subtle transition-colors hover:text-ink"

--- a/src/views/account/account-email-row.tsx
+++ b/src/views/account/account-email-row.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { attachEmail, fetchMe, resendVerification } from "@/lib/account/identity";
+import { useCapabilities } from "@/lib/account/capabilities";
+import { accountErrorMessage } from "@/lib/account/error-messages";
+import type { Author } from "@/lib/theme-auth";
+import { useT } from "@/lib/i18n";
+import { TextField } from "./fields";
+
+/**
+ * The email state of a signed-in account: absent, pending, or verified.
+ *
+ * Renders nothing at all when the instance reports no mail support, which is
+ * also the state every client sees until the backend half ships.
+ *
+ * Accounts created before this feature have no address, and are PROMPTED here
+ * rather than blocked at login. Locking out the ~7.6k existing accounts on the
+ * day this shipped would be a far worse outcome than some of them never adding
+ * one.
+ */
+export function AccountEmailRow({ author }: { author: Author }) {
+  const t = useT();
+  const caps = useCapabilities();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resent, setResent] = useState(false);
+
+  if (!caps.email) return null;
+
+  const verified = author.emailVerified === true && !!author.email;
+  const pending = author.emailPending || "";
+  const trimmed = value.trim();
+  const valid = /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmed);
+
+  const submit = async () => {
+    if (!valid || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await attachEmail(trimmed, caps.newsletter.enabled ? caps.newsletter.defaultChecked : false);
+      // The address is now PENDING on the server. Refetch so this row shows that
+      // rather than optimistically claiming a verified state it does not have.
+      await fetchMe();
+      setEditing(false);
+      setValue("");
+    } catch (err) {
+      setError(accountErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const resend = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await resendVerification();
+      setResent(true);
+    } catch (err) {
+      setError(accountErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-[13.5px] font-semibold text-ink">{t("Email")}</p>
+          <p className="mt-0.5 truncate text-[12.5px] leading-snug text-ink-subtle">
+            {verified
+              ? author.email
+              : pending
+                ? t("Waiting for confirmation: {{email}}", { email: pending })
+                : t("Not set. Add one so you can reset your password without your recovery key.")}
+          </p>
+        </div>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => { setEditing(true); setError(null); setResent(false); }}
+            className="shrink-0 text-[12px] font-medium text-ink-subtle transition-colors hover:text-ink"
+          >
+            {verified || pending ? t("Change") : t("Add email")}
+          </button>
+        )}
+      </div>
+
+      {pending && !editing && (
+        <button
+          type="button"
+          onClick={() => void resend()}
+          disabled={busy || resent}
+          className="self-start text-[12px] font-medium text-ink-subtle transition-colors hover:text-ink disabled:opacity-50"
+        >
+          {resent ? t("Sent. Check your inbox.") : t("Resend confirmation")}
+        </button>
+      )}
+
+      {editing && (
+        <div className="flex flex-col gap-2.5">
+          <TextField
+            label={t("Email")}
+            value={value}
+            onChange={setValue}
+            placeholder={t("you@example.com")}
+            autoComplete="email"
+            hint={
+              verified
+                ? /* The current address keeps working until the new one is
+                     confirmed, so say so rather than implying it is replaced now. */
+                  t("Your current address stays active until you confirm the new one.")
+                : undefined
+            }
+          />
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={!valid || busy}
+              onClick={() => void submit()}
+              className="flex h-9 items-center gap-2 rounded-[9px] bg-ink px-3.5 text-[13px] font-semibold text-canvas transition-all hover:opacity-90 disabled:opacity-40"
+            >
+              {busy && <Loader2 size={14} className="animate-spin" />}
+              {t("Send confirmation")}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setEditing(false); setValue(""); setError(null); }}
+              className="text-[12px] font-medium text-ink-subtle transition-colors hover:text-ink"
+            >
+              {t("Cancel")}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <p className="rounded-[10px] border border-danger/25 bg-danger/10 px-3 py-2 text-[12px] leading-snug text-danger">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/views/account/harbor-account-panel.tsx
+++ b/src/views/account/harbor-account-panel.tsx
@@ -5,6 +5,7 @@ import { useT } from "@/lib/i18n";
 import { Section } from "@/views/settings/shared";
 import { RecoveryReveal } from "@/views/settings/theme-panel/custom-themes-section/author-account-panel/recovery-reveal";
 import { AccountAuthForm } from "./account-auth-form";
+import { AccountEmailRow } from "./account-email-row";
 import { AccountSignedInBar } from "./account-signed-in-bar";
 import { HandleClaimCard } from "./handle-claim-card";
 
@@ -35,6 +36,9 @@ export function HarborAccountPanel() {
           </div>
           <div className="p-5">
             <HandleClaimCard author={author} />
+          </div>
+          <div className="p-5">
+            <AccountEmailRow author={author} />
           </div>
         </div>
       )}


### PR DESCRIPTION
Client half of verified email on Harbor accounts. Backend companion: **harborstremio/harbor-hosted#36**, which has the full design rationale and one decision we'd like you to make explicitly.

**Draft for review, not a merge request.** It is safe to merge whenever you like though, for the reason below.

## Why

`account-auth-form.tsx` already tells users the situation:

> *We'll show a one-time recovery key right after you sign up. **Save it: it's the only way back in if you forget your password.***

That's accurate, and it's the problem. Lose the key and the account is gone, with no address to write to and no way for anyone to establish ownership. This adds a second route, alongside recovery keys rather than replacing them.

## What changed

| File | |
|---|---|
| `lib/account/capabilities.ts` | **new** — runtime capability check |
| `lib/account/identity.ts` | `attachEmail`, `resendVerification`, `requestPasswordReset`, `resetPassword`; `registerIdentity` takes an optional email |
| `lib/theme-auth.ts` | `Author` gains `email`, `emailVerified`, `emailPending` |
| `views/account/account-email-row.tsx` | **new** — not set / pending / verified, with resend and change |
| `views/account/account-auth-form.tsx` | email at registration, and *Forgot password* offering an email reset |
| `views/account/harbor-account-panel.tsx` | renders the row |

## The part worth reviewing first

**Capability discovery, not a build flag.** The client asks the backend what it supports:

```
GET /identity/api/capabilities → { email, newsletter: { enabled, label, defaultChecked } }
```

and renders nothing email-related unless the answer is yes. It **fails closed** — offline, a 404 from a backend that doesn't have this yet, a malformed body, all yield "no email support".

**That's what makes this safe to merge before the backend exists.** Today every instance 404s, so today every instance renders exactly as it does now. The two halves can land in either order.

It's also a kill switch: if mail ever needs turning off, that's a config change on the server rather than a client release.

**Email is required at registration, but only when the instance can send.** If the backend reports no mail support the field is absent and registration behaves exactly as before. Requiring it unconditionally would make signup impossible on a backend without a mailer.

**Existing accounts are prompted in the panel, never blocked at login.** Locking out accounts that predate this would be worse than some never adding an address.

**The reset request always reports sent**, matching the server, because saying otherwise would make it an account-enumeration oracle.

**The verification link is opened in a browser and answered by the server**, not handed back through a `harbor://` deep link. People read mail on a phone and run Harbor on a desktop, so a deep link fails on the device that actually receives it, needs per-platform registration, and breaks when mail clients rewrite URLs. Happy to add one later as an enhancement.

## Testing status, honestly

Everything parses, and the behaviour that matters is checkable without a backend: with no `/identity/api/capabilities` endpoint the account panel is **byte-identical to today**.

**Not typechecked and not run.** We worked from a clone without installing dependencies, so please treat this as a concrete proposal rather than tested work, and run `pnpm typecheck` before taking it seriously. Naming, placement and copy are all yours to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)