### PR TITLE
Fix anime episode names and release dates

### DIFF
--- a/src/lib/providers/anime-detail.ts
+++ b/src/lib/providers/anime-detail.ts
@@ -1,6 +1,6 @@
 import type { Meta } from "@/lib/cinemeta";
 import { aniZipByKitsu } from "@/lib/providers/anizip";
-import { buildKitsuEpisodes, mergeAniZipEpisodes } from "@/lib/providers/anime-episode-build";
+import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes } from "@/lib/providers/anime-episode-build";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import { kitsuToTvdb, kitsuToImdb, externalToKitsu, kitsuToAnilist } from "@/lib/providers/anime-mapping";
 import { anilistFranchise, type AnilistFranchiseNode } from "@/lib/anilist/relations";
@@ -8,6 +8,7 @@ import { anilistArtById, anilistRecommendations } from "@/lib/anilist/browse";
 import { enrichEpisodes } from "@/lib/providers/anime-episode-enrich";
 import { fanartMovie, fanartTv } from "@/lib/providers/fanart";
 import { fetchTvdbArtwork } from "@/lib/providers/tvdb-proxy";
+import { tvdbEpisodesByType, tvdbEpisodesAbsolute, tvdbLangFromIso1 } from "@/lib/providers/tvdb";
 import {
   kitsuAnime,
   kitsuCharacters,
@@ -356,7 +357,7 @@ export async function animeDetails(
   const effectiveSlugs =
     anime.genreSlugs.length > 0 ? anime.genreSlugs : anime.genres.map(slugify).filter(Boolean);
 
-  const [kitsuRawEpisodes, characters, related, studios, streamers, genreSimilar, aniZip, anilistRecs] =
+  const [kitsuRawEpisodes, characters, related, studios, streamers, genreSimilar, aniZip, anilistRecs, tvdbEpsRaw] =
     await Promise.all([
       kitsuEpisodes(kitsuId, 100),
       kitsuCharacters(kitsuId, 30),
@@ -370,10 +371,25 @@ export async function animeDetails(
       kitsuToAnilist(kitsuId)
         .then((aid) => (aid ? anilistRecommendations(aid) : []))
         .catch(() => [] as Meta[]),
+      kitsuToTvdb(kitsuId)
+        .then((tid) => {
+          if (!tid) return null;
+          const lang = tvdbLangFromIso1(settings.tmdbLanguage || settings.uiLanguage);
+          return Promise.all([
+            tvdbEpisodesByType(settings.tvdbKey ?? "", tid, "default", lang),
+            tvdbEpisodesAbsolute(settings.tvdbKey ?? "", tid, lang)
+          ]).then(([def, abs]) => {
+            const all = [...def, ...abs];
+            const unique = new Map(all.map(e => [e.id, e]));
+            return Array.from(unique.values());
+          });
+        })
+        .catch(() => null),
     ]);
 
   const episodes = buildKitsuEpisodes(addonMeta, kitsuRawEpisodes);
   mergeAniZipEpisodes(episodes, aniZip);
+  mergeTvdbEpisodes(episodes, tvdbEpsRaw);
 
   let seriesImdb = aniZip?.mappings?.imdb_id ?? episodes.find((e) => e.imdbId)?.imdbId ?? null;
   if (!seriesImdb) seriesImdb = await kitsuToImdb(kitsuId).catch(() => null);

--- a/src/lib/providers/anime-episode-build.ts
+++ b/src/lib/providers/anime-episode-build.ts
@@ -1,6 +1,7 @@
 import { pickEpisodeTitle, type AniZipMapping } from "@/lib/providers/anizip";
 import type { AnimeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import type { KitsuEpisode } from "@/lib/providers/kitsu";
+import type { TvdbEpisode } from "@/lib/providers/tvdb";
 
 export function buildKitsuEpisodes(
   addonMeta: AnimeKitsuMeta | null,
@@ -58,6 +59,46 @@ export function mergeAniZipEpisodes(episodes: KitsuEpisode[], aniZip: AniZipMapp
       if (azImdb) ep.imdbId = azImdb;
       if (ep.imdbSeason == null) ep.imdbSeason = az.seasonNumber;
       if (ep.imdbEpisode == null) ep.imdbEpisode = az.episodeNumber;
+    }
+  }
+}
+
+export function mergeTvdbEpisodes(episodes: KitsuEpisode[], tvdbEps: TvdbEpisode[] | null): void {
+  if (!tvdbEps || tvdbEps.length === 0) return;
+  const tvdbById = new Map<number, TvdbEpisode>();
+  const tvdbByAbsolute = new Map<number, TvdbEpisode>();
+  const tvdbBySeasonAndEpisode = new Map<string, TvdbEpisode>();
+
+  for (const e of tvdbEps) {
+    tvdbById.set(e.id, e);
+    if (e.absoluteNumber != null) tvdbByAbsolute.set(e.absoluteNumber, e);
+    tvdbBySeasonAndEpisode.set(`${e.seasonNumber}:${e.number}`, e);
+  }
+
+  for (const ep of episodes) {
+    let tvdbEp: TvdbEpisode | undefined;
+
+    if (ep.tvdbEpisodeId) tvdbEp = tvdbById.get(ep.tvdbEpisodeId);
+    if (!tvdbEp && ep.absoluteNumber) tvdbEp = tvdbByAbsolute.get(ep.absoluteNumber);
+    if (!tvdbEp && ep.imdbSeason != null && ep.imdbEpisode != null) {
+      tvdbEp = tvdbBySeasonAndEpisode.get(`${ep.imdbSeason}:${ep.imdbEpisode}`);
+    }
+    if (!tvdbEp) tvdbEp = tvdbBySeasonAndEpisode.get(`${ep.seasonNumber}:${ep.number}`);
+    if (!tvdbEp) tvdbEp = tvdbByAbsolute.get(ep.number);
+
+    if (tvdbEp) {
+      if (tvdbEp.name && (!ep.title || ep.title === `Episode ${ep.number}`)) {
+        ep.title = tvdbEp.name;
+      }
+      if (tvdbEp.aired) ep.airdate = tvdbEp.aired;
+      if (tvdbEp.overview && !ep.synopsis) ep.synopsis = tvdbEp.overview;
+      if (tvdbEp.image) {
+        if (ep.thumbnail && ep.thumbnail !== tvdbEp.image && !ep.thumbnailFallback) {
+          ep.thumbnailFallback = ep.thumbnail;
+        }
+        ep.thumbnail = tvdbEp.image;
+      }
+      if (tvdbEp.runtime && !ep.length) ep.length = tvdbEp.runtime;
     }
   }
 }

--- a/src/lib/providers/anime-franchise-episodes.ts
+++ b/src/lib/providers/anime-franchise-episodes.ts
@@ -1,26 +1,45 @@
 import { aniZipByKitsu } from "@/lib/providers/anizip";
-import { buildKitsuEpisodes, mergeAniZipEpisodes } from "@/lib/providers/anime-episode-build";
+import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes } from "@/lib/providers/anime-episode-build";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import { kitsuEpisodes, type KitsuEpisode } from "@/lib/providers/kitsu";
+import { kitsuToTvdb } from "@/lib/providers/anime-mapping";
+import { tvdbEpisodesByType, tvdbEpisodesAbsolute, tvdbLangFromIso1 } from "@/lib/providers/tvdb";
+import type { Settings } from "@/lib/settings";
 
-const cache = new Map<number, Promise<KitsuEpisode[]>>();
+const cache = new Map<string, Promise<KitsuEpisode[]>>();
 
 function isPlayable(ep: KitsuEpisode): boolean {
   if (ep.streamId) return true;
   return !!(ep.imdbId?.startsWith("tt") && ep.imdbSeason != null && ep.imdbEpisode != null);
 }
 
-export function fetchEntryEpisodes(kitsuId: number): Promise<KitsuEpisode[]> {
-  const cached = cache.get(kitsuId);
+export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise<KitsuEpisode[]> {
+  const lang = tvdbLangFromIso1(settings.tmdbLanguage || settings.uiLanguage);
+  const cacheKey = `${kitsuId}:${lang}`;
+  const cached = cache.get(cacheKey);
   if (cached) return cached;
   const p = (async () => {
-    const [addonMeta, raw, aniZip] = await Promise.all([
+    const [addonMeta, raw, aniZip, tvdbEpsRaw] = await Promise.all([
       animeKitsuMeta(`kitsu:${kitsuId}`).catch(() => null),
       kitsuEpisodes(kitsuId, 100).catch(() => [] as KitsuEpisode[]),
       aniZipByKitsu(kitsuId).catch(() => null),
+      kitsuToTvdb(kitsuId)
+        .then((tid) => {
+          if (!tid) return null;
+          return Promise.all([
+            tvdbEpisodesByType(settings.tvdbKey ?? "", tid, "default", lang),
+            tvdbEpisodesAbsolute(settings.tvdbKey ?? "", tid, lang)
+          ]).then(([def, abs]) => {
+            const all = [...def, ...abs];
+            const unique = new Map(all.map(e => [e.id, e]));
+            return Array.from(unique.values());
+          });
+        })
+        .catch(() => null),
     ]);
     const eps = buildKitsuEpisodes(addonMeta, raw);
     mergeAniZipEpisodes(eps, aniZip);
+    mergeTvdbEpisodes(eps, tvdbEpsRaw);
     const sourceMetaId = `kitsu:${kitsuId}`;
     const out: KitsuEpisode[] = [];
     for (const ep of eps) {
@@ -29,6 +48,6 @@ export function fetchEntryEpisodes(kitsuId: number): Promise<KitsuEpisode[]> {
     }
     return out;
   })();
-  cache.set(kitsuId, p);
+  cache.set(cacheKey, p);
   return p;
 }

--- a/src/lib/providers/tvdb.ts
+++ b/src/lib/providers/tvdb.ts
@@ -356,7 +356,8 @@ const ISO1_TO_TVDB: Record<string, string> = {
 };
 
 export function tvdbLangFromIso1(iso1: string | null | undefined): string {
-  return ISO1_TO_TVDB[(iso1 ?? "").toLowerCase()] ?? "eng";
+  const short = (iso1 ?? "").split("-")[0].toLowerCase();
+  return ISO1_TO_TVDB[short] ?? "eng";
 }
 
 export async function tvdbEpisodesByType(
@@ -414,11 +415,13 @@ export async function tvdbOrderTypeHasEpisodes(
 export async function tvdbEpisodesAbsolute(
   apiKey: string,
   seriesId: number,
+  lang?: string,
 ): Promise<TvdbEpisode[]> {
   if (!seriesId) return [];
   const out: TvdbEpisode[] = [];
+  const langSeg = lang ? `/${lang}` : "";
   for (let page = 0; page < 12; page++) {
-    const data = await getJson<any>(apiKey, `/series/${seriesId}/episodes/absolute?page=${page}`);
+    const data = await getJson<any>(apiKey, `/series/${seriesId}/episodes/absolute${langSeg}?page=${page}`);
     const arr = (data?.episodes ?? []) as any[];
     if (arr.length === 0) break;
     for (const e of arr) {

--- a/src/views/detail/anime-episodes/use-franchise-episodes.ts
+++ b/src/views/detail/anime-episodes/use-franchise-episodes.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { isFranchiseExtra, type FranchiseEntry } from "@/lib/providers/anime-detail";
+import { useSettings } from "@/lib/settings";
 import { fetchEntryEpisodes } from "@/lib/providers/anime-franchise-episodes";
 import { parseKitsuId, type KitsuEpisode } from "@/lib/providers/kitsu";
 
@@ -9,6 +10,7 @@ export function useFranchiseEpisodes(
   currentEpisodes: KitsuEpisode[],
   enabled: boolean,
 ): KitsuEpisode[] {
+  const { settings } = useSettings();
   const otherIds = useMemo(() => {
     if (!enabled || franchise.length <= 1) return [] as number[];
     const current = franchise.find((f) => f.meta.id === currentId);
@@ -30,7 +32,7 @@ export function useFranchiseEpisodes(
       return;
     }
     let cancelled = false;
-    void Promise.all(otherIds.map((id) => fetchEntryEpisodes(id).catch(() => [] as KitsuEpisode[]))).then(
+    void Promise.all(otherIds.map((id) => fetchEntryEpisodes(id, settings).catch(() => [] as KitsuEpisode[]))).then(
       (lists) => {
         if (!cancelled) setExtra(lists.flat());
       },


### PR DESCRIPTION
 This PR addresses missing/incorrect anime episode metadata (such as titles defaulting to "Episode 1" or displaying
stale release dates)
• Anime Metadata via TVDB:
      • Implemented mergeTvdbEpisodes to robustly map TVDB episodes to Kitsu episodes (by exact ID, absolute number,
      or season/episode combinations).
      • Updated anime-detail.ts and anime-franchise-episodes.ts to concurrently fetch TVDB episodes and merge them,
      overriding missing titles, incorrect airdates, missing synopses, and thumbnails.
  • Localization Support:
      • Updated TVDB fetchers to respect the app's configured metadata language (tmdbLanguage with a fallback to
      uiLanguage), so episode names and descriptions are correctly localized.

## Summary

This PR improves anime episode metadata by fetching TVDB episode data to fill in missing information (such as
titles defaulting to "Episode 1") and correcting stale release dates. It also ensures the fetched metadata
correctly respects the app's preferred language settings.

## Why

Kitsu and AniZip data frequently have missing titles for ongoing anime episodes and sometimes cache stale release
dates. By mapping TVDB episodes directly to the Kitsu episodes, we ensure the UI displays the correct episode names,
synopses, and airdates using the user's preferred `tmdbLanguage`.

## Verification

vp run typecheck pnpm exec tsc -b --pretty false
Confirmed that ongoing anime seasons fallback to TVDB metadata correctly.


**Before:**
<img width="1814" height="944" alt="Ekran görüntüsü 2026-08-12 043342" src="https://github.com/user-attachments/assets/fb59b634-325e-48a3-b298-b72bccf17314" />

<img width="1811" height="926" alt="Ekran görüntüsü 2026-08-12 043400" src="https://github.com/user-attachments/assets/863d7fbc-1e78-4026-9f6f-38ec9281f0be" />

**After:**
<img width="1548" height="870" alt="Ekran görüntüsü 2026-08-12 043222" src="https://github.com/user-attachments/assets/99f8db7e-06aa-40e4-a713-34094023f087" />
<img width="1546" height="890" alt="Ekran görüntüsü 2026-08-12 043245" src="https://github.com/user-attachments/assets/d8139aa8-afd1-4456-bd21-60015e7cdc6d" />

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
