### PR TITLE
PR #1216 also works on search and library

### DIFF
--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -23,7 +23,8 @@ import { getWatchedBy } from "@/lib/watched-by";
 import { playLocalAware } from "@/lib/local-library/playback";
 import { localPlayerSrc } from "@/lib/local-library/player-src";
 import { fetchSeasonEpisodes } from "@/lib/series-episodes";
-import { aniZipByAnidb, aniZipByAnilist, aniZipByKitsu, aniZipByMal } from "@/lib/providers/anizip";
+import { aniZipByAnidb, aniZipByAnilist, aniZipByMal } from "@/lib/providers/anizip";
+import { aniZipByKitsuWithFallback } from "@/lib/providers/anime-mapping";
 import { peekCachedLogo, resolveLogo } from "@/lib/logo";
 import { resolvePreferredAnimeTitle } from "@/lib/anime-title";
 import { stripFranchiseSuffix } from "@/lib/providers/jikan";
@@ -327,7 +328,7 @@ export const ContinueCard = memo(function ContinueCard({
               ? aniZipByAnilist
               : key.scheme === "anidb"
                 ? aniZipByAnidb
-                : aniZipByKitsu;
+                : aniZipByKitsuWithFallback;
         episode = applyAniZipEpisode(episode, await lookup(key.id).catch(() => null));
       }
     }

--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -22,7 +22,7 @@ import { harborImdbTitle } from "@/lib/providers/harbor-imdb";
 import { mdblistCardPrefetch, useMdblistCardScores } from "@/lib/providers/mdblist-batch";
 import { needsImdbForPoster, needsTmdbForPoster, rpdbPoster } from "@/lib/providers/rpdb";
 import { useTitlePoster } from "@/lib/title-poster";
-import { externalToKitsu, kitsuToImdb, kitsuToTvdb } from "@/lib/providers/anime-mapping";
+import { externalToKitsu, kitsuToImdb, kitsuToTvdb, aniZipByKitsuWithFallback } from "@/lib/providers/anime-mapping";
 import {
   tmdbIdFromImdb,
   tmdbImdbId,
@@ -34,7 +34,7 @@ import { useSettings } from "@/lib/settings";
 import { useSimklCardScores, useSimklCardScoresByAnimeId } from "@/lib/simkl/ratings";
 import { simklRequest } from "@/lib/simkl/client";
 import { getLocalCache } from "@/lib/simkl/activities";
-import { aniZipByKitsu, aniZipByMal } from "@/lib/providers/anizip";
+import { aniZipByMal } from "@/lib/providers/anizip";
 import { useView } from "@/lib/view";
 import { TvCard } from "@/components/tv-card";
 import { useTilt } from "@/lib/use-tilt";
@@ -412,7 +412,7 @@ const PosterCard = memo(function PosterCard({
       }
 
       if (kitsuId) {
-        const map = await aniZipByKitsu(kitsuId).catch(() => null);
+        const map = await aniZipByKitsuWithFallback(kitsuId).catch(() => null);
         if (cancelled) return;
         if (map?.titles) {
           const title = getTitleFromAniZip(map.titles, preferred);

--- a/src/lib/anime-title.ts
+++ b/src/lib/anime-title.ts
@@ -1,4 +1,5 @@
-import { aniZipByAnilist, aniZipByKitsu, aniZipByMal, type AniZipMapping } from "@/lib/providers/anizip";
+import { aniZipByAnilist, aniZipByMal, type AniZipMapping } from "@/lib/providers/anizip";
+import { aniZipByKitsuWithFallback } from "@/lib/providers/anime-mapping";
 
 export type AnimeTitleLang = "english" | "romaji" | "native";
 
@@ -29,7 +30,7 @@ export async function resolvePreferredAnimeTitle(
   let mapping: AniZipMapping | null = null;
   if (id.startsWith("kitsu:")) {
     const n = parseInt(id.slice(6), 10);
-    if (Number.isFinite(n)) mapping = await aniZipByKitsu(n).catch(() => null);
+    if (Number.isFinite(n)) mapping = await aniZipByKitsuWithFallback(n).catch(() => null);
   } else if (id.startsWith("mal:")) {
     const n = parseInt(id.slice(4), 10);
     if (Number.isFinite(n)) mapping = await aniZipByMal(n).catch(() => null);

--- a/src/lib/calendar-library.ts
+++ b/src/lib/calendar-library.ts
@@ -8,7 +8,8 @@ import {
   tmdbMovieRelease,
   tmdbTvUpcoming,
 } from "./providers/tmdb/tmdb-calendar";
-import { aniZipByAnilist, aniZipByKitsu, aniZipByMal, pickEpisodeTitle } from "./providers/anizip";
+import { aniZipByAnilist, aniZipByMal, pickEpisodeTitle } from "./providers/anizip";
+import { aniZipByKitsuWithFallback } from "./providers/anime-mapping";
 import type { CalendarItem } from "./calendar";
 
 const SERIES_LIMIT = 80;
@@ -101,7 +102,7 @@ async function animeUpcoming(
   const numId = animeNumericId(id);
   if (numId == null) return null;
   const mapping = id.startsWith("kitsu:")
-    ? await aniZipByKitsu(numId)
+    ? await aniZipByKitsuWithFallback(numId)
     : id.startsWith("mal:")
       ? await aniZipByMal(numId)
       : await aniZipByAnilist(numId);

--- a/src/lib/providers/anime-detail.ts
+++ b/src/lib/providers/anime-detail.ts
@@ -1,8 +1,8 @@
 import type { Meta } from "@/lib/cinemeta";
-import { aniZipByKitsu } from "@/lib/providers/anizip";
+
 import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes } from "@/lib/providers/anime-episode-build";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
-import { kitsuToTvdb, kitsuToImdb, externalToKitsu, kitsuToAnilist } from "@/lib/providers/anime-mapping";
+import { kitsuToTvdb, kitsuToImdb, externalToKitsu, kitsuToAnilist, aniZipByKitsuWithFallback } from "@/lib/providers/anime-mapping";
 import { anilistFranchise, type AnilistFranchiseNode } from "@/lib/anilist/relations";
 import { anilistArtById, anilistRecommendations } from "@/lib/anilist/browse";
 import { enrichEpisodes } from "@/lib/providers/anime-episode-enrich";
@@ -367,7 +367,7 @@ export async function animeDetails(
       effectiveSlugs.length > 0
         ? kitsuSimilarByGenres(effectiveSlugs, kitsuId, 34)
         : Promise.resolve([] as Meta[]),
-      aniZipByKitsu(kitsuId).catch(() => null),
+      aniZipByKitsuWithFallback(kitsuId).catch(() => null),
       kitsuToAnilist(kitsuId)
         .then((aid) => (aid ? anilistRecommendations(aid) : []))
         .catch(() => [] as Meta[]),

--- a/src/lib/providers/anime-episode-build.ts
+++ b/src/lib/providers/anime-episode-build.ts
@@ -53,7 +53,11 @@ export function mergeAniZipEpisodes(episodes: KitsuEpisode[], aniZip: AniZipMapp
     if (az.tvdbId) ep.tvdbEpisodeId = az.tvdbId;
     if (ep.rating == null && az.rating != null) {
       const r = Number(az.rating);
-      if (Number.isFinite(r) && r > 0) ep.rating = r;
+      if (Number.isFinite(r) && r > 0) {
+        if (!ep.airdate || new Date(ep.airdate).getTime() <= Date.now()) {
+          ep.rating = r;
+        }
+      }
     }
     if (az.seasonNumber != null && az.seasonNumber > 0 && az.episodeNumber != null) {
       if (azImdb) ep.imdbId = azImdb;

--- a/src/lib/providers/anime-episode-enrich.ts
+++ b/src/lib/providers/anime-episode-enrich.ts
@@ -1,5 +1,6 @@
 import { kitsuToMal, kitsuToTvdb } from "@/lib/providers/anime-mapping";
 import { harborImdbEpisodes } from "@/lib/providers/harbor-imdb";
+import { omdbSeasonRatings } from "@/lib/providers/omdb";
 import { fillerEpisodes } from "@/lib/anime-fillers";
 import { fetchTvdbThumbs } from "@/lib/providers/anime-tvdb-thumbs";
 import { meta as fetchCinemetaMeta } from "@/lib/cinemeta";
@@ -83,10 +84,20 @@ async function enrichHarborImdb(episodes: KitsuEpisode[], imdbId: string | null)
   for (const ep of episodes) {
     const season = ep.imdbSeason ?? ep.seasonNumber ?? 1;
     const num = ep.imdbEpisode ?? ep.number;
-    const real = map.get(`${season}:${num}`);
+    let real = map.get(`${season}:${num}`);
+    
+    if (real == null && ep.number) {
+      real = map.get(`1:${ep.number}`);
+    }
+    if (real == null && ep.absoluteNumber) {
+      real = map.get(`1:${ep.absoluteNumber}`);
+    }
+
     if (real != null && real > 0) {
-      ep.rating = real;
-      ep.ratingIsImdb = true;
+      if (!ep.airdate || new Date(ep.airdate).getTime() <= Date.now()) {
+        ep.rating = real;
+        ep.ratingIsImdb = true;
+      }
     }
   }
 }
@@ -105,4 +116,48 @@ export async function enrichEpisodes(
       await enrichTvdbThumbs(episodes, settings, kitsuId);
     })(),
   ]);
+
+  if (settings.omdbKey && imdbId) {
+    const missingSeasons = new Set<number>();
+    const now = Date.now();
+    for (const ep of episodes) {
+      if (!ep.airdate) continue;
+      const airtime = new Date(ep.airdate).getTime();
+      if (airtime > now) {
+        ep.rating = undefined;
+        ep.ratingIsImdb = false;
+        continue;
+      }
+      
+      const isRecent = now - airtime < 14 * 24 * 60 * 60 * 1000;
+      if (!ep.ratingIsImdb || isRecent) {
+        missingSeasons.add(ep.imdbSeason ?? ep.seasonNumber ?? 1);
+      }
+    }
+    const seasonsToFetch = Array.from(missingSeasons).slice(0, 2);
+    if (seasonsToFetch.length > 0) {
+      const omdbMaps = await Promise.all(
+        seasonsToFetch.map((s) =>
+          omdbSeasonRatings(settings.omdbKey!, imdbId, s).then((m) => ({ s, m })),
+        ),
+      );
+      for (const ep of episodes) {
+        if (ep.airdate && new Date(ep.airdate).getTime() > now) continue;
+        
+        const isRecent = ep.airdate && (now - new Date(ep.airdate).getTime() < 14 * 24 * 60 * 60 * 1000);
+        if (ep.ratingIsImdb && !isRecent) continue;
+
+        const season = ep.imdbSeason ?? ep.seasonNumber ?? 1;
+        const num = ep.imdbEpisode ?? ep.number;
+        const omdbData = omdbMaps.find((x) => x.s === season);
+        if (omdbData) {
+          const rating = omdbData.m.get(num);
+          if (rating != null && rating > 0) {
+            ep.rating = rating;
+            ep.ratingIsImdb = true;
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/lib/providers/anime-franchise-episodes.ts
+++ b/src/lib/providers/anime-franchise-episodes.ts
@@ -1,5 +1,5 @@
-import { aniZipByKitsu } from "@/lib/providers/anizip";
 import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes } from "@/lib/providers/anime-episode-build";
+import { aniZipByKitsuWithFallback } from "@/lib/providers/anime-mapping";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import { kitsuEpisodes, type KitsuEpisode } from "@/lib/providers/kitsu";
 import { kitsuToTvdb } from "@/lib/providers/anime-mapping";
@@ -22,7 +22,7 @@ export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise
     const [addonMeta, raw, aniZip, tvdbEpsRaw] = await Promise.all([
       animeKitsuMeta(`kitsu:${kitsuId}`).catch(() => null),
       kitsuEpisodes(kitsuId, 100).catch(() => [] as KitsuEpisode[]),
-      aniZipByKitsu(kitsuId).catch(() => null),
+      aniZipByKitsuWithFallback(kitsuId).catch(() => null),
       kitsuToTvdb(kitsuId)
         .then((tid) => {
           if (!tid) return null;

--- a/src/lib/providers/anime-franchise-episodes.ts
+++ b/src/lib/providers/anime-franchise-episodes.ts
@@ -2,22 +2,25 @@ import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes } from "@/li
 import { aniZipByKitsuWithFallback } from "@/lib/providers/anime-mapping";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import { kitsuEpisodes, type KitsuEpisode } from "@/lib/providers/kitsu";
-import { kitsuToTvdb } from "@/lib/providers/anime-mapping";
+import { kitsuToTvdb, kitsuToImdb } from "@/lib/providers/anime-mapping";
 import { tvdbEpisodesByType, tvdbEpisodesAbsolute, tvdbLangFromIso1 } from "@/lib/providers/tvdb";
+import { enrichEpisodes } from "@/lib/providers/anime-episode-enrich";
+import { harborImdbEpisodesCached } from "@/lib/providers/harbor-imdb";
 import type { Settings } from "@/lib/settings";
 
-const cache = new Map<string, Promise<KitsuEpisode[]>>();
+const cache = new Map<string, Promise<{ base: KitsuEpisode[]; enrichPromise: Promise<void> }>>();
 
 function isPlayable(ep: KitsuEpisode): boolean {
   if (ep.streamId) return true;
   return !!(ep.imdbId?.startsWith("tt") && ep.imdbSeason != null && ep.imdbEpisode != null);
 }
 
-export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise<KitsuEpisode[]> {
+export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise<{ base: KitsuEpisode[]; enrichPromise: Promise<void> }> {
   const lang = tvdbLangFromIso1(settings.tmdbLanguage || settings.uiLanguage);
   const cacheKey = `${kitsuId}:${lang}`;
   const cached = cache.get(cacheKey);
   if (cached) return cached;
+  
   const p = (async () => {
     const [addonMeta, raw, aniZip, tvdbEpsRaw] = await Promise.all([
       animeKitsuMeta(`kitsu:${kitsuId}`).catch(() => null),
@@ -40,14 +43,54 @@ export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise
     const eps = buildKitsuEpisodes(addonMeta, raw);
     mergeAniZipEpisodes(eps, aniZip);
     mergeTvdbEpisodes(eps, tvdbEpsRaw);
+
+    let seriesImdb = aniZip?.mappings?.imdb_id ?? eps.find((e) => e.imdbId)?.imdbId ?? null;
+    if (!seriesImdb) seriesImdb = await kitsuToImdb(kitsuId).catch(() => null);
+
+    const cachedHarbor = seriesImdb ? harborImdbEpisodesCached(seriesImdb) : null;
+    if (cachedHarbor && cachedHarbor.size > 0) {
+      for (const ep of eps) {
+        const season = ep.imdbSeason ?? ep.seasonNumber ?? 1;
+        const num = ep.imdbEpisode ?? ep.number;
+        let rating = cachedHarbor.get(`${season}:${num}`);
+        
+        if (rating == null && ep.number) {
+          rating = cachedHarbor.get(`1:${ep.number}`);
+        }
+        if (rating == null && ep.absoluteNumber) {
+          rating = cachedHarbor.get(`1:${ep.absoluteNumber}`);
+        }
+
+        if (rating != null && rating > 0) {
+          if (!ep.airdate || new Date(ep.airdate).getTime() <= Date.now()) {
+            ep.rating = rating;
+            ep.ratingIsImdb = true;
+          }
+        }
+      }
+    }
+
     const sourceMetaId = `kitsu:${kitsuId}`;
-    const out: KitsuEpisode[] = [];
+    const base: KitsuEpisode[] = [];
     for (const ep of eps) {
       if (!isPlayable(ep)) continue;
-      out.push({ ...ep, sourceMetaId });
+      base.push({ ...ep, sourceMetaId });
     }
-    return out;
+
+    let resolveEnrich!: () => void;
+    let rejectEnrich!: (err: any) => void;
+    const enrichPromise = new Promise<void>((resolve, reject) => {
+      resolveEnrich = resolve;
+      rejectEnrich = reject;
+    });
+
+    enrichEpisodes(base, settings, kitsuId, seriesImdb)
+      .then(resolveEnrich)
+      .catch(rejectEnrich);
+
+    return { base, enrichPromise };
   })();
+
   cache.set(cacheKey, p);
   return p;
 }

--- a/src/lib/providers/anime-mapping.ts
+++ b/src/lib/providers/anime-mapping.ts
@@ -9,6 +9,26 @@ import {
 } from "@/lib/providers/anizip";
 import { kitsuMainTvSeries } from "@/lib/providers/kitsu";
 
+export async function aniZipByKitsuWithFallback(kitsuId: number): Promise<AniZipMapping | null> {
+  let az = await aniZipByKitsu(kitsuId).catch(() => null);
+  const hasTvdb = !!az?.mappings?.thetvdb_id;
+  const hasEps = !!az?.episodes && Object.keys(az.episodes).length > 0;
+  
+  if (!hasTvdb || !hasEps) {
+    const anilistId = await kitsuToAnilist(kitsuId).catch(() => null);
+    if (anilistId != null) {
+      const alt = await aniZipByAnilist(anilistId).catch(() => null);
+      const altHasTvdb = !!alt?.mappings?.thetvdb_id;
+      const altHasEps = !!alt?.episodes && Object.keys(alt.episodes).length > 0;
+      
+      if (altHasTvdb || (altHasEps && !hasEps)) {
+        az = alt;
+      }
+    }
+  }
+  return az;
+}
+
 const SIDE_ENTRY_TYPES = new Set(["ova", "ona", "special", "music"]);
 
 async function preferMainTv(kitsuId: number, type?: string): Promise<number> {

--- a/src/lib/series-episodes.ts
+++ b/src/lib/series-episodes.ts
@@ -6,9 +6,9 @@ import type { PlayEpisode } from "./view";
 import { tmdbDetails, tmdbSeasonEpisodes } from "./providers/tmdb";
 import { resolveMeta } from "./meta-resource";
 import { animeKitsuMeta } from "./providers/anime-kitsu-addon";
-import { externalToKitsu, kitsuToAnilist } from "./providers/anime-mapping";
+import { externalToKitsu, aniZipByKitsuWithFallback } from "./providers/anime-mapping";
 import { parseKitsuId } from "./providers/kitsu";
-import { aniZipByAnilist, aniZipByKitsu, pickEpisodeTitle } from "./providers/anizip";
+import { pickEpisodeTitle } from "./providers/anizip";
 import { fetchTvdbProxyImages, pickTvdbImage } from "./providers/tvdb-proxy";
 import { franchiseRoot } from "./providers/anime-franchise-root";
 
@@ -78,14 +78,7 @@ async function getAnimeEpisodes(id: string): Promise<PlayEpisode[] | null> {
   const seriesImdb = addonMeta?.imdb_id ?? eps.find((e) => e.imdbId)?.imdbId ?? undefined;
   const rootId = await franchiseRoot(id).catch(() => id);
   const rootKitsu = parseKitsuId(rootId) ?? kitsuId;
-  let az = await aniZipByKitsu(kitsuId).catch(() => null);
-  if (!az?.mappings?.thetvdb_id) {
-    const anilistId = await kitsuToAnilist(kitsuId).catch(() => null);
-    if (anilistId != null) {
-      const alt = await aniZipByAnilist(anilistId).catch(() => null);
-      if (alt?.mappings?.thetvdb_id || (alt?.episodes && !az?.episodes)) az = alt;
-    }
-  }
+  let az = await aniZipByKitsuWithFallback(kitsuId).catch(() => null);
   const tvdbImages = await fetchTvdbProxyImages({
     series: az?.mappings?.thetvdb_id,
     kitsuId: rootKitsu,

--- a/src/views/detail/anime-episodes/use-franchise-episodes.ts
+++ b/src/views/detail/anime-episodes/use-franchise-episodes.ts
@@ -32,11 +32,18 @@ export function useFranchiseEpisodes(
       return;
     }
     let cancelled = false;
-    void Promise.all(otherIds.map((id) => fetchEntryEpisodes(id, settings).catch(() => [] as KitsuEpisode[]))).then(
-      (lists) => {
-        if (!cancelled) setExtra(lists.flat());
-      },
-    );
+    void Promise.all(
+      otherIds.map((id) => {
+        return fetchEntryEpisodes(id, settings).catch(() => ({ base: [] as KitsuEpisode[], enrichPromise: Promise.resolve() }));
+      })
+    ).then((results) => {
+      if (!cancelled) {
+        setExtra(results.map((r) => r.base).flat());
+        void Promise.all(results.map((r) => r.enrichPromise)).then(() => {
+          if (!cancelled) setExtra((prev) => [...prev]);
+        });
+      }
+    });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
Made it so fixes in #1216 also takes effect even if user use these to open up the anime page:

-  CW & Top Pick cards
-  Library
-  Calendar
- Search

## Verification

vp run typecheck pnpm exec tsc -b --pretty false

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
