### PR TITLE
Fix: controller input firing while window unfocused

### DIFF
--- a/src/lib/gamepad/use-gamepad.ts
+++ b/src/lib/gamepad/use-gamepad.ts
@@ -67,6 +67,9 @@ export function useGamepad(): void {
   const playerRef = useRef(!!player);
   playerRef.current = !!player;
 
+  const backgroundRef = useRef(backgroundInput);
+  backgroundRef.current = backgroundInput;
+
   useEffect(() => {
     if (!isTauri || !enabled) return;
 
@@ -174,6 +177,7 @@ export function useGamepad(): void {
     });
 
     const stopWebSource = startWebGamepadSource({
+      inputAllowed: () => document.hasFocus() || backgroundRef.current,
       onButton: (button, isPressed) => {
         setLiveButton(button, isPressed);
         onButton(button, isPressed);

--- a/src/lib/gamepad/web-source.ts
+++ b/src/lib/gamepad/web-source.ts
@@ -41,6 +41,8 @@ export type WebGamepadHandlers = {
   onButton: (button: GpButton, pressed: boolean) => void;
   onAxis: (axis: GpAxis, value: number) => void;
   onPads: (pads: GamepadInfo[]) => void;
+  /** Gate input dispatch (e.g. on window focus loss). Defaults to always allowed. */
+  inputAllowed?: () => boolean;
 };
 
 export function startWebGamepadSource(h: WebGamepadHandlers): () => void {
@@ -51,6 +53,7 @@ export function startWebGamepadSource(h: WebGamepadHandlers): () => void {
 
   const pressed = new Map<string, boolean>();
   const axisValue = new Map<string, number>();
+  const inputAllowed = h.inputAllowed ?? (() => true);
   let padSignature = "";
   let raf = 0;
   let stopped = false;
@@ -78,7 +81,7 @@ export function startWebGamepadSource(h: WebGamepadHandlers): () => void {
         const down = btn.pressed || btn.value >= PRESS_THRESHOLD;
         if (pressed.get(key) === down) return;
         pressed.set(key, down);
-        h.onButton(name, down);
+        if (inputAllowed()) h.onButton(name, down);
       });
 
       pad.axes.forEach((value, i) => {
@@ -87,7 +90,7 @@ export function startWebGamepadSource(h: WebGamepadHandlers): () => void {
         const key = `${pad.index}:${name}`;
         if (axisValue.get(key) === value) return;
         axisValue.set(key, value);
-        h.onAxis(name, value);
+        if (inputAllowed()) h.onAxis(name, value);
       });
     }
 


### PR DESCRIPTION
## Summary

Harbor reads controller input from two sources: the native gilrs source (Rust) and, on Windows, a Web Gamepad API fallback for pads not handled natively (non-XInput devices such as DualShock/DualSense, Switch Pro, 8BitDo, etc.).

The native source was already focus-gated via gamepad_set_background_input / WindowEvent::Focused, but the web source polled navigator.getGamepads() in a requestAnimationFrame loop and dispatched button/axis events with no focus check at all. While Harbor was unfocused, the WebView kept polling and drove navigation in the background window.

This change applies the same focus policy the native side already enforces to the web source:

src/lib/gamepad/web-source.ts — added an optional inputAllowed predicate to WebGamepadHandlers (defaults to allow-all). Button/axis dispatch is gated on it. Pad state is still read every frame so the internal pressed/axis maps stay in sync (no spurious or stale events on refocus); onPads remains ungated so the connected-device list always updates, matching the native Connected/Disconnected events.
src/lib/gamepad/use-gamepad.ts — passes inputAllowed: () => document.hasFocus() || backgroundRef.current, reusing the same document.hasFocus() signal hotkeys.ts already relies on and honoring the existing "controller background input" setting.
## Why

Controller input leaked into the unfocused Harbor window while the user was driving the same controller in another app. The web gamepad source was the only input path that ignored both window focus and the controllerBackgroundInput setting. Fixing it at the source keeps behavior identical to the already-correct native path instead of adding a frontend-side workaround.

## Verification

tsc --noEmit -p tsconfig.json — passes (exit 0).

## UI Changes

None.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran vp check for the changed files.
- [x] I ran vp run typecheck after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes. (no TS test infra in repo; change is a small gate)
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.