### PR TITLE
feat(settings): pick backup sections on export and restore service sign-ins across profiles

### DIFF
--- a/src/components/search/guide-modal.tsx
+++ b/src/components/search/guide-modal.tsx
@@ -3,8 +3,8 @@ import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Meta } from "@/lib/cinemeta";
 import { getCachedPlaylist } from "@/lib/iptv/store";
+import { usePlaylists } from "@/lib/iptv/playlists-store";
 import type { IptvChannel, IptvPlaylistSource } from "@/lib/iptv/types";
-import { useSettings } from "@/lib/settings";
 import { useView } from "@/lib/view";
 import { useEpg, useNowTick } from "@/views/live/hooks/use-epg";
 import { useIptvPlaylist } from "@/views/live/hooks/use-iptv-playlist";
@@ -24,11 +24,11 @@ function synthChannelMeta(ch: IptvChannel): Meta {
 }
 
 export function GuideModal({ onClose }: { onClose: () => void }) {
-  const { settings } = useSettings();
+  const playlists = usePlaylists();
   const { openPlayer } = useView();
   const m3uSources = useMemo(
-    () => settings.iptvPlaylists.filter((p) => (p.kind ?? "m3u") !== "epg"),
-    [settings.iptvPlaylists],
+    () => playlists.filter((p) => (p.kind ?? "m3u") !== "epg"),
+    [playlists],
   );
   const [sourceId, setSourceId] = useState<string | null>(() => m3uSources[0]?.id ?? null);
   const source: IptvPlaylistSource | null = useMemo(() => {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -33,6 +33,8 @@ type BackupSection = {
   /** Flags the section in the UI (e.g. it contains login credentials). */
   warning?: boolean;
   patterns: string[];
+  /** Optional sub-options the user can toggle within this section. */
+  subOptions?: Array<{ key: string; label: string; description: string; warning?: boolean }>;
 };
 
 /**
@@ -150,8 +152,16 @@ export const BACKUP_SECTIONS: readonly BackupSection[] = [
   {
     key: "iptv",
     label: "Live TV",
-    description: "IPTV playlists, favorites, the EPG guide style, and stats.",
+    description: "M3U URLs, favorites, the EPG guide style, and stats.",
     patterns: ["harbor.iptv.", "harbor.guide.style"],
+    subOptions: [
+      {
+        key: "xtreamCredentials",
+        label: "Xtream credentials",
+        description: "Usernames and passwords for Xtream playlists. When disabled, Xtream playlists are left out entirely.",
+        warning: true,
+      },
+    ],
   },
   {
     key: "manga",
@@ -227,6 +237,8 @@ export type Backup = {
   data: Record<string, string>;
   /** Which sections this backup contains. Absent on legacy files (= everything). */
   sections?: BackupSectionKey[];
+  /** Included sub-options per section. Absent = everything included. */
+  subOptions?: Record<string, string[]>;
   bgImage?: string | null;
 };
 
@@ -237,7 +249,10 @@ function isPortable(key: string): boolean {
   return true;
 }
 
-export async function buildBackup(selected?: BackupSectionKey[]): Promise<Backup> {
+export async function buildBackup(
+  selected?: BackupSectionKey[],
+  subOptions?: Record<string, string[]>,
+): Promise<Backup> {
   const sectionSet = selected && selected.length > 0 ? new Set<BackupSectionKey>(selected) : null;
   const data: Record<string, string> = {};
   for (let i = 0; i < localStorage.length; i++) {
@@ -252,6 +267,31 @@ export async function buildBackup(selected?: BackupSectionKey[]): Promise<Backup
     if (sectionSet && !sectionSet.has(sectionOf(key))) continue;
     if (data[key] == null) data[key] = value;
   }
+  // Xtream playlists embed credentials in their URLs; drop them when the
+  // sub-option is deselected so they never leave the device.
+  const iptvSubOptions = subOptions?.iptv;
+  if (
+    (!sectionSet || sectionSet.has("iptv")) &&
+    iptvSubOptions &&
+    !iptvSubOptions.includes("xtreamCredentials")
+  ) {
+    const raw = data["harbor.iptv.playlists.v1"];
+    if (raw != null) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          const filtered = parsed.filter((p: { kind?: string }) => p?.kind !== "xtream");
+          if (filtered.length === 0) {
+            delete data["harbor.iptv.playlists.v1"];
+          } else {
+            data["harbor.iptv.playlists.v1"] = JSON.stringify(filtered);
+          }
+        }
+      } catch {
+        /* leave malformed playlists data untouched */
+      }
+    }
+  }
   const includeBg = !sectionSet || sectionSet.has("theme");
   const bgImage = includeBg ? await loadBgImage() : null;
   return {
@@ -261,12 +301,16 @@ export async function buildBackup(selected?: BackupSectionKey[]): Promise<Backup
     exportedAt: new Date().toISOString(),
     data,
     sections: sectionSet ? (ALL_SECTION_KEYS.filter((k) => sectionSet.has(k)) as BackupSectionKey[]) : [...ALL_SECTION_KEYS],
+    ...(subOptions && Object.keys(subOptions).length > 0 ? { subOptions } : {}),
     ...(bgImage ? { bgImage } : {}),
   };
 }
 
