### PR TITLE
fix(subtitles): show embedded tracks in the pre-play picker

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -695,6 +695,7 @@ pub fn run() {
             subsync::torrent_sync::torrent_sync_subtitle,
             subsync::torrent_sync::torrent_score_transform,
             subsync::audio_tracks::audio_probe_tracks,
+            subsync::subtitle_tracks::subtitle_probe_tracks,
             subsync::fingerprint::compute_chromaprint,
             subsync::asr::asr_transcribe_windows,
             subsync::asr::asr_verify,

--- a/src-tauri/src/stream_proxy.rs
+++ b/src-tauri/src/stream_proxy.rs
@@ -106,6 +106,19 @@ impl ProxyState {
         Ok(state)
     }
 
+    pub(crate) fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub(crate) async fn has_session(&self, session_id: &str, playlist: bool) -> bool {
+        self.sessions
+            .read()
+            .await
+            .get(session_id)
+            .map(|session| !playlist || session.base_url.is_some())
+            .unwrap_or(false)
+    }
+
     pub async fn register(&self, args: RegisterArgs) -> RegisterResult {
         let id = Uuid::new_v4().to_string();
         if !args.transcode {

--- a/src-tauri/src/subsync/mod.rs
+++ b/src-tauri/src/subsync/mod.rs
@@ -8,8 +8,12 @@ mod asr_match;
 pub mod scorer;
 pub mod torrent_sync;
 pub mod audio_tracks;
+pub mod subtitle_tracks;
 pub mod asr;
 pub mod fingerprint;
+
+#[cfg(test)]
+mod subtitle_tracks_tests;
 
 #[cfg(feature = "asr-whisper")]
 mod asr_whisper;

--- a/src-tauri/src/subsync/subtitle_tracks.rs
+++ b/src-tauri/src/subsync/subtitle_tracks.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::process::Command;
+use url::{Host, Url};
+
+use super::audio_tracks::norm_lang;
+use super::url_guard;
+use crate::stream_proxy::ProxyState;
+use crate::transcode::locate_ffprobe;
+
+const PROBE_TIMEOUT_SECS: u64 = 12;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum LoopbackSource {
+    Proxy { session_id: String, playlist: bool },
+    Torrent { info_hash: String, file_idx: usize },
+    Unrecognized,
+}
+
+pub(super) fn classify_loopback_source(
+    raw_url: &str,
+) -> Result<Option<(u16, LoopbackSource)>, String> {
+    let Ok(parsed) = Url::parse(raw_url.trim()) else {
+        return Ok(None);
+    };
+    let is_loopback = match parsed.host() {
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => {
+            ip.is_loopback()
+                || ip
+                    .to_ipv4_mapped()
+                    .is_some_and(|mapped| mapped.is_loopback())
+        }
+        _ => false,
+    };
+    if !is_loopback {
+        return Ok(None);
+    }
+    let port = parsed
+        .port_or_known_default()
+        .ok_or("loopback port missing")?;
+    if parsed.scheme() != "http" {
+        return Ok(Some((port, LoopbackSource::Unrecognized)));
+    }
+    let segments = parsed
+        .path_segments()
+        .map(|parts| parts.collect::<Vec<_>>())
+        .unwrap_or_default();
+    let source = match segments.as_slice() {
+        ["s", raw_session_id] if !raw_session_id.is_empty() => {
+            let session_id = raw_session_id.strip_suffix(".ts").unwrap_or(raw_session_id);
+            LoopbackSource::Proxy {
+                session_id: session_id.to_string(),
+                playlist: false,
+            }
+        }
+        ["p", session_id, _, ..] if !session_id.is_empty() => LoopbackSource::Proxy {
+            session_id: (*session_id).to_string(),
+            playlist: true,
+        },
+        ["stream", info_hash, file_idx] if !info_hash.is_empty() => match file_idx.parse() {
+            Ok(file_idx) => LoopbackSource::Torrent {
+                info_hash: (*info_hash).to_string(),
+                file_idx,
+            },
+            Err(_) => LoopbackSource::Unrecognized,
+        },
+        _ => LoopbackSource::Unrecognized,
+    };
+    Ok(Some((port, source)))
+}
+
+#[derive(serde::Deserialize)]
+struct ProbeRoot {
+    #[serde(default)]
+    streams: Vec<ProbeStream>,
+}
+
+#[derive(serde::Deserialize)]
+struct ProbeStream {
+    index: u32,
+    #[serde(default)]
+    codec_name: String,
+    #[serde(default)]
+    tags: ProbeTags,
+    #[serde(default)]
+    disposition: ProbeDisposition,
+}
+
+#[derive(Default, serde::Deserialize)]
+struct ProbeTags {
+    language: Option<String>,
+    title: Option<String>,
+}
+
+#[derive(Default, serde::Deserialize)]
+struct ProbeDisposition {
+    #[serde(default)]
+    default: u8,
+    #[serde(default)]
+    forced: u8,
+    #[serde(default)]
+    hearing_impaired: u8,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbeddedSubtitleTrack {
+    pub ff_index: u32,
+    pub sub_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lang: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub codec: String,
+    pub is_default: bool,
+    pub is_forced: bool,
+    pub is_hearing_impaired: bool,
+}
+
+pub(super) fn parse_probe_output(bytes: &[u8]) -> Result<Vec<EmbeddedSubtitleTrack>, String> {
+    let root: ProbeRoot =
+        serde_json::from_slice(bytes).map_err(|error| format!("parse ffprobe json: {error}"))?;
+    Ok(root
+        .streams
+        .into_iter()
+        .enumerate()
+        .map(|(sub_index, stream)| EmbeddedSubtitleTrack {
+            ff_index: stream.index,
+            sub_index: sub_index as u32,
+            lang: stream.tags.language.as_deref().and_then(norm_lang),
+            title: stream.tags.title,
+            codec: stream.codec_name,
+            is_default: stream.disposition.default == 1,
+            is_forced: stream.disposition.forced == 1,
+            is_hearing_impaired: stream.disposition.hearing_impaired == 1,
+        })
+        .collect())
+}
+
+async fn probe_subtitle_streams(
+    url: &str,
+    headers: &HashMap<String, String>,
+) -> Result<Vec<EmbeddedSubtitleTrack>, String> {
+    let ffprobe = locate_ffprobe().ok_or("ffprobe not found")?;
+    let mut command = Command::new(ffprobe);
+    command.arg("-v").arg("error");
+    command
+        .arg("-user_agent")
+        .arg(url_guard::user_agent(headers).unwrap_or_else(|| "Harbor".into()));
+    let header_blob = url_guard::safe_header_blob(headers);
+    if !header_blob.is_empty() {
+        command.arg("-headers").arg(header_blob);
+    }
+    command
+        .arg("-analyzeduration")
+        .arg("5M")
+        .arg("-probesize")
+        .arg("5M")
+        .arg("-select_streams")
+        .arg("s")
+        .arg("-show_entries")
+        .arg("stream=index,codec_name:stream_tags=language,title:stream_disposition=default,forced,hearing_impaired")
+        .arg("-of")
+        .arg("json")
+        .arg("-i")
+        .arg(url)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+    #[cfg(windows)]
+    command.creation_flags(0x0800_0000);
+
+    let output = tokio::time::timeout(Duration::from_secs(PROBE_TIMEOUT_SECS), command.output())
+        .await
+        .map_err(|_| "ffprobe timed out".to_string())?
+        .map_err(|_| "ffprobe failed".to_string())?;
+    if !output.status.success() {
+        return Err("ffprobe failed".into());
+    }
+    parse_probe_output(&output.stdout)
+}
+
+#[tauri::command]
+pub async fn subtitle_probe_tracks(
+    url: String,
+    headers: Option<HashMap<String, String>>,
+    proxy_state: tauri::State<'_, ProxyState>,
+) -> Result<Vec<EmbeddedSubtitleTrack>, String> {
+    match classify_loopback_source(&url)? {
+        Some((
+            port,
+            LoopbackSource::Proxy {
+                session_id,
+                playlist,
+            },
+        )) if port == proxy_state.port()
+            && proxy_state.has_session(&session_id, playlist).await => {}
+        Some((
+            port,
+            LoopbackSource::Torrent {
+                info_hash,
+                file_idx,
+            },
+        )) if crate::torrent_engine::owns_stream(port, &info_hash, file_idx) => {}
+        Some(_) => return Err("loopback-blocked".into()),
+        None => url_guard::validate_media_url(&url, true)?,
+    }
+    probe_subtitle_streams(&url, &headers.unwrap_or_default()).await
+}

--- a/src-tauri/src/subsync/subtitle_tracks_tests.rs
+++ b/src-tauri/src/subsync/subtitle_tracks_tests.rs
@@ -1,0 +1,109 @@
+use super::subtitle_tracks::{classify_loopback_source, parse_probe_output, LoopbackSource};
+
+#[test]
+fn classifies_only_exact_harbor_loopback_routes() {
+    assert_eq!(
+        classify_loopback_source("http://127.0.0.1:4512/s/proxy-id").unwrap(),
+        Some((
+            4512,
+            LoopbackSource::Proxy {
+                session_id: "proxy-id".into(),
+                playlist: false,
+            },
+        )),
+    );
+    assert_eq!(
+        classify_loopback_source("http://127.0.0.1:4512/p/playlist-id/video.m3u8").unwrap(),
+        Some((
+            4512,
+            LoopbackSource::Proxy {
+                session_id: "playlist-id".into(),
+                playlist: true,
+            },
+        )),
+    );
+    assert_eq!(
+        classify_loopback_source("http://[::1]:5312/stream/hash/7").unwrap(),
+        Some((
+            5312,
+            LoopbackSource::Torrent {
+                info_hash: "hash".into(),
+                file_idx: 7,
+            },
+        )),
+    );
+    assert_eq!(
+        classify_loopback_source("http://[::ffff:127.0.0.1]:5312/stream/hash/7").unwrap(),
+        Some((
+            5312,
+            LoopbackSource::Torrent {
+                info_hash: "hash".into(),
+                file_idx: 7,
+            },
+        )),
+    );
+    assert_eq!(
+        classify_loopback_source("http://127.0.0.1:9000/admin?next=/stream/hash/7").unwrap(),
+        Some((9000, LoopbackSource::Unrecognized)),
+    );
+    assert_eq!(
+        classify_loopback_source("https://cdn.example.test/movie.mkv").unwrap(),
+        None,
+    );
+    assert!(
+        super::url_guard::validate_media_url("http://localhost.:9000/stream/hash/7", true).is_err()
+    );
+}
+
+#[test]
+fn parses_embedded_subtitle_metadata_without_conflating_indices() {
+    let tracks = parse_probe_output(
+        br#"{
+          "streams": [
+            {
+              "index": 2,
+              "codec_name": "subrip",
+              "tags": { "language": "eng", "title": "English" },
+              "disposition": { "default": 1, "forced": 0, "hearing_impaired": 0 }
+            },
+            {
+              "index": 5,
+              "codec_name": "ass",
+              "tags": { "language": "pt-BR", "title": "Portuguese SDH" },
+              "disposition": { "default": 0, "forced": 0, "hearing_impaired": 1 }
+            },
+            {
+              "index": 8,
+              "codec_name": "hdmv_pgs_subtitle",
+              "tags": { "language": "und" },
+              "disposition": { "default": 0, "forced": 1, "hearing_impaired": 0 }
+            }
+          ]
+        }"#,
+    )
+    .expect("valid ffprobe fixture");
+
+    assert_eq!(tracks.len(), 3);
+
+    assert_eq!(tracks[0].ff_index, 2);
+    assert_eq!(tracks[0].sub_index, 0);
+    assert_eq!(tracks[0].lang.as_deref(), Some("en"));
+    assert_eq!(tracks[0].codec, "subrip");
+    assert!(tracks[0].is_default);
+
+    assert_eq!(tracks[1].ff_index, 5);
+    assert_eq!(tracks[1].sub_index, 1);
+    assert_eq!(tracks[1].lang.as_deref(), Some("pt"));
+    assert_eq!(tracks[1].title.as_deref(), Some("Portuguese SDH"));
+    assert!(tracks[1].is_hearing_impaired);
+
+    assert_eq!(tracks[2].ff_index, 8);
+    assert_eq!(tracks[2].sub_index, 2);
+    assert_eq!(tracks[2].lang, None);
+    assert!(tracks[2].is_forced);
+}
+
+#[test]
+fn rejects_invalid_ffprobe_json() {
+    assert!(parse_probe_output(b"not-json").is_err());
+}

--- a/src-tauri/src/subsync/url_guard.rs
+++ b/src-tauri/src/subsync/url_guard.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv4Addr;
+use url::{Host, Url};
 
 const HOP_BY_HOP: &[&str] = &[
     "connection",
@@ -19,15 +20,6 @@ const HOP_BY_HOP: &[&str] = &[
 fn is_abs_path(url: &str) -> bool {
     let b = url.as_bytes();
     (b.len() > 2 && b[1] == b':' && (b[2] == b'/' || b[2] == b'\\')) || url.starts_with('/')
-}
-
-fn host_of(after_scheme: &str) -> String {
-    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or("");
-    let host_port = authority.rsplit('@').next().unwrap_or(authority);
-    if let Some(rest) = host_port.strip_prefix('[') {
-        return rest.split(']').next().unwrap_or("").to_string();
-    }
-    host_port.split(':').next().unwrap_or("").to_string()
 }
 
 fn check_v4(ip: Ipv4Addr, is_stream: bool) -> Result<(), String> {
@@ -52,45 +44,54 @@ pub fn validate_media_url(url: &str, allow_local: bool) -> Result<(), String> {
             Err("local-source-not-allowed".into())
         };
     }
-    let rest = lower
-        .strip_prefix("http://")
-        .or_else(|| lower.strip_prefix("https://"))
-        .ok_or("scheme-not-allowed")?;
-    let host = host_of(rest);
-    if host.is_empty() {
-        return Err("no-host".into());
+    let parsed = Url::parse(trimmed).map_err(|_| "invalid-url")?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err("scheme-not-allowed".into());
     }
-    let is_stream = trimmed.contains("/stream/");
-    if let Ok(v4) = host.parse::<Ipv4Addr>() {
-        return check_v4(v4, is_stream);
+    let is_stream = parsed.path().starts_with("/stream/");
+    match parsed.host().ok_or("no-host")? {
+        Host::Ipv4(v4) => check_v4(v4, is_stream),
+        Host::Ipv6(v6) => {
+            if v6.is_loopback() {
+                return if is_stream {
+                    Ok(())
+                } else {
+                    Err("loopback-blocked".into())
+                };
+            }
+            if v6.is_unspecified() {
+                return Err("internal-ip-blocked".into());
+            }
+            let seg = v6.segments();
+            if (seg[0] & 0xffc0) == 0xfe80 || (seg[0] & 0xfe00) == 0xfc00 {
+                return Err("internal-ip-blocked".into());
+            }
+            let mapped = seg[0] == 0
+                && seg[1] == 0
+                && seg[2] == 0
+                && seg[3] == 0
+                && seg[4] == 0
+                && seg[5] == 0xffff;
+            if mapped {
+                let v4 = Ipv4Addr::new(
+                    (seg[6] >> 8) as u8,
+                    (seg[6] & 0xff) as u8,
+                    (seg[7] >> 8) as u8,
+                    (seg[7] & 0xff) as u8,
+                );
+                return check_v4(v4, is_stream);
+            }
+            Ok(())
+        }
+        Host::Domain(host) => {
+            let host = host.trim_end_matches('.');
+            if host == "localhost" || host.ends_with(".localhost") || host.ends_with(".local") {
+                Err("local-hostname-blocked".into())
+            } else {
+                Ok(())
+            }
+        }
     }
-    if let Ok(v6) = host.parse::<Ipv6Addr>() {
-        if v6.is_loopback() {
-            return if is_stream { Ok(()) } else { Err("loopback-blocked".into()) };
-        }
-        if v6.is_unspecified() {
-            return Err("internal-ip-blocked".into());
-        }
-        let seg = v6.segments();
-        if (seg[0] & 0xffc0) == 0xfe80 || (seg[0] & 0xfe00) == 0xfc00 {
-            return Err("internal-ip-blocked".into());
-        }
-        let mapped = seg[0] == 0 && seg[1] == 0 && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0xffff;
-        if mapped {
-            let v4 = Ipv4Addr::new(
-                (seg[6] >> 8) as u8,
-                (seg[6] & 0xff) as u8,
-                (seg[7] >> 8) as u8,
-                (seg[7] & 0xff) as u8,
-            );
-            return check_v4(v4, is_stream);
-        }
-        return Ok(());
-    }
-    if host == "localhost" || host.ends_with(".localhost") || host.ends_with(".local") {
-        return Err("local-hostname-blocked".into());
-    }
-    Ok(())
 }
 
 fn has_ctl(s: &str) -> bool {
@@ -113,7 +114,14 @@ pub fn user_agent(headers: &HashMap<String, String>) -> Option<String> {
     headers
         .iter()
         .find(|(k, _)| k.eq_ignore_ascii_case("user-agent"))
-        .map(|(_, v)| v.clone())
+        .and_then(|(_, value)| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() || has_ctl(value) {
+                None
+            } else {
+                Some(value.clone())
+            }
+        })
 }
 
 pub fn safe_map_spec(spec: Option<&str>) -> String {
@@ -141,6 +149,9 @@ mod tests {
         assert!(validate_media_url("http://[fe80::1]/x", true).is_err());
         assert!(validate_media_url("http://[::1]:9000/admin", true).is_err());
         assert!(validate_media_url("http://127.0.0.1:9000/admin", true).is_err());
+        assert!(
+            validate_media_url("http://127.0.0.1:9000/admin?next=/stream/abc/0", true).is_err()
+        );
     }
 
     #[test]
@@ -173,6 +184,13 @@ mod tests {
         assert!(!blob.contains("evil"));
         assert!(!blob.contains("connection"));
         assert!(!blob.contains("user-agent"));
+    }
+
+    #[test]
+    fn user_agent_rejects_control_character_injection() {
+        let mut h = HashMap::new();
+        h.insert("User-Agent".into(), "Harbor\r\nX-Injected: yes".into());
+        assert_eq!(user_agent(&h), None);
     }
 
     #[test]

--- a/src-tauri/src/torrent_engine.rs
+++ b/src-tauri/src/torrent_engine.rs
@@ -210,6 +210,24 @@ fn current_port() -> Option<u16> {
     engine().lock().unwrap().port
 }
 
+pub(crate) fn owns_stream(port: u16, info_hash: &str, file_idx: usize) -> bool {
+    if current_port() != Some(port) {
+        return false;
+    }
+    let Some(session) = current_session() else {
+        return false;
+    };
+    let Ok(id) = TorrentIdOrHash::parse(info_hash) else {
+        return false;
+    };
+    let Some(handle) = session.get(id) else {
+        return false;
+    };
+    handle
+        .with_metadata(|metadata| file_idx < metadata.file_infos.len())
+        .unwrap_or(false)
+}
+
 #[derive(Serialize)]
 pub struct EngineStatusDto {
     ready: bool,

--- a/src-tauri/src/transcode.rs
+++ b/src-tauri/src/transcode.rs
@@ -155,29 +155,154 @@ pub fn ffmpeg_present() -> bool {
     locate_ffmpeg().is_some()
 }
 
-pub fn locate_ffprobe() -> Option<std::path::PathBuf> {
-    let name = if cfg!(windows) { "ffprobe.exe" } else { "ffprobe" };
-    if let Some(ffmpeg) = locate_ffmpeg() {
-        if let Some(parent) = ffmpeg.parent() {
-            let candidate = parent.join(name);
-            if candidate.exists() {
-                return Some(candidate);
+fn ffprobe_sidecar_name() -> Option<String> {
+    let triple = if cfg!(all(target_arch = "x86_64", target_os = "windows")) {
+        "x86_64-pc-windows-msvc"
+    } else if cfg!(all(target_arch = "aarch64", target_os = "windows")) {
+        "aarch64-pc-windows-msvc"
+    } else if cfg!(all(target_arch = "x86_64", target_os = "macos")) {
+        "x86_64-apple-darwin"
+    } else if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
+        "aarch64-apple-darwin"
+    } else if cfg!(all(target_arch = "x86_64", target_os = "linux")) {
+        "x86_64-unknown-linux-gnu"
+    } else if cfg!(all(target_arch = "aarch64", target_os = "linux")) {
+        "aarch64-unknown-linux-gnu"
+    } else {
+        return None;
+    };
+    let extension = if cfg!(windows) { ".exe" } else { "" };
+    Some(format!("ffprobe-{triple}{extension}"))
+}
+
+fn ffprobe_candidates(
+    current_exe: Option<&std::path::Path>,
+    path: Option<&std::ffi::OsStr>,
+) -> Vec<std::path::PathBuf> {
+    let name = if cfg!(windows) {
+        "ffprobe.exe"
+    } else {
+        "ffprobe"
+    };
+    let sidecar_name = ffprobe_sidecar_name();
+    let mut candidates = Vec::new();
+    if let Some(dir) = current_exe.and_then(std::path::Path::parent) {
+        candidates.push(dir.join(name));
+        if let Some(sidecar) = sidecar_name.as_deref() {
+            candidates.push(dir.join(sidecar));
+            for relative in ["../binaries", "../../binaries", "../../../binaries"] {
+                candidates.push(dir.join(relative).join(sidecar));
             }
         }
     }
-    let mut cmd = std::process::Command::new(name);
-    cmd.arg("-version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
-    #[cfg(windows)]
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(sidecar) = sidecar_name.as_deref() {
+            candidates.push(cwd.join("src-tauri/binaries").join(sidecar));
+            candidates.push(cwd.join("binaries").join(sidecar));
+        }
+    }
+    if let Some(path) = path {
+        candidates.extend(std::env::split_paths(path).map(|dir| dir.join(name)));
+    }
+    if cfg!(windows) {
+        candidates.extend(
+            [
+                r"C:\ffmpeg\bin\ffprobe.exe",
+                r"C:\Program Files\ffmpeg\bin\ffprobe.exe",
+                r"C:\Program Files (x86)\ffmpeg\bin\ffprobe.exe",
+                r"C:\ProgramData\chocolatey\bin\ffprobe.exe",
+            ]
+            .into_iter()
+            .map(std::path::PathBuf::from),
+        );
+        if let Some(profile) = std::env::var_os("USERPROFILE") {
+            let profile = std::path::PathBuf::from(profile);
+            candidates.push(profile.join(r"scoop\shims\ffprobe.exe"));
+            candidates.push(profile.join(r"scoop\apps\ffmpeg\current\bin\ffprobe.exe"));
+        }
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            let packages = std::path::PathBuf::from(local).join(r"Microsoft\WinGet\Packages");
+            if let Ok(entries) = std::fs::read_dir(packages) {
+                for entry in entries.flatten().filter(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .to_ascii_lowercase()
+                        .contains("ffmpeg")
+                }) {
+                    if let Ok(builds) = std::fs::read_dir(entry.path()) {
+                        candidates.extend(
+                            builds
+                                .flatten()
+                                .map(|build| build.path().join(r"bin\ffprobe.exe")),
+                        );
+                    }
+                }
+            }
+        }
+    } else if cfg!(target_os = "macos") {
+        candidates.extend(
+            [
+                "/opt/homebrew/bin/ffprobe",
+                "/usr/local/bin/ffprobe",
+                "/opt/local/bin/ffprobe",
+            ]
+            .into_iter()
+            .map(std::path::PathBuf::from),
+        );
+    } else if cfg!(target_os = "linux") {
+        candidates.extend(
+            crate::binary_lookup::linux_binary_candidates("ffprobe")
+                .into_iter()
+                .filter(|candidate| candidate.is_absolute()),
+        );
+    }
+    candidates
+}
+
+fn is_executable_file(path: &std::path::Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
     {
-        use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x0800_0000);
+        use std::os::unix::fs::PermissionsExt;
+        return std::fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false);
     }
-    if matches!(cmd.status(), Ok(s) if s.success()) {
-        return Some(std::path::PathBuf::from(name));
+    #[cfg(not(unix))]
+    true
+}
+
+pub fn locate_ffprobe() -> Option<std::path::PathBuf> {
+    let current_exe = std::env::current_exe().ok();
+    ffprobe_candidates(current_exe.as_deref(), std::env::var_os("PATH").as_deref())
+        .into_iter()
+        .find(|candidate| is_executable_file(candidate))
+}
+
+#[cfg(test)]
+mod ffprobe_locator_tests {
+    use super::ffprobe_candidates;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn prefers_the_bundled_ffprobe_beside_the_current_executable() {
+        let executable = Path::new("app").join(if cfg!(windows) {
+            "harbor.exe"
+        } else {
+            "harbor"
+        });
+        let candidates = ffprobe_candidates(Some(&executable), None);
+        let expected = PathBuf::from("app").join(if cfg!(windows) {
+            "ffprobe.exe"
+        } else {
+            "ffprobe"
+        });
+
+        assert_eq!(candidates.first(), Some(&expected));
     }
-    None
 }
 
 #[derive(Default, Debug, Clone)]

--- a/src/lib/player/bridge.ts
+++ b/src/lib/player/bridge.ts
@@ -10,6 +10,7 @@ export type TrackInfo = {
   codec?: string;
   channels?: string;
   channelCount?: number;
+  ffIndex?: number;
   title?: string;
   external?: boolean;
   externalFilename?: string;

--- a/src/lib/player/mpv-track-list.ts
+++ b/src/lib/player/mpv-track-list.ts
@@ -1,0 +1,88 @@
+import type { TrackInfo } from "./bridge";
+
+export type ExternalTrackMetadata = {
+  url: string;
+  release?: string;
+  provider?: string;
+  matchScore?: number;
+  subId?: string;
+};
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+export function parseMpvTrackList(
+  list: Array<Record<string, unknown>>,
+  secondarySid: string | null,
+  externalByFilename: ReadonlyMap<string, ExternalTrackMetadata>,
+): { audioTracks: TrackInfo[]; subtitleTracks: TrackInfo[] } {
+  const audioTracks: TrackInfo[] = [];
+  const subtitleTracks: TrackInfo[] = [];
+
+  for (const track of list) {
+    const type = String(track.type ?? "");
+    if (type !== "audio" && type !== "sub") continue;
+    const id = String(track.id ?? "");
+    const lang = (track.lang ?? track.language) as string | undefined;
+    const title = track.title as string | undefined;
+    const codecDesc =
+      (track["codec-desc"] as string | undefined) || (track.codec as string | undefined);
+    const channels = track["demux-channels"] as string | undefined;
+    const channelCount =
+      typeof track["demux-channel-count"] === "number"
+        ? (track["demux-channel-count"] as number)
+        : undefined;
+    const ffIndex = nonNegativeInteger(track["ff-index"]);
+    const external = track.external === true;
+    const externalFilename = track["external-filename"] as string | undefined;
+    const forced = track.forced === true;
+    const isDefault = track.default === true;
+    const hearingImpaired = track["hearing-impaired"] === true;
+    const mainSelection =
+      typeof track["main-selection"] === "number" ? track["main-selection"] : null;
+    const secondary =
+      type === "sub" &&
+      track.selected === true &&
+      (mainSelection === 1 || (mainSelection == null && id === secondarySid));
+    const selected = track.selected === true && !secondary;
+    const codec = codecDesc ? codecDesc.toUpperCase() : undefined;
+    const baseLabel = title || lang || `${type} ${id}`;
+    const tags: string[] = [];
+    if (codec) tags.push(codec);
+    if (type === "audio" && channels) tags.push(channels);
+    if (forced) tags.push("Forced");
+    if (hearingImpaired) tags.push("SDH");
+    if (external) tags.push("External");
+    const label = tags.length > 0 ? `${baseLabel} · ${tags.join(" · ")}` : baseLabel;
+    const externalMetadata =
+      external && externalFilename ? externalByFilename.get(externalFilename) : undefined;
+    const info: TrackInfo = {
+      id,
+      label,
+      lang,
+      kind: type === "audio" ? "audio" : "subtitle",
+      selected,
+      codec,
+      channels,
+      channelCount,
+      ffIndex,
+      title,
+      external,
+      externalFilename,
+      forced,
+      default: isDefault,
+      hearingImpaired,
+      secondary,
+      url: external && externalFilename ? externalMetadata?.url : undefined,
+      release: externalMetadata?.release,
+      provider: externalMetadata?.provider,
+      matchScore: externalMetadata?.matchScore,
+      subId: externalMetadata?.subId,
+    };
+    if (type === "audio") audioTracks.push(info);
+    else subtitleTracks.push(info);
+  }
+
+  return { audioTracks, subtitleTracks };
+}

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -5,13 +5,13 @@ import { mpvFailureSnapshot } from "./mpv-failure";
 import { isLinuxDesktop, isMacDesktop, isWindowsDesktop } from "@/lib/platform";
 import { makeSafeTauriUnlisten } from "@/lib/tauri-unlisten";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { parseMpvTrackList, type ExternalTrackMetadata } from "./mpv-track-list";
 import {
   emptySnapshot,
   type PlayerBridge,
   type PlayerCapabilities,
   type PlayerSnapshot,
   type PlayerSource,
-  type TrackInfo,
 } from "./bridge";
 
 export type MpvProbe = {
@@ -122,7 +122,9 @@ async function applyHeaderProps(headers?: Record<string, string>): Promise<void>
     else fields.push(`${k}: ${v}`);
   }
   await invoke("mpv_set_property", { name: "user-agent", value: ua }).catch(() => {});
-  await invoke("mpv_set_property", { name: "http-header-fields", value: fields.join(",") }).catch(() => {});
+  await invoke("mpv_set_property", { name: "http-header-fields", value: fields.join(",") }).catch(
+    () => {},
+  );
 }
 
 export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
@@ -150,10 +152,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
   let suppressEndFileUntil = 0;
   let svpFilterFailed = false;
   let secondarySid: string | null = null;
-  const urlByExternalFilename = new Map<
-    string,
-    { url: string; release?: string; provider?: string; matchScore?: number; subId?: string }
-  >();
+  const urlByExternalFilename = new Map<string, ExternalTrackMetadata>();
 
   const handleSvpFilterFailure = () => {
     if (svpFilterFailed) return;
@@ -203,68 +202,9 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       if (name === "track-list" && Array.isArray(data)) {
         const list = data as Array<Record<string, unknown>>;
         pendingTracks["track-list"] = list;
-        const audio: TrackInfo[] = [];
-        const subs: TrackInfo[] = [];
-        for (const t of list) {
-          const type = String(t.type ?? "");
-          const id = String(t.id ?? "");
-          const lang = (t.lang ?? t.language) as string | undefined;
-          const title = t.title as string | undefined;
-          const codecDesc = (t["codec-desc"] as string | undefined) || (t.codec as string | undefined);
-          const channels = t["demux-channels"] as string | undefined;
-          const channelCount = typeof t["demux-channel-count"] === "number"
-            ? (t["demux-channel-count"] as number)
-            : undefined;
-          const external = t.external === true;
-          const externalFilename = t["external-filename"] as string | undefined;
-          const forced = t.forced === true;
-          const isDefault = t.default === true;
-          const hearingImpaired = t["hearing-impaired"] === true;
-          const mainSelection =
-            typeof t["main-selection"] === "number" ? (t["main-selection"] as number) : null;
-          const isSecondary =
-            type === "sub" &&
-            t.selected === true &&
-            (mainSelection === 1 || (mainSelection == null && id === secondarySid));
-          const selected = t.selected === true && !isSecondary;
-          const codec = codecDesc ? codecDesc.toUpperCase() : undefined;
-          const baseLabel = title || lang || `${type} ${id}`;
-          const tags: string[] = [];
-          if (codec) tags.push(codec);
-          if (type === "audio" && channels) tags.push(channels);
-          if (forced) tags.push("Forced");
-          if (hearingImpaired) tags.push("SDH");
-          if (external) tags.push("External");
-          const label = tags.length > 0 ? `${baseLabel} · ${tags.join(" · ")}` : baseLabel;
-          const extMeta =
-            external && externalFilename ? urlByExternalFilename.get(externalFilename) : undefined;
-          const info: TrackInfo = {
-            id,
-            label,
-            lang,
-            kind: type === "audio" ? "audio" : "subtitle",
-            selected,
-            codec,
-            channels,
-            channelCount,
-            title,
-            external,
-            externalFilename,
-            forced,
-            default: isDefault,
-            hearingImpaired,
-            secondary: isSecondary,
-            url: external && externalFilename ? extMeta?.url : undefined,
-            release: extMeta?.release,
-            provider: extMeta?.provider,
-            matchScore: extMeta?.matchScore,
-            subId: extMeta?.subId,
-          };
-          if (type === "audio") audio.push(info);
-          else if (type === "sub") subs.push(info);
-        }
-        snap.audioTracks = audio;
-        snap.subtitleTracks = subs;
+        const tracks = parseMpvTrackList(list, secondarySid, urlByExternalFilename);
+        snap.audioTracks = tracks.audioTracks;
+        snap.subtitleTracks = tracks.subtitleTracks;
       }
       if (name === "sub-delay" && typeof data === "number") snap.subDelaySec = data;
       if (name === "audio-delay" && typeof data === "number") snap.audioDelaySec = data;
@@ -376,7 +316,13 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
             await applyHeaderProps(src.headers);
             const startAt =
               typeof src.startAtSec === "number" && src.startAtSec > 0 ? src.startAtSec : 0;
-            const cmd: Array<string | number> = ["loadfile", src.url, "replace", 0, `start=${startAt}`];
+            const cmd: Array<string | number> = [
+              "loadfile",
+              src.url,
+              "replace",
+              0,
+              `start=${startAt}`,
+            ];
             await invoke("mpv_command", { cmd });
             for (const s of src.subtitles ?? []) {
               try {
@@ -429,7 +375,9 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
         });
         mpvStarted = true;
         if (opts.embed) {
-          await invoke("mpv_set_property", { name: "sub-visibility", value: false }).catch(() => {});
+          await invoke("mpv_set_property", { name: "sub-visibility", value: false }).catch(
+            () => {},
+          );
         }
         if (opts.embed && opts.getEmbedRect && geomKickHandler == null && !isLinuxDesktop()) {
           let lastRect: MpvRect | null = null;
@@ -572,7 +520,10 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
     },
     setAnime4kShaders(shaders) {
       const sep = isWindowsDesktop() ? ";" : ":";
-      const value = shaders.filter(Boolean).map((s) => s.replace(/\\/g, "/")).join(sep);
+      const value = shaders
+        .filter(Boolean)
+        .map((s) => s.replace(/\\/g, "/"))
+        .join(sep);
       invoke("mpv_set_property", { name: "glsl-shaders", value }).catch((e) =>
         console.warn("[shaders] glsl-shaders apply failed", e),
       );
@@ -689,8 +640,12 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       }
     },
     setAbLoop(a, b) {
-      invoke("mpv_set_property", { name: "ab-loop-a", value: a == null ? "no" : a }).catch(() => {});
-      invoke("mpv_set_property", { name: "ab-loop-b", value: b == null ? "no" : b }).catch(() => {});
+      invoke("mpv_set_property", { name: "ab-loop-a", value: a == null ? "no" : a }).catch(
+        () => {},
+      );
+      invoke("mpv_set_property", { name: "ab-loop-b", value: b == null ? "no" : b }).catch(
+        () => {},
+      );
     },
     async requestPiP() {},
     async exitPiP() {},

--- a/src/lib/subtitles/embedded-preselect.ts
+++ b/src/lib/subtitles/embedded-preselect.ts
@@ -1,0 +1,111 @@
+import type { TrackInfo } from "../player/bridge";
+
+export type EmbeddedSubtitleIdentity = { ffIndex: number; subIndex: number };
+
+type SubtitlePreselect = {
+  off: boolean;
+  url?: string;
+  embedded?: EmbeddedSubtitleIdentity;
+};
+
+type SubtitleMediaIdentity = {
+  url: string;
+  meta?: { id?: string };
+  episode?: { season?: number; episode?: number };
+};
+
+export function shouldEnforceSubtitleOff(
+  choice: SubtitlePreselect | undefined,
+  storedOff: boolean,
+): boolean {
+  return choice ? choice.off : storedOff;
+}
+
+export function enforceSubtitleOff(
+  choice: SubtitlePreselect | undefined,
+  storedOff: boolean,
+  tracks: { selected: boolean }[],
+  clear: () => void,
+): boolean {
+  if (!shouldEnforceSubtitleOff(choice, storedOff) || !tracks.some((track) => track.selected)) {
+    return false;
+  }
+  clear();
+  return true;
+}
+
+export function applySubtitleOffPreselect(
+  tracks: { selected: boolean }[],
+  clear: () => void,
+): boolean {
+  if (tracks.length === 0) return false;
+  enforceSubtitleOff({ off: true }, false, tracks, clear);
+  return true;
+}
+
+export function shouldEnforceStoredSubtitleOff(
+  choice: SubtitlePreselect | undefined,
+  storedOff: boolean,
+): boolean {
+  return choice === undefined && storedOff;
+}
+
+export function enforceStoredSubtitleOff(
+  choice: SubtitlePreselect | undefined,
+  storedOff: boolean,
+  tracks: { selected: boolean }[],
+  clear: () => void,
+): boolean {
+  if (
+    !shouldEnforceStoredSubtitleOff(choice, storedOff) ||
+    !tracks.some((track) => track.selected)
+  ) {
+    return false;
+  }
+  clear();
+  return true;
+}
+
+export function resolveEmbeddedSubtitleTrack(
+  tracks: TrackInfo[],
+  identity: EmbeddedSubtitleIdentity,
+): TrackInfo | null {
+  const embedded = tracks.filter(
+    (track) => track.kind === "subtitle" && track.external !== true && !track.url,
+  );
+  const exact = embedded.find((track) => track.ffIndex === identity.ffIndex);
+  if (exact) return exact;
+
+  // Once mpv exposes container indices, an ordinal fallback could select a sibling track.
+  if (embedded.some((track) => track.ffIndex !== undefined)) return null;
+  return embedded[identity.subIndex] ?? null;
+}
+
+export function applyEmbeddedSubtitlePreselect(
+  tracks: TrackInfo[],
+  identity: EmbeddedSubtitleIdentity,
+  select: (runtimeId: string) => void,
+): boolean {
+  const track = resolveEmbeddedSubtitleTrack(tracks, identity);
+  if (!track) return false;
+  select(track.id);
+  return true;
+}
+
+export function subtitlePreselectApplyKey(
+  src: SubtitleMediaIdentity,
+  choice: SubtitlePreselect,
+): string {
+  const selection = choice.off
+    ? ["off"]
+    : choice.embedded
+      ? ["embedded", choice.embedded.ffIndex, choice.embedded.subIndex]
+      : ["external", choice.url ?? ""];
+  return JSON.stringify([
+    src.meta?.id ?? "",
+    src.episode?.season ?? null,
+    src.episode?.episode ?? null,
+    src.url,
+    selection,
+  ]);
+}

--- a/src/lib/view.tsx
+++ b/src/lib/view.tsx
@@ -73,7 +73,13 @@ export type PlayerSrc = {
   notWebReady?: boolean;
   isAnime?: boolean;
   subtitles?: Array<{ url: string; lang?: string; id?: string }>;
-  subtitlePreselect?: { off: boolean; url?: string; lang?: string; title?: string };
+  subtitlePreselect?: {
+    off: boolean;
+    url?: string;
+    lang?: string;
+    title?: string;
+    embedded?: { ffIndex: number; subIndex: number };
+  };
   attempt?: number;
   autoFired?: boolean;
   resume?: boolean;

--- a/src/views/play-picker/hooks/use-subtitle-choices.ts
+++ b/src/views/play-picker/hooks/use-subtitle-choices.ts
@@ -1,15 +1,24 @@
 import { useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { useAuth } from "@/lib/auth";
 import type { Addon } from "@/lib/addons";
+import { probeMpv } from "@/lib/player/mpv";
+import { isWeb } from "@/lib/platform";
 import { gatherSubtitleAddons } from "@/lib/subtitles/addon-source";
 import { languageName } from "@/lib/subtitles/language";
 import { searchSubtitles } from "@/lib/subtitles/search";
-import type { SubResult } from "@/lib/subtitles/types";
+import { subtitleTrackLanguageLabel } from "@/lib/subtitles/track-label";
 import { useSettings } from "@/lib/settings";
 import { buildStreamIds } from "@/lib/streams/stream-ids";
 import type { PlayerSrc } from "@/lib/view";
+import {
+  loadEmbeddedTracksWhenMpvAvailable,
+  loadSubtitleChoices,
+  type EmbeddedSubtitleTrack,
+  type SubtitleChoice,
+} from "../subtitle-choice";
 
-export type SubtitleLangGroup = { langKey: string; langDisplay: string; items: SubResult[] };
+export type SubtitleLangGroup = { langKey: string; langDisplay: string; items: SubtitleChoice[] };
 
 function isAnimeSrc(src: PlayerSrc): boolean {
   return (
@@ -24,17 +33,22 @@ function isJapanese(lang: string): boolean {
   return l === "ja" || l === "jpn" || l === "jp" || l === "japanese";
 }
 
+function choiceLanguage(choice: SubtitleChoice): string {
+  if (choice.kind === "external") return languageName(choice.result.lang);
+  return subtitleTrackLanguageLabel({ lang: choice.track.lang, external: false });
+}
+
 export function useSubtitleChoices(src: PlayerSrc) {
   const { settings } = useSettings();
   const { authKey } = useAuth();
-  const [results, setResults] = useState<SubResult[] | null>(null);
+  const [choices, setChoices] = useState<SubtitleChoice[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
   const preferredLangs = useMemo(() => {
     const primary = settings.preferredSubLangs?.length
       ? settings.preferredSubLangs
-      : settings.preferredLanguages ?? [];
+      : (settings.preferredLanguages ?? []);
     const base = primary.length > 0 ? primary : ["English"];
     return isAnimeSrc(src) ? base : base.filter((l) => !isJapanese(l));
   }, [settings.preferredSubLangs, settings.preferredLanguages, src.meta.id]);
@@ -43,79 +57,103 @@ export function useSubtitleChoices(src: PlayerSrc) {
     let cancelled = false;
     setLoading(true);
     setError(false);
-    setResults(null);
+    setChoices(null);
     void (async () => {
-      let addons: Addon[] = [];
-      try {
-        addons = await gatherSubtitleAddons(authKey);
-      } catch {
-        addons = [];
-      }
-      const enabled = settings.subProvidersEnabled ?? {};
-      const candidateIds = buildStreamIds(
-        src.meta.id,
-        src.episode,
-        src.imdbId ?? null,
-        src.meta.behaviorHints?.defaultVideoId ?? null,
+      const result = await loadSubtitleChoices(
+        async () => {
+          let addons: Addon[] = [];
+          try {
+            addons = await gatherSubtitleAddons(authKey);
+          } catch {
+            addons = [];
+          }
+          const enabled = settings.subProvidersEnabled ?? {};
+          const candidateIds = buildStreamIds(
+            src.meta.id,
+            src.episode,
+            src.imdbId ?? null,
+            src.meta.behaviorHints?.defaultVideoId ?? null,
+          );
+          const animeIds = candidateIds.some(
+            (id) => id.startsWith("kitsu:") || id.startsWith("mal:"),
+          );
+          const imdbEpAligned =
+            !animeIds ||
+            src.episode?.imdbEpisode == null ||
+            src.episode.episode === src.episode.imdbEpisode;
+          return searchSubtitles(
+            {
+              imdbId: src.imdbId ?? (src.meta.id?.startsWith("tt") ? src.meta.id : undefined),
+              stremioId: src.meta.id,
+              candidateIds,
+              type: src.meta.type === "series" ? "series" : "movie",
+              season: imdbEpAligned
+                ? (src.episode?.imdbSeason ?? src.episode?.season)
+                : src.episode?.season,
+              episode: imdbEpAligned
+                ? (src.episode?.imdbEpisode ?? src.episode?.episode)
+                : src.episode?.episode,
+              langs: preferredLangs,
+              filename: src.streamRef?.parsedTitle ?? src.streamRef?.title ?? undefined,
+            },
+            {
+              timeoutMs: 7_000,
+              providers: {
+                wyzie: enabled.wyzie === true,
+                addons: enabled.addons !== false,
+                opensubtitles: enabled.opensubtitles !== false,
+              },
+              addons,
+              preferredLangs,
+              streamHints: {
+                release: src.streamRef?.title ?? src.streamRef?.parsedTitle ?? null,
+                source: src.streamRef?.source ?? null,
+                resolution: src.streamRef?.resolution ?? null,
+              },
+            },
+          );
+        },
+        async () => {
+          if (isWeb() || settings.playerEngine === "html5") return [];
+          return loadEmbeddedTracksWhenMpvAvailable(probeMpv, () =>
+            invoke<EmbeddedSubtitleTrack[]>("subtitle_probe_tracks", {
+              url: src.url,
+              headers: src.headers ?? null,
+            }),
+          );
+        },
+        (available) => {
+          if (cancelled) return;
+          setChoices(available.choices);
+          setError(available.externalError);
+          setLoading(false);
+        },
       );
-      const animeIds = candidateIds.some((i) => i.startsWith("kitsu:") || i.startsWith("mal:"));
-      const imdbEpAligned =
-        !animeIds || src.episode?.imdbEpisode == null || src.episode.episode === src.episode.imdbEpisode;
-      try {
-        const r = await searchSubtitles(
-          {
-            imdbId: src.imdbId ?? (src.meta.id?.startsWith("tt") ? src.meta.id : undefined),
-            stremioId: src.meta.id,
-            candidateIds,
-            type: src.meta.type === "series" ? "series" : "movie",
-            season: imdbEpAligned
-              ? src.episode?.imdbSeason ?? src.episode?.season
-              : src.episode?.season,
-            episode: imdbEpAligned
-              ? src.episode?.imdbEpisode ?? src.episode?.episode
-              : src.episode?.episode,
-            langs: preferredLangs,
-            filename: src.streamRef?.parsedTitle ?? src.streamRef?.title ?? undefined,
-          },
-          {
-            timeoutMs: 7_000,
-            providers: {
-              wyzie: enabled.wyzie === true,
-              addons: enabled.addons !== false,
-              opensubtitles: enabled.opensubtitles !== false,
-            },
-            addons,
-            preferredLangs,
-            streamHints: {
-              release: src.streamRef?.title ?? src.streamRef?.parsedTitle ?? null,
-              source: src.streamRef?.source ?? null,
-              resolution: src.streamRef?.resolution ?? null,
-            },
-          },
-        );
-        if (!cancelled) {
-          setResults(r);
-          setLoading(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setError(true);
-          setLoading(false);
-        }
+      if (!cancelled) {
+        setChoices(result.choices);
+        setError(result.externalError);
+        setLoading(false);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [src.url, authKey, preferredLangs, settings.subProvidersEnabled]);
+  }, [
+    src.url,
+    src.headers,
+    authKey,
+    preferredLangs,
+    settings.subProvidersEnabled,
+    settings.playerEngine,
+  ]);
 
   const groups = useMemo<SubtitleLangGroup[]>(() => {
-    if (!results) return [];
-    const m = new Map<string, SubResult[]>();
-    for (const r of results) {
-      const key = languageName(r.lang);
+    if (!choices) return [];
+    const m = new Map<string, SubtitleChoice[]>();
+    for (const choice of choices) {
+      const key = choiceLanguage(choice);
       const arr = m.get(key) ?? [];
-      arr.push(r);
+      arr.push(choice);
       m.set(key, arr);
     }
     return [...m.entries()].map(([langDisplay, items]) => ({
@@ -123,9 +161,9 @@ export function useSubtitleChoices(src: PlayerSrc) {
       langDisplay,
       items,
     }));
-  }, [results]);
+  }, [choices]);
 
-  const bestId = results && results.length > 0 ? results[0].id : null;
+  const bestKey = choices?.find((choice) => choice.kind === "external")?.key ?? null;
 
-  return { loading, error, results, groups, bestId };
+  return { loading, error, choices, groups, bestKey };
 }

--- a/src/views/play-picker/subtitle-choice.ts
+++ b/src/views/play-picker/subtitle-choice.ts
@@ -39,7 +39,7 @@ export function mergeSubtitleChoices(
   external: SubResult[],
   embedded: EmbeddedSubtitleTrack[],
 ): SubtitleChoice[] {
-  return [...external.map(externalChoice), ...embedded.map(embeddedChoice)];
+  return [...embedded.map(embeddedChoice), ...external.map(externalChoice)];
 }
 
 type SubtitleChoiceLoadResult = {

--- a/src/views/play-picker/subtitle-choice.ts
+++ b/src/views/play-picker/subtitle-choice.ts
@@ -1,0 +1,134 @@
+import type { SubResult } from "../../lib/subtitles/types";
+
+export type EmbeddedSubtitleTrack = {
+  ffIndex: number;
+  subIndex: number;
+  lang?: string;
+  title?: string;
+  codec: string;
+  isDefault: boolean;
+  isForced: boolean;
+  isHearingImpaired: boolean;
+};
+
+export type SubtitleChoice =
+  | { kind: "external"; key: string; result: SubResult }
+  | { kind: "embedded"; key: string; track: EmbeddedSubtitleTrack };
+
+export type PlayerSubtitlePreselect = {
+  off: boolean;
+  url?: string;
+  lang?: string;
+  title?: string;
+  embedded?: { ffIndex: number; subIndex: number };
+};
+
+function externalChoice(result: SubResult): SubtitleChoice {
+  return { kind: "external", key: `external:${result.id}`, result };
+}
+
+function embeddedChoice(track: EmbeddedSubtitleTrack): SubtitleChoice {
+  return {
+    kind: "embedded",
+    key: `embedded:${track.ffIndex}:${track.subIndex}`,
+    track,
+  };
+}
+
+export function mergeSubtitleChoices(
+  external: SubResult[],
+  embedded: EmbeddedSubtitleTrack[],
+): SubtitleChoice[] {
+  return [...external.map(externalChoice), ...embedded.map(embeddedChoice)];
+}
+
+type SubtitleChoiceLoadResult = {
+  choices: SubtitleChoice[];
+  externalError: boolean;
+  embeddedError: boolean;
+};
+
+function loadResult(
+  external: PromiseSettledResult<SubResult[]>,
+  embedded?: PromiseSettledResult<EmbeddedSubtitleTrack[]>,
+): SubtitleChoiceLoadResult {
+  return {
+    choices: mergeSubtitleChoices(
+      external.status === "fulfilled" ? external.value : [],
+      embedded?.status === "fulfilled" ? embedded.value : [],
+    ),
+    externalError: external.status === "rejected",
+    embeddedError: embedded?.status === "rejected",
+  };
+}
+
+function settle<T>(task: Promise<T>): Promise<PromiseSettledResult<T>> {
+  return task.then(
+    (value) => ({ status: "fulfilled", value }),
+    (reason) => ({ status: "rejected", reason }),
+  );
+}
+
+export async function loadSubtitleChoices(
+  loadExternal: () => Promise<SubResult[]>,
+  loadEmbedded: () => Promise<EmbeddedSubtitleTrack[]>,
+  onExternalReady?: (result: SubtitleChoiceLoadResult) => void,
+): Promise<SubtitleChoiceLoadResult> {
+  // Defer both calls to microtasks so a slow provider cannot delay the local probe.
+  const externalTask = settle(Promise.resolve().then(loadExternal));
+  let embeddedResult: PromiseSettledResult<EmbeddedSubtitleTrack[]> | undefined;
+  const embeddedTask = settle(Promise.resolve().then(loadEmbedded)).then((result) => {
+    embeddedResult = result;
+    return result;
+  });
+  const external = await externalTask;
+  onExternalReady?.(loadResult(external, embeddedResult));
+  const embedded = await embeddedTask;
+
+  return loadResult(external, embedded);
+}
+
+export async function loadEmbeddedTracksWhenMpvAvailable(
+  checkMpv: () => Promise<{ available: boolean }>,
+  loadEmbedded: () => Promise<EmbeddedSubtitleTrack[]>,
+): Promise<EmbeddedSubtitleTrack[]> {
+  if (!(await checkMpv()).available) return [];
+  return loadEmbedded();
+}
+
+export function buildPlayerSubtitleSelection<T extends object>(
+  src: T,
+  selected: string | "off" | "skip" | null,
+  choices: SubtitleChoice[],
+  languageTitle: (lang: string) => string = (lang) => lang,
+): T & { subtitlePreselect?: PlayerSubtitlePreselect } {
+  if (selected === null || selected === "skip") {
+    return src;
+  }
+  if (selected === "off") {
+    return { ...src, subtitlePreselect: { off: true } };
+  }
+
+  const choice = choices.find((candidate) => candidate.key === selected);
+  if (!choice) return src;
+  if (choice.kind === "external") {
+    const result = choice.result;
+    return {
+      ...src,
+      subtitlePreselect: {
+        off: false,
+        url: result.url,
+        lang: result.lang,
+        title: result.title || result.langName || languageTitle(result.lang),
+      },
+    };
+  }
+
+  return {
+    ...src,
+    subtitlePreselect: {
+      off: false,
+      embedded: { ffIndex: choice.track.ffIndex, subIndex: choice.track.subIndex },
+    },
+  };
+}

--- a/src/views/play-picker/subtitle-select-step.tsx
+++ b/src/views/play-picker/subtitle-select-step.tsx
@@ -4,12 +4,13 @@ import { Flag } from "@/components/flag";
 import { useContextMenu } from "@/lib/context-menu";
 import { languageName } from "@/lib/subtitles/language";
 import { saveSubtitleToDisk } from "@/lib/subtitles/save-to-disk";
-import type { SubResult } from "@/lib/subtitles/types";
+import { subtitleTrackLanguageLabel, subtitleTrackTitle } from "@/lib/subtitles/track-label";
 import { useT } from "@/lib/i18n";
 import type { PlayEpisode, PlayerSrc } from "@/lib/view";
 import { useWindowFullscreen } from "@/lib/use-window-fullscreen";
 import { BackdropLayer } from "./backdrop-layer";
 import { useSubtitleChoices } from "./hooks/use-subtitle-choices";
+import { buildPlayerSubtitleSelection, type SubtitleChoice } from "./subtitle-choice";
 
 type Selection = string | "off" | null;
 
@@ -24,7 +25,7 @@ export function SubtitleSelectStep({
 }) {
   const t = useT();
   const fs = useWindowFullscreen();
-  const { loading, error, results, groups, bestId } = useSubtitleChoices(src);
+  const { loading, error, choices, groups, bestKey } = useSubtitleChoices(src);
   const [selected, setSelected] = useState<Selection>(null);
   const [activeLang, setActiveLang] = useState<string>("all");
   const inited = useRef(false);
@@ -32,14 +33,14 @@ export function SubtitleSelectStep({
   useEffect(() => {
     if (loading || inited.current) return;
     inited.current = true;
-    if (bestId) {
-      setSelected(bestId);
-      const g = groups.find((gr) => gr.items.some((it) => it.id === bestId));
+    if (bestKey) {
+      setSelected(bestKey);
+      const g = groups.find((group) => group.items.some((item) => item.key === bestKey));
       setActiveLang(g?.langKey ?? "all");
     } else {
       setSelected("off");
     }
-  }, [loading, bestId, groups]);
+  }, [loading, bestKey, groups]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -50,30 +51,24 @@ export function SubtitleSelectStep({
   }, [onCancel]);
 
   const start = () => {
-    if (selected === "off") {
-      onStart({ ...src, subtitlePreselect: { off: true } });
-      return;
-    }
-    const r = results?.find((x) => x.id === selected);
-    if (r) {
-      onStart({
-        ...src,
-        subtitlePreselect: { off: false, url: r.url, lang: r.lang, title: r.title || languageName(r.lang) },
-      });
-      return;
-    }
-    onStart(src);
+    onStart(buildPlayerSubtitleSelection(src, selected, choices ?? [], languageName));
   };
 
   const visible =
-    activeLang === "all" ? results ?? [] : groups.find((g) => g.langKey === activeLang)?.items ?? [];
+    activeLang === "all"
+      ? (choices ?? [])
+      : (groups.find((g) => g.langKey === activeLang)?.items ?? []);
   const context = episodeContext(src.episode, src.meta.name);
-  const total = results?.length ?? 0;
+  const total = choices?.length ?? 0;
 
   return (
     <main className="absolute inset-0 z-50 flex flex-col overflow-hidden bg-canvas">
       <BackdropLayer src={src.episode?.still || src.meta.background || src.meta.poster} />
-      <div aria-hidden data-tauri-drag-region={fs ? "false" : "true"} className="absolute inset-x-0 top-0 z-10 h-20" />
+      <div
+        aria-hidden
+        data-tauri-drag-region={fs ? "false" : "true"}
+        className="absolute inset-x-0 top-0 z-10 h-20"
+      />
 
       <div className="relative mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col gap-6 px-10 pb-10 pt-24">
         <header className="flex items-start gap-4">
@@ -88,7 +83,9 @@ export function SubtitleSelectStep({
           <div className="flex min-w-0 flex-col gap-1">
             <div className="flex items-center gap-2.5">
               <Captions size={22} strokeWidth={2} className="shrink-0 text-accent" />
-              <h1 className="text-[26px] font-semibold tracking-tight text-ink">{t("Choose subtitles")}</h1>
+              <h1 className="text-[26px] font-semibold tracking-tight text-ink">
+                {t("Choose subtitles")}
+              </h1>
             </div>
             {context && <p className="truncate text-[14px] text-ink-muted">{context}</p>}
           </div>
@@ -120,18 +117,24 @@ export function SubtitleSelectStep({
                     icon={<Flag language={g.langDisplay} size="sm" showLabel={false} />}
                     label={g.langDisplay}
                     count={g.items.length}
-                    dot={g.items.some((it) => it.id === selected)}
+                    dot={g.items.some((item) => item.key === selected)}
                   />
                 ))}
               </aside>
 
               <section className="flex min-h-0 min-w-0 flex-1 flex-col">
                 <div className="min-h-0 flex-1 overflow-y-auto p-3">
-                  <OffRow selected={selected === "off"} onPick={() => setSelected("off")} label={t("No subtitles")} />
+                  <OffRow
+                    selected={selected === "off"}
+                    onPick={() => setSelected("off")}
+                    label={t("No subtitles")}
+                  />
 
                   {error && total === 0 && (
                     <p className="px-4 py-6 text-[14px] text-ink-muted">
-                      {t("Couldn't load subtitles. You can start anyway and add one later in the player.")}
+                      {t(
+                        "Couldn't load subtitles. You can start anyway and add one later in the player.",
+                      )}
                     </p>
                   )}
                   {!error && total === 0 && (
@@ -142,13 +145,13 @@ export function SubtitleSelectStep({
 
                   {visible.length > 0 && (
                     <div className="mt-1 flex flex-col gap-1.5">
-                      {visible.map((r) => (
+                      {visible.map((choice) => (
                         <TrackRow
-                          key={r.id}
-                          result={r}
-                          selected={r.id === selected}
-                          isBest={r.id === bestId}
-                          onPick={() => setSelected(r.id)}
+                          key={choice.key}
+                          choice={choice}
+                          selected={choice.key === selected}
+                          isBest={choice.key === bestKey}
+                          onPick={() => setSelected(choice.key)}
                         />
                       ))}
                     </div>
@@ -207,7 +210,9 @@ function SidebarItem({
     <button
       onClick={onClick}
       className={`flex min-h-[44px] items-center gap-2.5 rounded-xl px-3 text-start text-[13.5px] transition-colors ${
-        active ? "bg-elevated text-ink ring-1 ring-edge" : "text-ink-muted hover:bg-elevated/60 hover:text-ink"
+        active
+          ? "bg-elevated text-ink ring-1 ring-edge"
+          : "text-ink-muted hover:bg-elevated/60 hover:text-ink"
       }`}
     >
       {icon}
@@ -218,7 +223,15 @@ function SidebarItem({
   );
 }
 
-function OffRow({ selected, onPick, label }: { selected: boolean; onPick: () => void; label: string }) {
+function OffRow({
+  selected,
+  onPick,
+  label,
+}: {
+  selected: boolean;
+  onPick: () => void;
+  label: string;
+}) {
   return (
     <button
       onClick={onPick}
@@ -234,24 +247,35 @@ function OffRow({ selected, onPick, label }: { selected: boolean; onPick: () => 
 }
 
 function TrackRow({
-  result,
+  choice,
   selected,
   isBest,
   onPick,
 }: {
-  result: SubResult;
+  choice: SubtitleChoice;
   selected: boolean;
   isBest: boolean;
   onPick: () => void;
 }) {
   const t = useT();
   const { open } = useContextMenu();
-  const title = result.title || languageName(result.lang);
-  return (
-    <button
-      onClick={onPick}
-      onContextMenu={(e) =>
-        open(e, {
+  const result = choice.kind === "external" ? choice.result : null;
+  const track = choice.kind === "embedded" ? choice.track : null;
+  const title = result
+    ? result.title || languageName(result.lang)
+    : subtitleTrackTitle({
+        id: track ? String(track.subIndex + 1) : undefined,
+        lang: track?.lang,
+        title: track?.title,
+        codec: track?.codec,
+        external: false,
+      });
+  const langDisplay = result
+    ? languageName(result.lang)
+    : subtitleTrackLanguageLabel({ lang: track?.lang, external: false });
+  const onContextMenu = result
+    ? (event: React.MouseEvent<HTMLButtonElement>) =>
+        open(event, {
           kind: "subtitle",
           label: title,
           download: result.url
@@ -264,7 +288,11 @@ function TrackRow({
                 })
             : undefined,
         })
-      }
+    : undefined;
+  return (
+    <button
+      onClick={onPick}
+      onContextMenu={onContextMenu}
       className={`flex min-h-[56px] w-full items-center gap-3.5 rounded-2xl px-4 py-2.5 text-start transition-colors ${
         selected ? "bg-accent/12 ring-1 ring-accent/50" : "hover:bg-canvas/50"
       }`}
@@ -280,26 +308,33 @@ function TrackRow({
           )}
         </span>
         <span className="flex flex-wrap items-center gap-2 text-[12px] text-ink-subtle">
-          <span className="font-semibold capitalize text-ink-muted">{result.source}</span>
-          {result.format && (
+          <span className="font-semibold capitalize text-ink-muted">
+            {result ? result.source : t("Embedded")}
+          </span>
+          {(result?.format || track?.codec) && (
             <>
               <span aria-hidden>·</span>
-              <span className="uppercase">{result.format}</span>
+              <span className="uppercase">{result?.format ?? track?.codec}</span>
             </>
           )}
-          {result.hearingImpaired && (
+          {(result?.hearingImpaired || track?.isHearingImpaired) && (
             <span className="rounded bg-amber-400/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-amber-200">
               {t("HI/SDH")}
             </span>
           )}
-          {result.forced && (
+          {(result?.forced || track?.isForced) && (
             <span className="rounded bg-sky-400/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-sky-200">
               {t("Forced")}
             </span>
           )}
+          {track?.isDefault && (
+            <span className="rounded bg-white/8 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-ink-muted">
+              {t("Default")}
+            </span>
+          )}
         </span>
       </div>
-      <Flag language={languageName(result.lang)} size="md" showLabel={false} />
+      <Flag language={langDisplay} size="md" showLabel={false} />
     </button>
   );
 }
@@ -323,12 +358,20 @@ function LoadingSkeleton() {
       <div className="flex flex-1">
         <div className="flex w-[190px] shrink-0 flex-col gap-1.5 border-e border-edge-soft bg-canvas/30 p-3">
           {[0, 1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-11 animate-pulse rounded-xl bg-elevated/60" style={{ opacity: 1 - i * 0.15 }} />
+            <div
+              key={i}
+              className="h-11 animate-pulse rounded-xl bg-elevated/60"
+              style={{ opacity: 1 - i * 0.15 }}
+            />
           ))}
         </div>
         <div className="flex flex-1 flex-col gap-2 p-3">
           {[0, 1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="h-14 animate-pulse rounded-2xl bg-elevated/50" style={{ opacity: 1 - i * 0.12 }} />
+            <div
+              key={i}
+              className="h-14 animate-pulse rounded-2xl bg-elevated/50"
+              style={{ opacity: 1 - i * 0.12 }}
+            />
           ))}
         </div>
       </div>

--- a/src/views/player/hooks/use-track-autoload.ts
+++ b/src/views/player/hooks/use-track-autoload.ts
@@ -17,6 +17,13 @@ import { pickDesiredSubtitleTrack } from "@/lib/subtitles/track-selection";
 import { markAddedSub } from "@/lib/subtitles/added-subs";
 import { markImportedSub } from "@/lib/player/imported-subs";
 import { readRememberedSub, subtitleMediaKey } from "@/lib/subtitles/subtitle-memory";
+import {
+  applyEmbeddedSubtitlePreselect,
+  applySubtitleOffPreselect,
+  enforceStoredSubtitleOff,
+  shouldEnforceStoredSubtitleOff,
+  subtitlePreselectApplyKey,
+} from "@/lib/subtitles/embedded-preselect";
 
 export function useTrackAutoload(params: {
   bridgeRef: RefObject<PlayerBridge | null>;
@@ -122,7 +129,8 @@ export function useTrackAutoload(params: {
         setRefreshing(true);
         setLastAdded(null);
         clearLastAddedTimer();
-        void refetchRef.current()
+        void refetchRef
+          .current()
           .then((n) => setLastAdded(n))
           .catch(() => setLastAdded(0))
           .finally(() => {
@@ -166,12 +174,14 @@ export function useTrackAutoload(params: {
     publishSubtitleContext({ candidateIds, stremioId: src.meta.id ?? null });
     const animeIds = candidateIds.some((i) => i.startsWith("kitsu:") || i.startsWith("mal:"));
     const imdbEpAligned =
-      !animeIds || src.episode?.imdbEpisode == null || src.episode.episode === src.episode.imdbEpisode;
+      !animeIds ||
+      src.episode?.imdbEpisode == null ||
+      src.episode.episode === src.episode.imdbEpisode;
     const searchSeason = imdbEpAligned
-      ? src.episode?.imdbSeason ?? src.episode?.season
+      ? (src.episode?.imdbSeason ?? src.episode?.season)
       : src.episode?.season;
     const searchEpisode = imdbEpAligned
-      ? src.episode?.imdbEpisode ?? src.episode?.episode
+      ? (src.episode?.imdbEpisode ?? src.episode?.episode)
       : src.episode?.episode;
     autoSubLoadKeyRef.current = key;
     void (async () => {
@@ -182,9 +192,7 @@ export function useTrackAutoload(params: {
         episode: searchEpisode,
         langs,
       });
-      const { videoHash, videoSize } = settings.subtitleAutoSync
-        ? await resolveVideoHash(src)
-        : {};
+      const { videoHash, videoSize } = settings.subtitleAutoSync ? await resolveVideoHash(src) : {};
       if (videoHash) console.info(`[subs/autoload] moviehash ${videoHash} (${videoSize})`);
       const b = bridgeRef.current;
       if (!b || autoSubLoadKeyRef.current !== key) {
@@ -252,20 +260,48 @@ export function useTrackAutoload(params: {
   useEffect(() => {
     const choice = src.subtitlePreselect;
     if (!choice) return;
-    if (snap.audioTracks.length === 0 && snap.subtitleTracks.length === 0 && snap.durationSec === 0) return;
-    if (preselectAppliedRef.current === src.url) return;
-    preselectAppliedRef.current = src.url;
-    if (choice.off) {
-      if (snap.subtitleTracks.some((t) => t.selected)) bridgeRef.current?.setSubtitleTrack(null);
+    if (snap.audioTracks.length === 0 && snap.subtitleTracks.length === 0 && snap.durationSec === 0)
+      return;
+    const applyKey = subtitlePreselectApplyKey(src, choice);
+    if (preselectAppliedRef.current === applyKey) return;
+    if (!choice.off && choice.embedded) {
+      const bridge = bridgeRef.current;
+      if (!bridge) return;
+      const applied = applyEmbeddedSubtitlePreselect(
+        snap.subtitleTracks,
+        choice.embedded,
+        (runtimeId) => bridge.setSubtitleTrack(runtimeId),
+      );
+      if (!applied) return;
+      preselectAppliedRef.current = applyKey;
       return;
     }
+    if (choice.off) {
+      const applied = applySubtitleOffPreselect(snap.subtitleTracks, () =>
+        bridgeRef.current?.setSubtitleTrack(null),
+      );
+      if (!applied) return;
+      preselectAppliedRef.current = applyKey;
+      return;
+    }
+    preselectAppliedRef.current = applyKey;
     if (choice.url) {
       const url = choice.url;
       void bridgeRef.current?.addSubtitle(url, choice.lang, choice.title, true)?.then((ok) => {
         if (ok) markAddedSub(url);
       });
     }
-  }, [src.url, src.subtitlePreselect, snap.audioTracks.length, snap.subtitleTracks, snap.durationSec, bridgeRef]);
+  }, [
+    src.meta.id,
+    src.episode?.season,
+    src.episode?.episode,
+    src.url,
+    src.subtitlePreselect,
+    snap.audioTracks.length,
+    snap.subtitleTracks,
+    snap.durationSec,
+    bridgeRef,
+  ]);
   const subRestoreRef = useRef<string | null>(null);
   const subRestoreWaitRef = useRef<number | null>(null);
   const subRestoreLogRef = useRef<string | null>(null);
@@ -316,8 +352,7 @@ export function useTrackAutoload(params: {
         );
         if (cands.length === 0) return undefined;
         return (
-          cands.find((t) => !remembered.provider || t.provider === remembered.provider) ??
-          cands[0]
+          cands.find((t) => !remembered.provider || t.provider === remembered.provider) ?? cands[0]
         );
       };
       const existing = bySubId() ?? snap.subtitleTracks.find(sameSource) ?? byRelease();
@@ -344,11 +379,7 @@ export function useTrackAutoload(params: {
         console.info("[subs/restore] selecting remembered track", {
           id: existing.id,
           subId: existing.subId,
-          via: bySubId()
-            ? "subId"
-            : snap.subtitleTracks.find(sameSource)
-              ? "source"
-              : "release",
+          via: bySubId() ? "subId" : snap.subtitleTracks.find(sameSource) ? "source" : "release",
           url: existing.url,
           release: existing.release,
           title: existing.title,
@@ -468,7 +499,10 @@ export function useTrackAutoload(params: {
         }
       }
     }
-    const subsOff = subsOffFor(prefs, settings);
+    const subsOff = shouldEnforceStoredSubtitleOff(
+      src.subtitlePreselect,
+      subsOffFor(prefs, settings),
+    );
     if (subsOff) {
       if (snap.subtitleTracks.some((t) => t.selected)) bridgeRef.current?.setSubtitleTrack(null);
     } else if (
@@ -491,10 +525,10 @@ export function useTrackAutoload(params: {
           langScore(effAudio.lang ?? "", subLangs) >= 0;
         const want = nativeAudio
           ? (snap.subtitleTracks
-            .filter(isForcedTrack)
-            .sort(
-              (a, b) => langScore(b.lang ?? "", subLangs) - langScore(a.lang ?? "", subLangs),
-            )[0] ?? null)
+              .filter(isForcedTrack)
+              .sort(
+                (a, b) => langScore(b.lang ?? "", subLangs) - langScore(a.lang ?? "", subLangs),
+              )[0] ?? null)
           : pickDesiredSubtitleTrack(
               allow(snap.subtitleTracks),
               subLangs,
@@ -515,17 +549,29 @@ export function useTrackAutoload(params: {
         bridgeRef.current?.setRate(wanted);
       }
     }
-  }, [engine, src.url, src.meta.id, snap.audioTracks, snap.subtitleTracks, snap.rate, settings]);
+  }, [
+    engine,
+    src.url,
+    src.meta.id,
+    src.subtitlePreselect,
+    snap.audioTracks,
+    snap.subtitleTracks,
+    snap.rate,
+    settings,
+  ]);
 
   useEffect(() => {
     bridgeRef.current?.setSubDelay(readPlayerPrefs(src.meta.id)?.subDelaySec ?? 0);
   }, [src.url, src.meta.id]);
 
   useEffect(() => {
-    if (!subsOffFor(readPlayerPrefs(src.meta.id), settings)) return;
-    const selected = snap.subtitleTracks.find((t) => t.selected);
-    if (selected) bridgeRef.current?.setSubtitleTrack(null);
-  }, [src.meta.id, snap.subtitleTracks, settings]);
+    enforceStoredSubtitleOff(
+      src.subtitlePreselect,
+      subsOffFor(readPlayerPrefs(src.meta.id), settings),
+      snap.subtitleTracks,
+      () => bridgeRef.current?.setSubtitleTrack(null),
+    );
+  }, [src.meta.id, src.subtitlePreselect, snap.subtitleTracks, settings]);
 
   return { resolvedImdbId, resolvedImdbVerified, resolutionSettled };
 }
@@ -569,10 +615,7 @@ function isLoopback(url: string): boolean {
 }
 
 function raceTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
-  return Promise.race([
-    p,
-    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
-  ]);
+  return Promise.race([p, new Promise<null>((resolve) => setTimeout(() => resolve(null), ms))]);
 }
 
 async function resolveVideoHash(

--- a/tests/preplay-embedded-subtitles.test.ts
+++ b/tests/preplay-embedded-subtitles.test.ts
@@ -51,12 +51,19 @@ test("external and embedded picker choices have collision-safe identities", asyn
   const { mergeSubtitleChoices } = await loadChoiceModule();
   const choices = mergeSubtitleChoices([external], [embedded]);
 
+  assert.deepEqual(choices.map((choice) => choice.key).sort(), [
+    "embedded:5:0",
+    "external:embedded:5:0",
+  ]);
+});
+
+test("embedded picker choices appear before provider results", async () => {
+  const { mergeSubtitleChoices } = await loadChoiceModule();
+  const choices = mergeSubtitleChoices([external], [embedded]);
+
   assert.deepEqual(
-    choices.map((choice) => [choice.kind, choice.key]),
-    [
-      ["external", "external:embedded:5:0"],
-      ["embedded", "embedded:5:0"],
-    ],
+    choices.map((choice) => choice.kind),
+    ["embedded", "external"],
   );
 });
 
@@ -87,7 +94,7 @@ test("embedded probing starts alongside provider search", async () => {
   assert.equal(result.embeddedError, false);
   assert.deepEqual(
     result.choices.map((choice) => choice.kind),
-    ["external", "embedded"],
+    ["embedded", "external"],
   );
 });
 
@@ -116,7 +123,7 @@ test("provider results become usable while embedded probing is still pending", a
   resolveEmbedded([embedded]);
   assert.deepEqual(
     (await pending).choices.map((choice: { kind: string }) => choice.kind),
-    ["external", "embedded"],
+    ["embedded", "external"],
   );
 });
 

--- a/tests/preplay-embedded-subtitles.test.ts
+++ b/tests/preplay-embedded-subtitles.test.ts
@@ -1,0 +1,404 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+async function loadChoiceModule() {
+  try {
+    return await import("../src/views/play-picker/subtitle-choice.ts");
+  } catch (error) {
+    assert.fail(`pre-play subtitle choice support is missing: ${String(error)}`);
+  }
+}
+
+async function loadEmbeddedPreselectModule() {
+  try {
+    return await import("../src/lib/subtitles/embedded-preselect.ts");
+  } catch (error) {
+    assert.fail(`embedded preselection support is missing: ${String(error)}`);
+  }
+}
+
+async function loadMpvTrackListModule() {
+  try {
+    return await import("../src/lib/player/mpv-track-list.ts");
+  } catch (error) {
+    assert.fail(`mpv track-list identity parsing is missing: ${String(error)}`);
+  }
+}
+
+const external = {
+  id: "embedded:5:0",
+  url: "https://subtitles.example.test/en.srt",
+  lang: "en",
+  title: "External English",
+  source: "opensubtitles" as const,
+  format: "srt" as const,
+};
+
+const embedded = {
+  ffIndex: 5,
+  subIndex: 0,
+  lang: "en",
+  title: "English SDH",
+  codec: "ass",
+  isDefault: true,
+  isForced: false,
+  isHearingImpaired: true,
+};
+
+test("external and embedded picker choices have collision-safe identities", async () => {
+  const { mergeSubtitleChoices } = await loadChoiceModule();
+  const choices = mergeSubtitleChoices([external], [embedded]);
+
+  assert.deepEqual(
+    choices.map((choice) => [choice.kind, choice.key]),
+    [
+      ["external", "external:embedded:5:0"],
+      ["embedded", "embedded:5:0"],
+    ],
+  );
+});
+
+test("embedded probing starts alongside provider search", async () => {
+  const { loadSubtitleChoices } = await loadChoiceModule();
+  const started: string[] = [];
+  let resolveExternal!: (value: (typeof external)[]) => void;
+
+  const pending = loadSubtitleChoices(
+    () => {
+      started.push("external");
+      return new Promise<(typeof external)[]>((resolve) => {
+        resolveExternal = resolve;
+      });
+    },
+    async () => {
+      started.push("embedded");
+      return [embedded];
+    },
+  );
+
+  await Promise.resolve();
+  assert.deepEqual(started, ["external", "embedded"]);
+  resolveExternal([external]);
+
+  const result = await pending;
+  assert.equal(result.externalError, false);
+  assert.equal(result.embeddedError, false);
+  assert.deepEqual(
+    result.choices.map((choice) => choice.kind),
+    ["external", "embedded"],
+  );
+});
+
+test("provider results become usable while embedded probing is still pending", async () => {
+  const { loadSubtitleChoices } = await loadChoiceModule();
+  let resolveEmbedded!: (value: (typeof embedded)[]) => void;
+  const snapshots: { choices: { kind: string }[]; externalError: boolean }[] = [];
+
+  const pending = loadSubtitleChoices(
+    async () => [external],
+    () =>
+      new Promise<(typeof embedded)[]>((resolve) => {
+        resolveEmbedded = resolve;
+      }),
+    (result: { choices: { kind: string }[]; externalError: boolean }) => {
+      snapshots.push(result);
+    },
+  );
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(
+    snapshots.map((result) => result.choices.map((choice) => choice.kind)),
+    [["external"]],
+  );
+
+  resolveEmbedded([embedded]);
+  assert.deepEqual(
+    (await pending).choices.map((choice: { kind: string }) => choice.kind),
+    ["external", "embedded"],
+  );
+});
+
+test("mpv-unavailable playback does not invoke the native embedded probe", async () => {
+  const { loadEmbeddedTracksWhenMpvAvailable } = await loadChoiceModule();
+  let nativeProbeCalls = 0;
+
+  const tracks = await loadEmbeddedTracksWhenMpvAvailable(
+    async () => ({ available: false }),
+    async () => {
+      nativeProbeCalls += 1;
+      return [embedded];
+    },
+  );
+
+  assert.deepEqual(tracks, []);
+  assert.equal(nativeProbeCalls, 0);
+});
+
+test("a failed embedded probe preserves external subtitle results", async () => {
+  const { loadSubtitleChoices } = await loadChoiceModule();
+  const result = await loadSubtitleChoices(
+    async () => [external],
+    async () => {
+      throw new Error("ffprobe unavailable");
+    },
+  );
+
+  assert.equal(result.externalError, false);
+  assert.equal(result.embeddedError, true);
+  assert.deepEqual(
+    result.choices.map((choice) => choice.kind),
+    ["external"],
+  );
+});
+
+test("media without embedded tracks keeps provider-only choices", async () => {
+  const { loadSubtitleChoices } = await loadChoiceModule();
+  const result = await loadSubtitleChoices(
+    async () => [external],
+    async () => [],
+  );
+
+  assert.deepEqual(
+    result.choices.map((choice) => choice.key),
+    ["external:embedded:5:0"],
+  );
+});
+
+test("external, off, and skip selections preserve their existing behavior", async () => {
+  const { buildPlayerSubtitleSelection, mergeSubtitleChoices } = await loadChoiceModule();
+  const source = {
+    meta: { id: "tt0848228", name: "The Avengers", type: "movie" },
+    url: "https://media.example.test/movie.mkv",
+    title: "The Avengers",
+  };
+  const choices = mergeSubtitleChoices([external], [embedded]);
+
+  assert.deepEqual(
+    buildPlayerSubtitleSelection(source, "external:embedded:5:0", choices).subtitlePreselect,
+    {
+      off: false,
+      url: external.url,
+      lang: "en",
+      title: "External English",
+    },
+  );
+  assert.deepEqual(buildPlayerSubtitleSelection(source, "off", choices).subtitlePreselect, {
+    off: true,
+  });
+  assert.strictEqual(buildPlayerSubtitleSelection(source, "skip", choices), source);
+});
+
+test("an embedded picker selection carries both stable probe identities", async () => {
+  const { buildPlayerSubtitleSelection, mergeSubtitleChoices } = await loadChoiceModule();
+  const source = {
+    meta: { id: "tt0848228", name: "The Avengers", type: "movie" },
+    url: "https://media.example.test/movie.mkv",
+    title: "The Avengers",
+  };
+  const choices = mergeSubtitleChoices([], [embedded]);
+
+  assert.deepEqual(
+    buildPlayerSubtitleSelection(source, "embedded:5:0", choices).subtitlePreselect,
+    {
+      off: false,
+      embedded: { ffIndex: 5, subIndex: 0 },
+    },
+  );
+});
+
+test("an explicit pre-play choice overrides stored subtitles-off policy", async () => {
+  const { shouldEnforceSubtitleOff } = await loadEmbeddedPreselectModule();
+
+  assert.equal(shouldEnforceSubtitleOff(undefined, true), true);
+  assert.equal(shouldEnforceSubtitleOff({ off: true }, true), true);
+  assert.equal(
+    shouldEnforceSubtitleOff({ off: false, embedded: { ffIndex: 5, subIndex: 0 } }, true),
+    false,
+  );
+  assert.equal(
+    shouldEnforceSubtitleOff({ off: false, url: "https://subtitles.example.test/en.srt" }, true),
+    false,
+  );
+});
+
+test("explicit no-subtitles remains enforced when runtime tracks arrive late", async () => {
+  const { enforceSubtitleOff } = await loadEmbeddedPreselectModule();
+  const selections: null[] = [];
+
+  assert.equal(
+    enforceSubtitleOff({ off: true }, false, [], () => selections.push(null)),
+    false,
+  );
+  assert.equal(
+    enforceSubtitleOff({ off: true }, false, [{ selected: true }], () => selections.push(null)),
+    true,
+  );
+  assert.deepEqual(selections, [null]);
+});
+
+test("pre-play no-subtitles clears a late default once and then allows manual selection", async () => {
+  const { applySubtitleOffPreselect, enforceStoredSubtitleOff, shouldEnforceStoredSubtitleOff } =
+    await loadEmbeddedPreselectModule();
+  const selections: null[] = [];
+  const choice = { off: true };
+  let consumed = false;
+  const render = (tracks: { selected: boolean }[]) => {
+    if (!consumed) {
+      consumed = applySubtitleOffPreselect(tracks, () => selections.push(null));
+    }
+    if (shouldEnforceStoredSubtitleOff(choice, true) && tracks.some((track) => track.selected)) {
+      selections.push(null);
+    }
+    enforceStoredSubtitleOff(choice, true, tracks, () => selections.push(null));
+  };
+
+  render([]);
+  assert.equal(consumed, false);
+
+  render([{ selected: true }]);
+  assert.equal(consumed, true);
+  assert.deepEqual(selections, [null]);
+
+  render([{ selected: true }]);
+  assert.deepEqual(selections, [null]);
+});
+
+test("ffprobe index, subtitle ordinal, and mpv runtime id remain distinct", async () => {
+  const { parseMpvTrackList } = await loadMpvTrackListModule();
+  const { resolveEmbeddedSubtitleTrack } = await loadEmbeddedPreselectModule();
+  const parsed = parseMpvTrackList(
+    [
+      { type: "sub", id: 41, "ff-index": 9, lang: "es" },
+      { type: "sub", id: 77, "ff-index": 5, lang: "en", title: "English SDH" },
+    ],
+    null,
+    new Map(),
+  );
+
+  const selected = resolveEmbeddedSubtitleTrack(parsed.subtitleTracks, {
+    ffIndex: 5,
+    subIndex: 0,
+  });
+
+  assert.equal(selected?.id, "77");
+  assert.equal(selected?.ffIndex, 5);
+});
+
+test("mpv track parsing preserves existing audio and external subtitle metadata", async () => {
+  const { parseMpvTrackList } = await loadMpvTrackListModule();
+  const parsed = parseMpvTrackList(
+    [
+      {
+        type: "audio",
+        id: 2,
+        selected: true,
+        lang: "en",
+        "codec-desc": "aac",
+        "demux-channels": "stereo",
+        "demux-channel-count": 2,
+      },
+      {
+        type: "sub",
+        id: 8,
+        selected: true,
+        "main-selection": 1,
+        external: true,
+        "external-filename": "downloaded.srt",
+      },
+    ],
+    "8",
+    new Map([
+      [
+        "downloaded.srt",
+        {
+          url: "https://subtitles.example.test/external.srt",
+          provider: "opensubtitles",
+          subId: "external-8",
+        },
+      ],
+    ]),
+  );
+
+  assert.equal(parsed.audioTracks[0]?.selected, true);
+  assert.equal(parsed.audioTracks[0]?.codec, "AAC");
+  assert.equal(parsed.audioTracks[0]?.channelCount, 2);
+  assert.equal(parsed.subtitleTracks[0]?.selected, false);
+  assert.equal(parsed.subtitleTracks[0]?.secondary, true);
+  assert.equal(parsed.subtitleTracks[0]?.url, "https://subtitles.example.test/external.srt");
+  assert.equal(parsed.subtitleTracks[0]?.subId, "external-8");
+});
+
+test("embedded selection waits for delayed runtime tracks", async () => {
+  const { applyEmbeddedSubtitlePreselect } = await loadEmbeddedPreselectModule();
+  const selectedIds: string[] = [];
+  const identity = { ffIndex: 5, subIndex: 1 };
+
+  assert.equal(
+    applyEmbeddedSubtitlePreselect([], identity, (id) => selectedIds.push(id)),
+    false,
+  );
+  assert.deepEqual(selectedIds, []);
+
+  const tracks = [
+    { id: "41", label: "Spanish", lang: "es", kind: "subtitle" as const, selected: false },
+    {
+      id: "77",
+      ffIndex: 5,
+      label: "English SDH",
+      lang: "en",
+      kind: "subtitle" as const,
+      selected: false,
+    },
+  ];
+  assert.equal(
+    applyEmbeddedSubtitlePreselect(tracks, identity, (id) => selectedIds.push(id)),
+    true,
+  );
+  assert.deepEqual(selectedIds, ["77"]);
+});
+
+test("ordinal fallback is used only when mpv exposes no ff-index values", async () => {
+  const { resolveEmbeddedSubtitleTrack } = await loadEmbeddedPreselectModule();
+  const withoutFfIndex = [
+    { id: "10", label: "First", kind: "subtitle" as const, selected: false },
+    { id: "11", label: "Second", kind: "subtitle" as const, selected: false },
+  ];
+  assert.equal(
+    resolveEmbeddedSubtitleTrack(withoutFfIndex, { ffIndex: 99, subIndex: 1 })?.id,
+    "11",
+  );
+
+  const withDifferentFfIndices = withoutFfIndex.map((track, index) => ({
+    ...track,
+    ffIndex: index + 20,
+  }));
+  assert.equal(
+    resolveEmbeddedSubtitleTrack(withDifferentFfIndices, { ffIndex: 99, subIndex: 1 }),
+    null,
+  );
+});
+
+test("the applied guard key includes media and embedded choice identity", async () => {
+  const { subtitlePreselectApplyKey } = await loadEmbeddedPreselectModule();
+  const base = {
+    meta: { id: "tt0848228", name: "The Avengers", type: "movie" },
+    url: "https://media.example.test/movie.mkv",
+    title: "The Avengers",
+    subtitlePreselect: { off: false, embedded: { ffIndex: 5, subIndex: 0 } },
+  };
+
+  const first = subtitlePreselectApplyKey(base, base.subtitlePreselect);
+  const differentMedia = subtitlePreselectApplyKey(
+    { ...base, meta: { ...base.meta, id: "tt9999999" } },
+    base.subtitlePreselect,
+  );
+  const differentChoice = subtitlePreselectApplyKey(base, {
+    off: false,
+    embedded: { ffIndex: 6, subIndex: 1 },
+  });
+
+  assert.notEqual(first, differentMedia);
+  assert.notEqual(first, differentChoice);
+});


### PR DESCRIPTION
## Summary

- show embedded subtitle streams above provider results in the **Choose subtitles** step
- probe embedded tracks concurrently without blocking usable provider results, and keep external subtitles as the initial best match
- carry ffprobe stream identity into playback and resolve it to the runtime mpv track ID after the delayed track list arrives
- preserve explicit external, embedded, off, and skip choices without letting stored subtitle-off policy override a picker selection
- bound native probing, preserve packaged and installed ffprobe discovery, and require live Harbor ownership for loopback proxy or torrent sources

## Why

The pre-play subtitle picker only searched external providers. Embedded streams became visible only after mpv loaded the source, so users could see them in the in-player menu but could not choose them before playback.

The fix keeps ffprobe's global stream index, subtitle ordinal, and mpv's runtime track ID distinct. The picker carries both stable probe identities, then the player waits for mpv's track list and selects only the resolved runtime ID. External search and embedded probing fail independently; web, HTML5, unavailable-mpv, and no-embedded-track cases keep the existing provider-only behavior.

## Verification

- `node --test tests/preplay-embedded-subtitles.test.ts`: 17/17 passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib subsync::subtitle_tracks_tests`: 3/3 passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib ffprobe_locator_tests`: 1/1 passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib subsync::url_guard::tests::user_agent`: passed
- `pnpm exec tsc -b --pretty false`: passed
- `pnpm exec vp fmt --check <10 changed TypeScript files>`: passed
- `pnpm exec vp check --no-fmt <10 changed TypeScript files>`: no warnings or lint errors
- `cargo check --manifest-path src-tauri/Cargo.toml`: passed with two existing dead-code warnings
- `pnpm run build`: passed (existing Vite eval, dynamic-import, and chunk-size warnings remain)
- `pnpm tauri build --no-bundle`: passed on Windows and produced `src-tauri/target/release/harbor.exe`
- `node --test tests/*.test.ts`: 288/294 passed on this branch versus 271/277 on `beta-branch`; both have the same six baseline failures (`cw-anime-sync-ids`, `i18n-coverage`, `i18n-plurals`, `mentions`, `rtl-pin-entry`, and `subtitle-font-selection`)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`: 140/142 passed on this branch versus 132/134 on `beta-branch`; both have the same two baseline failures (`phonetic_folds_homophones` and `redacts_authorization_bearer`)

## Platform Impact

Windows production and Tauri builds passed. Fresh manual Windows/mpv picker discovery and ordering were verified on commit c0677e22c5919e1de28bd7c9046a68a599565350; playback-selection verification remains pending. Web and explicit HTML5 playback skip the native probe and retain provider-only results. The ffprobe locator retains packaged Windows, macOS, and Linux sidecar support, but macOS and Linux were not separately built or tested. No TV-input behavior changed.

The new command accepts loopback media only when the current Harbor proxy or torrent engine owns the exact route. Public-host DNS resolution and redirect target revalidation remain inherited player/ffprobe behavior and are unchanged by this PR.

## UI Changes

Manual Windows/mpv picker verification on commit c0677e22c5919e1de28bd7c9046a68a599565350. The embedded BTM track is selected manually in the After capture; automatic selection remains the first external Best Match.

### Before

The pre-play picker showed provider results only; embedded subtitle tracks were unavailable.

<img width="1145" height="1291" alt="Before: provider-only pre-play subtitle picker" src="https://github.com/user-attachments/assets/b4c25129-3922-4caf-8c54-b9bb389fe224" />

### After

Embedded subtitle tracks appear immediately below **No subtitles** and above provider results.

<img width="1118" height="1302" alt="After: embedded subtitles above provider results" src="https://github.com/user-attachments/assets/59357a48-b5cd-482e-a4d9-22dafb642ffa" />

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes. The repository has no `typecheck` task; the direct `pnpm exec tsc -b --pretty false` equivalent passed.
- [x] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific. Windows/mpv picker discovery and ordering were manually verified; playback-selection verification remains pending.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.