### PR TITLE
Fix: reload same URL when a stream ends prematurely instead of stopping

### DIFF
--- a/src/views/player/hooks/use-auto-retry.ts
+++ b/src/views/player/hooks/use-auto-retry.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
 import type { PlayerBridge, PlayerSnapshot } from "@/lib/player/bridge";
 import { getPlaybackBuffered, getPlaybackPosition, usePlaybackFlag } from "@/lib/player/playback-clock";
 import { isLocalUrl } from "@/lib/player/local-url";
+import { isTruncatedEnd } from "@/lib/player/playback-end";
 import { clearOnePickerCache } from "@/lib/picker-cache";
 import { resolveViaDebrids } from "@/lib/streams/resolve";
 import { registerStreamProxy } from "@/lib/stream-proxy";
@@ -101,6 +102,8 @@ export function useAutoRetry(params: {
   const debridFailoverTriedRef = useRef(false);
   const liveRetryCountRef = useRef(0);
   const livePlayedRef = useRef(false);
+  const truncatedReloadedRef = useRef(false);
+  const resumedAfterTruncatedRef = useRef(false);
   const [transcodedUrl, setTranscodedUrl] = useState<string | null>(null);
   const [sourceError, setSourceError] = useState<SourceError | null>(null);
   useEffect(() => {
@@ -113,6 +116,8 @@ export function useAutoRetry(params: {
     debridFailoverTriedRef.current = false;
     liveRetryCountRef.current = 0;
     livePlayedRef.current = false;
+    truncatedReloadedRef.current = false;
+    resumedAfterTruncatedRef.current = false;
     dlRef.current = { bytes: 0, at: Date.now() };
     setTranscodedUrl(null);
   }, [src.url]);
@@ -315,6 +320,53 @@ export function useAutoRetry(params: {
     bridgeRef,
     isP2pEngine,
     engineFailure,
+  ]);
+
+  // Distinguishes a genuine re-truncation after reload from the same EOF re-emitted:
+  // any departure from "ended" (loading/playing) after the reload marks the next
+  // ended as a real second death, even if it never managed to play.
+  useEffect(() => {
+    if (snap.status !== "ended") resumedAfterTruncatedRef.current = true;
+  }, [snap.status]);
+
+  // Premature EOF: reload the same URL once (sidecar re-registers a fresh session),
+  // and only escalate to candidate retry if the reloaded stream also dies.
+  useEffect(() => {
+    if (snap.status !== "ended") return;
+    if (isLocal) return;
+    if (isLive) return;
+    const pos = snap.positionSec > 0 ? snap.positionSec : getPlaybackPosition();
+    if (!isTruncatedEnd(snap, pos)) return;
+    const b = bridgeRef.current;
+    if (!b) return;
+    if (!truncatedReloadedRef.current) {
+      truncatedReloadedRef.current = true;
+      resumedAfterTruncatedRef.current = false;
+      console.warn(
+        `[player] stream ended prematurely at ${pos.toFixed(1)}s of ${snap.durationSec.toFixed(1)}s — reloading same URL for a fresh session`,
+      );
+      void b.load({
+        url: src.url,
+        subtitles: src.subtitles,
+        notWebReady: src.notWebReady,
+        isLive,
+        headers: src.headers,
+      });
+      return;
+    }
+    if (!resumedAfterTruncatedRef.current) return;
+    triggerAutoRetry("stream ended prematurely again after reload");
+  }, [
+    snap.status,
+    snap.durationSec,
+    snap.positionSec,
+    triggerAutoRetry,
+    isLocal,
+    isLive,
+    src.url,
+    src.subtitles,
+    src.notWebReady,
+    bridgeRef,
   ]);
 
   const lastPosRef = useRef({ pos: 0, at: 0, started: false, urlAt: 0 });


### PR DESCRIPTION
## Summary

When a stream ends prematurely — before the player has reached the end of the media — Harbor now reloads the same URL once to obtain a fresh session instead of treating the premature EOF as a natural end and stopping playback.

The detection lives in src/views/player/hooks/use-auto-retry.ts:

A stream reporting ended before 85% of its duration is classified as a truncated stream via isTruncatedEnd (src/lib/player/playback-end.ts)
The first truncated end reloads the same URL (b.load), which re-registers a fresh session with the sidecar
Only if the reloaded stream also ends prematurely does it escalate to the existing candidate auto-retry path
resumedAfterTruncatedRef distinguishes a genuine second death from the same EOF being re-emitted, preventing a double escalate

Local files and live streams are skipped; the refs reset when src.url changes

## Why

Stremio-server sidecar sessions can be evicted mid-stream (e.g. under load). When that happens, mpv receives a truncated response: EOF fires far short of the real duration, and any reconnect gets a 404 for the evicted session:

http: Stream ends prematurely at 565615889, should be 1723021317
http: Will reconnect ... error=I/O error
http: HTTP error 404 Not Found
EOF reached.

Before this change, Harbor treated that premature EOF as a natural ending, so playback just stopped — even though a fresh request to the same URL would have resurrected the session and served the full file. Reloading the same URL once matches how the sidecar already behaves, fits the existing auto-retry architecture (same b.load bridge call, same candidate escalation), and keeps the change minimal — no new state, no new dependencies.

## Verification

npx tsc -b --pretty false — exit 0
node --test tests/playback-end.test.ts — 4/4 pass (covers isNaturalEnd / isTruncatedEnd classification)
Manual, in-app (Windows dev build, pnpm tauri dev): played a mock URL served by a truncating HTTP server that kills the socket at 33% and resurrects on a fresh request:
1. Stream truncated at 33% → mpv reconnect 404 → ended
2. Hook reloaded the same URL → server log: fresh session resurrected ... serving full file
3. Playback restarted and played to completion — previously it stopped dead

## Platform Impact

None

## UI Changes

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