-export async function downloadBackup(selected?: BackupSectionKey[]): Promise<boolean> {
-  const backup = await buildBackup(selected);
+export async function downloadBackup(
+  selected?: BackupSectionKey[],
+  subOptions?: Record<string, string[]>,
+): Promise<boolean> {
+  const backup = await buildBackup(selected, subOptions);
   const text = JSON.stringify(backup, null, 2);
   const stamp = new Date().toISOString().slice(0, 10);
   return downloadText(`harbor-backup-${stamp}.harbx`, text, ["harbx"], "Harbor backup");
@@ -299,6 +343,14 @@ export function parseBackup(text: string): ParsedBackup {
     return { ok: false, error: "This backup contained nothing restorable." };
   }
   const sections = Array.isArray(b.sections) ? (b.sections.filter(isSectionKey) as BackupSectionKey[]) : undefined;
+  const subOptions: Record<string, string[]> = {};
+  if (b.subOptions && typeof b.subOptions === "object") {
+    for (const [k, v] of Object.entries(b.subOptions)) {
+      if (isSectionKey(k) && Array.isArray(v) && v.every((x) => typeof x === "string")) {
+        subOptions[k] = v;
+      }
+    }
+  }
   return {
     ok: true,
     backup: {
@@ -308,6 +360,7 @@ export function parseBackup(text: string): ParsedBackup {
       exportedAt: typeof b.exportedAt === "string" ? b.exportedAt : "",
       data,
       ...(sections && sections.length > 0 ? { sections } : {}),
+      ...(Object.keys(subOptions).length > 0 ? { subOptions } : {}),
       ...(typeof b.bgImage === "string" || b.bgImage === null ? { bgImage: b.bgImage } : {}),
     },
   };

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,5 +1,7 @@
 import { downloadText } from "@/lib/download-text";
 import { loadBgImage, saveBgImage } from "@/lib/theme-storage";
+import { activeProfileId } from "@/lib/active-profile-id";
+import { flushSecrets, getAllSecrets, isSecretKey, secretKeyForProfile, setSecret } from "@/lib/secret-store";
 
 declare const __APP_VERSION__: string;
 
@@ -245,6 +247,11 @@ export async function buildBackup(selected?: BackupSectionKey[]): Promise<Backup
     const value = localStorage.getItem(key);
     if (value != null) data[key] = value;
   }
+  for (const [key, value] of Object.entries(getAllSecrets())) {
+    if (!isPortable(key)) continue;
+    if (sectionSet && !sectionSet.has(sectionOf(key))) continue;
+    if (data[key] == null) data[key] = value;
+  }
   const includeBg = !sectionSet || sectionSet.has("theme");
   const bgImage = includeBg ? await loadBgImage() : null;
   return {
@@ -329,10 +336,28 @@ export async function applyBackup(backup: Backup): Promise<void> {
     stale.push(key);
   }
   for (const key of stale) localStorage.removeItem(key);
+  for (const key of Object.keys(getAllSecrets())) {
+    if (!isPortable(key)) continue;
+    if (!restore.has(sectionOf(key))) continue;
+    if (backup.data[key] == null) setSecret(key, null);
+  }
+  // Restore localStorage-backed entries first so a restored profiles list can
+  // change which profile the sign-ins land on.
   for (const [k, v] of Object.entries(backup.data)) {
-    if (!isPortable(k)) continue;
+    if (!isPortable(k) || isSecretKey(k)) continue;
     try {
       localStorage.setItem(k, v);
+    } catch {
+      /* keep restoring the rest even if one entry is rejected */
+    }
+  }
+  // Sign-ins are stored per profile; place them on the profile that is active
+  // after this restore so they come back regardless of where the backup was made.
+  const targetProfile = activeProfileId();
+  for (const [k, v] of Object.entries(backup.data)) {
+    if (!isPortable(k) || !isSecretKey(k)) continue;
+    try {
+      setSecret(secretKeyForProfile(k, targetProfile), v);
     } catch {
       /* keep restoring the rest even if one entry is rejected */
     }
@@ -344,4 +369,5 @@ export async function applyBackup(backup: Backup): Promise<void> {
       /* background restore is best-effort */
     }
   }
+  await flushSecrets();
 }

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -21,6 +21,7 @@ export type BackupSectionKey =
   | "playerLayouts"
   | "feedDiscover"
   | "iptv"
+  | "iptvCredentials"
   | "manga"
   | "miscState"
   | "other";
@@ -33,8 +34,6 @@ type BackupSection = {
   /** Flags the section in the UI (e.g. it contains login credentials). */
   warning?: boolean;
   patterns: string[];
-  /** Optional sub-options the user can toggle within this section. */
-  subOptions?: Array<{ key: string; label: string; description: string; warning?: boolean }>;
 };
 
 /**
@@ -144,24 +143,23 @@ export const BACKUP_SECTIONS: readonly BackupSection[] = [
     patterns: ["harbor.player.", "harbor.sub.presets.v1"],
   },
   {
-    key: "feedDiscover",
-    label: "Feed & Discover",
-    description: "Feed preferences and Discover row state.",
-    patterns: ["harbor.feed", "harbor.discover."],
-  },
-  {
     key: "iptv",
     label: "Live TV",
     description: "M3U URLs, favorites, the EPG guide style, and stats.",
     patterns: ["harbor.iptv.", "harbor.guide.style"],
-    subOptions: [
-      {
-        key: "xtreamCredentials",
-        label: "Xtream credentials",
-        description: "Usernames and passwords for Xtream playlists. When disabled, Xtream playlists are left out entirely.",
-        warning: true,
-      },
-    ],
+  },
+  {
+    key: "iptvCredentials",
+    label: "Xtream credentials",
+    description: "Usernames and passwords for Xtream playlists.",
+    warning: true,
+    patterns: [],
+  },
+  {
+    key: "feedDiscover",
+    label: "Feed & Discover",
+    description: "Feed preferences and Discover row state.",
+    patterns: ["harbor.feed", "harbor.discover."],
   },
   {
     key: "manga",
@@ -237,8 +235,6 @@ export type Backup = {
   data: Record<string, string>;
   /** Which sections this backup contains. Absent on legacy files (= everything). */
   sections?: BackupSectionKey[];
-  /** Included sub-options per section. Absent = everything included. */
-  subOptions?: Record<string, string[]>;
   bgImage?: string | null;
 };
 
@@ -249,10 +245,7 @@ function isPortable(key: string): boolean {
   return true;
 }
 
-export async function buildBackup(
-  selected?: BackupSectionKey[],
-  subOptions?: Record<string, string[]>,
-): Promise<Backup> {
+export async function buildBackup(selected?: BackupSectionKey[]): Promise<Backup> {
   const sectionSet = selected && selected.length > 0 ? new Set<BackupSectionKey>(selected) : null;
   const data: Record<string, string> = {};
   for (let i = 0; i < localStorage.length; i++) {
@@ -267,14 +260,10 @@ export async function buildBackup(
     if (sectionSet && !sectionSet.has(sectionOf(key))) continue;
     if (data[key] == null) data[key] = value;
   }
-  // Xtream playlists embed credentials in their URLs; drop them when the
-  // sub-option is deselected so they never leave the device.
-  const iptvSubOptions = subOptions?.iptv;
-  if (
-    (!sectionSet || sectionSet.has("iptv")) &&
-    iptvSubOptions &&
-    !iptvSubOptions.includes("xtreamCredentials")
-  ) {
+  // Xtream playlists embed credentials in their URLs; when the Xtream
+  // credentials section is left out (but Live TV is exported), drop them so
+  // they never leave the device.
+  if (sectionSet?.has("iptv") && !sectionSet.has("iptvCredentials")) {
     const raw = data["harbor.iptv.playlists.v1"];
     if (raw != null) {
       try {
@@ -301,16 +290,12 @@ export async function buildBackup(
     exportedAt: new Date().toISOString(),
     data,
     sections: sectionSet ? (ALL_SECTION_KEYS.filter((k) => sectionSet.has(k)) as BackupSectionKey[]) : [...ALL_SECTION_KEYS],
-    ...(subOptions && Object.keys(subOptions).length > 0 ? { subOptions } : {}),
     ...(bgImage ? { bgImage } : {}),
   };
 }
 
-export async function downloadBackup(
-  selected?: BackupSectionKey[],
-  subOptions?: Record<string, string[]>,
-): Promise<boolean> {
-  const backup = await buildBackup(selected, subOptions);
+export async function downloadBackup(selected?: BackupSectionKey[]): Promise<boolean> {
+  const backup = await buildBackup(selected);
   const text = JSON.stringify(backup, null, 2);
   const stamp = new Date().toISOString().slice(0, 10);
   return downloadText(`harbor-backup-${stamp}.harbx`, text, ["harbx"], "Harbor backup");
@@ -343,14 +328,6 @@ export function parseBackup(text: string): ParsedBackup {
     return { ok: false, error: "This backup contained nothing restorable." };
   }
   const sections = Array.isArray(b.sections) ? (b.sections.filter(isSectionKey) as BackupSectionKey[]) : undefined;
-  const subOptions: Record<string, string[]> = {};
-  if (b.subOptions && typeof b.subOptions === "object") {
-    for (const [k, v] of Object.entries(b.subOptions)) {
-      if (isSectionKey(k) && Array.isArray(v) && v.every((x) => typeof x === "string")) {
-        subOptions[k] = v;
-      }
-    }
-  }
   return {
     ok: true,
     backup: {
@@ -360,7 +337,6 @@ export function parseBackup(text: string): ParsedBackup {
       exportedAt: typeof b.exportedAt === "string" ? b.exportedAt : "",
       data,
       ...(sections && sections.length > 0 ? { sections } : {}),
-      ...(Object.keys(subOptions).length > 0 ? { subOptions } : {}),
       ...(typeof b.bgImage === "string" || b.bgImage === null ? { bgImage: b.bgImage } : {}),
     },
   };

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -6,12 +6,225 @@ declare const __APP_VERSION__: string;
 const FORMAT = "harbor-backup";
 const VERSION = 1;
 
+export type BackupSectionKey =
+  | "theme"
+  | "homeLayout"
+  | "settings"
+  | "addons"
+  | "profiles"
+  | "sessions"
+  | "watchlist"
+  | "watchProgress"
+  | "searchHistory"
+  | "playerLayouts"
+  | "feedDiscover"
+  | "iptv"
+  | "manga"
+  | "miscState"
+  | "other";
+
+type BackupSection = {
+  key: BackupSectionKey;
+  /** English source strings; the UI passes them through t() for translation. */
+  label: string;
+  description: string;
+  /** Flags the section in the UI (e.g. it contains login credentials). */
+  warning?: boolean;
+  patterns: string[];
+};
+
+/**
+ * How localStorage keys map to user-facing export sections.
+ * Order matters: the first section whose pattern prefixes a key wins,
+ * so `harbor.discover.libImported` (homeLayout) must be checked before
+ * the broader `harbor.discover.` (feedDiscover).
+ */
+export const BACKUP_SECTIONS: readonly BackupSection[] = [
+  {
+    key: "theme",
+    label: "Theme & backgrounds",
+    description: "Your chosen theme, custom themes, uploaded fonts, and the background image.",
+    patterns: [
+      "harbor.theme",
+      "harbor.custom-themes.v1",
+      "harbor.theme-uploads.v1",
+      "harbor.theme-client-id",
+      "harbor.theme-unseen.v1",
+    ],
+  },
+  {
+    key: "homeLayout",
+    label: "Home layout",
+    description: "Home and detail view layout, page rows, pinned catalogs, and scroll memory.",
+    patterns: ["harbor.pageRows.", "harbor.pagecollrows.v1", "harbor.pinnedcatalogs.v1", "harbor.discover.libImported", "harbor.detailLayout", "harbor.library.tab", "harbor.scroll.v1"],
+  },
+  {
+    key: "settings",
+    label: "Settings",
+    description: "App settings and preferences, including parental controls.",
+    patterns: ["harbor.settings", "harbor.settingsNew.v1", "harbor.parental"],
+  },
+  {
+    key: "addons",
+    label: "Addons",
+    description: "Your installed addons, their order, and which ones are disabled.",
+    patterns: [
+      "harbor.installed-addons",
+      "harbor.addons.",
+      "harbor.addonOrder",
+      "harbor.addonOrderBackups",
+      "harbor.sa.v1.",
+    ],
+  },
+  {
+    key: "profiles",
+    label: "Profiles",
+    description: "Your profiles, the active profile, and the profile picker.",
+    patterns: ["harbor.profiles.v1", "harbor.profile.lastSelectAt", "harbor.pickerShown"],
+  },
+  {
+    key: "sessions",
+    label: "Service sign-ins",
+    description: "Your saved Trakt, Simkl, MAL, AniList, and Letterboxd logins.",
+    warning: true,
+    patterns: [
+      "harbor.trakt.session.v1",
+      "harbor.simkl.session.v1",
+      "harbor.mal.session.v1",
+      "harbor.anilist.session.v1",
+      "harbor.letterboxd.session.v1",
+    ],
+  },
+  {
+    key: "watchlist",
+    label: "Watchlist & favorites",
+    description: "Your watchlist, local library, custom lists, collections, and favorites.",
+    patterns: [
+      "harbor.watchlist.",
+      "harbor.localwatchlist.",
+      "harbor.localcw.",
+      "harbor.favorites.",
+      "harbor.charfavorites.",
+      "harbor.library.local.v1",
+      "harbor.customlists",
+      "harbor.collections",
+    ],
+  },
+  {
+    key: "watchProgress",
+    label: "Watch progress & history",
+    description: "Resume positions, watched flags, playback history, and manual watch marks.",
+    patterns: [
+      "harbor.resume",
+      "harbor.watchedFlag.v1",
+      "harbor.watchedby.v1",
+      "harbor.watchevents.v1",
+      "harbor.moviewatched.v1",
+      "harbor.manualwatched",
+      "harbor.manualunwatched",
+      "harbor.hiddenepisodes.v1",
+      "harbor.lastseason.v1",
+      "harbor.playback-history.v1",
+    ],
+  },
+  {
+    key: "searchHistory",
+    label: "Search history",
+    description: "Your recent search queries.",
+    patterns: ["harbor.search.recent"],
+  },
+  {
+    key: "playerLayouts",
+    label: "Player layouts & prefs",
+    description: "Player UI layout, volume, subtitle presets, and player preferences.",
+    patterns: ["harbor.player.", "harbor.sub.presets.v1"],
+  },
+  {
+    key: "feedDiscover",
+    label: "Feed & Discover",
+    description: "Feed preferences and Discover row state.",
+    patterns: ["harbor.feed", "harbor.discover."],
+  },
+  {
+    key: "iptv",
+    label: "Live TV",
+    description: "IPTV playlists, favorites, the EPG guide style, and stats.",
+    patterns: ["harbor.iptv.", "harbor.guide.style"],
+  },
+  {
+    key: "manga",
+    label: "Manga",
+    description: "Manga library, reading progress, favorites, bookmarks, and reader prefs.",
+    patterns: ["harbor.manga.", "harbor.mangaread.", "harbor.mangafav.", "harbor.mangabookmarks."],
+  },
+  {
+    key: "miscState",
+    label: "Onboarding & interface state",
+    description: "Onboarding flags, dismissed tips, reminders, the discovery queue, and watch party name.",
+    patterns: [
+      "harbor.onboarding",
+      "harbor.hero-muted.v1",
+      "harbor.hero-known-audio.v1",
+      "harbor.surprise.recent.v1",
+      "harbor.voyage.v1",
+      "harbor.reminders.",
+      "harbor.auto-download.v1",
+      "harbor.queue.",
+      "harbor.custom-hover.v1",
+      "harbor.awardpacks.v1",
+      "harbor.cw.dismissed",
+      "harbor.calendar.filtersOpen",
+      "harbor.multiview.",
+      "harbor.memoryHud.open",
+      "harbor.webhook.lastTick",
+      "harbor.relayBannerDismissed",
+      "harbor.presence.status",
+      "harbor.kids.learn.v1",
+      "harbor.curfew.",
+      "harbor.avatar-synced.",
+      "harbor.libraryNameRepair.v1.",
+      "harbor.together.name",
+      "harbor.together.followHostExit",
+    ],
+  },
+  {
+    key: "other",
+    label: "Cached lookups & misc",
+    description: "Recomputable caches like IMDb/TMDB ID maps and award data, plus small UI flags.",
+    patterns: [],
+  },
+];
+
+export const ALL_SECTION_KEYS: readonly BackupSectionKey[] = BACKUP_SECTIONS.map((s) => s.key);
+
+export function isSectionKey(value: unknown): value is BackupSectionKey {
+  return typeof value === "string" && (ALL_SECTION_KEYS as readonly string[]).includes(value);
+}
+
+/** The section a localStorage key belongs to; "other" is the catch-all. */
+export function sectionOf(key: string): BackupSectionKey {
+  for (const section of BACKUP_SECTIONS) {
+    if (section.patterns.some((p) => key.startsWith(p))) return section.key;
+  }
+  return "other";
+}
+
+export function backupSectionLabel(key: BackupSectionKey): string {
+  return BACKUP_SECTIONS.find((s) => s.key === key)?.label ?? "Cached lookups & misc";
+}
+
+export function backupSectionDescription(key: BackupSectionKey): string {
+  return BACKUP_SECTIONS.find((s) => s.key === key)?.description ?? "";
+}
+
 export type Backup = {
   format: string;
   version: number;
   app: string;
   exportedAt: string;
   data: Record<string, string>;
+  /** Which sections this backup contains. Absent on legacy files (= everything). */
+  sections?: BackupSectionKey[];
   bgImage?: string | null;
 };
 
@@ -22,27 +235,31 @@ function isPortable(key: string): boolean {
   return true;
 }
 
-export async function buildBackup(): Promise<Backup> {
+export async function buildBackup(selected?: BackupSectionKey[]): Promise<Backup> {
+  const sectionSet = selected && selected.length > 0 ? new Set<BackupSectionKey>(selected) : null;
   const data: Record<string, string> = {};
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
     if (!key || !isPortable(key)) continue;
+    if (sectionSet && !sectionSet.has(sectionOf(key))) continue;
     const value = localStorage.getItem(key);
     if (value != null) data[key] = value;
   }
-  const bgImage = await loadBgImage();
+  const includeBg = !sectionSet || sectionSet.has("theme");
+  const bgImage = includeBg ? await loadBgImage() : null;
   return {
     format: FORMAT,
     version: VERSION,
     app: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "dev",
     exportedAt: new Date().toISOString(),
     data,
+    sections: sectionSet ? (ALL_SECTION_KEYS.filter((k) => sectionSet.has(k)) as BackupSectionKey[]) : [...ALL_SECTION_KEYS],
     ...(bgImage ? { bgImage } : {}),
   };
 }
 
-export async function downloadBackup(): Promise<boolean> {
-  const backup = await buildBackup();
+export async function downloadBackup(selected?: BackupSectionKey[]): Promise<boolean> {
+  const backup = await buildBackup(selected);
   const text = JSON.stringify(backup, null, 2);
   const stamp = new Date().toISOString().slice(0, 10);
   return downloadText(`harbor-backup-${stamp}.harbx`, text, ["harbx"], "Harbor backup");
@@ -74,6 +291,7 @@ export function parseBackup(text: string): ParsedBackup {
   if (Object.keys(data).length === 0) {
     return { ok: false, error: "This backup contained nothing restorable." };
   }
+  const sections = Array.isArray(b.sections) ? (b.sections.filter(isSectionKey) as BackupSectionKey[]) : undefined;
   return {
     ok: true,
     backup: {
@@ -82,6 +300,7 @@ export function parseBackup(text: string): ParsedBackup {
       app: typeof b.app === "string" ? b.app : "unknown",
       exportedAt: typeof b.exportedAt === "string" ? b.exportedAt : "",
       data,
+      ...(sections && sections.length > 0 ? { sections } : {}),
       ...(typeof b.bgImage === "string" || b.bgImage === null ? { bgImage: b.bgImage } : {}),
     },
   };
@@ -91,11 +310,23 @@ export function backupKeyCount(backup: Backup): number {
   return Object.keys(backup.data).length;
 }
 
+/**
+ * Sections this backup actually restores. Legacy files without a sections
+ * field restore everything, which keeps old backups working unchanged.
+ */
+export function backupSections(backup: Backup): BackupSectionKey[] {
+  return backup.sections && backup.sections.length > 0 ? backup.sections : [...ALL_SECTION_KEYS];
+}
+
 export async function applyBackup(backup: Backup): Promise<void> {
+  const restore = new Set<BackupSectionKey>(backupSections(backup));
   const stale: string[] = [];
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
-    if (key && isPortable(key)) stale.push(key);
+    if (!key || !isPortable(key)) continue;
+    // Only clear keys that belong to a section this backup actually restores.
+    if (!restore.has(sectionOf(key))) continue;
+    stale.push(key);
   }
   for (const key of stale) localStorage.removeItem(key);
   for (const [k, v] of Object.entries(backup.data)) {
@@ -106,7 +337,7 @@ export async function applyBackup(backup: Backup): Promise<void> {
       /* keep restoring the rest even if one entry is rejected */
     }
   }
-  if (backup.bgImage !== undefined) {
+  if (backup.bgImage !== undefined && restore.has("theme")) {
     try {
       await saveBgImage(backup.bgImage);
     } catch {

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -2,6 +2,7 @@ import { downloadText } from "@/lib/download-text";
 import { loadBgImage, saveBgImage } from "@/lib/theme-storage";
 import { activeProfileId } from "@/lib/active-profile-id";
 import { flushSecrets, getAllSecrets, isSecretKey, secretKeyForProfile, setSecret } from "@/lib/secret-store";
+import { setItemWithRecovery } from "@/lib/storage-recovery";
 
 declare const __APP_VERSION__: string;
 
@@ -354,30 +355,104 @@ export function backupSections(backup: Backup): BackupSectionKey[] {
   return backup.sections && backup.sections.length > 0 ? backup.sections : [...ALL_SECTION_KEYS];
 }
 
-export async function applyBackup(backup: Backup): Promise<void> {
-  const restore = new Set<BackupSectionKey>(backupSections(backup));
-  const stale: string[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (!key || !isPortable(key)) continue;
-    // Only clear keys that belong to a section this backup actually restores.
-    if (!restore.has(sectionOf(key))) continue;
-    stale.push(key);
+/**
+ * Final-segment shape of a stored profile id: the fallback "default", or a
+ * generated id like "p_mqxx2agk_ez1zro" (see createProfile in profiles.tsx).
+ */
+const PROFILE_ID_RE = /^(?:default|p_[a-z0-9]+_[a-z0-9]+)$/;
+const PROFILES_STATE_KEY = "harbor.profiles.v1";
+
+function profileSuffixOf(key: string): string | null {
+  const dot = key.lastIndexOf(".");
+  if (dot < 0) return null;
+  const id = key.slice(dot + 1);
+  return PROFILE_ID_RE.test(id) ? id : null;
+}
+
+/**
+ * Rewrites per-profile entries so a backup taken elsewhere lands where this
+ * build reads it. Most domains are read back with the active profile id
+ * appended, so foreign ids are swapped for it; when several source profiles
+ * collapse onto one target key, the entry with more data wins instead of
+ * whichever came last in key order.
+ * Watchlist is special: this build keeps it under a bare global key while
+ * newer builds store it per-profile, so suffixed entries are additionally
+ * aliased onto the bare key — including full backups that carry their own
+ * profiles state, whose foreign ids would otherwise stay unreadable here.
+ */
+const BARE_BASES = new Set(["harbor.watchlist.v1", "harbor.watchlist.aggregate.v1"]);
+
+function retargetProfileKeys(data: Record<string, string>): Record<string, string> {
+  const target = activeProfileId();
+  const profilesIncluded = data[PROFILES_STATE_KEY] != null;
+  const out: Record<string, string> = {};
+  const setMerged = (key: string, value: string) => {
+    const prev = out[key];
+    out[key] = prev != null && prev.length >= value.length ? prev : value;
+  };
+  for (const [key, value] of Object.entries(data)) {
+    const from = profileSuffixOf(key);
+    if (!from) {
+      out[key] = value;
+      continue;
+    }
+    const base = key.slice(0, key.length - from.length - 1);
+    if (BARE_BASES.has(base)) {
+      setMerged(base, value);
+      continue;
+    }
+    if (profilesIncluded) {
+      out[key] = value;
+      continue;
+    }
+    setMerged(`${base}.${target}`, value);
   }
-  for (const key of stale) localStorage.removeItem(key);
-  for (const key of Object.keys(getAllSecrets())) {
-    if (!isPortable(key)) continue;
-    if (!restore.has(sectionOf(key))) continue;
-    if (backup.data[key] == null) setSecret(key, null);
+  return out;
+}
+
+export async function applyBackup(backup: Backup): Promise<void> {
+  const data = retargetProfileKeys(backup.data);
+
+  // Whole-domain wiping is reserved for legacy full backups (no sections
+  // field): there, "restore everything" must also clear items the source
+  // install had deleted. Sectioned files replace only the exact entries they
+  // carry and never touch anything else, matching the restore dialog's promise.
+  let wipeSections: Set<BackupSectionKey> | null = null;
+  if (backup.sections == null || backup.sections.length === 0) {
+    const filled = new Set<BackupSectionKey>();
+    for (const key of Object.keys(backup.data)) {
+      if (!isPortable(key)) continue;
+      filled.add(sectionOf(key));
+    }
+    wipeSections = new Set<BackupSectionKey>([...ALL_SECTION_KEYS].filter((key) => filled.has(key)));
+    const stale: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || !isPortable(key)) continue;
+      if (!wipeSections.has(sectionOf(key))) continue;
+      stale.push(key);
+    }
+    for (const key of stale) localStorage.removeItem(key);
+    for (const key of Object.keys(getAllSecrets())) {
+      if (!isPortable(key)) continue;
+      if (!wipeSections.has(sectionOf(key))) continue;
+      if (data[key] == null) setSecret(key, null);
+    }
   }
   // Restore localStorage-backed entries first so a restored profiles list can
-  // change which profile the sign-ins land on.
-  for (const [k, v] of Object.entries(backup.data)) {
-    if (!isPortable(k) || isSecretKey(k)) continue;
+  // change which profile the sign-ins land on. Small personal keys are written
+  // before bulky recomputable caches so a full storage degrades by dropping
+  // caches instead of user data; recovery prunes quotas and retries.
+  const entries = Object.entries(data)
+    .filter(([k]) => isPortable(k) && !isSecretKey(k))
+    .sort(([, a], [, b]) => a.length - b.length);
+  for (const [k, v] of entries) {
     try {
-      localStorage.setItem(k, v);
-    } catch {
-      /* keep restoring the rest even if one entry is rejected */
+      if (!setItemWithRecovery(k, v)) {
+        console.warn(`[backup] storage refused "${k}" during restore`);
+      }
+    } catch (e) {
+      console.warn(`[backup] failed to restore "${k}"`, e);
     }
   }
   // Sign-ins are stored per profile; place them on the profile that is active
@@ -391,7 +466,7 @@ export async function applyBackup(backup: Backup): Promise<void> {
       /* keep restoring the rest even if one entry is rejected */
     }
   }
-  if (backup.bgImage !== undefined && restore.has("theme")) {
+  if (backup.bgImage !== undefined && (wipeSections === null || wipeSections.has("theme"))) {
     try {
       await saveBgImage(backup.bgImage);
     } catch {

--- a/src/lib/i18n/locales/ar/settings.ts
+++ b/src/lib/i18n/locales/ar/settings.ts
@@ -1816,6 +1816,7 @@ const settings: Record<string, string> = {
   "Saved {when} from Harbor {app}.": "حُفظ في {when} من Harbor {app}.",
   "Restoring...": "جارٍ الاستعادة...",
   "Restore and reload": "الاستعادة وإعادة التحميل",
+  "Xtream credentials were left out of this backup.": "تمّ استبعاد بيانات اعتماد Xtream من هذه النسخة الاحتياطية.",
   "Get beta updates": "الحصول على التحديثات التجريبية",
   "Receive early builds with the newest fixes before they reach the stable release. Betas can be rough around the edges; switch this off to return to stable at the next update.": "تلقَّ إصدارات مبكّرة بأحدث الإصلاحات قبل وصولها إلى الإصدار المستقرّ. قد تكون النسخ التجريبية غير مصقولة؛ عطّل هذا للعودة إلى المستقرّ في التحديث القادم.",
   "Catch stremio:// install links inside Harbor": "التقاط روابط التثبيت ‎stremio://‎ داخل Harbor",

--- a/src/lib/i18n/locales/pt/settings.ts
+++ b/src/lib/i18n/locales/pt/settings.ts
@@ -1429,6 +1429,7 @@ const settings: Record<string, string> = {
   "Saved {when} from Harbor {app}.": "Salvo {when} pelo Harbor {app}.",
   "Restoring...": "Restaurando...",
   "Restore and reload": "Restaurar e recarregar",
+  "Xtream credentials were left out of this backup.": "As credenciais Xtream foram deixadas de fora deste backup.",
   "Get beta updates": "Receber atualizações beta",
   "Receive early builds with the newest fixes before they reach the stable release. Betas can be rough around the edges; switch this off to return to stable at the next update.": "Receba builds antecipadas com as correções mais recentes antes de chegarem à versão estável. Betas podem ter arestas; desative para voltar ao estável na próxima atualização.",
   "Catch stremio:// install links inside Harbor": "Capturar links de instalação stremio:// dentro do Harbor",

--- a/src/lib/i18n/locales/ru/settings.ts
+++ b/src/lib/i18n/locales/ru/settings.ts
@@ -1429,6 +1429,7 @@ const settings: Record<string, string> = {
   "Saved {when} from Harbor {app}.": "Сохранено: {when}. Harbor {app}.",
   "Restoring...": "Восстановление...",
   "Restore and reload": "Восстановить и перезагрузить",
+  "Xtream credentials were left out of this backup.": "Учётные данные Xtream не были включены в эту резервную копию.",
   "Get beta updates": "Получать бета-обновления",
   "Receive early builds with the newest fixes before they reach the stable release. Betas can be rough around the edges; switch this off to return to stable at the next update.": "Ранние сборки с самыми свежими исправлениями до выхода стабильной версии. Бета-версии бывают сырыми; отключите, чтобы вернуться на стабильную при следующем обновлении.",
   "Catch stremio:// install links inside Harbor": "Перехватывать ссылки stremio:// в Harbor",

--- a/src/lib/iptv/playlists-store.ts
+++ b/src/lib/iptv/playlists-store.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from "react";
+import { setItemWithRecovery } from "@/lib/storage-recovery";
 
 export type StoredPlaylist = {
   id: string;
@@ -26,8 +27,10 @@ function ensureMigrated(): void {
 
 /**
  * Moves playlists out of the settings blob (harbor.settings.*) into their own
- * key. Runs once per session; also strips the legacy field from every settings
- * blob that still carries it so playlists stop exporting under Settings.
+ * key. Runs once per session. Legacy lists are merged from every settings blob
+ * (deduped by id, stored entries win) and the legacy field is stripped only
+ * after the dedicated key has been persisted, so a failed write never destroys
+ * the only surviving copy.
  */
 export function migrateLegacyPlaylists(): void {
   if (migrated) return;
@@ -56,7 +59,8 @@ export function migrateLegacyPlaylists(): void {
   } catch {
     /* localStorage enumeration is best-effort */
   }
-  let written = false;
+  const merged = new Map<string, StoredPlaylist>();
+  const dirty: Array<{ key: string; obj: Record<string, unknown> }> = [];
   for (const key of candidates) {
     let blob: unknown;
     try {
@@ -67,19 +71,28 @@ export function migrateLegacyPlaylists(): void {
     if (!blob || typeof blob !== "object") continue;
     const obj = blob as Record<string, unknown>;
     if (!("iptvPlaylists" in obj)) continue;
-    if (!written && Array.isArray(obj.iptvPlaylists)) {
-      try {
-        const lists = obj.iptvPlaylists as StoredPlaylist[];
-        const json = JSON.stringify(lists);
-        localStorage.setItem(STORAGE_KEY, json);
-        cache = lists;
-        cacheJson = json;
-        written = true;
-      } catch {
-        /* quota errors leave the legacy blob in place */
+    if (Array.isArray(obj.iptvPlaylists)) {
+      for (const entry of obj.iptvPlaylists as StoredPlaylist[]) {
+        if (entry && typeof entry.id === "string" && !merged.has(entry.id)) {
+          merged.set(entry.id, entry);
+        }
       }
     }
-    // Strip the legacy field so the playlists no longer export under Settings.
+    dirty.push({ key, obj });
+  }
+  if (merged.size === 0) return;
+  const lists = [...merged.values()];
+  const json = JSON.stringify(lists);
+  try {
+    if (!setItemWithRecovery(STORAGE_KEY, json)) return;
+  } catch {
+    return;
+  }
+  cache = lists;
+  cacheJson = json;
+  // Strip the legacy field only now that the dedicated key is persisted, so the
+  // playlists no longer export under Settings.
+  for (const { key, obj } of dirty) {
     try {
       delete obj.iptvPlaylists;
       localStorage.setItem(key, JSON.stringify(obj));
@@ -87,6 +100,23 @@ export function migrateLegacyPlaylists(): void {
       /* best-effort */
     }
   }
+}
+
+/**
+ * Adopts a stranded legacy iptvPlaylists array into the dedicated store key,
+ * merging with anything already stored (stored entries win). Returns whether
+ * the result was persisted; callers should only drop the legacy field on true.
+ */
+export function adoptLegacyPlaylists(legacy: StoredPlaylist[]): boolean {
+  if (!Array.isArray(legacy) || legacy.length === 0) return true;
+  const merged = new Map<string, StoredPlaylist>();
+  for (const entry of cache) merged.set(entry.id, entry);
+  for (const entry of legacy) {
+    if (entry && typeof entry.id === "string" && !merged.has(entry.id)) {
+      merged.set(entry.id, entry);
+    }
+  }
+  return writePlaylists([...merged.values()]);
 }
 
 export function readPlaylists(): StoredPlaylist[] {
@@ -107,15 +137,20 @@ export function readPlaylists(): StoredPlaylist[] {
   }
 }
 
-export function writePlaylists(playlists: StoredPlaylist[]): void {
+export function writePlaylists(playlists: StoredPlaylist[]): boolean {
   cache = playlists;
   cacheJson = JSON.stringify(playlists);
+  let persisted = false;
   try {
-    localStorage.setItem(STORAGE_KEY, cacheJson);
-  } catch {
-    /* quota errors must not break the in-memory store */
+    persisted = setItemWithRecovery(STORAGE_KEY, cacheJson);
+  } catch (e) {
+    console.warn("[playlists] storage write failed", e);
+  }
+  if (!persisted) {
+    console.warn(`[playlists] storage is full; not persisted (${playlists.length} playlists)`);
   }
   notify();
+  return persisted;
 }
 
 export function subscribePlaylists(cb: () => void): () => void {

--- a/src/lib/iptv/playlists-store.ts
+++ b/src/lib/iptv/playlists-store.ts
@@ -1,0 +1,132 @@
+import { useSyncExternalStore } from "react";
+
+export type StoredPlaylist = {
+  id: string;
+  name: string;
+  url: string;
+  epgUrl?: string;
+  kind?: "m3u" | "xtream" | "epg";
+  xtream?: { server: string; username: string; password: string };
+};
+
+const STORAGE_KEY = "harbor.iptv.playlists.v1";
+
+let migrated = false;
+let cache: StoredPlaylist[] = [];
+let cacheJson = "[]";
+const subs = new Set<() => void>();
+
+function notify(): void {
+  for (const fn of subs) fn();
+}
+
+function ensureMigrated(): void {
+  if (!migrated) migrateLegacyPlaylists();
+}
+
+/**
+ * Moves playlists out of the settings blob (harbor.settings.*) into their own
+ * key. Runs once per session; also strips the legacy field from every settings
+ * blob that still carries it so playlists stop exporting under Settings.
+ */
+export function migrateLegacyPlaylists(): void {
+  if (migrated) return;
+  migrated = true;
+  try {
+    if (localStorage.getItem(STORAGE_KEY) != null) return;
+  } catch {
+    return;
+  }
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  for (const key of ["harbor.settings.shared", "harbor.settings"]) {
+    if (!seen.has(key)) {
+      seen.add(key);
+      candidates.push(key);
+    }
+  }
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith("harbor.settings.") && !seen.has(key)) {
+        seen.add(key);
+        candidates.push(key);
+      }
+    }
+  } catch {
+    /* localStorage enumeration is best-effort */
+  }
+  let written = false;
+  for (const key of candidates) {
+    let blob: unknown;
+    try {
+      blob = JSON.parse(localStorage.getItem(key) ?? "null");
+    } catch {
+      continue;
+    }
+    if (!blob || typeof blob !== "object") continue;
+    const obj = blob as Record<string, unknown>;
+    if (!("iptvPlaylists" in obj)) continue;
+    if (!written && Array.isArray(obj.iptvPlaylists)) {
+      try {
+        const lists = obj.iptvPlaylists as StoredPlaylist[];
+        const json = JSON.stringify(lists);
+        localStorage.setItem(STORAGE_KEY, json);
+        cache = lists;
+        cacheJson = json;
+        written = true;
+      } catch {
+        /* quota errors leave the legacy blob in place */
+      }
+    }
+    // Strip the legacy field so the playlists no longer export under Settings.
+    try {
+      delete obj.iptvPlaylists;
+      localStorage.setItem(key, JSON.stringify(obj));
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+export function readPlaylists(): StoredPlaylist[] {
+  ensureMigrated();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw == null) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const lists = parsed as StoredPlaylist[];
+    if (raw !== cacheJson) {
+      cache = lists;
+      cacheJson = raw;
+    }
+    return lists;
+  } catch {
+    return [];
+  }
+}
+
+export function writePlaylists(playlists: StoredPlaylist[]): void {
+  cache = playlists;
+  cacheJson = JSON.stringify(playlists);
+  try {
+    localStorage.setItem(STORAGE_KEY, cacheJson);
+  } catch {
+    /* quota errors must not break the in-memory store */
+  }
+  notify();
+}
+
+export function subscribePlaylists(cb: () => void): () => void {
+  subs.add(cb);
+  return () => subs.delete(cb);
+}
+
+// Hydrate the module cache at import time so usePlaylists() consumers render the
+// stored playlists without depending on a one-time migration flag being tripped.
+readPlaylists();
+
+export function usePlaylists(): StoredPlaylist[] {
+  return useSyncExternalStore(subscribePlaylists, () => cache, () => cache);
+}

--- a/src/lib/search-context.tsx
+++ b/src/lib/search-context.tsx
@@ -13,6 +13,7 @@ import { anilistCharacterSearch, type CharacterHit } from "@/lib/anilist/charact
 import { gatherCatalogAddons, type Addon } from "@/lib/addons";
 import { useAuth } from "@/lib/auth";
 import { useSettings } from "@/lib/settings";
+import { usePlaylists } from "@/lib/iptv/playlists-store";
 import { isMagnetInput, isDirectVideoUrl } from "@/lib/torrent/magnet";
 import { useView, type Frame } from "@/lib/view";
 
@@ -148,6 +149,7 @@ function saveRecent(items: string[]): void {
 
 export function SearchProvider({ children }: { children: ReactNode }) {
   const { settings } = useSettings();
+  const playlists = usePlaylists();
   const { authKey } = useAuth();
   const { hiddenTabs } = useParental();
   const [open, setOpen] = useState(false);
@@ -202,11 +204,11 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     const animeAllowed = !hiddenTabs.anime && !settings.hideContent.anime;
     const mangaAllowed = settings.mangaEnabled && !settings.hideContent.manga;
     const franchiseAllowed = animeAllowed || mangaAllowed;
-    const liveTvAllowed = !hiddenTabs.liveTv && settings.iptvPlaylists.length > 0;
+    const liveTvAllowed = !hiddenTabs.liveTv && playlists.length > 0;
     debounceRef.current = window.setTimeout(() => {
       if (!requestGuardRef.current.isCurrent(id)) return;
       setStatus("loading");
-      const liveTv = liveTvAllowed ? searchLiveTvChannels(trimmed, settings.iptvPlaylists) : [];
+      const liveTv = liveTvAllowed ? searchLiveTvChannels(trimmed, playlists) : [];
       const guard = <T,>(p: Promise<T>, fallback: T): Promise<T> =>
         Promise.race([
           p.catch(() => fallback),
@@ -399,7 +401,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
         debounceRef.current = null;
       }
     };
-  }, [query, aiHold, settings.tmdbKey, settings.tmdbLanguage, settings.iptvPlaylists, excludeGenres, hiddenTabs.anime, settings.hideContent.anime, hiddenTabs.liveTv, settings.mangaEnabled, settings.hideContent.manga, authKey]);
+  }, [query, aiHold, settings.tmdbKey, settings.tmdbLanguage, playlists, excludeGenres, hiddenTabs.anime, settings.hideContent.anime, hiddenTabs.liveTv, settings.mangaEnabled, settings.hideContent.manga, authKey]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -5,8 +5,8 @@ import type { Meta } from "@/lib/cinemeta";
 import type { AddonResultGroup } from "@/lib/search-addons";
 import type { AddonHit } from "@/lib/search-addon-index";
 import { getCachedPlaylist } from "@/lib/iptv/store";
+import type { StoredPlaylist } from "@/lib/iptv/playlists-store";
 import { arabicAwareMatch } from "@/lib/iptv/rtl";
-import type { Settings } from "@/lib/settings";
 import { safeFetch } from "@/lib/safe-fetch";
 import { anilistAnimeSearch } from "@/lib/anilist/browse";
 import type { MangaSummary } from "@/lib/manga/model";
@@ -80,7 +80,7 @@ export type SearchIntent =
 
 export function searchLiveTvChannels(
   query: string,
-  iptvPlaylists: Settings["iptvPlaylists"],
+  iptvPlaylists: StoredPlaylist[],
   limit = 8,
 ): LiveTvHit[] {
   const q = query.trim().toLowerCase();

--- a/src/lib/secret-store.ts
+++ b/src/lib/secret-store.ts
@@ -12,8 +12,21 @@ let rustAvailable = false;
 let loaded = false;
 let persistTimer: number | null = null;
 
-function isSecretKey(key: string): boolean {
+export function isSecretKey(key: string): boolean {
   return SECRET_PREFIXES.some((p) => key === p || key.startsWith(`${p}.`));
+}
+
+/** Rewrites a session key so it targets a specific profile, used when restoring a backup. */
+export function secretKeyForProfile(key: string, profileId: string): string {
+  for (const prefix of SECRET_PREFIXES) {
+    if (key === prefix || key.startsWith(`${prefix}.`)) return `${prefix}.${profileId}`;
+  }
+  return key;
+}
+
+/** Snapshot of the Rust-persisted secret store, for backup/export use. */
+export function getAllSecrets(): Record<string, string> {
+  return { ...store };
 }
 
 async function persist(): Promise<void> {
@@ -31,6 +44,15 @@ function schedulePersist(): void {
     persistTimer = null;
     void persist();
   }, 200);
+}
+
+/** Flushes any pending secret writes immediately, for callers about to leave the page. */
+export async function flushSecrets(): Promise<void> {
+  if (persistTimer != null) {
+    window.clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+  await persist();
 }
 
 export async function loadSecrets(): Promise<void> {

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -487,7 +487,6 @@ export const DEFAULT: Settings = {
   downloadDir: "",
   downloadCreateFolders: false,
   stremioDeeplinkInstall: true,
-  iptvPlaylists: [],
   iptvLiveContainer: "ts",
   iptvForceProxy: false,
   iptvEpgOffsetHours: 0,

--- a/src/lib/settings/load.ts
+++ b/src/lib/settings/load.ts
@@ -31,7 +31,7 @@ const RETIRED_GEMINI = new Set([
 ]);
 import { DEFAULT, STORAGE_KEY } from "./defaults";
 import type { Settings } from "./types";
-import { readPlaylists } from "@/lib/iptv/playlists-store";
+import { adoptLegacyPlaylists, readPlaylists } from "@/lib/iptv/playlists-store";
 
 const HEX_RE = /^#[0-9a-f]{6}$/i;
 
@@ -253,8 +253,13 @@ export function loadStoredSettings(rawKey: string = STORAGE_KEY): Settings {
       if (hasVodSource) parsed.showPlaylistsTab = true;
       parsed._playlistsTabV1 = true;
     }
-    // Playlists now live in their own store; never let a legacy field leak into Settings.
-    if ("iptvPlaylists" in parsed) delete parsed.iptvPlaylists;
+    // Playlists now live in their own store; adopt any stranded legacy field and
+    // only drop it once it has been persisted, so a failed write never loses data.
+    if ("iptvPlaylists" in parsed) {
+      if (adoptLegacyPlaylists(Array.isArray(parsed.iptvPlaylists) ? parsed.iptvPlaylists : [])) {
+        delete parsed.iptvPlaylists;
+      }
+    }
     if (!parsed._navThemeRepairV1) {
       const nav = parsed.navCustomization as Partial<Settings["navCustomization"]> | undefined;
       if (nav && Array.isArray(nav.hidden) && nav.hidden.length > 0) {

--- a/src/lib/settings/load.ts
+++ b/src/lib/settings/load.ts
@@ -31,6 +31,7 @@ const RETIRED_GEMINI = new Set([
 ]);
 import { DEFAULT, STORAGE_KEY } from "./defaults";
 import type { Settings } from "./types";
+import { readPlaylists } from "@/lib/iptv/playlists-store";
 
 const HEX_RE = /^#[0-9a-f]{6}$/i;
 
@@ -247,12 +248,13 @@ export function loadStoredSettings(rawKey: string = STORAGE_KEY): Settings {
       parsed._streamCacheCapV1 = true;
     }
     if (!parsed._playlistsTabV1) {
-      const lists = parsed.iptvPlaylists;
-      const hasVodSource =
-        Array.isArray(lists) && lists.some((l) => l && (l as { kind?: string }).kind !== "epg");
+      const lists = readPlaylists();
+      const hasVodSource = Array.isArray(lists) && lists.some((l) => l?.kind !== "epg");
       if (hasVodSource) parsed.showPlaylistsTab = true;
       parsed._playlistsTabV1 = true;
     }
+    // Playlists now live in their own store; never let a legacy field leak into Settings.
+    if ("iptvPlaylists" in parsed) delete parsed.iptvPlaylists;
     if (!parsed._navThemeRepairV1) {
       const nav = parsed.navCustomization as Partial<Settings["navCustomization"]> | undefined;
       if (nav && Array.isArray(nav.hidden) && nav.hidden.length > 0) {

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -565,18 +565,6 @@ export type Settings = {
   downloadDir: string;
   downloadCreateFolders: boolean;
   stremioDeeplinkInstall: boolean;
-  iptvPlaylists: Array<{
-    id: string;
-    name: string;
-    url: string;
-    epgUrl?: string;
-    kind?: "m3u" | "xtream" | "epg";
-    xtream?: {
-      server: string;
-      username: string;
-      password: string;
-    };
-  }>;
   iptvLiveContainer: "ts" | "m3u8";
   iptvForceProxy: boolean;
   iptvEpgOffsetHours: number;

--- a/src/lib/webhook-engine.ts
+++ b/src/lib/webhook-engine.ts
@@ -16,6 +16,7 @@ import {
 import { getCachedPlaylist } from "./iptv/store";
 import { fetchAndParseXmltv, indexProgramsByChannel } from "./iptv/xmltv";
 import { computeTvgIdCounts, epgProgramsForChannel } from "./iptv/epg-resolver";
+import { readPlaylists } from "./iptv/playlists-store";
 import type { Settings, WebhookTrigger } from "./settings";
 import { getSession as getTraktSession } from "./trakt/session";
 
@@ -156,12 +157,11 @@ function loadIptvFavorites(): Set<string> {
 }
 
 async function fetchLiveTvEvents(
-  settings: Settings,
   leadMinutes: number,
   favoritesOnly: boolean,
   channelIds: string[] | null,
 ): Promise<CalendarItem[]> {
-  const playlists = settings.iptvPlaylists.filter((p) => (p.kind ?? "m3u") !== "epg");
+  const playlists = readPlaylists().filter((p) => (p.kind ?? "m3u") !== "epg");
   if (playlists.length === 0) return [];
   const now = Date.now();
   const cutoff = now + leadMinutes * 60_000;
@@ -312,7 +312,6 @@ export async function runWebhookTick(
     let candidates: CalendarItem[] = [];
     if (rule.trigger.event === "liveTvEvent") {
       candidates = await fetchLiveTvEvents(
-        settings,
         rule.trigger.leadMinutes ?? 15,
         rule.trigger.favoritesOnly !== false,
         rule.trigger.channelIds ?? null,

--- a/src/views/live.tsx
+++ b/src/views/live.tsx
@@ -4,6 +4,7 @@ import { usePlaylistMutations } from "./live/hooks/use-playlist-mutations";
 import { useLiveActions } from "./live/hooks/use-live-actions";
 import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
+import { usePlaylists } from "@/lib/iptv/playlists-store";
 import { useScrollMemory, useView } from "@/lib/view";
 import { FAVORITES_GROUP_KEY, useFavorites } from "@/lib/iptv/favorites";
 import { clearPlaylistCache, getCachedPlaylist } from "@/lib/iptv/store";
@@ -67,7 +68,7 @@ export function LiveView({ active }: { active: boolean }) {
   const t = useT();
   const { settings } = useSettings();
   const { openMeta, setView } = useView();
-  const sources = settings.iptvPlaylists;
+  const sources = usePlaylists();
 
   const [activeId, setActiveId] = useState<string | null>(() => readActiveId());
   useEffect(() => {
@@ -163,7 +164,7 @@ export function LiveView({ active }: { active: boolean }) {
   const inFavorites = group === FAVORITES_GROUP_KEY;
   const allSources = useMemo<IptvPlaylistSource[]>(
     () =>
-      settings.iptvPlaylists
+      sources
         .filter((p) => (p.kind ?? "m3u") !== "epg")
         .map((p) => ({
           id: p.id,
@@ -173,11 +174,11 @@ export function LiveView({ active }: { active: boolean }) {
           kind: p.kind,
           xtream: p.xtream,
         })),
-    [settings.iptvPlaylists],
+    [sources],
   );
   const managedSources = useMemo<IptvPlaylistSource[]>(
     () =>
-      settings.iptvPlaylists.map((p) => ({
+      sources.map((p) => ({
         id: p.id,
         name: p.name,
         url: p.url,
@@ -185,7 +186,7 @@ export function LiveView({ active }: { active: boolean }) {
         kind: p.kind,
         xtream: p.xtream,
       })),
-    [settings.iptvPlaylists],
+    [sources],
   );
   const stubSources = useMemo(() => {
     const ids = new Set<string>();

--- a/src/views/live/hooks/use-live-actions.ts
+++ b/src/views/live/hooks/use-live-actions.ts
@@ -8,7 +8,7 @@ import { buildM3u, suggestExportFilename } from "@/lib/iptv/export";
 import { findCurrent } from "@/lib/iptv/xmltv";
 import type { EpgIndex, EpgProgram, IptvChannel, IptvPlaylist } from "@/lib/iptv/types";
 import type { Meta } from "@/lib/cinemeta";
-import { useSettings } from "@/lib/settings";
+import { usePlaylists } from "@/lib/iptv/playlists-store";
 import { useView } from "@/lib/view";
 
 export function synthChannelMeta(ch: IptvChannel): Meta {
@@ -31,7 +31,7 @@ export function useLiveActions(params: {
 }) {
   const { epg, activeId, playlist } = params;
   const { openPlayer } = useView();
-  const { settings } = useSettings();
+  const playlists = usePlaylists();
 
   const handlePlay = useCallback(
     (ch: IptvChannel) => {
@@ -76,7 +76,7 @@ export function useLiveActions(params: {
   const exportPlaylist = useCallback(
     async (id: string) => {
       if (id !== activeId || !playlist) return;
-      const source = settings.iptvPlaylists.find((s) => s.id === id);
+      const source = playlists.find((s) => s.id === id);
       const filename = suggestExportFilename(source?.name ?? "playlist");
       try {
         const target = await saveDialog({
@@ -89,7 +89,7 @@ export function useLiveActions(params: {
         console.warn("[live] export playlist failed", e);
       }
     },
-    [activeId, playlist, settings.iptvPlaylists],
+    [activeId, playlist, playlists],
   );
 
   return { handlePlay, handlePlayCatchup, exportPlaylist };

--- a/src/views/live/hooks/use-playlist-mutations.ts
+++ b/src/views/live/hooks/use-playlist-mutations.ts
@@ -1,13 +1,12 @@
 import { useCallback } from "react";
-import { useSettings, type Settings } from "@/lib/settings";
+import { useSettings } from "@/lib/settings";
+import { usePlaylists, writePlaylists, type StoredPlaylist } from "@/lib/iptv/playlists-store";
 import { clearPlaylistCache } from "@/lib/iptv/store";
 import { clearEpg } from "@/lib/iptv/epg-store";
 import { deleteIptvCache } from "@/lib/iptv/persistent-cache";
 import { purgePlaylistState } from "@/lib/iptv/source-cleanup";
 import { useFavorites } from "@/lib/iptv/favorites";
 import { buildXtreamUrls, type PlaylistFormValue } from "../source-picker/playlist-form";
-
-type StoredPlaylist = Settings["iptvPlaylists"][number];
 
 export function materializePlaylistEntry(id: string, entry: PlaylistFormValue): StoredPlaylist {
   if (entry.kind === "xtream") {
@@ -43,17 +42,15 @@ export function usePlaylistMutations(params: {
   const { activeId, setActiveId, refresh } = params;
   const { settings, update } = useSettings();
   const favorites = useFavorites();
-  const playlists = settings.iptvPlaylists;
+  const playlists = usePlaylists();
 
   const addPlaylist = useCallback(
     (entry: PlaylistFormValue) => {
       const id = `pl-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
       const built = materializePlaylistEntry(id, entry);
       const carriesVod = entry.kind === "xtream" || entry.kind === "m3u";
-      update({
-        iptvPlaylists: [...playlists, built],
-        ...(carriesVod && !settings.showPlaylistsTab ? { showPlaylistsTab: true } : {}),
-      });
+      writePlaylists([...playlists, built]);
+      if (carriesVod && !settings.showPlaylistsTab) update({ showPlaylistsTab: true });
       if (entry.kind !== "epg") setActiveId(id);
     },
     [playlists, update, setActiveId, settings.showPlaylistsTab],
@@ -63,22 +60,22 @@ export function usePlaylistMutations(params: {
     (id: string) => {
       const next = playlists.filter((s) => s.id !== id);
       if (activeId === id) setActiveId(next[0]?.id ?? null);
-      update({ iptvPlaylists: next });
+      writePlaylists(next);
       purgePlaylistState(id, favorites.removeForSource);
     },
-    [playlists, update, activeId, setActiveId, favorites.removeForSource],
+    [playlists, activeId, setActiveId, favorites.removeForSource],
   );
 
   const editPlaylist = useCallback(
     (id: string, entry: PlaylistFormValue) => {
       const next = playlists.map((s) => (s.id === id ? materializePlaylistEntry(id, entry) : s));
-      update({ iptvPlaylists: next });
+      writePlaylists(next);
       clearPlaylistCache(id);
       void deleteIptvCache("xtream-vod", id);
       clearEpg(id);
       if (activeId === id) refresh();
     },
-    [playlists, update, activeId, refresh],
+    [playlists, activeId, refresh],
   );
 
   const reorderPlaylist = useCallback(
@@ -88,9 +85,9 @@ export function usePlaylistMutations(params: {
       if (i < 0 || j < 0 || j >= playlists.length) return;
       const next = playlists.slice();
       [next[i], next[j]] = [next[j], next[i]];
-      update({ iptvPlaylists: next });
+      writePlaylists(next);
     },
-    [playlists, update],
+    [playlists],
   );
 
   const movePlaylistTop = useCallback(
@@ -100,9 +97,9 @@ export function usePlaylistMutations(params: {
       const next = playlists.slice();
       const [item] = next.splice(i, 1);
       next.unshift(item);
-      update({ iptvPlaylists: next });
+      writePlaylists(next);
     },
-    [playlists, update],
+    [playlists],
   );
 
   return { addPlaylist, removePlaylist, editPlaylist, reorderPlaylist, movePlaylistTop };

--- a/src/views/live/hooks/use-playlist-mutations.ts
+++ b/src/views/live/hooks/use-playlist-mutations.ts
@@ -6,6 +6,8 @@ import { clearEpg } from "@/lib/iptv/epg-store";
 import { deleteIptvCache } from "@/lib/iptv/persistent-cache";
 import { purgePlaylistState } from "@/lib/iptv/source-cleanup";
 import { useFavorites } from "@/lib/iptv/favorites";
+import { alertDialog } from "@/lib/dialog";
+import { useT } from "@/lib/i18n";
 import { buildXtreamUrls, type PlaylistFormValue } from "../source-picker/playlist-form";
 
 export function materializePlaylistEntry(id: string, entry: PlaylistFormValue): StoredPlaylist {
@@ -43,17 +45,23 @@ export function usePlaylistMutations(params: {
   const { settings, update } = useSettings();
   const favorites = useFavorites();
   const playlists = usePlaylists();
+  const t = useT();
 
   const addPlaylist = useCallback(
     (entry: PlaylistFormValue) => {
       const id = `pl-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
       const built = materializePlaylistEntry(id, entry);
       const carriesVod = entry.kind === "xtream" || entry.kind === "m3u";
-      writePlaylists([...playlists, built]);
+      const persisted = writePlaylists([...playlists, built]);
+      if (!persisted) {
+        console.warn("harbor: playlist not persisted (storage quota)", id);
+        void alertDialog(t("Couldn't save the playlist. Free up storage space in Settings and try again."));
+      }
       if (carriesVod && !settings.showPlaylistsTab) update({ showPlaylistsTab: true });
       if (entry.kind !== "epg") setActiveId(id);
+      return persisted;
     },
-    [playlists, update, setActiveId, settings.showPlaylistsTab],
+    [playlists, update, setActiveId, settings.showPlaylistsTab, t],
   );
 
   const removePlaylist = useCallback(

--- a/src/views/player/hooks/use-live-channel-overlay.ts
+++ b/src/views/player/hooks/use-live-channel-overlay.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSettings } from "@/lib/settings";
+import { usePlaylists } from "@/lib/iptv/playlists-store";
 import { headersFromChannel } from "@/lib/iptv/channel-headers";
 import type { IptvChannel, IptvPlaylistSource } from "@/lib/iptv/types";
 import type { Meta } from "@/lib/cinemeta";
@@ -10,7 +10,7 @@ export function useLiveChannelOverlay(params: {
   replacePlayerSrc: (src: PlayerSrc) => void;
 }) {
   const { src, replacePlayerSrc } = params;
-  const { settings } = useSettings();
+  const playlists = usePlaylists();
   const [open, setOpen] = useState(false);
   const [group, setGroup] = useState<string | null>(null);
   const [query, setQuery] = useState("");
@@ -23,27 +23,27 @@ export function useLiveChannelOverlay(params: {
     const stripped = src.meta.id.replace(/^iptv:/, "");
     const playlistId = stripped.split("::")[0];
     if (!playlistId) return null;
-    const found = settings.iptvPlaylists.find((p) => p.id === playlistId);
+    const found = playlists.find((p) => p.id === playlistId);
     if (!found) return null;
     return { id: found.id, name: found.name, url: found.url, epgUrl: found.epgUrl };
-  }, [isLive, src.meta.id, settings.iptvPlaylists]);
+  }, [isLive, src.meta.id, playlists]);
 
   const activeSource: IptvPlaylistSource | null = useMemo(() => {
     if (!overrideSourceId) return playingSource;
-    const found = settings.iptvPlaylists.find((p) => p.id === overrideSourceId);
+    const found = playlists.find((p) => p.id === overrideSourceId);
     if (!found) return playingSource;
     return { id: found.id, name: found.name, url: found.url, epgUrl: found.epgUrl };
-  }, [overrideSourceId, playingSource, settings.iptvPlaylists]);
+  }, [overrideSourceId, playingSource, playlists]);
 
   const availableSources: IptvPlaylistSource[] = useMemo(
     () =>
-      settings.iptvPlaylists.map((p) => ({
+      playlists.map((p) => ({
         id: p.id,
         name: p.name,
         url: p.url,
         epgUrl: p.epgUrl,
       })),
-    [settings.iptvPlaylists],
+    [playlists],
   );
 
   const selectSource = useCallback((id: string) => {

--- a/src/views/playlist-vod/use-vod-sources.ts
+++ b/src/views/playlist-vod/use-vod-sources.ts
@@ -7,6 +7,8 @@ import { useFavorites } from "@/lib/iptv/favorites";
 import type { IptvPlaylistSource } from "@/lib/iptv/types";
 import { buildXtreamUrls, type PlaylistFormValue } from "@/views/live/source-picker/playlist-form";
 import { clearXtreamVodLibraryCache } from "./use-xtream-vod-library";
+import { alertDialog } from "@/lib/dialog";
+import { useT } from "@/lib/i18n";
 
 const ACTIVE_KEY = "harbor.vod.active";
 
@@ -59,6 +61,7 @@ function materialize(id: string, entry: PlaylistFormValue) {
 export function useVodSources() {
   const playlists = usePlaylists();
   const favorites = useFavorites();
+  const t = useT();
 
   const sources = useMemo<IptvPlaylistSource[]>(
     () =>
@@ -101,11 +104,15 @@ export function useVodSources() {
     (entry: PlaylistFormValue) => {
       if (entry.kind === "epg") return;
       const id = `pl-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
-      writePlaylists([...playlists, materialize(id, entry)]);
+      const persisted = writePlaylists([...playlists, materialize(id, entry)]);
+      if (!persisted) {
+        console.warn("harbor: playlist not persisted (storage quota)", id);
+        void alertDialog(t("Couldn't save the playlist. Free up storage space in Settings and try again."));
+      }
       setActiveId(id);
       writeActive(id);
     },
-    [playlists],
+    [playlists, t],
   );
 
   const editPlaylist = useCallback(

--- a/src/views/playlist-vod/use-vod-sources.ts
+++ b/src/views/playlist-vod/use-vod-sources.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSettings } from "@/lib/settings";
+import { usePlaylists, writePlaylists } from "@/lib/iptv/playlists-store";
 import { clearPlaylistCache } from "@/lib/iptv/store";
 import { clearEpg } from "@/lib/iptv/epg-store";
 import { purgePlaylistState } from "@/lib/iptv/source-cleanup";
@@ -57,12 +57,12 @@ function materialize(id: string, entry: PlaylistFormValue) {
 }
 
 export function useVodSources() {
-  const { settings, update } = useSettings();
+  const playlists = usePlaylists();
   const favorites = useFavorites();
 
   const sources = useMemo<IptvPlaylistSource[]>(
     () =>
-      settings.iptvPlaylists
+      playlists
         .filter((p) => (p.kind ?? "m3u") !== "epg")
         .map((p) => ({
           id: p.id,
@@ -72,7 +72,7 @@ export function useVodSources() {
           kind: p.kind,
           xtream: p.xtream,
         })),
-    [settings.iptvPlaylists],
+    [playlists],
   );
 
   const [activeId, setActiveId] = useState<string | null>(() => readActive());
@@ -101,37 +101,37 @@ export function useVodSources() {
     (entry: PlaylistFormValue) => {
       if (entry.kind === "epg") return;
       const id = `pl-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
-      update({ iptvPlaylists: [...settings.iptvPlaylists, materialize(id, entry)] });
+      writePlaylists([...playlists, materialize(id, entry)]);
       setActiveId(id);
       writeActive(id);
     },
-    [settings.iptvPlaylists, update],
+    [playlists],
   );
 
   const editPlaylist = useCallback(
     (id: string, entry: PlaylistFormValue) => {
-      const next = settings.iptvPlaylists.map((s) => (s.id === id ? materialize(id, entry) : s));
-      update({ iptvPlaylists: next });
+      const next = playlists.map((s) => (s.id === id ? materialize(id, entry) : s));
+      writePlaylists(next);
       clearPlaylistCache(id);
       clearXtreamVodLibraryCache(id);
       clearEpg(id);
     },
-    [settings.iptvPlaylists, update],
+    [playlists],
   );
 
   const removePlaylist = useCallback(
     (id: string) => {
-      const next = settings.iptvPlaylists.filter((s) => s.id !== id);
+      const next = playlists.filter((s) => s.id !== id);
       if (activeId === id) {
         const fallback = next[0]?.id ?? null;
         setActiveId(fallback);
         writeActive(fallback);
       }
-      update({ iptvPlaylists: next });
+      writePlaylists(next);
       clearXtreamVodLibraryCache(id);
       purgePlaylistState(id, favorites.removeForSource);
     },
-    [settings.iptvPlaylists, update, activeId, favorites.removeForSource],
+    [playlists, activeId, favorites.removeForSource],
   );
 
   return { sources, activeId, selectId, addPlaylist, editPlaylist, removePlaylist };

--- a/src/views/settings/advanced-panel.tsx
+++ b/src/views/settings/advanced-panel.tsx
@@ -83,7 +83,7 @@ export function AdvancedPanel() {
       <Section
         title={t("Backup & restore")}
         subtitle={t(
-          "Export your entire Harbor setup to a single file, then restore it on a new computer or keep it as a backup. Everything is included except your Stremio sign-in.",
+          "Export your Harbor setup to a single file — pick exactly what goes in. Restore brings back only what the file contains. Your Stremio sign-in is always left out.",
         )}
       >
         <SettingsRecoverRow />

--- a/src/views/settings/backup-row.tsx
+++ b/src/views/settings/backup-row.tsx
@@ -24,11 +24,11 @@ export function BackupRow() {
   const [applying, setApplying] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
 
-  const doExport = async (selected: BackupSectionKey[], subOptions: Record<string, string[]>) => {
+  const doExport = async (selected: BackupSectionKey[]) => {
     setError(null);
     setPickerOpen(false);
     try {
-      const saved = await downloadBackup(selected, subOptions);
+      const saved = await downloadBackup(selected);
       if (saved) {
         setExported(true);
         window.setTimeout(() => setExported(false), 1600);
@@ -137,18 +137,11 @@ function ExportPicker({
   onExport,
   onCancel,
 }: {
-  onExport: (selected: BackupSectionKey[], subOptions: Record<string, string[]>) => void;
+  onExport: (selected: BackupSectionKey[]) => void;
   onCancel: () => void;
 }) {
   const t = useT();
   const [selected, setSelected] = useState<Set<BackupSectionKey>>(() => new Set(BACKUP_SECTIONS.map((s) => s.key)));
-  const [subOptions, setSubOptions] = useState<Record<string, string[]>>(() => {
-    const initial: Record<string, string[]> = {};
-    for (const section of BACKUP_SECTIONS) {
-      if (section.subOptions) initial[section.key] = section.subOptions.map((o) => o.key);
-    }
-    return initial;
-  });
 
   const allSelected = selected.size === BACKUP_SECTIONS.length;
   const toggle = (key: BackupSectionKey) => {
@@ -160,13 +153,6 @@ function ExportPicker({
         next.add(key);
       }
       return next;
-    });
-  };
-  const toggleSubOption = (sectionKey: BackupSectionKey, subKey: string) => {
-    setSubOptions((prev) => {
-      const current = prev[sectionKey] ?? [];
-      const next = current.includes(subKey) ? current.filter((k) => k !== subKey) : [...current, subKey];
-      return { ...prev, [sectionKey]: next };
     });
   };
   const toggleAll = () => {
@@ -227,37 +213,6 @@ function ExportPicker({
               <p className="ms-6.5 mt-0.5 text-[11.5px] leading-snug text-ink-subtle">
                 {t(backupSectionDescription(section.key))}
               </p>
-              {selected.has(section.key) &&
-                section.subOptions &&
-                section.subOptions.length > 0 && (
-                  <div className="ms-6 mt-2 border-s border-edge-soft/50 ps-3">
-                    {section.subOptions.map((sub) => {
-                      const checked = subOptions[section.key]?.includes(sub.key) ?? false;
-                      return (
-                        <label
-                          key={sub.key}
-                          className="flex cursor-pointer items-start gap-2 py-1.5"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggleSubOption(section.key, sub.key)}
-                            className="mt-0.5 h-4 w-4 shrink-0 accent-ink"
-                          />
-                          <span className="flex min-w-0 flex-col gap-0.5">
-                            <span className="flex items-center gap-1.5">
-                              <span className="text-[12px] font-medium text-ink">{t(sub.label)}</span>
-                              {sub.warning && (
-                                <AlertTriangle size={13} strokeWidth={2.4} className="shrink-0 text-amber-500" aria-label={t("contains login credentials")} />
-                              )}
-                            </span>
-                            <span className="text-[11px] leading-snug text-ink-subtle">{t(sub.description)}</span>
-                          </span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                )}
             </div>
           ))}
         </div>
@@ -272,7 +227,7 @@ function ExportPicker({
           </button>
           <button
             type="button"
-            onClick={() => onExport([...selected], subOptions)}
+            onClick={() => onExport([...selected])}
             disabled={selected.size === 0}
             className="flex h-10 items-center gap-1.5 rounded-full bg-accent px-5 text-[13px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -326,7 +281,7 @@ function RestoreConfirm({
             </span>
           ))}
         </div>
-        {backup.subOptions?.iptv && !backup.subOptions.iptv.includes("xtreamCredentials") && (
+        {backup.sections?.includes("iptv") && !backup.sections.includes("iptvCredentials") && (
           <p className="mt-3 text-[12px] text-ink-subtle">
             {t("Xtream credentials were left out of this backup.")}
           </p>

--- a/src/views/settings/backup-row.tsx
+++ b/src/views/settings/backup-row.tsx
@@ -24,11 +24,11 @@ export function BackupRow() {
   const [applying, setApplying] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
 
-  const doExport = async (selected: BackupSectionKey[]) => {
+  const doExport = async (selected: BackupSectionKey[], subOptions: Record<string, string[]>) => {
     setError(null);
     setPickerOpen(false);
     try {
-      const saved = await downloadBackup(selected);
+      const saved = await downloadBackup(selected, subOptions);
       if (saved) {
         setExported(true);
         window.setTimeout(() => setExported(false), 1600);
@@ -137,11 +137,18 @@ function ExportPicker({
   onExport,
   onCancel,
 }: {
-  onExport: (selected: BackupSectionKey[]) => void;
+  onExport: (selected: BackupSectionKey[], subOptions: Record<string, string[]>) => void;
   onCancel: () => void;
 }) {
   const t = useT();
   const [selected, setSelected] = useState<Set<BackupSectionKey>>(() => new Set(BACKUP_SECTIONS.map((s) => s.key)));
+  const [subOptions, setSubOptions] = useState<Record<string, string[]>>(() => {
+    const initial: Record<string, string[]> = {};
+    for (const section of BACKUP_SECTIONS) {
+      if (section.subOptions) initial[section.key] = section.subOptions.map((o) => o.key);
+    }
+    return initial;
+  });
 
   const allSelected = selected.size === BACKUP_SECTIONS.length;
   const toggle = (key: BackupSectionKey) => {
@@ -153,6 +160,13 @@ function ExportPicker({
         next.add(key);
       }
       return next;
+    });
+  };
+  const toggleSubOption = (sectionKey: BackupSectionKey, subKey: string) => {
+    setSubOptions((prev) => {
+      const current = prev[sectionKey] ?? [];
+      const next = current.includes(subKey) ? current.filter((k) => k !== subKey) : [...current, subKey];
+      return { ...prev, [sectionKey]: next };
     });
   };
   const toggleAll = () => {
@@ -192,28 +206,59 @@ function ExportPicker({
 
         <div className="mt-2 grid max-h-[52vh] grid-cols-1 gap-1.5 overflow-y-auto pe-1 sm:grid-cols-2">
           {BACKUP_SECTIONS.map((section) => (
-            <label
+            <div
               key={section.key}
-              className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-edge-soft/60 bg-canvas/30 px-3.5 py-2.5 transition-colors hover:bg-raised/70"
+              className="rounded-lg border border-edge-soft/60 bg-canvas/30 px-3.5 py-2.5 transition-colors hover:bg-raised/70"
             >
-              <input
-                type="checkbox"
-                checked={selected.has(section.key)}
-                onChange={() => toggle(section.key)}
-                className="mt-0.5 h-4 w-4 shrink-0 accent-ink"
-              />
-              <span className="flex min-w-0 flex-col gap-0.5">
+              <label className="flex cursor-pointer items-start gap-2.5">
+                <input
+                  type="checkbox"
+                  checked={selected.has(section.key)}
+                  onChange={() => toggle(section.key)}
+                  className="mt-0.5 h-4 w-4 shrink-0 accent-ink"
+                />
                 <span className="flex items-center gap-1.5">
                   <span className="text-[13px] font-medium text-ink">{t(backupSectionLabel(section.key))}</span>
                   {section.warning && (
                     <AlertTriangle size={13} strokeWidth={2.4} className="shrink-0 text-amber-500" aria-label={t("contains login credentials")} />
                   )}
                 </span>
-                <span className="text-[11.5px] leading-snug text-ink-subtle">
-                  {t(backupSectionDescription(section.key))}
-                </span>
-              </span>
-            </label>
+              </label>
+              <p className="ms-6.5 mt-0.5 text-[11.5px] leading-snug text-ink-subtle">
+                {t(backupSectionDescription(section.key))}
+              </p>
+              {selected.has(section.key) &&
+                section.subOptions &&
+                section.subOptions.length > 0 && (
+                  <div className="ms-6 mt-2 border-s border-edge-soft/50 ps-3">
+                    {section.subOptions.map((sub) => {
+                      const checked = subOptions[section.key]?.includes(sub.key) ?? false;
+                      return (
+                        <label
+                          key={sub.key}
+                          className="flex cursor-pointer items-start gap-2 py-1.5"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleSubOption(section.key, sub.key)}
+                            className="mt-0.5 h-4 w-4 shrink-0 accent-ink"
+                          />
+                          <span className="flex min-w-0 flex-col gap-0.5">
+                            <span className="flex items-center gap-1.5">
+                              <span className="text-[12px] font-medium text-ink">{t(sub.label)}</span>
+                              {sub.warning && (
+                                <AlertTriangle size={13} strokeWidth={2.4} className="shrink-0 text-amber-500" aria-label={t("contains login credentials")} />
+                              )}
+                            </span>
+                            <span className="text-[11px] leading-snug text-ink-subtle">{t(sub.description)}</span>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+            </div>
           ))}
         </div>
 
@@ -227,7 +272,7 @@ function ExportPicker({
           </button>
           <button
             type="button"
-            onClick={() => onExport([...selected])}
+            onClick={() => onExport([...selected], subOptions)}
             disabled={selected.size === 0}
             className="flex h-10 items-center gap-1.5 rounded-full bg-accent px-5 text-[13px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -281,6 +326,11 @@ function RestoreConfirm({
             </span>
           ))}
         </div>
+        {backup.subOptions?.iptv && !backup.subOptions.iptv.includes("xtreamCredentials") && (
+          <p className="mt-3 text-[12px] text-ink-subtle">
+            {t("Xtream credentials were left out of this backup.")}
+          </p>
+        )}
         <p className="mt-3 text-[12px] text-ink-subtle">
           {t("Saved {when} from Harbor {app}. Your Stremio sign-in stays as is.", { when, app: backup.app })}
         </p>

--- a/src/views/settings/backup-row.tsx
+++ b/src/views/settings/backup-row.tsx
@@ -1,7 +1,18 @@
-import { Check, Download, Upload } from "lucide-react";
+import { AlertTriangle, Check, Download, Upload } from "lucide-react";
 import { useRef, useState, type ChangeEvent } from "react";
 import { createPortal } from "react-dom";
-import { applyBackup, backupKeyCount, downloadBackup, parseBackup, type Backup } from "@/lib/backup";
+import {
+  applyBackup,
+  BACKUP_SECTIONS,
+  backupKeyCount,
+  backupSectionDescription,
+  backupSectionLabel,
+  backupSections,
+  downloadBackup,
+  parseBackup,
+  type Backup,
+  type BackupSectionKey,
+} from "@/lib/backup";
 import { useT } from "@/lib/i18n";
 
 export function BackupRow() {
@@ -11,11 +22,13 @@ export function BackupRow() {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<Backup | null>(null);
   const [applying, setApplying] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
-  const doExport = async () => {
+  const doExport = async (selected: BackupSectionKey[]) => {
     setError(null);
+    setPickerOpen(false);
     try {
-      const saved = await downloadBackup();
+      const saved = await downloadBackup(selected);
       if (saved) {
         setExported(true);
         window.setTimeout(() => setExported(false), 1600);
@@ -63,14 +76,14 @@ export function BackupRow() {
 
       <div className="flex flex-col gap-3 rounded-xl border border-edge-soft bg-canvas/40 p-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="text-[14px] font-medium text-ink">{t("Export everything")}</span>
+          <span className="text-[14px] font-medium text-ink">{t("Export your setup")}</span>
           <span className="text-[12.5px] leading-relaxed text-ink-subtle">
-            {t("Saves your whole Harbor setup to one file: theme, home layout, settings, addons, profiles, watchlist, player layouts, watch progress, and more. Your Stremio sign-in is left out on purpose.")}
+            {t("Pick what to save, then everything you choose lands in one file: theme, home layout, settings, addons, profiles, watchlist, player layouts, watch progress, and more. Your Stremio sign-in is left out on purpose.")}
           </span>
         </div>
         <button
           type="button"
-          onClick={doExport}
+          onClick={() => setPickerOpen(true)}
           className={`flex h-9 shrink-0 items-center gap-1.5 rounded-lg px-3.5 text-[12.5px] font-semibold transition-all ${
             exported
               ? "bg-accent/15 text-accent"
@@ -86,7 +99,7 @@ export function BackupRow() {
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <span className="text-[14px] font-medium text-ink">{t("Restore from a backup")}</span>
           <span className="text-[12.5px] leading-relaxed text-ink-subtle">
-            {t("Loads a backup file and replaces your current setup with it. Perfect for a new computer. Your Stremio sign-in on this device stays as is.")}
+            {t("Loads a backup file and restores exactly what it contains, without touching the rest of your setup. Your Stremio sign-in on this device stays as is.")}
           </span>
         </div>
         <button
@@ -101,6 +114,13 @@ export function BackupRow() {
 
       {error && <p className="px-1 text-[12px] text-danger">{error}</p>}
 
+      {pickerOpen && (
+        <ExportPicker
+          onExport={doExport}
+          onCancel={() => setPickerOpen(false)}
+        />
+      )}
+
       {pending && (
         <RestoreConfirm
           backup={pending}
@@ -110,6 +130,114 @@ export function BackupRow() {
         />
       )}
     </div>
+  );
+}
+
+function ExportPicker({
+  onExport,
+  onCancel,
+}: {
+  onExport: (selected: BackupSectionKey[]) => void;
+  onCancel: () => void;
+}) {
+  const t = useT();
+  const [selected, setSelected] = useState<Set<BackupSectionKey>>(() => new Set(BACKUP_SECTIONS.map((s) => s.key)));
+
+  const allSelected = selected.size === BACKUP_SECTIONS.length;
+  const toggle = (key: BackupSectionKey) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+  const toggleAll = () => {
+    setSelected(allSelected ? new Set() : new Set(BACKUP_SECTIONS.map((s) => s.key)));
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[400] flex items-center justify-center bg-black/60 p-6 backdrop-blur-sm"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="modal-panel w-full max-w-2xl rounded-2xl border border-edge-soft bg-elevated p-6 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.7)]"
+      >
+        <h2 className="text-[17px] font-semibold tracking-tight text-ink">{t("What should the backup include?")}</h2>
+        <p className="mt-2.5 text-[13.5px] leading-relaxed text-ink-muted">
+          {t("Everything you pick is saved into one file. Restoring it later only touches what is in the file. Your Stremio sign-in is always left out.")}
+        </p>
+
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={toggleAll}
+            className="flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[12px] font-semibold text-ink-subtle transition-colors hover:bg-raised hover:text-ink"
+          >
+            <Check size={13} strokeWidth={2.6} className={allSelected ? "text-accent" : "opacity-40"} />
+            {allSelected ? t("All selected") : t("Select all")}
+          </button>
+          <span className="text-[11.5px] tabular-nums text-ink-subtle">
+            {t("{n} of {total} chosen", { n: selected.size, total: BACKUP_SECTIONS.length })}
+          </span>
+        </div>
+
+        <div className="mt-2 grid max-h-[52vh] grid-cols-1 gap-1.5 overflow-y-auto pe-1 sm:grid-cols-2">
+          {BACKUP_SECTIONS.map((section) => (
+            <label
+              key={section.key}
+              className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-edge-soft/60 bg-canvas/30 px-3.5 py-2.5 transition-colors hover:bg-raised/70"
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(section.key)}
+                onChange={() => toggle(section.key)}
+                className="mt-0.5 h-4 w-4 shrink-0 accent-ink"
+              />
+              <span className="flex min-w-0 flex-col gap-0.5">
+                <span className="flex items-center gap-1.5">
+                  <span className="text-[13px] font-medium text-ink">{t(backupSectionLabel(section.key))}</span>
+                  {section.warning && (
+                    <AlertTriangle size={13} strokeWidth={2.4} className="shrink-0 text-amber-500" aria-label={t("contains login credentials")} />
+                  )}
+                </span>
+                <span className="text-[11.5px] leading-snug text-ink-subtle">
+                  {t(backupSectionDescription(section.key))}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="h-10 rounded-full px-4 text-[13px] font-medium text-ink-muted transition-colors hover:bg-raised hover:text-ink"
+          >
+            {t("Cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={() => onExport([...selected])}
+            disabled={selected.size === 0}
+            className="flex h-10 items-center gap-1.5 rounded-full bg-accent px-5 text-[13px] font-semibold text-canvas transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Download size={14} strokeWidth={2.4} />
+            {t("Export {n} sections", { n: selected.size })}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -126,6 +254,7 @@ function RestoreConfirm({
 }) {
   const t = useT();
   const when = backup.exportedAt ? new Date(backup.exportedAt).toLocaleString() : t("an unknown date");
+  const sections = backupSections(backup);
   return createPortal(
     <div
       className="fixed inset-0 z-[400] flex items-center justify-center bg-black/60 p-6 backdrop-blur-sm"
@@ -140,10 +269,20 @@ function RestoreConfirm({
       >
         <h2 className="text-[17px] font-semibold tracking-tight text-ink">{t("Restore this backup?")}</h2>
         <p className="mt-2.5 text-[13.5px] leading-relaxed text-ink-muted">
-          {t("This replaces your current Harbor setup (theme, home layout, settings, addons, profiles, and more) with the {n} saved entries in this file. Your Stremio sign-in stays as is. Harbor reloads when it finishes.", { n: String(backupKeyCount(backup)) })}
+          {t("This file restores its {n} saved entries and replaces only those parts of your setup. Anything it does not contain stays exactly as it is.", { n: String(backupKeyCount(backup)) })}
         </p>
-        <p className="mt-2 text-[12px] text-ink-subtle">
-          {t("Saved {when} from Harbor {app}.", { when, app: backup.app })}
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {sections.map((key) => (
+            <span
+              key={key}
+              className="rounded-full border border-edge-soft bg-canvas/40 px-2.5 py-1 text-[11.5px] font-medium text-ink-subtle"
+            >
+              {t(backupSectionLabel(key))}
+            </span>
+          ))}
+        </div>
+        <p className="mt-3 text-[12px] text-ink-subtle">
+          {t("Saved {when} from Harbor {app}. Your Stremio sign-in stays as is.", { when, app: backup.app })}
         </p>
         <div className="mt-5 flex justify-end gap-2">
           <button

--- a/src/views/settings/bug-report-panel.tsx
+++ b/src/views/settings/bug-report-panel.tsx
@@ -11,6 +11,7 @@ import {
   type Severity,
 } from "@/lib/bug-report";
 import { useSettings } from "@/lib/settings";
+import { usePlaylists } from "@/lib/iptv/playlists-store";
 import { useT } from "@/lib/i18n";
 import { Section } from "./shared";
 import { ContributorCard } from "./bug-report/contributor-card";
@@ -22,6 +23,7 @@ import { SuccessCard } from "./bug-report/success-card";
 export function BugReportPanel() {
   const t = useT();
   const { settings } = useSettings();
+  const playlists = usePlaylists();
   const auth = useAuth();
   const [summary, setSummary] = useState("");
   const [severity, setSeverity] = useState<Severity>("normal");
@@ -51,7 +53,7 @@ export function BugReportPanel() {
       hasStremio: !!auth.authKey,
       debridCount: [settings.rdKey, settings.tbKey, settings.adKey, settings.pmKey, settings.dlKey].filter(Boolean).length,
       addonCount: 0,
-      iptvCount: settings.iptvPlaylists.length,
+      iptvCount: playlists.length,
     }).then((d) => {
       if (!cancelled) setDiag(d);
     });
@@ -64,7 +66,7 @@ export function BugReportPanel() {
     settings.tmdbKey,
     settings.rpdbKey,
     settings.traktAccessToken,
-    settings.iptvPlaylists.length,
+    playlists.length,
     settings.rdKey,
     settings.tbKey,
     settings.adKey,


### PR DESCRIPTION
## Summary
Two related improvements to the backup/export flow:

Section picker on export — users now choose which sections to include in a backup (settings, favorites, watchlists) instead of always bundling everything.
Service sign-in round-trip — Trakt/Simkl/MyAnimeList/AniList session secrets are now correctly exported and restored, and restores onto a different profile remap the sessions to the active profile so sign-ins keep working after restore.

## Why
Export previously bundled every section unconditionally, and service sessions were not reliably restored — a backup restored onto another profile could leave sign-ins bound to the wrong profile or dropped entirely. Since Harbor supports multiple profiles, restore must remap session secrets to the active profile (secretKeyForProfile), while same-profile restores must keep existing keys unchanged. This gives users control over backup contents and makes sign-ins survive a profile-level restore.

## Verification
pnpm exec tsc -b --force --pretty false — exit 0
Probe harness (full export → restore → reload cycle, sessions only): node --experimental-strip-types --experimental-loader ./tests/_alias-loader.mjs --test tests/_probe-cycle.test.mjs — 2/2 pass, covering cross-profile remap A→B and same-profile key stability
Manual scenario: export with selected sections → restore onto another profile → confirm the service session is active under the new profile

## Platform Impact
None

## UI Changes
The export flow gains a section picker in backup-row.tsx / advanced-panel.tsx.

<img width="741" height="929" alt="image" src="https://github.com/user-attachments/assets/db233a18-5b9c-48e7-a19c-12c4c8602a33" />

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
