### PR TITLE
feat: Anime4K shader status indicator update fix

### DIFF
--- a/src/components/player/anime4k-indicator.tsx
+++ b/src/components/player/anime4k-indicator.tsx
@@ -34,13 +34,19 @@ export function Anime4kIndicator({ engine, chromeVisible, suppressed = false }: 
 
   if (!active) return null;
 
+  // Determine the effective mode: HUD override takes precedence over base setting
+  const choice = (settings.playerAnime4kOverride as Anime4kChoice) || "auto";
+  const isAuto = choice === "auto";
+  const autoActive = isAuto && settings.playerAnime4k && settings.playerAnime4kFolder;
+  const effectiveMode = isAuto && autoActive ? (settings.playerAnime4kMode as Anime4kMode) : (choice === "off" ? "Off" : choice);
+
   return (
     <div
       className={`pointer-events-none absolute left-1/2 top-[3.25rem] z-30 flex -translate-x-1/2 items-center gap-2 rounded-full border border-edge-soft bg-canvas/85 px-3 py-1.5 text-[11px] font-semibold tracking-wide text-ink/85 shadow-[0_8px_24px_-12px_rgba(0,0,0,0.6)] backdrop-blur-md transition-opacity duration-300 ${chromeVisible && !suppressed ? "opacity-100" : "opacity-0"}`}
     >
       <Sparkles size={13} className="text-accent" />
       <span>Anime4K</span>
-      {settings.playerAnime4kMode && <span className="text-ink-subtle">{settings.playerAnime4kMode}</span>}
+      {effectiveMode && <span className="text-ink-subtle">{effectiveMode}</span>}
     </div>
   );
 }

--- a/src/components/player/anime4k-indicator.tsx
+++ b/src/components/player/anime4k-indicator.tsx
@@ -2,6 +2,8 @@ import { Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSettings } from "@/lib/settings";
+import type { Anime4kMode } from "@/lib/player/anime4k-modes";
+import type { Anime4kChoice } from "@/views/player/hooks/use-anime4k";
 
 const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 

--- a/src/views/player/hooks/use-anime4k.ts
+++ b/src/views/player/hooks/use-anime4k.ts
@@ -76,6 +76,7 @@ export function useAnime4k(
   const available = !!settings.playerAnime4kFolder;
   const dims: Anime4kDims = { srcWidth: videoWidth, displayWidth: screenWidthPx() };
   const generalKey = generalShaderKey(settings);
+  const mode = settings.playerAnime4kMode as Anime4kMode | undefined;
 
   const applyShaders = (c: Anime4kChoice) => {
     const chain = [...anime4kShadersFor(settings, src, c, dims), ...generalShaderChain(settings)];
@@ -86,7 +87,7 @@ export function useAnime4k(
   useEffect(() => {
     applyShaders(choice);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [srcKey, videoWidth, generalKey]);
+  }, [srcKey, videoWidth, generalKey, mode]);
 
   const setMode = (c: string) => {
     update({ playerAnime4kOverride: c });


### PR DESCRIPTION
## Summary

Two fixes for the Anime4K shader status indicator in Harbor:
1. useAnime4k hook dependency fix — Added playerAnime4kMode to the useEffect dependency array so the shader chain properly re-calculates when the base mode changes from Settings → Shaders.

2. Anime4kIndicator effective mode display — The indicator now computes and displays the effective mode, prioritizing the HUD override (playerAnime4kOverride) over the base setting (playerAnime4kMode). This means the badge correctly shows whichever mode is active, whether changed from Settings or from the player HUD shader menu

## Why

Problem: The Anime4K shader status indicator had two failure modes:
- Changing the base mode from Settings → Shaders → Mode A/B/C/AA/BB/CA had no effect — the indicator badge stayed stuck on the previous mode.
- Changing modes from the player HUD shader menu showed the base setting in the indicator, not the overridden mode the user just selected.

## Verification

1. Start Harbor with a video playing and Anime4K enabled
2. Open Settings → Shaders and change the mode from "Mode A" to "Mode C" — the Anime4K indicator badge should now update to reflect "Mode C"
3. Open the player HUD shader menu and switch from "Mode A" to "Mode B" — the indicator should show "B" (the HUD override)
4. Toggle Anime4K off then back on — the indicator should disappear/reappear
5. Verify the indicator text matches the active mode in all scenarios

## Platform Impact

None

## UI Changes

<img width="2381" height="1307" alt="image" src="https://github.com/user-attachments/assets/210a21f5-5d33-4705-89ff-bb807f8a3faa" />
<img width="2483" height="1318" alt="image" src="https://github.com/user-attachments/assets/c65a17a9-6898-4743-af17-ad087b4669a1" />

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
