### PR TITLE
feat(subtitles): add native source FPS control

### DIFF
--- a/src/components/player/autosync/autosync-store.ts
+++ b/src/components/player/autosync/autosync-store.ts
@@ -1,36 +1,12 @@
 import { useSyncExternalStore } from "react";
 import type { AutoSyncHandle } from "@/views/player/hooks/use-auto-sync";
-import { resetMpvSubtitleFpsForTransition } from "@/lib/player/mpv-properties";
 
 let current: AutoSyncHandle | null = null;
 const listeners = new Set<() => void>();
 
 export function publishAutoSync(handle: AutoSyncHandle | null): void {
-  const resetSubtitleFps = () =>
-    resetMpvSubtitleFpsForTransition((error) =>
-      console.warn("[auto-sync] subtitle FPS reset failed", error),
-    );
-  const afterSubtitleFpsReset = (action: () => void) => () => {
-    void resetSubtitleFps()
-      .then(action)
-      .catch(() => {});
-  };
-  current = handle
-    ? {
-        ...handle,
-        run: afterSubtitleFpsReset(handle.run),
-        retry: afterSubtitleFpsReset(handle.retry),
-        applyOffer: afterSubtitleFpsReset(handle.applyOffer),
-      }
-    : null;
-  if (
-    handle?.status === "analyzing" ||
-    handle?.status === "synced" ||
-    handle?.status === "best-effort" ||
-    handle?.status === "offer"
-  ) {
-    void resetSubtitleFps().catch(handle.stop);
-  }
+  if (current === handle) return;
+  current = handle;
   listeners.forEach((l) => l());
 }
 

--- a/src/components/player/autosync/autosync-store.ts
+++ b/src/components/player/autosync/autosync-store.ts
@@ -1,12 +1,36 @@
 import { useSyncExternalStore } from "react";
 import type { AutoSyncHandle } from "@/views/player/hooks/use-auto-sync";
+import { resetMpvSubtitleFpsForTransition } from "@/lib/player/mpv-properties";
 
 let current: AutoSyncHandle | null = null;
 const listeners = new Set<() => void>();
 
 export function publishAutoSync(handle: AutoSyncHandle | null): void {
-  if (current === handle) return;
-  current = handle;
+  const resetSubtitleFps = () =>
+    resetMpvSubtitleFpsForTransition((error) =>
+      console.warn("[auto-sync] subtitle FPS reset failed", error),
+    );
+  const afterSubtitleFpsReset = (action: () => void) => () => {
+    void resetSubtitleFps()
+      .then(action)
+      .catch(() => {});
+  };
+  current = handle
+    ? {
+        ...handle,
+        run: afterSubtitleFpsReset(handle.run),
+        retry: afterSubtitleFpsReset(handle.retry),
+        applyOffer: afterSubtitleFpsReset(handle.applyOffer),
+      }
+    : null;
+  if (
+    handle?.status === "analyzing" ||
+    handle?.status === "synced" ||
+    handle?.status === "best-effort" ||
+    handle?.status === "offer"
+  ) {
+    void resetSubtitleFps().catch(handle.stop);
+  }
   listeners.forEach((l) => l());
 }
 

--- a/src/components/player/subtitle-menu/menu-body.tsx
+++ b/src/components/player/subtitle-menu/menu-body.tsx
@@ -141,8 +141,10 @@ export function MenuBody(props: SubtitleMenuProps & { onClose: () => void }) {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <MenuHeader
+        engine={props.engine ?? "html5"}
         count={languageTracks.length}
         selectedTrack={selectedTrack}
+        hasSecondary={secondaryTrack != null}
         delaySec={delaySec}
         delayNonZero={delayNonZero}
         onOpenStyleBar={onOpenStyleBar}

--- a/src/components/player/subtitle-menu/menu-header.tsx
+++ b/src/components/player/subtitle-menu/menu-header.tsx
@@ -3,11 +3,14 @@ import type { TrackInfo } from "@/lib/player/bridge";
 import { useT } from "@/lib/i18n";
 import { useAutoSyncHandle } from "@/components/player/autosync/autosync-store";
 import { HoverTooltip } from "@/components/hover-tooltip";
+import { SubtitleFpsControl } from "./subtitle-fps-control";
 import { SyncControl } from "./sync-control";
 
 type Props = {
+  engine: "html5" | "mpv";
   count: number;
   selectedTrack: TrackInfo | null;
+  hasSecondary: boolean;
   delaySec: number;
   delayNonZero: boolean;
   onOpenStyleBar?: () => void;
@@ -39,6 +42,11 @@ export function MenuHeader(p: Props) {
           delaySec={p.delaySec}
           delayNonZero={p.delayNonZero}
           onClose={p.onClose}
+        />
+        <SubtitleFpsControl
+          engine={p.engine}
+          track={p.selectedTrack}
+          hasSecondary={p.hasSecondary}
         />
 
         {p.onOpenStyleBar && (

--- a/src/components/player/subtitle-menu/subtitle-fps-control.tsx
+++ b/src/components/player/subtitle-menu/subtitle-fps-control.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { HoverTooltip } from "@/components/hover-tooltip";
@@ -6,6 +6,7 @@ import { useAutoSyncHandle } from "@/components/player/autosync/autosync-store";
 import { useT } from "@/lib/i18n";
 import type { TrackInfo } from "@/lib/player/bridge";
 import { readMpvSubtitleFps } from "@/lib/player/mpv-properties";
+import { createSubtitleFpsAvailabilityController } from "@/lib/player/subtitle-fps";
 import { SubtitleFpsIcon } from "./subtitle-fps-icon";
 import { SubtitleFpsPanel } from "./subtitle-fps-panel";
 
@@ -34,6 +35,20 @@ export function SubtitleFpsControl({
   const [supported, setSupported] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const supportControllerRef = useRef<ReturnType<
+    typeof createSubtitleFpsAvailabilityController
+  > | null>(null);
+  if (!supportControllerRef.current) {
+    supportControllerRef.current = createSubtitleFpsAvailabilityController({
+      read: async () => (await readMpvSubtitleFps()).supported,
+      commit: setSupported,
+    });
+  }
+
+  const refreshSupport = useCallback((hideWhileChecking = false) => {
+    if (hideWhileChecking) setSupported(false);
+    void supportControllerRef.current?.refresh();
+  }, []);
 
   const closeAndRestoreFocus = () => {
     setOpen(false);
@@ -42,19 +57,17 @@ export function SubtitleFpsControl({
 
   useEffect(() => {
     if (engine !== "mpv" || !isMainTauriWindow()) {
+      supportControllerRef.current?.invalidate();
       setSupported(false);
       setOpen(false);
       return;
     }
 
-    let cancelled = false;
-    void readMpvSubtitleFps().then((result) => {
-      if (!cancelled) setSupported(result.supported);
-    });
+    refreshSupport();
     return () => {
-      cancelled = true;
+      supportControllerRef.current?.invalidate();
     };
-  }, [engine, track?.id]);
+  }, [engine, refreshSupport, track?.id]);
 
   useEffect(() => {
     if (engine !== "mpv" || !isMainTauriWindow()) return;
@@ -63,14 +76,12 @@ export function SubtitleFpsControl({
     let unlisten: UnlistenFn | null = null;
     void listen<MpvPlaybackEvent>("mpv://event", ({ payload }) => {
       if (payload.event === "file-loaded") {
-        void readMpvSubtitleFps().then((result) => {
-          if (!disposed) setSupported(result.supported);
-        });
+        refreshSupport();
         return;
       }
       if (payload.event === "end-file" || payload.event === "shutdown") {
-        setSupported(false);
         setOpen(false);
+        refreshSupport(true);
       }
     })
       .then((dispose) => {
@@ -82,9 +93,10 @@ export function SubtitleFpsControl({
       );
     return () => {
       disposed = true;
+      supportControllerRef.current?.invalidate();
       unlisten?.();
     };
-  }, [engine]);
+  }, [engine, refreshSupport]);
 
   useEffect(() => {
     if (!open) return;
@@ -136,6 +148,7 @@ export function SubtitleFpsControl({
             engine={engine}
             hasSecondary={hasSecondary}
             autoSyncActive={autoSyncActive}
+            onBeforeApply={autoSync?.stop}
             onBack={closeAndRestoreFocus}
           />
         </div>

--- a/src/components/player/subtitle-menu/subtitle-fps-control.tsx
+++ b/src/components/player/subtitle-menu/subtitle-fps-control.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { HoverTooltip } from "@/components/hover-tooltip";
+import { useAutoSyncHandle } from "@/components/player/autosync/autosync-store";
+import { useT } from "@/lib/i18n";
+import type { TrackInfo } from "@/lib/player/bridge";
+import { readMpvSubtitleFps } from "@/lib/player/mpv-properties";
+import { SubtitleFpsIcon } from "./subtitle-fps-icon";
+import { SubtitleFpsPanel } from "./subtitle-fps-panel";
+
+type MpvPlaybackEvent = { event: string };
+
+function isMainTauriWindow(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "__TAURI_INTERNALS__" in window &&
+    getCurrentWindow().label === "main"
+  );
+}
+
+export function SubtitleFpsControl({
+  engine,
+  track,
+  hasSecondary,
+}: {
+  engine: "html5" | "mpv";
+  track: TrackInfo | null;
+  hasSecondary: boolean;
+}) {
+  const tr = useT();
+  const autoSync = useAutoSyncHandle();
+  const [open, setOpen] = useState(false);
+  const [supported, setSupported] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const closeAndRestoreFocus = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (engine !== "mpv" || !isMainTauriWindow()) {
+      setSupported(false);
+      setOpen(false);
+      return;
+    }
+
+    let cancelled = false;
+    void readMpvSubtitleFps().then((result) => {
+      if (!cancelled) setSupported(result.supported);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [engine, track?.id]);
+
+  useEffect(() => {
+    if (engine !== "mpv" || !isMainTauriWindow()) return;
+
+    let disposed = false;
+    let unlisten: UnlistenFn | null = null;
+    void listen<MpvPlaybackEvent>("mpv://event", ({ payload }) => {
+      if (payload.event === "file-loaded") {
+        void readMpvSubtitleFps().then((result) => {
+          if (!disposed) setSupported(result.supported);
+        });
+        return;
+      }
+      if (payload.event === "end-file" || payload.event === "shutdown") {
+        setSupported(false);
+        setOpen(false);
+      }
+    })
+      .then((dispose) => {
+        if (disposed) dispose();
+        else unlisten = dispose;
+      })
+      .catch((error) =>
+        console.warn("[subtitles] could not observe mpv playback availability", error),
+      );
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [engine]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.stopPropagation();
+      closeAndRestoreFocus();
+    };
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [open]);
+
+  if (engine !== "mpv" || !supported) return null;
+
+  const autoSyncActive =
+    autoSync?.status === "analyzing" ||
+    autoSync?.status === "synced" ||
+    autoSync?.status === "best-effort" ||
+    autoSync?.status === "offer";
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <HoverTooltip label={tr("Subtitle FPS")} side="bottom" align="end">
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          aria-label={tr("Subtitle FPS")}
+          aria-expanded={open}
+          className={`flex h-9 w-9 items-center justify-center rounded-full transition-colors ${
+            open ? "bg-raised text-ink" : "text-ink-muted hover:bg-raised hover:text-ink"
+          }`}
+        >
+          <SubtitleFpsIcon size={18} />
+        </button>
+      </HoverTooltip>
+
+      {open && (
+        <div className="absolute end-0 top-[calc(100%+6px)] z-[60] w-[340px] overflow-hidden rounded-xl border border-edge bg-elevated shadow-[0_18px_44px_-18px_rgba(0,0,0,0.85)]">
+          <SubtitleFpsPanel
+            track={track}
+            engine={engine}
+            hasSecondary={hasSecondary}
+            autoSyncActive={autoSyncActive}
+            onBack={closeAndRestoreFocus}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/player/subtitle-menu/subtitle-fps-icon.tsx
+++ b/src/components/player/subtitle-menu/subtitle-fps-icon.tsx
@@ -1,0 +1,52 @@
+type Props = {
+  size?: number;
+  className?: string;
+};
+
+export function SubtitleFpsIcon({ size = 18, className }: Props) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+    >
+      <rect
+        x="2.75"
+        y="3.25"
+        width="15.5"
+        height="10.5"
+        rx="2.25"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path d="M6 7h9M6 10h6" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+      <path
+        d="M3.75 19.5h16.5M5.75 17.75v3.5M9.75 18.25v2.5M13.75 17.75v3.5M18.25 18.25v2.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="17.75"
+        cy="14.25"
+        r="4.25"
+        fill="currentColor"
+        fillOpacity="0.14"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M17.75 11.75v2.75l1.75 1"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/player/subtitle-menu/subtitle-fps-panel.tsx
+++ b/src/components/player/subtitle-menu/subtitle-fps-panel.tsx
@@ -24,10 +24,18 @@ type Props = {
   track: TrackInfo | null;
   hasSecondary: boolean;
   autoSyncActive: boolean;
+  onBeforeApply?: () => void;
   onBack: () => void;
 };
 
-export function SubtitleFpsPanel({ engine, track, hasSecondary, autoSyncActive, onBack }: Props) {
+export function SubtitleFpsPanel({
+  engine,
+  track,
+  hasSecondary,
+  autoSyncActive,
+  onBeforeApply,
+  onBack,
+}: Props) {
   const tr = useT();
   const [videoFps, setVideoFps] = useState<number | null>(null);
   const [subtitleFps, setSubtitleFps] = useState<number | null>(null);
@@ -86,7 +94,8 @@ export function SubtitleFpsPanel({ engine, track, hasSecondary, autoSyncActive, 
     setSaving(true);
     setError(null);
     try {
-      await writeMpvSubtitleFps(choice, getMpvSubtitleFpsGeneration(), track.id);
+      onBeforeApply?.();
+      await writeMpvSubtitleFps(choice, getMpvSubtitleFpsGeneration());
       if (request !== applyRequestRef.current) return;
       const value = choice === "default" ? null : choice;
       setSubtitleFps(value);
@@ -136,7 +145,11 @@ export function SubtitleFpsPanel({ engine, track, hasSecondary, autoSyncActive, 
           <ArrowLeft size={15} strokeWidth={2.2} className="rtl:-scale-x-100" />
         </button>
         <p className="text-[13px] font-semibold text-ink">{tr("Subtitle FPS")}</p>
-        {saving && <Loader2 size={14} className="ms-auto animate-spin text-ink-muted" />}
+        {saving && (
+          <span role="status" aria-label={tr("Saving")} className="ms-auto text-ink-muted">
+            <Loader2 size={14} className="animate-spin motion-reduce:animate-none" />
+          </span>
+        )}
       </div>
 
       <div className="p-3">

--- a/src/components/player/subtitle-menu/subtitle-fps-panel.tsx
+++ b/src/components/player/subtitle-menu/subtitle-fps-panel.tsx
@@ -1,0 +1,245 @@
+import { ArrowLeft, Check, Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useT } from "@/lib/i18n";
+import type { TrackInfo } from "@/lib/player/bridge";
+import {
+  getMpvSubtitleFpsGeneration,
+  readMpvSubtitleFps,
+  readMpvVideoFps,
+  writeMpvSubtitleFps,
+} from "@/lib/player/mpv-properties";
+import { isTextSubTrack } from "@/lib/player/sub-format";
+import {
+  SUBTITLE_FPS_PRESETS,
+  formatSubtitleFps,
+  matchingSubtitleFpsPreset,
+  subtitleFpsAvailability,
+  validateSubtitleFps,
+  type SubtitleFpsChoice,
+  type SubtitleFpsUnavailableReason,
+} from "@/lib/player/subtitle-fps";
+
+type Props = {
+  engine: "html5" | "mpv";
+  track: TrackInfo | null;
+  hasSecondary: boolean;
+  autoSyncActive: boolean;
+  onBack: () => void;
+};
+
+export function SubtitleFpsPanel({ engine, track, hasSecondary, autoSyncActive, onBack }: Props) {
+  const tr = useT();
+  const [videoFps, setVideoFps] = useState<number | null>(null);
+  const [subtitleFps, setSubtitleFps] = useState<number | null>(null);
+  const [nativeSupported, setNativeSupported] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [draft, setDraft] = useState("25");
+  const [customOpen, setCustomOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const applyRequestRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    applyRequestRef.current += 1;
+    setError(null);
+    setSaving(false);
+    setCustomOpen(false);
+    setVideoFps(null);
+    setSubtitleFps(null);
+
+    setLoading(true);
+    void Promise.all([readMpvVideoFps(), readMpvSubtitleFps()]).then(([video, subtitle]) => {
+      if (cancelled) return;
+      const resetByPlayer = autoSyncActive || hasSecondary || !isTextSubTrack(track);
+      const value = resetByPlayer ? null : subtitle.value;
+      setVideoFps(video);
+      setSubtitleFps(value);
+      setNativeSupported(subtitle.supported);
+      setDraft(formatSubtitleFps(value ?? video ?? 25, 6));
+      setCustomOpen(value != null && matchingSubtitleFpsPreset(value) == null);
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [autoSyncActive, hasSecondary, track?.id]);
+
+  const availability = subtitleFpsAvailability({
+    engine,
+    hasTrack: track != null,
+    textBased: isTextSubTrack(track),
+    hasSecondary,
+    videoFps,
+    nativeSupported,
+    autoSyncActive,
+  });
+  const disabled = loading || saving || !availability.enabled;
+  const selectedPreset = matchingSubtitleFpsPreset(subtitleFps);
+  const selectedValue = subtitleFps == null ? "default" : (selectedPreset ?? "custom");
+  const reason = availability.enabled ? null : unavailableMessage(availability.reason, tr);
+
+  const applySourceFps = async (choice: SubtitleFpsChoice) => {
+    if (!availability.enabled || !track) return;
+    const request = ++applyRequestRef.current;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMpvSubtitleFps(choice, getMpvSubtitleFpsGeneration(), track.id);
+      if (request !== applyRequestRef.current) return;
+      const value = choice === "default" ? null : choice;
+      setSubtitleFps(value);
+      setCustomOpen(value != null && matchingSubtitleFpsPreset(value) == null);
+      if (value != null) setDraft(formatSubtitleFps(value, 6));
+    } catch (cause) {
+      if (request !== applyRequestRef.current) return;
+      console.warn("[subtitles] could not set subtitle FPS", cause);
+      setError(tr("Couldn't apply subtitle FPS. Try again."));
+    } finally {
+      if (request === applyRequestRef.current) setSaving(false);
+    }
+  };
+
+  const selectOption = (value: string) => {
+    if (value === "default") {
+      void applySourceFps("default");
+      return;
+    }
+    if (value === "custom") {
+      setDraft(formatSubtitleFps(subtitleFps ?? videoFps ?? 25, 6));
+      setCustomOpen(true);
+      return;
+    }
+    const preset = SUBTITLE_FPS_PRESETS.find((item) => item.label === value);
+    if (preset) void applySourceFps(preset.value);
+  };
+
+  const commitCustom = () => {
+    const result = validateSubtitleFps(draft);
+    if (!result.ok) {
+      setError(tr("Enter an FPS from 1 to 240."));
+      return;
+    }
+    void applySourceFps(result.value);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 border-b border-edge-soft px-3 py-2.5">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label={tr("Back")}
+          className="flex h-7 w-7 items-center justify-center rounded-full text-ink-muted transition-colors hover:bg-raised hover:text-ink"
+        >
+          <ArrowLeft size={15} strokeWidth={2.2} className="rtl:-scale-x-100" />
+        </button>
+        <p className="text-[13px] font-semibold text-ink">{tr("Subtitle FPS")}</p>
+        {saving && <Loader2 size={14} className="ms-auto animate-spin text-ink-muted" />}
+      </div>
+
+      <div className="p-3">
+        <p className="text-[11px] font-bold uppercase text-ink-subtle">
+          {tr("Subtitle source FPS")}
+        </p>
+        <p className="mt-0.5 text-[11.5px] leading-snug text-ink-muted">
+          {tr("Choose the frame rate the subtitle was authored for.")}
+        </p>
+
+        <select
+          value={customOpen ? "custom" : selectedValue}
+          disabled={disabled}
+          onChange={(event) => selectOption(event.currentTarget.value)}
+          aria-label={tr("Subtitle source FPS")}
+          className="mt-2 h-9 w-full rounded-md border border-edge-soft bg-canvas px-2 text-[12px] font-semibold text-ink outline-none transition-colors hover:bg-raised focus:border-accent disabled:cursor-not-allowed disabled:opacity-45"
+        >
+          <option value="default">{tr("No correction (default)")}</option>
+          {SUBTITLE_FPS_PRESETS.map((preset) => (
+            <option key={preset.label} value={preset.label}>
+              {preset.label}
+            </option>
+          ))}
+          <option value="custom">{tr("Custom...")}</option>
+        </select>
+
+        {customOpen && !loading && (
+          <form
+            className="mt-2 flex items-center gap-1.5"
+            onSubmit={(event) => {
+              event.preventDefault();
+              commitCustom();
+            }}
+          >
+            <input
+              type="number"
+              value={draft}
+              disabled={!availability.enabled || saving}
+              inputMode="decimal"
+              min="1"
+              max="240"
+              step="any"
+              onChange={(event) => setDraft(event.currentTarget.value)}
+              aria-label={tr("Custom subtitle FPS")}
+              className="h-8 min-w-0 flex-1 rounded-md border border-edge-soft bg-canvas px-2 text-end font-mono text-[12px] tabular-nums text-ink outline-none transition-colors focus:border-accent disabled:cursor-not-allowed disabled:opacity-45"
+            />
+            <button
+              type="submit"
+              disabled={!availability.enabled || saving}
+              aria-label={tr("Apply custom subtitle FPS")}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent text-canvas transition-[filter] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-45"
+            >
+              <Check size={15} strokeWidth={2.5} />
+            </button>
+          </form>
+        )}
+
+        <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11.5px]">
+          <dt className="text-ink-muted">{tr("Video FPS")}</dt>
+          <dd className="text-end font-mono font-semibold tabular-nums text-ink">
+            {videoFps == null ? "-" : formatSubtitleFps(videoFps, 6)}
+          </dd>
+          <dt className="text-ink-muted">{tr("Subtitle source FPS")}</dt>
+          <dd className="text-end font-mono font-semibold tabular-nums text-ink">
+            {loading
+              ? "-"
+              : subtitleFps == null
+                ? tr("No correction")
+                : formatSubtitleFps(subtitleFps, 6)}
+          </dd>
+        </dl>
+      </div>
+
+      {(reason || error) && !loading && (
+        <p
+          className="mx-3 mb-3 rounded-md border border-edge-soft bg-raised/50 px-2 py-1.5 text-[11.5px] leading-snug text-ink-muted"
+          role={error ? "alert" : undefined}
+        >
+          {error ?? reason}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function unavailableMessage(
+  reason: SubtitleFpsUnavailableReason,
+  tr: (key: string) => string,
+): string {
+  switch (reason) {
+    case "no-track":
+      return tr("Select a subtitle track first.");
+    case "html5":
+      return tr("Subtitle FPS is only available with the libmpv player.");
+    case "not-text-based":
+      return tr("Subtitle FPS conversion is only available for text-based subtitles.");
+    case "secondary-active":
+      return tr("Subtitle FPS is unavailable while a secondary subtitle is active.");
+    case "video-fps-unavailable":
+      return tr("Video FPS is unavailable.");
+    case "native-unavailable":
+      return tr("Subtitle FPS is unavailable in this libmpv runtime.");
+    case "auto-sync-active":
+      return tr("Turn off Auto Sync before changing subtitle FPS.");
+  }
+}

--- a/src/components/player/subtitle-menu/types.ts
+++ b/src/components/player/subtitle-menu/types.ts
@@ -2,6 +2,7 @@ import type { TrackInfo } from "@/lib/player/bridge";
 import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 
 export type SubtitleMenuProps = {
+  engine?: "html5" | "mpv";
   tracks: TrackInfo[];
   selectedId: string | null;
   delaySec: number;

--- a/src/components/player/transport/control-renderer-stremio.tsx
+++ b/src/components/player/transport/control-renderer-stremio.tsx
@@ -16,7 +16,13 @@ import { hdrFormatLabel, realQualityLabel } from "@/lib/player/resolution-label"
 import type { PlayerCapabilities, PlayerSnapshot } from "@/lib/player/bridge";
 import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 import type { Meta } from "@/lib/cinemeta";
-import { getCustomIcon, type CustomIconMap, type PlayerControlId, type TimeFormat, type VolumeStyle } from "@/lib/player-chrome";
+import {
+  getCustomIcon,
+  type CustomIconMap,
+  type PlayerControlId,
+  type TimeFormat,
+  type VolumeStyle,
+} from "@/lib/player-chrome";
 import type { DownloadStatus } from "@/views/player/hooks/use-video-download";
 import { useT } from "@/lib/i18n";
 import { SubtitleMenu } from "../subtitle-menu";
@@ -44,8 +50,10 @@ import { FullscreenClock } from "@/components/player/fullscreen-clock";
 
 function qualityInfoOn(): boolean {
   try {
-    return (JSON.parse(localStorage.getItem("harbor.settings") ?? "{}") as { showQualityInfo?: boolean })
-      .showQualityInfo === true;
+    return (
+      (JSON.parse(localStorage.getItem("harbor.settings") ?? "{}") as { showQualityInfo?: boolean })
+        .showQualityInfo === true
+    );
   } catch {
     return false;
   }
@@ -191,7 +199,9 @@ export function RenderedStremioControl({
               <span className="flex min-w-0 items-center gap-2 truncate">
                 <h1 className="truncate text-[19px] font-medium leading-tight">{ctx.title}</h1>
                 {ctx.subtitle && (
-                  <span className="shrink-0 text-[13px] font-normal text-white/55">{ctx.subtitle}</span>
+                  <span className="shrink-0 text-[13px] font-normal text-white/55">
+                    {ctx.subtitle}
+                  </span>
                 )}
                 {!showQuality && res && (
                   <span className="shrink-0 rounded-md bg-white/15 px-1.5 py-0.5 text-[10.5px] font-bold uppercase tracking-wide text-white/80">
@@ -205,10 +215,16 @@ export function RenderedStremioControl({
                 )}
               </span>
               {showQuality && (
-                <span className="truncate text-[12px] font-normal tabular-nums text-white/55">{ctx.quality}</span>
+                <span className="truncate text-[12px] font-normal tabular-nums text-white/55">
+                  {ctx.quality}
+                </span>
               )}
             </span>
-            <Info size={13} strokeWidth={2.1} className="shrink-0 opacity-40 transition-opacity group-hover:opacity-90" />
+            <Info
+              size={13}
+              strokeWidth={2.1}
+              className="shrink-0 opacity-40 transition-opacity group-hover:opacity-90"
+            />
           </button>
         );
       }
@@ -264,7 +280,11 @@ export function RenderedStremioControl({
       if (!ctx.showEpisodeNav) return null;
       return (
         <Tooltip label={tr("Previous episode")}>
-          <StremioBtn onClick={ctx.onPrevEp} ariaLabel={tr("Previous episode")} disabled={!ctx.hasPrevEp}>
+          <StremioBtn
+            onClick={ctx.onPrevEp}
+            ariaLabel={tr("Previous episode")}
+            disabled={!ctx.hasPrevEp}
+          >
             <SkipBack size={26} strokeWidth={2} fill="currentColor" />
           </StremioBtn>
         </Tooltip>
@@ -273,7 +293,11 @@ export function RenderedStremioControl({
       if (!ctx.showEpisodeNav) return null;
       return (
         <Tooltip label={tr("Next episode")}>
-          <StremioBtn onClick={ctx.onNextEp} ariaLabel={tr("Next episode")} disabled={!ctx.hasNextEp}>
+          <StremioBtn
+            onClick={ctx.onNextEp}
+            ariaLabel={tr("Next episode")}
+            disabled={!ctx.hasNextEp}
+          >
             <SkipForward size={26} strokeWidth={2} fill="currentColor" />
           </StremioBtn>
         </Tooltip>
@@ -313,7 +337,11 @@ export function RenderedStremioControl({
             onClick={ctx.onPickAnother}
             ariaLabel={ctx.isLiveChannel ? tr("TV Guide") : tr("Switch stream")}
           >
-            {ctx.isLiveChannel ? <Tv size={26} strokeWidth={1.9} /> : <Replace size={26} strokeWidth={1.9} />}
+            {ctx.isLiveChannel ? (
+              <Tv size={26} strokeWidth={1.9} />
+            ) : (
+              <Replace size={26} strokeWidth={1.9} />
+            )}
           </StremioBtn>
         </Tooltip>
       );
@@ -322,7 +350,14 @@ export function RenderedStremioControl({
       return <DvrButton channelName={ctx.meta?.name ?? tr("Live")} onClick={ctx.onOpenDvr} />;
     case "download":
       if (ctx.isLiveChannel) return null;
-      if (!ctx.download || !ctx.onDownloadStart || !ctx.onDownloadCancel || !ctx.onDownloadReveal || !ctx.onDownloadReset) return null;
+      if (
+        !ctx.download ||
+        !ctx.onDownloadStart ||
+        !ctx.onDownloadCancel ||
+        !ctx.onDownloadReveal ||
+        !ctx.onDownloadReset
+      )
+        return null;
       return (
         <DownloadButton
           status={ctx.download}
@@ -450,7 +485,11 @@ export function RenderedStremioControl({
       return (
         <Tooltip label={ctx.fullscreen ? tr("Exit fullscreen") : tr("Fullscreen")} side="bottom">
           <StremioBtn onClick={ctx.onFullscreen} ariaLabel={tr("Fullscreen")}>
-            {ctx.fullscreen ? <Minimize size={28} strokeWidth={2} /> : <Maximize size={28} strokeWidth={2} />}
+            {ctx.fullscreen ? (
+              <Minimize size={28} strokeWidth={2} />
+            ) : (
+              <Maximize size={28} strokeWidth={2} />
+            )}
           </StremioBtn>
         </Tooltip>
       );

--- a/src/components/player/transport/control-renderer-stremio.tsx
+++ b/src/components/player/transport/control-renderer-stremio.tsx
@@ -420,6 +420,7 @@ export function RenderedStremioControl({
       if (ctx.isLiveChannel && ctx.snap.subtitleTracks.length === 0) return null;
       return (
         <SubtitleMenu
+          engine={ctx.engine}
           tracks={ctx.snap.subtitleTracks}
           selectedId={ctx.snap.subtitleTracks.find((t) => t.selected)?.id ?? null}
           delaySec={ctx.snap.subDelaySec}

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -470,6 +470,7 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
       if (ctx.isLiveChannel && ctx.snap.subtitleTracks.length === 0) return null;
       return (
         <SubtitleMenu
+          engine={ctx.engine}
           tracks={ctx.snap.subtitleTracks}
           selectedId={ctx.snap.subtitleTracks.find((t) => t.selected)?.id ?? null}
           delaySec={ctx.snap.subDelaySec}

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -1,12 +1,31 @@
 import { togglePictureBar } from "@/lib/player/picture-bar";
 import { t as translate } from "@/lib/i18n";
 import { StremioVolume } from "./stremio-volume";
-import { Camera, ChevronLeft, Info, Maximize, Minimize, PauseCircle, PictureInPicture2, PlayCircle, Replace, SlidersHorizontal, Tv } from "lucide-react";
+import {
+  Camera,
+  ChevronLeft,
+  Info,
+  Maximize,
+  Minimize,
+  PauseCircle,
+  PictureInPicture2,
+  PlayCircle,
+  Replace,
+  SlidersHorizontal,
+  Tv,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import type { PlayerCapabilities, PlayerSnapshot } from "@/lib/player/bridge";
 import type { SubtitleAddHandler } from "@/lib/player/subtitle-load";
 import type { Meta } from "@/lib/cinemeta";
-import { getCustomIcon, type ControlVariant, type CustomIconMap, type PlayerControlId, type TimeFormat, type VolumeStyle } from "@/lib/player-chrome";
+import {
+  getCustomIcon,
+  type ControlVariant,
+  type CustomIconMap,
+  type PlayerControlId,
+  type TimeFormat,
+  type VolumeStyle,
+} from "@/lib/player-chrome";
 import type { DownloadStatus } from "@/views/player/hooks/use-video-download";
 import { CustomIcon, renderCustomIconControl } from "./custom-icon-renderer";
 import { hdrFormatLabel, realQualityLabel } from "@/lib/player/resolution-label";
@@ -181,7 +200,11 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
               aria-label={t("Back")}
               className="pointer-events-auto flex h-full w-full items-center justify-center rounded-full bg-transparent text-white transition-colors hover:bg-white/[0.06]"
             >
-              {iconUrl ? <CustomIcon url={iconUrl} size={24} /> : <ChevronLeft size={26} strokeWidth={2.2} />}
+              {iconUrl ? (
+                <CustomIcon url={iconUrl} size={24} />
+              ) : (
+                <ChevronLeft size={26} strokeWidth={2.2} />
+              )}
             </button>
           </ThreeLiquidGlassSurface>
         </Tooltip>
@@ -243,7 +266,9 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
         );
       }
       return (
-        <div className="pointer-events-none flex flex-col items-start gap-0.5 text-start">{lines}</div>
+        <div className="pointer-events-none flex flex-col items-start gap-0.5 text-start">
+          {lines}
+        </div>
       );
     }
     case "local-time":
@@ -306,7 +331,13 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
     }
     case "download": {
       if (ctx.mid || ctx.isLiveChannel) return null;
-      if (!ctx.download || !ctx.onDownloadStart || !ctx.onDownloadCancel || !ctx.onDownloadReveal || !ctx.onDownloadReset) {
+      if (
+        !ctx.download ||
+        !ctx.onDownloadStart ||
+        !ctx.onDownloadCancel ||
+        !ctx.onDownloadReveal ||
+        !ctx.onDownloadReset
+      ) {
         return null;
       }
       return (
@@ -478,7 +509,8 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
       );
     }
     case "anime4k-menu": {
-      if (ctx.tight || ctx.engine === "html5" || !ctx.onAnime4kMode || !ctx.anime4kAvailable) return null;
+      if (ctx.tight || ctx.engine === "html5" || !ctx.onAnime4kMode || !ctx.anime4kAvailable)
+        return null;
       return (
         <Anime4kMenu
           mode={(ctx.anime4kMode as Anime4kChoice) ?? "auto"}
@@ -548,7 +580,11 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
     case "pip": {
       if (!ctx.capabilities.pictureInPicture) return null;
       return (
-        <BigButton onClick={ctx.onPiP} ariaLabel={t("Picture in Picture")} tooltip={t("Picture in Picture")}>
+        <BigButton
+          onClick={ctx.onPiP}
+          ariaLabel={t("Picture in Picture")}
+          tooltip={t("Picture in Picture")}
+        >
           <PictureInPicture2 size={22} strokeWidth={1.9} />
         </BigButton>
       );

--- a/src/lib/hdr-overlay.ts
+++ b/src/lib/hdr-overlay.ts
@@ -1,5 +1,32 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import type { SubtitleLoadMetadata } from "@/lib/subtitles/types";
+
+export const HDR_OVERLAY_WINDOW_LABEL = "harbor-hdr-overlay";
+export const HDR_STAGE_SET_SUBTITLE_TRACK = "hdr-stage://set-subtitle-track";
+export const HDR_STAGE_SET_SECONDARY_SUBTITLE_TRACK = "hdr-stage://set-secondary-subtitle-track";
+export const HDR_STAGE_ADD_SUBTITLE = "hdr-stage://add-subtitle";
+export const HDR_STAGE_ADD_SUBTITLE_RESULT = "hdr-stage://add-subtitle-result";
+
+export type HdrStageSubtitleTrackRequest = {
+  mediaKey: string;
+  id: string | null;
+};
+
+export type HdrStageAddSubtitleRequest = {
+  requestId: string;
+  mediaKey: string;
+  url: string;
+  lang?: string;
+  title?: string;
+  select?: boolean;
+  metadata?: SubtitleLoadMetadata;
+};
+
+export type HdrStageAddSubtitleResult = {
+  requestId: string;
+  ok: boolean;
+};
 
 export async function hdrOverlayOpen(): Promise<void> {
   await invoke("hdr_overlay_open").catch(() => {});

--- a/src/lib/i18n/locales/ar/player.ts
+++ b/src/lib/i18n/locales/ar/player.ts
@@ -433,6 +433,30 @@ const player: Record<string, string> = {
   "Next and Previous behavior": "سلوك زرّي التالي والسابق",
   "Next and Previous follow your queue": "التالي والسابق يتبعان قائمة انتظارك",
   "Next and Previous follow this show": "التالي والسابق يتبعان هذا المسلسل",
+  "Subtitle FPS": "معدل إطارات الترجمة",
+  "Subtitle source FPS": "معدل إطارات مصدر الترجمة",
+  "Choose the frame rate the subtitle was authored for.":
+    "اختر معدل الإطارات الذي أُنشئت الترجمة على أساسه.",
+  "No correction (default)": "بلا تصحيح (الافتراضي)",
+  "Custom...": "مخصص...",
+  "Custom subtitle FPS": "معدل إطارات مخصص للترجمة",
+  "Apply custom subtitle FPS": "تطبيق معدل الإطارات المخصص للترجمة",
+  "Video FPS": "معدل إطارات الفيديو",
+  "No correction": "بلا تصحيح",
+  "Couldn't apply subtitle FPS. Try again.": "تعذّر تطبيق معدل إطارات الترجمة. حاول مرة أخرى.",
+  "Enter an FPS from 1 to 240.": "أدخل معدل إطارات من 1 إلى 240.",
+  "Select a subtitle track first.": "اختر مسار ترجمة أولًا.",
+  "Subtitle FPS is only available with the libmpv player.":
+    "لا يتوفر تعديل معدل إطارات الترجمة إلا مع مشغل libmpv.",
+  "Subtitle FPS conversion is only available for text-based subtitles.":
+    "لا يتوفر تحويل معدل الإطارات إلا للترجمات النصية.",
+  "Subtitle FPS is unavailable while a secondary subtitle is active.":
+    "لا يتوفر تعديل معدل إطارات الترجمة أثناء تفعيل ترجمة ثانوية.",
+  "Video FPS is unavailable.": "معدل إطارات الفيديو غير متوفر.",
+  "Subtitle FPS is unavailable in this libmpv runtime.":
+    "معدل إطارات الترجمة غير متوفر في إصدار libmpv الحالي.",
+  "Turn off Auto Sync before changing subtitle FPS.":
+    "أوقف المزامنة التلقائية قبل تغيير معدل إطارات الترجمة.",
 };
 
 export default player;

--- a/src/lib/i18n/locales/pt/player.ts
+++ b/src/lib/i18n/locales/pt/player.ts
@@ -404,6 +404,31 @@ const player: Record<string, string> = {
   "Next and Previous behavior": "Comportamento de Próximo e Anterior",
   "Next and Previous follow your queue": "Próximo e Anterior seguem sua fila",
   "Next and Previous follow this show": "Próximo e Anterior seguem esta série",
+  "Subtitle FPS": "FPS da legenda",
+  "Subtitle source FPS": "FPS de origem da legenda",
+  "Choose the frame rate the subtitle was authored for.":
+    "Escolha a taxa de fotogramas para a qual a legenda foi criada.",
+  "No correction (default)": "Sem correção (predefinição)",
+  "Custom...": "Personalizado...",
+  "Custom subtitle FPS": "FPS personalizado da legenda",
+  "Apply custom subtitle FPS": "Aplicar FPS personalizado da legenda",
+  "Video FPS": "FPS do vídeo",
+  "No correction": "Sem correção",
+  "Couldn't apply subtitle FPS. Try again.":
+    "Não foi possível aplicar o FPS da legenda. Tente novamente.",
+  "Enter an FPS from 1 to 240.": "Introduza uma taxa de FPS entre 1 e 240.",
+  "Select a subtitle track first.": "Selecione primeiro uma faixa de legendas.",
+  "Subtitle FPS is only available with the libmpv player.":
+    "O FPS da legenda só está disponível com o leitor libmpv.",
+  "Subtitle FPS conversion is only available for text-based subtitles.":
+    "A conversão de FPS só está disponível para legendas de texto.",
+  "Subtitle FPS is unavailable while a secondary subtitle is active.":
+    "O FPS da legenda não está disponível enquanto houver uma legenda secundária ativa.",
+  "Video FPS is unavailable.": "O FPS do vídeo não está disponível.",
+  "Subtitle FPS is unavailable in this libmpv runtime.":
+    "O FPS da legenda não está disponível nesta versão do libmpv.",
+  "Turn off Auto Sync before changing subtitle FPS.":
+    "Desative a sincronização automática antes de alterar o FPS da legenda.",
 };
 
 export default player;

--- a/src/lib/i18n/locales/ru/player.ts
+++ b/src/lib/i18n/locales/ru/player.ts
@@ -402,6 +402,31 @@ const player: Record<string, string> = {
   "Next and Previous behavior": "Поведение кнопок «Следующее» и «Предыдущее»",
   "Next and Previous follow your queue": "«Следующее» и «Предыдущее» следуют вашей очереди",
   "Next and Previous follow this show": "«Следующее» и «Предыдущее» следуют этому шоу",
+  "Subtitle FPS": "Частота кадров субтитров",
+  "Subtitle source FPS": "Исходная частота кадров субтитров",
+  "Choose the frame rate the subtitle was authored for.":
+    "Выберите частоту кадров, для которой были созданы субтитры.",
+  "No correction (default)": "Без коррекции (по умолчанию)",
+  "Custom...": "Другая...",
+  "Custom subtitle FPS": "Другая частота кадров субтитров",
+  "Apply custom subtitle FPS": "Применить другую частоту кадров субтитров",
+  "Video FPS": "Частота кадров видео",
+  "No correction": "Без коррекции",
+  "Couldn't apply subtitle FPS. Try again.":
+    "Не удалось применить частоту кадров субтитров. Повторите попытку.",
+  "Enter an FPS from 1 to 240.": "Введите частоту кадров от 1 до 240.",
+  "Select a subtitle track first.": "Сначала выберите дорожку субтитров.",
+  "Subtitle FPS is only available with the libmpv player.":
+    "Настройка частоты кадров субтитров доступна только в проигрывателе libmpv.",
+  "Subtitle FPS conversion is only available for text-based subtitles.":
+    "Преобразование частоты кадров доступно только для текстовых субтитров.",
+  "Subtitle FPS is unavailable while a secondary subtitle is active.":
+    "Настройка частоты кадров недоступна, пока включены вторые субтитры.",
+  "Video FPS is unavailable.": "Частота кадров видео недоступна.",
+  "Subtitle FPS is unavailable in this libmpv runtime.":
+    "Настройка частоты кадров субтитров недоступна в этой версии libmpv.",
+  "Turn off Auto Sync before changing subtitle FPS.":
+    "Отключите автосинхронизацию перед изменением частоты кадров субтитров.",
 };
 
 export default player;

--- a/src/lib/player/mpv-forward.ts
+++ b/src/lib/player/mpv-forward.ts
@@ -1,14 +1,61 @@
 import { invoke } from "@tauri-apps/api/core";
-import { emptySnapshot, type PlayerBridge, type PlayerCapabilities, type PlayerSnapshot } from "./bridge";
+import { emitTo, listen, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  emptySnapshot,
+  type PlayerBridge,
+  type PlayerCapabilities,
+  type PlayerSnapshot,
+} from "./bridge";
 import { isWindowsDesktop } from "@/lib/platform";
-import { subtitleDownloadArgs } from "./subtitle-load";
+import {
+  HDR_STAGE_ADD_SUBTITLE,
+  HDR_STAGE_ADD_SUBTITLE_RESULT,
+  HDR_STAGE_SET_SECONDARY_SUBTITLE_TRACK,
+  HDR_STAGE_SET_SUBTITLE_TRACK,
+  type HdrStageAddSubtitleRequest,
+  type HdrStageAddSubtitleResult,
+  type HdrStageSubtitleTrackRequest,
+} from "@/lib/hdr-overlay";
+
+const FORWARDED_SUBTITLE_TIMEOUT_MS = 120_000;
+
+async function forwardSubtitleAdd(
+  request: Omit<HdrStageAddSubtitleRequest, "requestId">,
+): Promise<boolean> {
+  const requestId = crypto.randomUUID();
+  let unlisten: UnlistenFn | null = null;
+  let timeoutId: number | null = null;
+  let resolveResult: (ok: boolean) => void = () => {};
+  const result = new Promise<boolean>((resolve) => {
+    resolveResult = resolve;
+  });
+
+  try {
+    unlisten = await listen<HdrStageAddSubtitleResult>(
+      HDR_STAGE_ADD_SUBTITLE_RESULT,
+      ({ payload }) => {
+        if (payload.requestId === requestId) resolveResult(payload.ok === true);
+      },
+    );
+    timeoutId = window.setTimeout(() => resolveResult(false), FORWARDED_SUBTITLE_TIMEOUT_MS);
+    await emitTo("main", HDR_STAGE_ADD_SUBTITLE, { ...request, requestId });
+    return await result;
+  } catch (error) {
+    console.warn("[hdr-overlay] could not forward subtitle addition", error);
+    return false;
+  } finally {
+    if (timeoutId != null) window.clearTimeout(timeoutId);
+    unlisten?.();
+  }
+}
 
 export type ForwardingBridge = PlayerBridge & {
-  pushSnapshot: (snap: PlayerSnapshot) => void;
+  pushSnapshot: (snap: PlayerSnapshot, mediaKey: string) => void;
 };
 
 export function createForwardingMpvBridge(): ForwardingBridge {
   let snap: PlayerSnapshot = { ...emptySnapshot };
+  let mediaKey = "";
   const listeners = new Set<(s: PlayerSnapshot) => void>();
   const emit = () => {
     const next = { ...snap };
@@ -19,8 +66,9 @@ export function createForwardingMpvBridge(): ForwardingBridge {
   const cmd = (c: Array<string | number>) => invoke("mpv_command", { cmd: c }).catch(() => {});
 
   return {
-    pushSnapshot(next) {
+    pushSnapshot(next, nextMediaKey) {
       snap = next;
+      mediaKey = nextMediaKey;
       emit();
     },
     attach() {},
@@ -48,10 +96,16 @@ export function createForwardingMpvBridge(): ForwardingBridge {
       void set("aid", Number(id) || id);
     },
     setSubtitleTrack(id) {
-      void set("sid", id == null ? "no" : Number(id) || id);
+      const request: HdrStageSubtitleTrackRequest = { id, mediaKey };
+      void emitTo("main", HDR_STAGE_SET_SUBTITLE_TRACK, request).catch((error) =>
+        console.warn("[hdr-overlay] could not forward subtitle selection", error),
+      );
     },
     setSecondarySubtitleTrack(id) {
-      void set("secondary-sid", id == null ? "no" : Number(id) || id);
+      const request: HdrStageSubtitleTrackRequest = { id, mediaKey };
+      void emitTo("main", HDR_STAGE_SET_SECONDARY_SUBTITLE_TRACK, request).catch((error) =>
+        console.warn("[hdr-overlay] could not forward secondary subtitle selection", error),
+      );
     },
     setSubVisible(on) {
       void set("sub-visibility", on);
@@ -79,34 +133,31 @@ export function createForwardingMpvBridge(): ForwardingBridge {
     },
     setAnime4kShaders(shaders) {
       const sep = isWindowsDesktop() ? ";" : ":";
-      void set("glsl-shaders", shaders.filter(Boolean).map((s) => s.replace(/\\/g, "/")).join(sep));
+      void set(
+        "glsl-shaders",
+        shaders
+          .filter(Boolean)
+          .map((s) => s.replace(/\\/g, "/"))
+          .join(sep),
+      );
     },
     setShaderProps(props) {
       for (const [name, value] of Object.entries(props)) void set(name, value);
     },
     async addSubtitle(url, lang, title, select, metadata) {
-      try {
-        const resolvedUrl = /^https?:/i.test(url)
-          ? await invoke<string>("sub_download", subtitleDownloadArgs(url, { ...metadata, lang }))
-          : url;
-        await invoke("mpv_sub_add", {
-          url: resolvedUrl,
-          lang: lang ?? null,
-          title: title ?? null,
-          select: select ?? true,
-        });
-        return true;
-      } catch {
-        return false;
-      }
+      return forwardSubtitleAdd({ url, lang, title, select, metadata, mediaKey });
     },
     setAudioNormalize() {},
     setAudioProfile() {},
     setAudioDevice(name) {
       void set("audio-device", name && name !== "auto" ? name : "auto");
     },
-    getSelectedTrackCues() { return null; },
-    getSelectedTrackUrl() { return null; },
+    getSelectedTrackCues() {
+      return null;
+    },
+    getSelectedTrackUrl() {
+      return null;
+    },
     setMediaInfo() {},
     async screenshot(path) {
       try {

--- a/src/lib/player/mpv-properties.ts
+++ b/src/lib/player/mpv-properties.ts
@@ -1,19 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import {
   createSubtitleFpsCoordinator,
   validateSubtitleFps,
   type SubtitleFpsChoice,
 } from "./subtitle-fps";
-import { isTextSubTrack } from "./sub-format";
 
 const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 let subtitleFpsGeneration = 0;
-let activeTrackId: string | null = null;
-let pendingRequest: { trackId: string } | null = null;
-let lifecycleListener: Promise<boolean> | null = null;
-
-type MpvEvent = { event: string; name?: string; data?: unknown };
 
 async function readMpvNumber(name: string): Promise<number | null> {
   if (!isTauri) return null;
@@ -56,11 +49,14 @@ export async function readMpvSubtitleFps(): Promise<{
   if ((await readMpvBoolean("idle-active")) !== false) {
     return { supported: false, value: null };
   }
-  if (!(await ensureSubtitleFpsLifecycleListener())) {
+  await waitForMpvSubtitleFpsTransitions();
+  if ((await readMpvBoolean("idle-active")) !== false) {
     return { supported: false, value: null };
   }
-  await waitForMpvSubtitleFpsTransitions();
   const raw = await readMpvNumber("sub-fps");
+  if ((await readMpvBoolean("idle-active")) !== false) {
+    return { supported: false, value: null };
+  }
   if (raw == null) return { supported: false, value: null };
   if (raw === 0) return { supported: true, value: null };
   const result = validateSubtitleFps(raw);
@@ -82,95 +78,23 @@ async function waitForMpvSubtitleFpsTransitions(): Promise<void> {
   }
 }
 
-function ensureSubtitleFpsLifecycleListener(): Promise<boolean> {
-  if (!isTauri) return Promise.resolve(false);
-  if (lifecycleListener) return lifecycleListener;
-  lifecycleListener = listen<MpvEvent>("mpv://event", ({ payload }) => {
-    if (payload.event === "shutdown") {
-      invalidateMpvSubtitleFpsContext();
-      activeTrackId = null;
-      pendingRequest = null;
-      coordinator.markSessionRecreated();
-      return;
-    }
-    if (payload.event === "file-loaded" || payload.event === "end-file") {
-      invalidateMpvSubtitleFpsContext();
-      pendingRequest = null;
-      if (coordinator.isActive()) {
-        void resetMpvSubtitleFpsForTransition((error) =>
-          console.warn("[subtitles] FPS reset at media boundary failed", error),
-        ).catch(() => {});
-      }
-      return;
-    }
-    if (payload.event !== "property-change" || payload.name !== "track-list") return;
-    const tracks = Array.isArray(payload.data)
-      ? (payload.data as Array<Record<string, unknown>>)
-      : [];
-    const selected = tracks.filter((track) => track.type === "sub" && track.selected === true);
-    const current = selected.find((track) => Number(track["main-selection"]) !== 1) ?? selected[0];
-    const contextTrackId = pendingRequest?.trackId ?? activeTrackId;
-    const stillEligible =
-      contextTrackId != null &&
-      selected.length === 1 &&
-      String(current?.id ?? "") === contextTrackId &&
-      isTextSubTrack({
-        id: String(current?.id ?? ""),
-        label: "",
-        kind: "subtitle",
-        selected: true,
-        codec: String(current?.["codec-desc"] ?? current?.codec ?? ""),
-        title: typeof current?.title === "string" ? current.title : undefined,
-        externalFilename:
-          typeof current?.["external-filename"] === "string"
-            ? current["external-filename"]
-            : undefined,
-      });
-    if ((contextTrackId != null || coordinator.isActive()) && !stillEligible) {
-      invalidateMpvSubtitleFpsContext();
-      pendingRequest = null;
-      void resetMpvSubtitleFpsForTransition((error) =>
-        console.warn("[subtitles] FPS reset at track boundary failed", error),
-      ).catch(() => {});
-    }
-  })
-    .then(() => true)
-    .catch((error) => {
-      lifecycleListener = null;
-      console.warn("[subtitles] could not observe mpv subtitle FPS boundaries", error);
-      return false;
-    });
-  return lifecycleListener;
-}
-
 export async function writeMpvSubtitleFps(
   choice: SubtitleFpsChoice,
   generation: number,
-  trackId: string,
 ): Promise<void> {
-  if (!(await ensureSubtitleFpsLifecycleListener())) {
-    throw new Error("mpv subtitle FPS lifecycle is unavailable.");
-  }
-  const request = { trackId };
-  pendingRequest = request;
-  try {
-    await coordinator.apply(
-      choice,
-      () => generation === subtitleFpsGeneration && pendingRequest === request,
-    );
-    activeTrackId = choice === "default" ? null : trackId;
-  } finally {
-    if (pendingRequest === request) pendingRequest = null;
-  }
+  await coordinator.apply(choice, () => generation === subtitleFpsGeneration);
 }
 
 export async function resetMpvSubtitleFpsForTransition(
   onResetError?: (error: unknown) => void,
 ): Promise<void> {
   invalidateMpvSubtitleFpsContext();
-  pendingRequest = null;
   await coordinator.resetForTransition(onResetError);
-  activeTrackId = null;
+}
+
+export function markMpvSubtitleFpsSessionRecreated(): void {
+  invalidateMpvSubtitleFpsContext();
+  coordinator.markSessionRecreated();
 }
 
 export function invalidateMpvSubtitleFpsContext(): number {

--- a/src/lib/player/mpv-properties.ts
+++ b/src/lib/player/mpv-properties.ts
@@ -1,0 +1,183 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import {
+  createSubtitleFpsCoordinator,
+  validateSubtitleFps,
+  type SubtitleFpsChoice,
+} from "./subtitle-fps";
+import { isTextSubTrack } from "./sub-format";
+
+const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+let subtitleFpsGeneration = 0;
+let activeTrackId: string | null = null;
+let pendingRequest: { trackId: string } | null = null;
+let lifecycleListener: Promise<boolean> | null = null;
+
+type MpvEvent = { event: string; name?: string; data?: unknown };
+
+async function readMpvNumber(name: string): Promise<number | null> {
+  if (!isTauri) return null;
+  try {
+    const value = await invoke<number | string>("mpv_get_property", { name });
+    if (value == null || value === "") return null;
+    const parsed = typeof value === "number" ? value : Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readMpvBoolean(name: string): Promise<boolean | null> {
+  if (!isTauri) return null;
+  try {
+    const value = await invoke<boolean | number | string>("mpv_get_property", { name });
+    if (typeof value === "boolean") return value;
+    if (typeof value === "number") return value !== 0;
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "yes" || normalized === "true" || normalized === "1") return true;
+    if (normalized === "no" || normalized === "false" || normalized === "0") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readMpvVideoFps(): Promise<number | null> {
+  const estimated = await readMpvNumber("estimated-vf-fps");
+  if (estimated != null && estimated > 0) return estimated;
+  const container = await readMpvNumber("container-fps");
+  return container != null && container > 0 ? container : null;
+}
+
+export async function readMpvSubtitleFps(): Promise<{
+  supported: boolean;
+  value: number | null;
+}> {
+  if ((await readMpvBoolean("idle-active")) !== false) {
+    return { supported: false, value: null };
+  }
+  if (!(await ensureSubtitleFpsLifecycleListener())) {
+    return { supported: false, value: null };
+  }
+  await waitForMpvSubtitleFpsTransitions();
+  const raw = await readMpvNumber("sub-fps");
+  if (raw == null) return { supported: false, value: null };
+  if (raw === 0) return { supported: true, value: null };
+  const result = validateSubtitleFps(raw);
+  return result.ok ? { supported: true, value: result.value } : { supported: false, value: null };
+}
+
+async function writeMpvSubtitleFpsValue(value: number): Promise<void> {
+  if (!isTauri) throw new Error("mpv is unavailable outside the desktop player.");
+  await invoke("mpv_set_property", { name: "sub-fps", value });
+}
+
+const coordinator = createSubtitleFpsCoordinator({ writeFps: writeMpvSubtitleFpsValue });
+
+async function waitForMpvSubtitleFpsTransitions(): Promise<void> {
+  while (true) {
+    const generation = subtitleFpsGeneration;
+    await coordinator.whenSettled();
+    if (generation === subtitleFpsGeneration) return;
+  }
+}
+
+function ensureSubtitleFpsLifecycleListener(): Promise<boolean> {
+  if (!isTauri) return Promise.resolve(false);
+  if (lifecycleListener) return lifecycleListener;
+  lifecycleListener = listen<MpvEvent>("mpv://event", ({ payload }) => {
+    if (payload.event === "shutdown") {
+      invalidateMpvSubtitleFpsContext();
+      activeTrackId = null;
+      pendingRequest = null;
+      coordinator.markSessionRecreated();
+      return;
+    }
+    if (payload.event === "file-loaded" || payload.event === "end-file") {
+      invalidateMpvSubtitleFpsContext();
+      pendingRequest = null;
+      if (coordinator.isActive()) {
+        void resetMpvSubtitleFpsForTransition((error) =>
+          console.warn("[subtitles] FPS reset at media boundary failed", error),
+        ).catch(() => {});
+      }
+      return;
+    }
+    if (payload.event !== "property-change" || payload.name !== "track-list") return;
+    const tracks = Array.isArray(payload.data)
+      ? (payload.data as Array<Record<string, unknown>>)
+      : [];
+    const selected = tracks.filter((track) => track.type === "sub" && track.selected === true);
+    const current = selected.find((track) => Number(track["main-selection"]) !== 1) ?? selected[0];
+    const contextTrackId = pendingRequest?.trackId ?? activeTrackId;
+    const stillEligible =
+      contextTrackId != null &&
+      selected.length === 1 &&
+      String(current?.id ?? "") === contextTrackId &&
+      isTextSubTrack({
+        id: String(current?.id ?? ""),
+        label: "",
+        kind: "subtitle",
+        selected: true,
+        codec: String(current?.["codec-desc"] ?? current?.codec ?? ""),
+        title: typeof current?.title === "string" ? current.title : undefined,
+        externalFilename:
+          typeof current?.["external-filename"] === "string"
+            ? current["external-filename"]
+            : undefined,
+      });
+    if ((contextTrackId != null || coordinator.isActive()) && !stillEligible) {
+      invalidateMpvSubtitleFpsContext();
+      pendingRequest = null;
+      void resetMpvSubtitleFpsForTransition((error) =>
+        console.warn("[subtitles] FPS reset at track boundary failed", error),
+      ).catch(() => {});
+    }
+  })
+    .then(() => true)
+    .catch((error) => {
+      lifecycleListener = null;
+      console.warn("[subtitles] could not observe mpv subtitle FPS boundaries", error);
+      return false;
+    });
+  return lifecycleListener;
+}
+
+export async function writeMpvSubtitleFps(
+  choice: SubtitleFpsChoice,
+  generation: number,
+  trackId: string,
+): Promise<void> {
+  if (!(await ensureSubtitleFpsLifecycleListener())) {
+    throw new Error("mpv subtitle FPS lifecycle is unavailable.");
+  }
+  const request = { trackId };
+  pendingRequest = request;
+  try {
+    await coordinator.apply(
+      choice,
+      () => generation === subtitleFpsGeneration && pendingRequest === request,
+    );
+    activeTrackId = choice === "default" ? null : trackId;
+  } finally {
+    if (pendingRequest === request) pendingRequest = null;
+  }
+}
+
+export async function resetMpvSubtitleFpsForTransition(
+  onResetError?: (error: unknown) => void,
+): Promise<void> {
+  invalidateMpvSubtitleFpsContext();
+  pendingRequest = null;
+  await coordinator.resetForTransition(onResetError);
+  activeTrackId = null;
+}
+
+export function invalidateMpvSubtitleFpsContext(): number {
+  subtitleFpsGeneration += 1;
+  return subtitleFpsGeneration;
+}
+
+export function getMpvSubtitleFpsGeneration(): number {
+  return subtitleFpsGeneration;
+}

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -6,6 +6,10 @@ import { isLinuxDesktop, isMacDesktop, isWindowsDesktop } from "@/lib/platform";
 import { makeSafeTauriUnlisten } from "@/lib/tauri-unlisten";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
+  markMpvSubtitleFpsSessionRecreated,
+  resetMpvSubtitleFpsForTransition,
+} from "./mpv-properties";
+import {
   emptySnapshot,
   type PlayerBridge,
   type PlayerCapabilities,
@@ -88,6 +92,10 @@ const AUDIO_PROFILE_AF: Record<string, string> = {
 
 const DEFAULT_UA = "VLC/3.0.20 LibVLC/3.0.20";
 
+async function resetSubtitleFpsBeforeMpvTransition(): Promise<void> {
+  await resetMpvSubtitleFpsForTransition();
+}
+
 let appliedAudioDevice: string | null = null;
 
 async function applyAudioDevice(want: string): Promise<void> {
@@ -122,7 +130,9 @@ async function applyHeaderProps(headers?: Record<string, string>): Promise<void>
     else fields.push(`${k}: ${v}`);
   }
   await invoke("mpv_set_property", { name: "user-agent", value: ua }).catch(() => {});
-  await invoke("mpv_set_property", { name: "http-header-fields", value: fields.join(",") }).catch(() => {});
+  await invoke("mpv_set_property", { name: "http-header-fields", value: fields.join(",") }).catch(
+    () => {},
+  );
 }
 
 export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
@@ -147,6 +157,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
   let geomResizeObserver: ResizeObserver | null = null;
   let geomTauriUnlisten: Array<() => void> = [];
   let mpvStarted = false;
+  let mediaRevision = 0;
   let suppressEndFileUntil = 0;
   let svpFilterFailed = false;
   let secondarySid: string | null = null;
@@ -186,6 +197,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
     if (raw.event === "player-failure") {
       const reason = String((raw as { reason?: unknown }).reason ?? "");
       snap = mpvFailureSnapshot(snap, reason);
+      mediaRevision += 1;
       mpvStarted = false;
       invoke("mpv_stop").catch(() => {});
       emit();
@@ -210,11 +222,13 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
           const id = String(t.id ?? "");
           const lang = (t.lang ?? t.language) as string | undefined;
           const title = t.title as string | undefined;
-          const codecDesc = (t["codec-desc"] as string | undefined) || (t.codec as string | undefined);
+          const codecDesc =
+            (t["codec-desc"] as string | undefined) || (t.codec as string | undefined);
           const channels = t["demux-channels"] as string | undefined;
-          const channelCount = typeof t["demux-channel-count"] === "number"
-            ? (t["demux-channel-count"] as number)
-            : undefined;
+          const channelCount =
+            typeof t["demux-channel-count"] === "number"
+              ? (t["demux-channel-count"] as number)
+              : undefined;
           const external = t.external === true;
           const externalFilename = t["external-filename"] as string | undefined;
           const forced = t.forced === true;
@@ -341,6 +355,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       host = null;
     },
     async load(src: PlayerSource) {
+      mediaRevision += 1;
       svpFilterFailed = false;
       snap.status = "loading";
       snap.errorCode = null;
@@ -359,6 +374,16 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       pendingTracks = {};
       urlByExternalFilename.clear();
       emit();
+      try {
+        await resetSubtitleFpsBeforeMpvTransition();
+      } catch (error) {
+        console.warn(
+          "[mpv] could not reset subtitle FPS before loading media; recreating the mpv session",
+          error,
+        );
+        markMpvSubtitleFpsSessionRecreated();
+        mpvStarted = false;
+      }
       if (!unlistenEvent) {
         unlistenEvent = makeSafeTauriUnlisten(
           await listen<MpvEvent>("mpv://event", (ev) => handleEvent(ev.payload)),
@@ -376,7 +401,13 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
             await applyHeaderProps(src.headers);
             const startAt =
               typeof src.startAtSec === "number" && src.startAtSec > 0 ? src.startAtSec : 0;
-            const cmd: Array<string | number> = ["loadfile", src.url, "replace", 0, `start=${startAt}`];
+            const cmd: Array<string | number> = [
+              "loadfile",
+              src.url,
+              "replace",
+              0,
+              `start=${startAt}`,
+            ];
             await invoke("mpv_command", { cmd });
             for (const s of src.subtitles ?? []) {
               try {
@@ -429,7 +460,9 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
         });
         mpvStarted = true;
         if (opts.embed) {
-          await invoke("mpv_set_property", { name: "sub-visibility", value: false }).catch(() => {});
+          await invoke("mpv_set_property", { name: "sub-visibility", value: false }).catch(
+            () => {},
+          );
         }
         if (opts.embed && opts.getEmbedRect && geomKickHandler == null && !isLinuxDesktop()) {
           let lastRect: MpvRect | null = null;
@@ -524,26 +557,43 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       invoke("mpv_set_property", { name: "aid", value: Number(id) || id }).catch(() => {});
     },
     setSubtitleTrack(id) {
-      if (id == null) {
-        invoke("mpv_set_property", { name: "sid", value: "no" }).catch(() => {});
-        snap.subText = "";
-        snap.subStartSec = 0;
-        emit();
-      } else {
-        invoke("mpv_set_property", { name: "sid", value: Number(id) || id }).catch(() => {});
-        snap.subText = "";
-        snap.subStartSec = 0;
-        emit();
-      }
+      const requestMediaRevision = mediaRevision;
+      snap.subText = "";
+      snap.subStartSec = 0;
+      emit();
+      void (async () => {
+        try {
+          await resetSubtitleFpsBeforeMpvTransition();
+          if (requestMediaRevision !== mediaRevision) return;
+          await invoke("mpv_set_property", {
+            name: "sid",
+            value: id == null ? "no" : Number(id) || id,
+          });
+        } catch (error) {
+          console.warn("[mpv] could not select a subtitle after resetting subtitle FPS", error);
+        }
+      })();
     },
     setSecondarySubtitleTrack(id) {
-      secondarySid = id;
+      const requestMediaRevision = mediaRevision;
       snap.secondarySubText = "";
       emit();
-      invoke("mpv_set_property", {
-        name: "secondary-sid",
-        value: id == null ? "no" : Number(id) || id,
-      }).catch(() => {});
+      void (async () => {
+        try {
+          await resetSubtitleFpsBeforeMpvTransition();
+          if (requestMediaRevision !== mediaRevision) return;
+          secondarySid = id;
+          await invoke("mpv_set_property", {
+            name: "secondary-sid",
+            value: id == null ? "no" : Number(id) || id,
+          });
+        } catch (error) {
+          console.warn(
+            "[mpv] could not select a secondary subtitle after resetting subtitle FPS",
+            error,
+          );
+        }
+      })();
     },
     setSubVisible(on) {
       invoke("mpv_set_property", { name: "sub-visibility", value: on }).catch(() => {});
@@ -572,7 +622,10 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
     },
     setAnime4kShaders(shaders) {
       const sep = isWindowsDesktop() ? ";" : ":";
-      const value = shaders.filter(Boolean).map((s) => s.replace(/\\/g, "/")).join(sep);
+      const value = shaders
+        .filter(Boolean)
+        .map((s) => s.replace(/\\/g, "/"))
+        .join(sep);
       invoke("mpv_set_property", { name: "glsl-shaders", value }).catch((e) =>
         console.warn("[shaders] glsl-shaders apply failed", e),
       );
@@ -585,6 +638,7 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       }
     },
     async addSubtitle(url, lang, title, select, metadata): Promise<boolean> {
+      const requestMediaRevision = mediaRevision;
       let mpvUrl = url;
       if (/^https?:/i.test(url)) {
         try {
@@ -601,15 +655,20 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
           }
         }
       }
+      if (requestMediaRevision !== mediaRevision) return false;
       mpvUrl = mpvUrl.replace(/\\/g, "/");
-      urlByExternalFilename.set(mpvUrl, {
-        url,
-        release: metadata?.release,
-        provider: metadata?.provider,
-        matchScore: metadata?.matchScore,
-        subId: metadata?.subId,
-      });
       try {
+        if (select ?? true) {
+          await resetSubtitleFpsBeforeMpvTransition();
+        }
+        if (requestMediaRevision !== mediaRevision) return false;
+        urlByExternalFilename.set(mpvUrl, {
+          url,
+          release: metadata?.release,
+          provider: metadata?.provider,
+          matchScore: metadata?.matchScore,
+          subId: metadata?.subId,
+        });
         await invoke("mpv_sub_add", {
           url: mpvUrl,
           lang: lang ?? null,
@@ -689,8 +748,12 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       }
     },
     setAbLoop(a, b) {
-      invoke("mpv_set_property", { name: "ab-loop-a", value: a == null ? "no" : a }).catch(() => {});
-      invoke("mpv_set_property", { name: "ab-loop-b", value: b == null ? "no" : b }).catch(() => {});
+      invoke("mpv_set_property", { name: "ab-loop-a", value: a == null ? "no" : a }).catch(
+        () => {},
+      );
+      invoke("mpv_set_property", { name: "ab-loop-b", value: b == null ? "no" : b }).catch(
+        () => {},
+      );
     },
     async requestPiP() {},
     async exitPiP() {},
@@ -718,6 +781,8 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       };
     },
     destroy() {
+      mediaRevision += 1;
+      markMpvSubtitleFpsSessionRecreated();
       if (geomTimer != null) {
         window.clearInterval(geomTimer);
         geomTimer = null;

--- a/src/lib/player/sub-format.ts
+++ b/src/lib/player/sub-format.ts
@@ -23,8 +23,34 @@ export function isImageSubTrack(track: TrackInfo | null | undefined): boolean {
     codec.includes("HDMV") ||
     codec.includes("DVD_SUB") ||
     codec.includes("DVD SUBTITLES") ||
+    codec.includes("DVD SUBTITLE") ||
     codec.includes("DVB") ||
     codec.includes("VOBSUB") ||
     codec.includes("XSUB")
   );
+}
+
+export function isTextSubTrack(track: TrackInfo | null | undefined): boolean {
+  if (!track) return false;
+  if (isImageSubTrack(track)) return false;
+  const codec = (track.codec ?? "").toUpperCase();
+  if (
+    codec.includes("SUBRIP") ||
+    /\bSRT\b/.test(codec) ||
+    codec.includes("WEBVTT") ||
+    /\bVTT\b/.test(codec) ||
+    /\bASS\b/.test(codec) ||
+    /\bSSA\b/.test(codec) ||
+    codec.includes("SUBSTATION") ||
+    codec.includes("SUB STATION") ||
+    /\bMOV[ _-]?TEXT\b/.test(codec) ||
+    /\bTEXT(?: SUBTITLE)?\b/.test(codec)
+  ) {
+    return true;
+  }
+
+  const source = [track.externalFilename, track.url, track.title]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+  return /\.(?:srt|vtt|ass|ssa)(?:$|[?#\s])/i.test(source);
 }

--- a/src/lib/player/subtitle-fps.ts
+++ b/src/lib/player/subtitle-fps.ts
@@ -81,9 +81,82 @@ export function subtitleFpsAvailability(input: {
   return { enabled: true, reason: null };
 }
 
+export async function runAfterSubtitleFpsReset(
+  reset: () => Promise<void>,
+  action: () => void | Promise<void>,
+  onResetError: (error: unknown) => void,
+  isCurrent: () => boolean = () => true,
+): Promise<boolean> {
+  try {
+    await reset();
+  } catch (error) {
+    onResetError(error);
+    return false;
+  }
+  if (!isCurrent()) return false;
+  await action();
+  return isCurrent();
+}
+
+export function buildSubtitleTimingMediaKey(input: {
+  sourceUrl: string;
+  mediaId: string;
+  season?: number | null;
+  episode?: number | null;
+}): string {
+  return JSON.stringify([
+    input.sourceUrl,
+    input.mediaId,
+    input.season ?? null,
+    input.episode ?? null,
+  ]);
+}
+
+export function createSubtitleFpsRequestGuard() {
+  let revision = 0;
+  return {
+    begin: () => {
+      const requestRevision = ++revision;
+      return () => requestRevision === revision;
+    },
+    invalidate: () => {
+      revision += 1;
+    },
+  };
+}
+
+export function createSubtitleFpsAvailabilityController(deps: {
+  read: () => Promise<boolean>;
+  commit: (supported: boolean) => void;
+}) {
+  const guard = createSubtitleFpsRequestGuard();
+  return {
+    refresh: async (): Promise<boolean> => {
+      const isCurrent = guard.begin();
+      const supported = await deps.read();
+      if (!isCurrent()) return false;
+      deps.commit(supported);
+      return true;
+    },
+    invalidate: guard.invalidate,
+  };
+}
+
+export function isAutoSyncScopeCurrent(
+  scope: { mediaKey: string; trackId: string } | null,
+  current: { mediaKey: string; trackId: string | null; syncedTrack: boolean },
+): boolean {
+  return (
+    scope != null &&
+    scope.mediaKey === current.mediaKey &&
+    (scope.trackId === current.trackId || current.syncedTrack)
+  );
+}
+
 export function createSubtitleFpsCoordinator(deps: { writeFps: (value: number) => Promise<void> }) {
   let tail: Promise<void> = Promise.resolve();
   let active = false;
+  let sessionRevision = 0;
 
   const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
     const result = tail.then(operation);
@@ -106,11 +179,17 @@ export function createSubtitleFpsCoordinator(deps: { writeFps: (value: number) =
   };
 
   return {
-    apply: (choice: SubtitleFpsChoice, isCurrent: () => boolean = () => true) =>
-      enqueue(async () => {
-        if (!isCurrent()) throw new Error("Subtitle FPS context changed.");
+    apply: (choice: SubtitleFpsChoice, isCurrent: () => boolean = () => true) => {
+      const requestSession = sessionRevision;
+      return enqueue(async () => {
+        if (requestSession !== sessionRevision || !isCurrent()) {
+          throw new Error("Subtitle FPS context changed.");
+        }
         const value = subtitleFpsToMpvValue(choice);
         await deps.writeFps(value);
+        if (requestSession !== sessionRevision) {
+          throw new Error("Subtitle FPS context changed.");
+        }
         active = value !== 0;
         if (isCurrent()) return;
 
@@ -123,10 +202,12 @@ export function createSubtitleFpsCoordinator(deps: { writeFps: (value: number) =
           }
         }
         throw new Error("Subtitle FPS context changed.");
-      }),
+      });
+    },
     resetForTransition: (onResetError?: (error: unknown) => void) =>
       enqueue(() => resetActive(onResetError)),
     markSessionRecreated: () => {
+      sessionRevision += 1;
       active = false;
     },
     whenSettled: () => tail,

--- a/src/lib/player/subtitle-fps.ts
+++ b/src/lib/player/subtitle-fps.ts
@@ -1,0 +1,135 @@
+export const SUBTITLE_FPS_PRESETS = [
+  { label: "23.976", value: 24_000 / 1_001 },
+  { label: "24", value: 24 },
+  { label: "25", value: 25 },
+  { label: "29.97", value: 30_000 / 1_001 },
+  { label: "30", value: 30 },
+  { label: "50", value: 50 },
+  { label: "59.94", value: 60_000 / 1_001 },
+  { label: "60", value: 60 },
+] as const;
+
+export const MIN_SUBTITLE_FPS = 1;
+export const MAX_SUBTITLE_FPS = 240;
+
+export type SubtitleFpsChoice = "default" | number;
+export type SubtitleFpsUnavailableReason =
+  | "no-track"
+  | "html5"
+  | "not-text-based"
+  | "secondary-active"
+  | "video-fps-unavailable"
+  | "native-unavailable"
+  | "auto-sync-active";
+
+export function validateSubtitleFps(
+  input: unknown,
+): { ok: true; value: number } | { ok: false; error: "out-of-range" } {
+  if (typeof input !== "number" && typeof input !== "string") {
+    return { ok: false, error: "out-of-range" };
+  }
+  if (typeof input === "string" && input.trim() === "") {
+    return { ok: false, error: "out-of-range" };
+  }
+  const value = typeof input === "number" ? input : Number(input);
+  if (!Number.isFinite(value) || value < MIN_SUBTITLE_FPS || value > MAX_SUBTITLE_FPS) {
+    return { ok: false, error: "out-of-range" };
+  }
+  return { ok: true, value };
+}
+
+export function subtitleFpsToMpvValue(choice: SubtitleFpsChoice): number {
+  if (choice === "default") return 0;
+  const result = validateSubtitleFps(choice);
+  if (!result.ok) throw new RangeError("Subtitle FPS must be between 1 and 240.");
+  return result.value;
+}
+
+export function matchingSubtitleFpsPreset(value: number | null): string | null {
+  if (value == null) return null;
+  return (
+    SUBTITLE_FPS_PRESETS.find((preset) => Math.abs(preset.value - value) < 0.001)?.label ?? null
+  );
+}
+
+export function formatSubtitleFps(value: number | null | undefined, digits = 3): string {
+  if (value == null || !Number.isFinite(value) || value <= 0) return "-";
+  const preset = matchingSubtitleFpsPreset(value);
+  if (preset) return preset;
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(digits).replace(/\.?0+$/, "");
+}
+
+export function subtitleFpsAvailability(input: {
+  engine: "html5" | "mpv";
+  hasTrack: boolean;
+  textBased: boolean;
+  hasSecondary: boolean;
+  videoFps: number | null;
+  nativeSupported: boolean;
+  autoSyncActive: boolean;
+}): { enabled: true; reason: null } | { enabled: false; reason: SubtitleFpsUnavailableReason } {
+  if (!input.hasTrack) return { enabled: false, reason: "no-track" };
+  if (input.engine !== "mpv") return { enabled: false, reason: "html5" };
+  if (!input.textBased) return { enabled: false, reason: "not-text-based" };
+  if (input.hasSecondary) return { enabled: false, reason: "secondary-active" };
+  if (input.autoSyncActive) return { enabled: false, reason: "auto-sync-active" };
+  if (input.videoFps == null || !Number.isFinite(input.videoFps) || input.videoFps <= 0) {
+    return { enabled: false, reason: "video-fps-unavailable" };
+  }
+  if (!input.nativeSupported) return { enabled: false, reason: "native-unavailable" };
+  return { enabled: true, reason: null };
+}
+
+export function createSubtitleFpsCoordinator(deps: { writeFps: (value: number) => Promise<void> }) {
+  let tail: Promise<void> = Promise.resolve();
+  let active = false;
+
+  const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = tail.then(operation);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const resetActive = async (onResetError?: (error: unknown) => void) => {
+    if (!active) return;
+    try {
+      await deps.writeFps(0);
+      active = false;
+    } catch (error) {
+      onResetError?.(error);
+      throw error;
+    }
+  };
+
+  return {
+    apply: (choice: SubtitleFpsChoice, isCurrent: () => boolean = () => true) =>
+      enqueue(async () => {
+        if (!isCurrent()) throw new Error("Subtitle FPS context changed.");
+        const value = subtitleFpsToMpvValue(choice);
+        await deps.writeFps(value);
+        active = value !== 0;
+        if (isCurrent()) return;
+
+        if (active) {
+          try {
+            await deps.writeFps(0);
+            active = false;
+          } catch {
+            active = true;
+          }
+        }
+        throw new Error("Subtitle FPS context changed.");
+      }),
+    resetForTransition: (onResetError?: (error: unknown) => void) =>
+      enqueue(() => resetActive(onResetError)),
+    markSessionRecreated: () => {
+      active = false;
+    },
+    whenSettled: () => tail,
+    isActive: () => active,
+  };
+}

--- a/src/views/hdr-overlay-app.tsx
+++ b/src/views/hdr-overlay-app.tsx
@@ -5,6 +5,7 @@ import { ShellLayer } from "./player/shell-layer";
 import { DragClickStage } from "./player/drag-click-stage";
 import { emptySnapshot, type PlayerSnapshot } from "@/lib/player/bridge";
 import { createForwardingMpvBridge } from "@/lib/player/mpv-forward";
+import { buildSubtitleTimingMediaKey } from "@/lib/player/subtitle-fps";
 import { hdrOverlayEmitAction, onHdrStageProps } from "@/lib/hdr-overlay";
 import type { PlayerSrc } from "@/lib/view";
 
@@ -76,7 +77,15 @@ function HdrOverlayChrome() {
       gotPayloadRef.current = true;
       setPayload(p);
       snapRef.current = p.snap;
-      bridge.pushSnapshot(p.snap);
+      bridge.pushSnapshot(
+        p.snap,
+        buildSubtitleTimingMediaKey({
+          sourceUrl: p.src.url,
+          mediaId: p.src.meta.id,
+          season: p.src.episode?.season,
+          episode: p.src.episode?.episode,
+        }),
+      );
     });
     void hdrOverlayEmitAction("hdr-stage://request", {});
     let tries = 0;

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -92,7 +92,8 @@ import { useKeyboardNavigation } from "@/lib/keyboard-navigation";
 let hdrFallbackNoticeShown = false;
 
 export function PlayerView({ src }: { src: PlayerSrc }) {
-  const { setChromeHidden, topPath, openPicker, exitPlayback, replacePlayerSrc, exitPlayer } = useView();
+  const { setChromeHidden, topPath, openPicker, exitPlayback, replacePlayerSrc, exitPlayer } =
+    useView();
   const { settings, update } = useSettings();
   const isKid = useActiveKid() != null;
   const t = useT();
@@ -108,14 +109,8 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
       delete root.dataset.playerBlack;
     };
   }, [settings.playerMenuBlack]);
-  const {
-    avatarsCorner,
-    chatCorner,
-    episodesCorner,
-    avatarsHidden,
-    chatHidden,
-    episodesHidden,
-  } = useChromeConfig(chromeTheme);
+  const { avatarsCorner, chatCorner, episodesCorner, avatarsHidden, chatHidden, episodesHidden } =
+    useChromeConfig(chromeTheme);
   const { authKey } = useAuth();
   const debrids = useDebridClients();
   const {
@@ -178,11 +173,23 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     } else {
       setPlaybackDownloaded(0);
     }
-  }, [engineStats?.streamProgress, engineStats?.streamLen, src.url, isP2pEngine, src.isLive, src.meta.id, snap.positionSec, snap.bufferedSec, snap.durationSec]);
+  }, [
+    engineStats?.streamProgress,
+    engineStats?.streamLen,
+    src.url,
+    isP2pEngine,
+    src.isLive,
+    src.meta.id,
+    snap.positionSec,
+    snap.bufferedSec,
+    snap.durationSec,
+  ]);
   const shellSnapRef = useRef(snap);
   const snapRef = useRef(snap);
   snapRef.current = snap;
-  const [foreignNotice, setForeignNotice] = useState<{ title: string | null; from: string } | null>(null);
+  const [foreignNotice, setForeignNotice] = useState<{ title: string | null; from: string } | null>(
+    null,
+  );
   const [hasStarted, setHasStarted] = useState(false);
   const cast = usePlayerCast({ src, debrids, snapRef, bridgeRef, settings });
   const [now, setNow] = useState(() => Date.now());
@@ -247,13 +254,14 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     sendDraw,
   });
 
-  const { chromeVisible, wakeChrome, hideForResume, setAnyMenuOpen, cursorStyle } = useChromeVisibility({
-    playing,
-    drawMode,
-    pipMode,
-    setChromeHidden,
-    keyboardPauseShowsControls: settings.keyboardPauseShowsControls,
-  });
+  const { chromeVisible, wakeChrome, hideForResume, setAnyMenuOpen, cursorStyle } =
+    useChromeVisibility({
+      playing,
+      drawMode,
+      pipMode,
+      setChromeHidden,
+      keyboardPauseShowsControls: settings.keyboardPauseShowsControls,
+    });
 
   const { adjacent, swappingEp, goToEpisode } = useEpisodeNavigation({
     src,
@@ -347,22 +355,23 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const clip = useClipRecorder({ src });
   const svpToast = useSvpGuard(settings.playerSvp && !!settings.svpVpyPath);
 
-  const { resolvedImdbId, subAssNative, captureExitSnapshot, download, subDropToast } = usePlayerMedia({
-    src,
-    snap,
-    engine,
-    settings,
-    authKey,
-    bridgeRef,
-    bridgeReady,
-    bridgeKey,
-    svpActive,
-    videoMountRef,
-    toggleFullscreen,
-    castActiveRef: cast.castActiveRef,
-    season,
-    episode,
-  });
+  const { resolvedImdbId, subAssNative, captureExitSnapshot, download, subDropToast } =
+    usePlayerMedia({
+      src,
+      snap,
+      engine,
+      settings,
+      authKey,
+      bridgeRef,
+      bridgeReady,
+      bridgeKey,
+      svpActive,
+      videoMountRef,
+      toggleFullscreen,
+      castActiveRef: cast.castActiveRef,
+      season,
+      episode,
+    });
 
   const contentAdvisory = useContentAdvisory(
     settings.contentAdvisoryToast,
@@ -409,7 +418,8 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const isLiveLike =
     liveOverlay.isLive ||
     !!src.meta.id?.startsWith("iptv:") ||
-    (!!src.meta.type && !["movie", "series", "anime"].includes(String(src.meta.type).toLowerCase()));
+    (!!src.meta.type &&
+      !["movie", "series", "anime"].includes(String(src.meta.type).toLowerCase()));
   const { hasNextEpisodeNow, hasPrevEpisodeNow, playNext, playPrev, playNextRef, playPrevRef } =
     useQueueNav({
       src,
@@ -571,7 +581,9 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     isSeriesPlayback || (settings.queueDrivesNav && queue.length > 0 && !isLiveLike);
 
   const showHeaderWarning =
-    src.notWebReady === true && engine === "html5" && (snap.status === "error" || snap.status === "loading");
+    src.notWebReady === true &&
+    engine === "html5" &&
+    (snap.status === "error" || snap.status === "loading");
   const [noAudioDismissed, setNoAudioDismissed] = useState(false);
   useEffect(() => {
     setNoAudioDismissed(false);
@@ -618,21 +630,22 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     mediaKey: `${src.meta.id}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}`,
   });
 
-  const { rememberSubChoice, cycleSubtitles, playPauseToggle, seekStep, seekTo } = usePlaybackControls({
-    bridgeRef,
-    snapRef,
-    metaId: src.meta.id,
-    mediaKey: `${src.meta.id}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}`,
-    inRoom,
-    isHost,
-    hasStarted,
-    canControl,
-    castDevice: cast.castDevice,
-    startHost: lobby.startHost,
-    togglePlayCast: cast.togglePlayCast,
-    seekCast: cast.seekCast,
-    sendCommand,
-  });
+  const { rememberSubChoice, cycleSubtitles, playPauseToggle, seekStep, seekTo } =
+    usePlaybackControls({
+      bridgeRef,
+      snapRef,
+      metaId: src.meta.id,
+      mediaKey: `${src.meta.id}|${src.episode?.season ?? ""}|${src.episode?.episode ?? ""}`,
+      inRoom,
+      isHost,
+      hasStarted,
+      canControl,
+      castDevice: cast.castDevice,
+      startHost: lobby.startHost,
+      togglePlayCast: cast.togglePlayCast,
+      seekCast: cast.seekCast,
+      sendCommand,
+    });
 
   const textSync = useTextSync(bridgeRef.current, src.meta.id);
   const [syncToast, setSyncToast] = useState<ToastInfo | null>(null);
@@ -640,7 +653,10 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   const showSyncToast = useCallback((kind: "ok" | "error", text: string) => {
     if (syncToastTimerRef.current != null) window.clearTimeout(syncToastTimerRef.current);
     setSyncToast({ kind, text });
-    syncToastTimerRef.current = window.setTimeout(() => setSyncToast(null), kind === "error" ? 5000 : 3000);
+    syncToastTimerRef.current = window.setTimeout(
+      () => setSyncToast(null),
+      kind === "error" ? 5000 : 3000,
+    );
   }, []);
   const handleEnterSync = useCallback(() => {
     void textSync.enter(src.url, src.headers);
@@ -729,9 +745,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
 
   useEffect(() => {
     const ep = src.episode;
-    const subtitle = ep
-      ? `S${ep.season} E${ep.episode}${ep.name ? ` · ${ep.name}` : ""}`
-      : "";
+    const subtitle = ep ? `S${ep.season} E${ep.episode}${ep.name ? ` · ${ep.name}` : ""}` : "";
     updateMediaControls(playing, src.meta.name, subtitle);
   }, [playing, src.meta.name, src.episode]);
   useEffect(() => () => clearMediaControls(), []);
@@ -909,19 +923,22 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   useEffect(() => {
     volumeRef.current = snap.volume;
   }, [snap.volume]);
-  const onVolumeWheel = useCallback((deltaY: number) => {
-    const dir = deltaY < 0 ? 1 : -1;
-    const boost = !isKid && bridgeRef.current?.capabilities().engine === "mpv";
-    const max = boost ? Math.max(1, Math.min(6, settings.volumeBoostMax || 2)) : 1;
-    const next = Math.min(max, Math.max(0, volumeRef.current + dir * 0.05));
-    volumeRef.current = next;
-    bridgeRef.current?.setVolume(next);
-    bridgeRef.current?.setMuted(false);
-    writePlayerVolume({ volume: next, muted: false });
+  const onVolumeWheel = useCallback(
+    (deltaY: number) => {
+      const dir = deltaY < 0 ? 1 : -1;
+      const boost = !isKid && bridgeRef.current?.capabilities().engine === "mpv";
+      const max = boost ? Math.max(1, Math.min(6, settings.volumeBoostMax || 2)) : 1;
+      const next = Math.min(max, Math.max(0, volumeRef.current + dir * 0.05));
+      volumeRef.current = next;
+      bridgeRef.current?.setVolume(next);
+      bridgeRef.current?.setMuted(false);
+      writePlayerVolume({ volume: next, muted: false });
 
-    if (settings.playerVolumeSfx) SFX.volumeChange(dir > 0);
-    showVolumeFeedback(next, false);
-  }, [showVolumeFeedback, isKid, settings.playerVolumeSfx, settings.volumeBoostMax]);
+      if (settings.playerVolumeSfx) SFX.volumeChange(dir > 0);
+      showVolumeFeedback(next, false);
+    },
+    [showVolumeFeedback, isKid, settings.playerVolumeSfx, settings.volumeBoostMax],
+  );
 
   const onLoaderRetry = useCallback(() => {
     const b = bridgeRef.current;
@@ -1072,7 +1089,14 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     episodePanelOpen,
     setEpisodePanelOpen,
     upNextButtonVisible:
-      showEpisodePanel && chromeVisible && !episodePanelOpen && !switcherOpen && !pipMode && !drawMode && !episodesHidden && !roomGuest,
+      showEpisodePanel &&
+      chromeVisible &&
+      !episodePanelOpen &&
+      !switcherOpen &&
+      !pipMode &&
+      !drawMode &&
+      !episodesHidden &&
+      !roomGuest,
     episodesCorner,
     episodesHidden,
     roomGuest,
@@ -1116,7 +1140,9 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
         <StillWatchingPrompt
           show={src.meta.name ?? ""}
           nextLabel={
-            src.meta.type === "series" ? `S${stillPrompt.season} E${stillPrompt.episode}` : undefined
+            src.meta.type === "series"
+              ? `S${stillPrompt.season} E${stillPrompt.episode}`
+              : undefined
           }
           onContinue={continueWatching}
           onExit={stopWatching}
@@ -1158,6 +1184,11 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
           seek: seekTo,
           seekStep,
           rememberSub: rememberSubChoice,
+          setSubtitleTrack: (id) => bridgeRef.current?.setSubtitleTrack(id),
+          setSecondarySubtitleTrack: (id) => bridgeRef.current?.setSecondarySubtitleTrack(id),
+          addSubtitle: (url, lang, title, select, metadata) =>
+            bridgeRef.current?.addSubtitle(url, lang, title, select, metadata) ??
+            Promise.resolve(false),
           pip: togglePipMode,
           cast: () => cast.openCastMenu(null),
           back: closePlayer,

--- a/src/views/player/hdr-stage-bridge.tsx
+++ b/src/views/player/hdr-stage-bridge.tsx
@@ -1,5 +1,17 @@
 import { useEffect, useRef } from "react";
-import { hdrOverlayEmitProps } from "@/lib/hdr-overlay";
+import {
+  HDR_OVERLAY_WINDOW_LABEL,
+  HDR_STAGE_ADD_SUBTITLE,
+  HDR_STAGE_ADD_SUBTITLE_RESULT,
+  HDR_STAGE_SET_SECONDARY_SUBTITLE_TRACK,
+  HDR_STAGE_SET_SUBTITLE_TRACK,
+  hdrOverlayEmitProps,
+  type HdrStageAddSubtitleRequest,
+  type HdrStageAddSubtitleResult,
+  type HdrStageSubtitleTrackRequest,
+} from "@/lib/hdr-overlay";
+import type { PlayerBridge } from "@/lib/player/bridge";
+import { buildSubtitleTimingMediaKey } from "@/lib/player/subtitle-fps";
 import type { HdrStagePayload } from "../hdr-overlay-app";
 
 export type HdrStageHandlers = {
@@ -17,7 +29,7 @@ export type HdrStageHandlers = {
   screenshot: () => void;
   menuOpen: (open: boolean) => void;
   activity: () => void;
-};
+} & Pick<PlayerBridge, "setSubtitleTrack" | "setSecondarySubtitleTrack" | "addSubtitle">;
 
 export function HdrStageBridge({
   active,
@@ -51,13 +63,26 @@ export function HdrStageBridge({
     let cancelled = false;
     const offs: Array<() => void> = [];
     void (async () => {
-      const { listen } = await import("@tauri-apps/api/event");
+      const { emitTo, listen } = await import("@tauri-apps/api/event");
       const bind = async (event: string, fn: (p: unknown) => void) => {
         const off = await listen(event, (e) => fn(e.payload));
         if (cancelled) off();
         else offs.push(off);
       };
       const h = () => handlersRef.current;
+      const isCurrentMediaRequest = (mediaKey: unknown) => {
+        const current = payloadRef.current.src;
+        return (
+          typeof mediaKey === "string" &&
+          mediaKey ===
+            buildSubtitleTimingMediaKey({
+              sourceUrl: current.url,
+              mediaId: current.meta.id,
+              season: current.episode?.season,
+              episode: current.episode?.episode,
+            })
+        );
+      };
       await bind("hdr-stage://play-pause", () => h().playPause());
       await bind("hdr-stage://fullscreen", () => h().fullscreen());
       await bind("hdr-stage://seek", (p) => h().seek((p as { sec: number }).sec));
@@ -76,6 +101,51 @@ export function HdrStageBridge({
       await bind("hdr-stage://menu-open", (p) => h().menuOpen((p as { open: boolean }).open));
       await bind("hdr-stage://activity", () => h().activity());
       await bind("hdr-stage://request", () => void hdrOverlayEmitProps(payloadRef.current));
+      await bind(HDR_STAGE_SET_SUBTITLE_TRACK, (p) => {
+        const request = p as Partial<HdrStageSubtitleTrackRequest>;
+        if (!isCurrentMediaRequest(request.mediaKey)) return;
+        if (request.id === null || typeof request.id === "string") {
+          h().setSubtitleTrack(request.id);
+        }
+      });
+      await bind(HDR_STAGE_SET_SECONDARY_SUBTITLE_TRACK, (p) => {
+        const request = p as Partial<HdrStageSubtitleTrackRequest>;
+        if (!isCurrentMediaRequest(request.mediaKey)) return;
+        if (request.id === null || typeof request.id === "string") {
+          h().setSecondarySubtitleTrack(request.id);
+        }
+      });
+      await bind(HDR_STAGE_ADD_SUBTITLE, (p) => {
+        const request = p as Partial<HdrStageAddSubtitleRequest>;
+        if (typeof request.requestId !== "string") return;
+        const requestId = request.requestId;
+        void (async () => {
+          let ok = false;
+          if (
+            isCurrentMediaRequest(request.mediaKey) &&
+            typeof request.url === "string" &&
+            request.url.length > 0
+          ) {
+            try {
+              ok = await h().addSubtitle(
+                request.url,
+                typeof request.lang === "string" ? request.lang : undefined,
+                typeof request.title === "string" ? request.title : undefined,
+                typeof request.select === "boolean" ? request.select : undefined,
+                request.metadata && typeof request.metadata === "object"
+                  ? request.metadata
+                  : undefined,
+              );
+            } catch (error) {
+              console.warn("[hdr-overlay] forwarded subtitle addition failed", error);
+            }
+          }
+          const result: HdrStageAddSubtitleResult = { requestId, ok };
+          await emitTo(HDR_OVERLAY_WINDOW_LABEL, HDR_STAGE_ADD_SUBTITLE_RESULT, result).catch(
+            (error) => console.warn("[hdr-overlay] could not return subtitle result", error),
+          );
+        })();
+      });
     })();
     return () => {
       cancelled = true;

--- a/src/views/player/hooks/use-auto-sync.ts
+++ b/src/views/player/hooks/use-auto-sync.ts
@@ -6,9 +6,17 @@ import type { Settings } from "@/lib/settings";
 import { dwarn } from "@/lib/debug";
 import { fetchAndParse, type SubCue } from "@/lib/subtitles/parser";
 import { toSrt, toVtt } from "@/lib/subtitles/serialize";
-import { runAutoSync, type PipelineContext, type PipelineOutcome } from "@/lib/subtitles/autosync/pipeline";
+import {
+  runAutoSync,
+  type PipelineContext,
+  type PipelineOutcome,
+} from "@/lib/subtitles/autosync/pipeline";
 import { buildTierPorts, defaultOsConfig } from "@/lib/subtitles/autosync/context";
-import { crowdConfigFromSettings, reportCrowdFeedback, reportVerifiedSync } from "@/lib/subtitles/autosync/crowd-db";
+import {
+  crowdConfigFromSettings,
+  reportCrowdFeedback,
+  reportVerifiedSync,
+} from "@/lib/subtitles/autosync/crowd-db";
 import {
   classifyTorrentSource,
   scheduleProgressiveTorrentSync,
@@ -18,10 +26,33 @@ import {
 import { resolveSwapCues, type OsConfig } from "@/lib/subtitles/autosync/opensubtitles";
 import { type SyncTransform } from "@/lib/subtitles/autosync/fp-gate";
 import { transformCues } from "@/lib/subtitles/autosync/html5-sync";
-import { DriftMonitor, makeTauriDriftPorts, type DriftDeps } from "@/lib/subtitles/autosync/drift-monitor";
-import { buildContext, isLoopback, outcomeScore, subLanguages, toDriftState } from "./use-auto-sync.helpers";
+import {
+  DriftMonitor,
+  makeTauriDriftPorts,
+  type DriftDeps,
+} from "@/lib/subtitles/autosync/drift-monitor";
+import { resetMpvSubtitleFpsForTransition } from "@/lib/player/mpv-properties";
+import {
+  buildSubtitleTimingMediaKey,
+  isAutoSyncScopeCurrent,
+  runAfterSubtitleFpsReset,
+} from "@/lib/player/subtitle-fps";
+import {
+  buildContext,
+  isLoopback,
+  outcomeScore,
+  subLanguages,
+  toDriftState,
+} from "./use-auto-sync.helpers";
 
-export type AutoSyncStatus = "idle" | "analyzing" | "synced" | "best-effort" | "offer" | "declined" | "error";
+export type AutoSyncStatus =
+  | "idle"
+  | "analyzing"
+  | "synced"
+  | "best-effort"
+  | "offer"
+  | "declined"
+  | "error";
 
 export type AutoSyncHandle = {
   status: AutoSyncStatus;
@@ -35,7 +66,14 @@ export type AutoSyncHandle = {
 };
 
 type SubFmt = "srt" | "vtt";
-type AppliedState = { transform: SyncTransform | null; originalTrackId: string | null; subDelayBefore: number };
+type AutoSyncScope = { mediaKey: string; trackId: string };
+type AppliedState = {
+  transform: SyncTransform | null;
+  originalTrackId: string | null;
+  subDelayBefore: number;
+  scope: AutoSyncScope | null;
+  changed: boolean;
+};
 type AutoSyncFlags = { autoSyncDrift?: boolean; subtitleAutoSyncAsr?: boolean };
 
 const MIN_DURATION_SEC = 60;
@@ -47,6 +85,19 @@ const SWAP_AUTO_APPLY = false;
 
 function isSyncedTrack(t: { title?: string } | null | undefined): boolean {
   return /^Synced \((?:SRT|VTT)\)/.test(t?.title ?? "");
+}
+
+function autoSyncMediaKey(src: PlayerSrc): string {
+  return buildSubtitleTimingMediaKey({
+    sourceUrl: src.url,
+    mediaId: src.meta.id,
+    season: src.episode?.season,
+    episode: src.episode?.episode,
+  });
+}
+
+function autoSyncRunKey(mediaKey: string, trackId: string): string {
+  return JSON.stringify([mediaKey, trackId]);
 }
 
 export function useAutoSync(params: {
@@ -61,15 +112,29 @@ export function useAutoSync(params: {
   const [offer, setOffer] = useState<PipelineOutcome | null>(null);
 
   const doneKeyRef = useRef<string | null>(null);
-  const firedRef = useRef<{ url: string; langs: Set<string> }>({ url: "", langs: new Set() });
-  const appliedRef = useRef<AppliedState>({ transform: null, originalTrackId: null, subDelayBefore: 0 });
+  const firedRef = useRef<{ mediaKey: string; langs: Set<string> }>({
+    mediaKey: "",
+    langs: new Set(),
+  });
+  const appliedRef = useRef<AppliedState>({
+    transform: null,
+    originalTrackId: null,
+    subDelayBefore: 0,
+    scope: null,
+    changed: false,
+  });
   const driftRef = useRef<DriftMonitor | null>(null);
   const driftTimerRef = useRef<number | null>(null);
   const progressiveRef = useRef<ProgressiveHandle | null>(null);
   const bestScoreRef = useRef(-1);
   const retryRef = useRef<(() => void) | null>(null);
   const activeDisposeRef = useRef<(() => void) | null>(null);
-  const lastReportRef = useRef<{ ctx: PipelineContext; transform: SyncTransform; confidence: number } | null>(null);
+  const lastReportRef = useRef<{
+    ctx: PipelineContext;
+    transform: SyncTransform;
+    confidence: number;
+  } | null>(null);
+  const statusScopeRef = useRef<AutoSyncScope | null>(null);
   const liveSnapRef = useRef(snap);
   const srcRef = useRef(src);
   const settingsRef = useRef(settings);
@@ -82,13 +147,18 @@ export function useAutoSync(params: {
 
   const selected = snap.subtitleTracks.find((t) => t.selected) ?? null;
   const selectedSynced = isSyncedTrack(selected);
+  const mediaKey = autoSyncMediaKey(src);
   const ready =
     engine === "mpv" &&
     settings.subtitleAutoSync === true &&
     snap.durationSec >= MIN_DURATION_SEC &&
     selected?.external === true &&
     !selectedSynced;
-  const runKey = selectedSynced ? doneKeyRef.current : ready && selected ? `${src.url}|${selected.id}` : null;
+  const runKey = selectedSynced
+    ? doneKeyRef.current
+    : ready && selected
+      ? autoSyncRunKey(mediaKey, selected.id)
+      : null;
 
   const stopDrift = useCallback(() => {
     if (driftTimerRef.current !== null) {
@@ -99,41 +169,100 @@ export function useAutoSync(params: {
     driftRef.current = null;
   }, []);
 
-  const applyTransform = useCallback(async (b: PlayerBridge, cues: SubCue[], fmt: SubFmt, t: SyncTransform) => {
-    const a = appliedRef.current;
-    if (t.kind === "affine" && Math.abs(t.ratio - 1) < RATIO_EPS) {
-      if (Math.abs(t.offsetSec) < OFFSET_EPS && !a.transform) return;
-      if (a.originalTrackId) b.setSubtitleTrack(a.originalTrackId);
-      b.setSubDelay(t.offsetSec);
-      a.transform = t;
-      return;
-    }
-    const finalCues = transformCues(cues, t);
-    if (finalCues.length === 0) return;
-    const text = fmt === "vtt" ? toVtt(finalCues) : toSrt(finalCues);
-    await writeSyncedTrack(b, text, fmt);
-    a.transform = t;
+  const runWithSubtitleFpsReset = useCallback(
+    (
+      action: () => void | Promise<void>,
+      cancelled?: { current: boolean },
+      isCurrent: () => boolean = () => true,
+    ) =>
+      runAfterSubtitleFpsReset(
+        () => resetMpvSubtitleFpsForTransition(),
+        action,
+        (error) => {
+          dwarn("[auto-sync] subtitle FPS reset failed", error);
+          if (!cancelled?.current) setStatus("error");
+        },
+        () => cancelled?.current !== true && isCurrent(),
+      ),
+    [],
+  );
+
+  const isCurrentAutoSyncScope = useCallback((scope: AutoSyncScope | null) => {
+    const currentSelected =
+      liveSnapRef.current.subtitleTracks.find((track) => track.selected) ?? null;
+    return isAutoSyncScopeCurrent(scope, {
+      mediaKey: autoSyncMediaKey(srcRef.current),
+      trackId: currentSelected?.id ?? null,
+      syncedTrack: isSyncedTrack(currentSelected),
+    });
   }, []);
 
-  const startDrift = useCallback((b: PlayerBridge, cues: SubCue[]) => {
-    if (flagsRef.current.autoSyncDrift !== true || driftRef.current) return;
-    const active = srcRef.current;
-    const trackKey = doneKeyRef.current ?? active.url;
-    const ports = makeTauriDriftPorts(active.url, active.headers, {
-      enableAsr: flagsRef.current.subtitleAutoSyncAsr === true,
-    });
-    const deps: DriftDeps = {
-      getState: () => toDriftState(liveSnapRef.current, cues, trackKey),
-      setSubDelay: (s) => b.setSubDelay(s),
-    };
-    const mon = new DriftMonitor(ports, deps);
-    driftRef.current = mon;
-    driftTimerRef.current = window.setInterval(() => mon.observe(), DRIFT_TICK_MS);
-  }, []);
+  const applyTransform = useCallback(
+    async (
+      b: PlayerBridge,
+      cues: SubCue[],
+      fmt: SubFmt,
+      t: SyncTransform,
+      isCurrent: () => boolean,
+    ): Promise<boolean> => {
+      if (!isCurrent()) return false;
+      const a = appliedRef.current;
+      if (t.kind === "affine" && Math.abs(t.ratio - 1) < RATIO_EPS) {
+        if (Math.abs(t.offsetSec) < OFFSET_EPS && !a.transform) return true;
+        if (!isCurrent()) return false;
+        if (a.originalTrackId) b.setSubtitleTrack(a.originalTrackId);
+        b.setSubDelay(t.offsetSec);
+        a.changed = true;
+        if (!isCurrent()) return false;
+        a.transform = t;
+        return true;
+      }
+      const finalCues = transformCues(cues, t);
+      if (finalCues.length === 0 || !isCurrent()) return false;
+      const text = fmt === "vtt" ? toVtt(finalCues) : toSrt(finalCues);
+      if (!(await writeSyncedTrack(b, text, fmt, isCurrent))) return false;
+      if (!isCurrent()) return false;
+      a.changed = true;
+      a.transform = t;
+      return true;
+    },
+    [],
+  );
+
+  const startDrift = useCallback(
+    (b: PlayerBridge, cues: SubCue[]) => {
+      if (flagsRef.current.autoSyncDrift !== true || driftRef.current) return;
+      const active = srcRef.current;
+      const trackKey = doneKeyRef.current ?? active.url;
+      const ports = makeTauriDriftPorts(active.url, active.headers, {
+        enableAsr: flagsRef.current.subtitleAutoSyncAsr === true,
+      });
+      const deps: DriftDeps = {
+        getState: () => toDriftState(liveSnapRef.current, cues, trackKey),
+        setSubDelay: (s) => {
+          const a = appliedRef.current;
+          if (!isCurrentAutoSyncScope(a.scope)) return;
+          b.setSubDelay(s);
+          a.changed = true;
+        },
+      };
+      const mon = new DriftMonitor(ports, deps);
+      driftRef.current = mon;
+      driftTimerRef.current = window.setInterval(() => mon.observe(), DRIFT_TICK_MS);
+    },
+    [isCurrentAutoSyncScope],
+  );
 
   const handleOutcome = useCallback(
-    (o: PipelineOutcome, cues: SubCue[], fmt: SubFmt, cancelled: { current: boolean }) => {
-      if (cancelled.current) return;
+    (
+      o: PipelineOutcome,
+      cues: SubCue[],
+      fmt: SubFmt,
+      cancelled: { current: boolean },
+      scope: AutoSyncScope,
+    ) => {
+      const isCurrent = () => isCurrentAutoSyncScope(scope);
+      if (cancelled.current || !isCurrent()) return;
       const dec = o.decision.decision;
       dwarn(
         `[auto-sync] decision=${dec} reason="${o.decision.reason}" tiers=[${o.tiersRun.join(",")}] bestEffort=${o.bestEffort ?? false}`,
@@ -152,15 +281,25 @@ export function useAutoSync(params: {
       const t = o.candidate;
       const b = bridgeRef.current;
       if (!t || !b) return;
-      bestScoreRef.current = score;
-      setOffer(null);
-      void applyTransform(b, cues, fmt, t).then(() => {
-        if (cancelled.current) return;
-        setStatus(o.bestEffort ? "best-effort" : "synced");
-        startDrift(b, cues);
+      void runWithSubtitleFpsReset(
+        async () => {
+          if (!isCurrent()) return;
+          if (!o.bestEffort && score <= bestScoreRef.current) return;
+          bestScoreRef.current = score;
+          setOffer(null);
+          const applied = await applyTransform(b, cues, fmt, t, isCurrent);
+          if (!applied || !isCurrent()) return;
+          setStatus(o.bestEffort ? "best-effort" : "synced");
+          startDrift(b, cues);
+        },
+        cancelled,
+        isCurrent,
+      ).catch((error) => {
+        dwarn("[auto-sync] apply failed", error);
+        if (!cancelled.current && isCurrent()) setStatus("error");
       });
     },
-    [applyTransform, startDrift, bridgeRef],
+    [applyTransform, startDrift, bridgeRef, isCurrentAutoSyncScope, runWithSubtitleFpsReset],
   );
 
   const beginRun = useCallback(
@@ -169,9 +308,11 @@ export function useAutoSync(params: {
       const activeSnap = liveSnapRef.current;
       const activeSelected = activeSnap.subtitleTracks.find((t) => t.selected) ?? null;
       if (engine !== "mpv" || activeSnap.durationSec < MIN_DURATION_SEC) return null;
-      if (!activeSelected || activeSelected.external !== true || isSyncedTrack(activeSelected)) return null;
+      if (!activeSelected || activeSelected.external !== true || isSyncedTrack(activeSelected))
+        return null;
 
-      const key = `${active.url}|${activeSelected.id}`;
+      const activeMediaKey = autoSyncMediaKey(active);
+      const key = autoSyncRunKey(activeMediaKey, activeSelected.id);
       if (!force && doneKeyRef.current === key) return null;
 
       const cls = classifyTorrentSource(active.url, {
@@ -186,66 +327,89 @@ export function useAutoSync(params: {
       activeDisposeRef.current?.();
 
       doneKeyRef.current = key;
-      appliedRef.current = { transform: null, originalTrackId: activeSelected.id, subDelayBefore: activeSnap.subDelaySec };
+      const statusScope = { mediaKey: activeMediaKey, trackId: activeSelected.id };
+      statusScopeRef.current = statusScope;
+      appliedRef.current = {
+        transform: null,
+        originalTrackId: activeSelected.id,
+        subDelayBefore: activeSnap.subDelaySec,
+        scope: statusScope,
+        changed: false,
+      };
       bestScoreRef.current = -1;
       setOffer(null);
-      if (force) setStatus("analyzing");
+      setStatus("analyzing");
 
       const cancelled = { current: false };
 
-      void (async () => {
-        const b = bridgeRef.current;
-        if (!b) return;
-        const cues = await loadCues(b);
-        if (cancelled.current) return;
-        if (!cues || cues.length < MIN_CUES) {
-          if (force) setStatus("error");
-          return;
-        }
-        setStatus("analyzing");
-        const fmt = formatOf(b);
-        const langs = subLanguages(activeSelected.lang, settingsRef.current.preferredSubLangs);
-        const ctx = buildContext(active, activeSnap, sourceKind, cues, langs);
-        const os = defaultOsConfig(settingsRef.current);
-        const applyAndCapture = (o: PipelineOutcome) => {
-          handleOutcome(o, cues, fmt, cancelled);
-          if (!cancelled.current && o.candidate && o.candidate.kind === "affine" && o.decision.decision !== "refuse") {
-            lastReportRef.current = { ctx, transform: o.candidate, confidence: o.decision.pCorrect };
-          }
-        };
-        try {
-          if (isTorrent && ctx.infoHash) {
-            const basePorts = buildTierPorts(ctx, settingsRef.current, {
-              osConfig: os,
-              torrent: { fileIdx, getPositionSec: () => liveSnapRef.current.positionSec },
-            });
-            progressiveRef.current = scheduleProgressiveTorrentSync({
-              ctx,
-              fileIdx,
-              basePorts,
-              osConfig: os ?? undefined,
-              getSnapshot: () => ({
-                positionSec: liveSnapRef.current.positionSec,
-                durationSec: liveSnapRef.current.durationSec || ctx.durationSec,
-              }),
-              onOutcome: (o) => applyAndCapture(o),
-            });
-            retryRef.current = () =>
-              void runAutoSync(ctx, basePorts, { tryHarder: true }).then((o) => applyAndCapture(o));
-          } else {
-            const ports = buildTierPorts(ctx, settingsRef.current, { osConfig: os });
-            const runDirect = async (tryHarder: boolean) => {
-              const outcome = await runAutoSync(ctx, ports, { tryHarder });
-              applyAndCapture(outcome);
+      void runWithSubtitleFpsReset(
+        async () => {
+          const b = bridgeRef.current;
+          if (!b) return;
+          try {
+            const cues = await loadCues(b);
+            if (cancelled.current) return;
+            if (!cues || cues.length < MIN_CUES) {
+              setStatus(force ? "error" : "idle");
+              return;
+            }
+            const fmt = formatOf(b);
+            const langs = subLanguages(activeSelected.lang, settingsRef.current.preferredSubLangs);
+            const ctx = buildContext(active, activeSnap, sourceKind, cues, langs);
+            const os = defaultOsConfig(settingsRef.current);
+            const applyAndCapture = (o: PipelineOutcome) => {
+              handleOutcome(o, cues, fmt, cancelled, statusScope);
+              if (
+                !cancelled.current &&
+                isCurrentAutoSyncScope(statusScope) &&
+                o.candidate &&
+                o.candidate.kind === "affine" &&
+                o.decision.decision !== "refuse"
+              ) {
+                lastReportRef.current = {
+                  ctx,
+                  transform: o.candidate,
+                  confidence: o.decision.pCorrect,
+                };
+              }
             };
-            retryRef.current = () => void runDirect(true);
-            await runDirect(force);
+            if (isTorrent && ctx.infoHash) {
+              const basePorts = buildTierPorts(ctx, settingsRef.current, {
+                osConfig: os,
+                torrent: { fileIdx, getPositionSec: () => liveSnapRef.current.positionSec },
+              });
+              progressiveRef.current = scheduleProgressiveTorrentSync({
+                ctx,
+                fileIdx,
+                basePorts,
+                osConfig: os ?? undefined,
+                getSnapshot: () => ({
+                  positionSec: liveSnapRef.current.positionSec,
+                  durationSec: liveSnapRef.current.durationSec || ctx.durationSec,
+                }),
+                onOutcome: (o) => applyAndCapture(o),
+              });
+              retryRef.current = () =>
+                void runAutoSync(ctx, basePorts, { tryHarder: true }).then((o) =>
+                  applyAndCapture(o),
+                );
+            } else {
+              const ports = buildTierPorts(ctx, settingsRef.current, { osConfig: os });
+              const runDirect = async (tryHarder: boolean) => {
+                const outcome = await runAutoSync(ctx, ports, { tryHarder });
+                applyAndCapture(outcome);
+              };
+              retryRef.current = () => void runDirect(true);
+              await runDirect(force);
+            }
+          } catch (e) {
+            dwarn("[auto-sync] failed", e);
+            if (!cancelled.current) setStatus("error");
           }
-        } catch (e) {
-          dwarn("[auto-sync] failed", e);
-          if (!cancelled.current) setStatus("error");
-        }
-      })();
+        },
+        cancelled,
+        () => isCurrentAutoSyncScope(statusScope),
+      );
 
       const dispose = () => {
         cancelled.current = true;
@@ -258,18 +422,22 @@ export function useAutoSync(params: {
       activeDisposeRef.current = dispose;
       return dispose;
     },
-    [engine, bridgeRef, handleOutcome, stopDrift],
+    [engine, bridgeRef, handleOutcome, isCurrentAutoSyncScope, runWithSubtitleFpsReset, stopDrift],
   );
 
-  const selKey = selectedSynced ? doneKeyRef.current : selected ? `${src.url}|${selected.id}` : null;
+  const selKey = selectedSynced
+    ? doneKeyRef.current
+    : selected
+      ? autoSyncRunKey(mediaKey, selected.id)
+      : null;
   useEffect(() => {
     if (!runKey) return () => activeDisposeRef.current?.();
     const snapSel = liveSnapRef.current.subtitleTracks.find((t) => t.selected) ?? null;
-    const url = srcRef.current.url;
+    const currentMediaKey = autoSyncMediaKey(srcRef.current);
     const lang = snapSel?.lang ?? "";
     const fired = firedRef.current;
-    if (fired.url !== url) {
-      fired.url = url;
+    if (fired.mediaKey !== currentMediaKey) {
+      fired.mediaKey = currentMediaKey;
       fired.langs = new Set();
     }
     if (!fired.langs.has(lang)) {
@@ -285,19 +453,40 @@ export function useAutoSync(params: {
     stopDrift();
     const b = bridgeRef.current;
     const a = appliedRef.current;
-    if (b) {
+    const canRevert = a.changed && isCurrentAutoSyncScope(a.scope);
+    if (b && canRevert) {
       if (a.originalTrackId) b.setSubtitleTrack(a.originalTrackId);
       b.setSubDelay(a.subDelayBefore);
     }
-    a.transform = null;
+    appliedRef.current = {
+      transform: null,
+      originalTrackId: null,
+      subDelayBefore: 0,
+      scope: null,
+      changed: false,
+    };
+    statusScopeRef.current = null;
     bestScoreRef.current = -1;
     setOffer(null);
     setStatus("idle");
-  }, [bridgeRef, stopDrift]);
+  }, [bridgeRef, isCurrentAutoSyncScope, stopDrift]);
 
   const retry = useCallback(() => {
-    retryRef.current?.();
-  }, []);
+    const action = retryRef.current;
+    if (!action) {
+      beginRun(true);
+      return;
+    }
+    const statusScope = statusScopeRef.current;
+    setStatus("analyzing");
+    void runWithSubtitleFpsReset(
+      () => {
+        if (retryRef.current === action) action();
+      },
+      undefined,
+      () => isCurrentAutoSyncScope(statusScope),
+    );
+  }, [beginRun, isCurrentAutoSyncScope, runWithSubtitleFpsReset]);
 
   const run = useCallback(() => {
     beginRun(true);
@@ -321,44 +510,99 @@ export function useAutoSync(params: {
 
   const applyOffer = useCallback(() => {
     const o = offer;
-    const b = bridgeRef.current;
-    if (!o || !b) return;
-    setOffer(null);
-    if (o.subSwap) {
-      const os = defaultOsConfig(settingsRef.current) ?? { apiKey: "", userAgent: "Harbor autosync" };
-      const swap = o.subSwap;
-      void applySwap(b, swap, os).then((ok) => setStatus(ok ? "synced" : "error"));
-      return;
-    }
-    const t = o.candidate;
-    const cues = b.getSelectedTrackCues();
-    if (!t || !cues) return;
-    void applyTransform(b, cues, formatOf(b), t).then(() => {
-      setStatus("synced");
-      startDrift(b, cues);
+    if (!o) return;
+    const statusScope = statusScopeRef.current;
+    const isCurrent = () => isCurrentAutoSyncScope(statusScope);
+    void runWithSubtitleFpsReset(
+      async () => {
+        const b = bridgeRef.current;
+        if (!b || !isCurrent()) return;
+        setOffer(null);
+        if (o.subSwap) {
+          const os = defaultOsConfig(settingsRef.current) ?? {
+            apiKey: "",
+            userAgent: "Harbor autosync",
+          };
+          const swap = o.subSwap;
+          const applied = await applySwap(b, swap, os, isCurrent);
+          if (applied) appliedRef.current.changed = true;
+          if (isCurrent()) setStatus(applied ? "synced" : "error");
+          return;
+        }
+        const t = o.candidate;
+        const cues = b.getSelectedTrackCues();
+        if (!t || !cues) return;
+        const applied = await applyTransform(b, cues, formatOf(b), t, isCurrent);
+        if (!applied || !isCurrent()) return;
+        setStatus("synced");
+        startDrift(b, cues);
+      },
+      undefined,
+      isCurrent,
+    ).catch((error) => {
+      dwarn("[auto-sync] offer apply failed", error);
+      if (isCurrent()) setStatus("error");
     });
-  }, [offer, bridgeRef, applyTransform, startDrift]);
+  }, [
+    offer,
+    bridgeRef,
+    applyTransform,
+    isCurrentAutoSyncScope,
+    runWithSubtitleFpsReset,
+    startDrift,
+  ]);
 
-  return { status, offer, applyOffer, revert, retry, run, stop, feedback };
+  const scopeCurrent = isAutoSyncScopeCurrent(statusScopeRef.current, {
+    mediaKey,
+    trackId: selected?.id ?? null,
+    syncedTrack: selectedSynced,
+  });
+  return {
+    status: status === "idle" || scopeCurrent ? status : "idle",
+    offer: scopeCurrent ? offer : null,
+    applyOffer,
+    revert,
+    retry,
+    run,
+    stop,
+    feedback,
+  };
 }
 
-async function writeSyncedTrack(b: PlayerBridge, text: string, fmt: SubFmt): Promise<void> {
+async function writeSyncedTrack(
+  b: PlayerBridge,
+  text: string,
+  fmt: SubFmt,
+  isCurrent: () => boolean,
+): Promise<boolean> {
+  if (!isCurrent()) return false;
   const pathMod = await import("@tauri-apps/api/path");
   const dir = await pathMod.join(await pathMod.tempDir(), "harbor-subs");
   const filePath = await pathMod.join(dir, `autosync-${Date.now()}.${fmt}`);
   await invoke("save_text_file", { path: filePath, contents: text });
-  await b.addSubtitle(filePath, undefined, `Synced (${fmt.toUpperCase()})`, true);
+  if (!isCurrent()) return false;
+  const added = await b.addSubtitle(filePath, undefined, `Synced (${fmt.toUpperCase()})`, true);
+  if (!added || !isCurrent()) return false;
   b.setSubDelay(0);
+  return true;
 }
 
-async function applySwap(b: PlayerBridge, subSwap: { url: string; format: SubFmt }, os: OsConfig): Promise<boolean> {
+async function applySwap(
+  b: PlayerBridge,
+  subSwap: { url: string; format: SubFmt },
+  os: OsConfig,
+  isCurrent: () => boolean,
+): Promise<boolean> {
   const swap = await resolveSwapCues(subSwap, os);
-  if (!swap || swap.cues.length < MIN_CUES) return false;
-  const cues: SubCue[] = swap.cues.map((c, i) => ({ start: c[0], end: c[1], text: swap.cueText[i] ?? "" }));
+  if (!swap || swap.cues.length < MIN_CUES || !isCurrent()) return false;
+  const cues: SubCue[] = swap.cues.map((c, i) => ({
+    start: c[0],
+    end: c[1],
+    text: swap.cueText[i] ?? "",
+  }));
   const text = subSwap.format === "vtt" ? toVtt(cues) : toSrt(cues);
   try {
-    await writeSyncedTrack(b, text, subSwap.format);
-    return true;
+    return await writeSyncedTrack(b, text, subSwap.format, isCurrent);
   } catch (e) {
     dwarn("[auto-sync] swap failed", e);
     return false;

--- a/tests/autosync-switch-retrigger.test.ts
+++ b/tests/autosync-switch-retrigger.test.ts
@@ -20,12 +20,15 @@ test("a manual (forced) run always starts fresh, never a silent retry shortcut",
 
 test("a forced run tries hard immediately", () => {
   assert.match(hook, /await runDirect\(force\);/);
-  assert.ok(!/await runDirect\(false\);/.test(hook), "forced button press should not run the low-effort pass");
+  assert.ok(
+    !/await runDirect\(false\);/.test(hook),
+    "forced button press should not run the low-effort pass",
+  );
 });
 
-test("auto-fire happens once per source and language, not on every track switch", () => {
-  assert.match(hook, /firedRef = useRef<\{ url: string; langs: Set<string> \}>/);
+test("auto-fire happens once per media item and language, not on every track switch", () => {
+  assert.match(hook, /firedRef = useRef<\{ mediaKey: string; langs: Set<string> \}>/);
   assert.match(hook, /if \(!fired\.langs\.has\(lang\)\) \{/);
   assert.match(hook, /fired\.langs\.add\(lang\);/);
-  assert.match(hook, /if \(fired\.url !== url\) \{/);
+  assert.match(hook, /if \(fired\.mediaKey !== currentMediaKey\) \{/);
 });

--- a/tests/subtitle-fps.test.ts
+++ b/tests/subtitle-fps.test.ts
@@ -6,9 +6,13 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   SUBTITLE_FPS_PRESETS,
+  buildSubtitleTimingMediaKey,
+  createSubtitleFpsAvailabilityController,
   createSubtitleFpsCoordinator,
   formatSubtitleFps,
+  isAutoSyncScopeCurrent,
   matchingSubtitleFpsPreset,
+  runAfterSubtitleFpsReset,
   subtitleFpsAvailability,
   subtitleFpsToMpvValue,
   validateSubtitleFps,
@@ -219,6 +223,190 @@ test("native reads can wait for an in-flight subtitle FPS transition", async () 
   assert.equal(settled, true);
 });
 
+test("a completed write from a destroyed mpv session cannot become active", async () => {
+  let releaseWrite: (() => void) | null = null;
+  let markWriteStarted: (() => void) | null = null;
+  const writeStarted = new Promise<void>((resolve) => {
+    markWriteStarted = resolve;
+  });
+  const coordinator = createSubtitleFpsCoordinator({
+    writeFps: async () => {
+      markWriteStarted?.();
+      await new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+    },
+  });
+
+  const pending = coordinator.apply(25);
+  await writeStarted;
+  coordinator.markSessionRecreated();
+  releaseWrite?.();
+
+  await assert.rejects(pending, /context changed/);
+  assert.equal(coordinator.isActive(), false);
+});
+
+test("Auto Sync waits for the FPS reset and surfaces reset failures", async () => {
+  const order: string[] = [];
+  let releaseReset: (() => void) | null = null;
+  const pending = runAfterSubtitleFpsReset(
+    async () => {
+      order.push("reset");
+      await new Promise<void>((resolve) => {
+        releaseReset = resolve;
+      });
+    },
+    () => {
+      order.push("action");
+    },
+    () => {
+      order.push("error");
+    },
+  );
+
+  await Promise.resolve();
+  assert.deepEqual(order, ["reset"]);
+  releaseReset?.();
+  assert.equal(await pending, true);
+  assert.deepEqual(order, ["reset", "action"]);
+
+  const failure = new Error("reset failed");
+  let actionRan = false;
+  let reported: unknown = null;
+  assert.equal(
+    await runAfterSubtitleFpsReset(
+      async () => {
+        throw failure;
+      },
+      () => {
+        actionRan = true;
+      },
+      (error) => {
+        reported = error;
+      },
+    ),
+    false,
+  );
+  assert.equal(actionRan, false);
+  assert.equal(reported, failure);
+});
+
+test("Auto Sync drops an action when its media changes during the FPS reset", async () => {
+  let current = true;
+  let actionRan = false;
+  const result = await runAfterSubtitleFpsReset(
+    async () => {
+      current = false;
+    },
+    () => {
+      actionRan = true;
+    },
+    () => assert.fail("reset should succeed"),
+    () => current,
+  );
+
+  assert.equal(result, false);
+  assert.equal(actionRan, false);
+});
+
+test("Auto Sync reports a stale result when its media changes during the action", async () => {
+  let current = true;
+  const result = await runAfterSubtitleFpsReset(
+    async () => {},
+    () => {
+      current = false;
+    },
+    () => assert.fail("reset should succeed"),
+    () => current,
+  );
+
+  assert.equal(result, false);
+});
+
+test("stale asynchronous FPS reads cannot commit after a playback boundary", async () => {
+  const reads: Array<(supported: boolean) => void> = [];
+  const commits: boolean[] = [];
+  const controller = createSubtitleFpsAvailabilityController({
+    read: () =>
+      new Promise<boolean>((resolve) => {
+        reads.push(resolve);
+      }),
+    commit: (supported) => commits.push(supported),
+  });
+
+  const stale = controller.refresh();
+  controller.invalidate();
+  const latest = controller.refresh();
+  reads[1](true);
+  assert.equal(await latest, true);
+  reads[0](false);
+  assert.equal(await stale, false);
+  assert.deepEqual(commits, [true]);
+});
+
+test("subtitle timing media identity distinguishes episodes that reuse a stream URL", () => {
+  const episode1 = buildSubtitleTimingMediaKey({
+    sourceUrl: "https://stream/shared",
+    mediaId: "series:1",
+    season: 1,
+    episode: 1,
+  });
+  const episode2 = buildSubtitleTimingMediaKey({
+    sourceUrl: "https://stream/shared",
+    mediaId: "series:1",
+    season: 1,
+    episode: 2,
+  });
+
+  assert.notEqual(episode1, episode2);
+  assert.equal(
+    episode1,
+    buildSubtitleTimingMediaKey({
+      sourceUrl: "https://stream/shared",
+      mediaId: "series:1",
+      season: 1,
+      episode: 1,
+    }),
+  );
+});
+
+test("Auto Sync status applies only to its current media and subtitle track", () => {
+  const scope = { mediaKey: "episode-1", trackId: "2" };
+  assert.equal(
+    isAutoSyncScopeCurrent(scope, {
+      mediaKey: "episode-1",
+      trackId: "2",
+      syncedTrack: false,
+    }),
+    true,
+  );
+  assert.equal(
+    isAutoSyncScopeCurrent(scope, {
+      mediaKey: "episode-2",
+      trackId: "2",
+      syncedTrack: false,
+    }),
+    false,
+  );
+  assert.equal(
+    isAutoSyncScopeCurrent(scope, {
+      mediaKey: "episode-1",
+      trackId: "3",
+      syncedTrack: false,
+    }),
+    false,
+  );
+  assert.equal(
+    isAutoSyncScopeCurrent(scope, {
+      mediaKey: "episode-1",
+      trackId: "9",
+      syncedTrack: true,
+    }),
+    true,
+  );
+});
+
 test("the feature reuses Playback Stats FPS properties and only writes mpv sub-fps", () => {
   const stats = read("src/components/player/stats-overlay.tsx");
   const properties = read("src/lib/player/mpv-properties.ts");
@@ -253,6 +441,7 @@ test("the FPS control stays in the active main mpv player and does no per-frame 
   assert.match(controls, /engine !== "mpv"/);
   assert.match(controls, /triggerRef\.current\?\.focus\(\)/);
   assert.match(controls, /listen<MpvPlaybackEvent>\("mpv:\/\/event"/);
+  assert.match(controls, /createSubtitleFpsAvailabilityController/);
   for (const event of ["file-loaded", "end-file", "shutdown"]) {
     assert.match(controls, new RegExp(`"${event}"`), event);
   }
@@ -275,28 +464,98 @@ test("the FPS trigger uses the dedicated vector subtitle timing icon", () => {
 });
 
 test("the panel refreshes after Auto Sync or secondary subtitles reset the native value", () => {
+  const controls = read("src/components/player/subtitle-menu/subtitle-fps-control.tsx");
   const panel = read("src/components/player/subtitle-menu/subtitle-fps-panel.tsx");
   assert.match(panel, /\[autoSyncActive, hasSecondary, track\?\.id\]/);
   assert.match(panel, /resetByPlayer[\s\S]*autoSyncActive[\s\S]*hasSecondary/);
+  assert.match(controls, /onBeforeApply=\{autoSync\?\.stop\}/);
+  assert.match(panel, /onBeforeApply\?\.\(\)[\s\S]*writeMpvSubtitleFps/);
 });
 
 test("mpv lifecycle and Auto Sync boundaries reset only subtitle FPS", () => {
   const properties = read("src/lib/player/mpv-properties.ts");
   const autoSyncStore = read("src/components/player/autosync/autosync-store.ts");
   const bridge = read("src/lib/player/mpv.ts");
+  const forwardingBridge = read("src/lib/player/mpv-forward.ts");
+  const hdrStageBridge = read("src/views/player/hdr-stage-bridge.tsx");
   const autoSync = read("src/views/player/hooks/use-auto-sync.ts");
 
-  assert.match(properties, /listen<MpvEvent>\("mpv:\/\/event"/);
-  for (const boundary of ["track-list", "file-loaded", "end-file", "shutdown"]) {
-    assert.match(properties, new RegExp(`"${boundary}"`), boundary);
-  }
-  assert.match(properties, /contextTrackId != null \|\| coordinator\.isActive\(\)/);
-  assert.match(properties, /pendingRequest === request/);
+  assert.doesNotMatch(properties, /listen<MpvEvent>\("mpv:\/\/event"/);
   assert.match(properties, /await coordinator\.whenSettled\(\)/);
-  assert.match(autoSyncStore, /resetMpvSubtitleFpsForTransition/);
-  for (const action of ["run", "retry", "applyOffer"]) {
-    assert.match(autoSyncStore, new RegExp(`${action}: afterSubtitleFpsReset`), action);
+  assert.match(bridge, /resetMpvSubtitleFpsForTransition/);
+  assert.match(bridge, /markMpvSubtitleFpsSessionRecreated/);
+  assert.match(
+    bridge,
+    /setSubtitleTrack\(id\)[\s\S]*const requestMediaRevision = mediaRevision[\s\S]*await resetSubtitleFpsBeforeMpvTransition\([\s\S]*requestMediaRevision !== mediaRevision[\s\S]*name: "sid"/,
+  );
+  assert.match(
+    bridge,
+    /setSecondarySubtitleTrack\(id\)[\s\S]*const requestMediaRevision = mediaRevision[\s\S]*await resetSubtitleFpsBeforeMpvTransition\([\s\S]*requestMediaRevision !== mediaRevision[\s\S]*name: "secondary-sid"/,
+  );
+  assert.match(
+    bridge,
+    /could not reset subtitle FPS before loading media[\s\S]*markMpvSubtitleFpsSessionRecreated\(\)[\s\S]*mpvStarted = false/,
+  );
+  assert.match(bridge, /let mediaRevision = 0/);
+  assert.match(bridge, /async load\(src[\s\S]*mediaRevision \+= 1/);
+  assert.match(
+    bridge,
+    /async addSubtitle[\s\S]*const requestMediaRevision = mediaRevision[\s\S]*requestMediaRevision !== mediaRevision[\s\S]*resetSubtitleFpsBeforeMpvTransition\(\)[\s\S]*requestMediaRevision !== mediaRevision[\s\S]*"mpv_sub_add"/,
+  );
+  assert.match(
+    forwardingBridge,
+    /setSubtitleTrack\(id\)[\s\S]*\{ id, mediaKey \}[\s\S]*HDR_STAGE_SET_SUBTITLE_TRACK/,
+  );
+  assert.match(
+    forwardingBridge,
+    /setSecondarySubtitleTrack\(id\)[\s\S]*\{ id, mediaKey \}[\s\S]*HDR_STAGE_SET_SECONDARY_SUBTITLE_TRACK/,
+  );
+  assert.match(forwardingBridge, /async addSubtitle[\s\S]*forwardSubtitleAdd\(\{[\s\S]*mediaKey/);
+  assert.doesNotMatch(forwardingBridge, /name: "sid"|name: "secondary-sid"|"mpv_sub_add"/);
+  assert.match(
+    hdrStageBridge,
+    /HDR_STAGE_SET_SUBTITLE_TRACK[\s\S]*isCurrentMediaRequest[\s\S]*setSubtitleTrack/,
+  );
+  assert.match(
+    hdrStageBridge,
+    /HDR_STAGE_SET_SECONDARY_SUBTITLE_TRACK[\s\S]*isCurrentMediaRequest[\s\S]*setSecondarySubtitleTrack/,
+  );
+  assert.match(
+    hdrStageBridge,
+    /HDR_STAGE_ADD_SUBTITLE[\s\S]*isCurrentMediaRequest[\s\S]*addSubtitle[\s\S]*HDR_STAGE_ADD_SUBTITLE_RESULT/,
+  );
+  for (const boundary of [
+    "async load",
+    "setSubtitleTrack",
+    "setSecondarySubtitleTrack",
+    "async addSubtitle",
+    "destroy",
+  ]) {
+    assert.match(bridge, new RegExp(boundary), boundary);
   }
-  assert.doesNotMatch(bridge, /mpv-properties|SubtitleFps/);
-  assert.doesNotMatch(autoSync, /mpv-properties|SubtitleFps|readMpvSubtitleDelay/);
+  assert.doesNotMatch(autoSyncStore, /resetMpvSubtitleFpsForTransition/);
+  assert.match(autoSync, /resetMpvSubtitleFpsForTransition/);
+  assert.match(autoSync, /runAfterSubtitleFpsReset/);
+  assert.match(autoSync, /subtitle FPS reset failed[\s\S]*setStatus\("error"\)/);
+  assert.match(autoSync, /handleOutcome[\s\S]*runWithSubtitleFpsReset/);
+  assert.match(autoSync, /applyOffer[\s\S]*isCurrentAutoSyncScope/);
+  assert.match(autoSync, /type AppliedState = \{[\s\S]*scope: AutoSyncScope \| null/);
+  assert.match(
+    autoSync,
+    /const canRevert = a\.changed && isCurrentAutoSyncScope\(a\.scope\)[\s\S]*if \(b && canRevert\)/,
+  );
+  assert.match(autoSync, /changed: boolean/);
+  assert.match(autoSync, /a\.changed = true/);
+  assert.match(
+    autoSync,
+    /setSubDelay: \(s\) => \{[\s\S]*isCurrentAutoSyncScope\(a\.scope\)[\s\S]*b\.setSubDelay\(s\)[\s\S]*a\.changed = true/,
+  );
+  assert.doesNotMatch(autoSync, /readMpvSubtitleDelay/);
+});
+
+test("the FPS save state respects reduced motion and is announced", () => {
+  const panel = read("src/components/player/subtitle-menu/subtitle-fps-panel.tsx");
+  assert.match(panel, /motion-reduce:animate-none/);
+  assert.match(panel, /role="status"/);
+  assert.match(panel, /aria-label=\{tr\("Saving"\)\}/);
 });

--- a/tests/subtitle-fps.test.ts
+++ b/tests/subtitle-fps.test.ts
@@ -1,0 +1,302 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  SUBTITLE_FPS_PRESETS,
+  createSubtitleFpsCoordinator,
+  formatSubtitleFps,
+  matchingSubtitleFpsPreset,
+  subtitleFpsAvailability,
+  subtitleFpsToMpvValue,
+  validateSubtitleFps,
+} from "../src/lib/player/subtitle-fps.ts";
+import { isTextSubTrack } from "../src/lib/player/sub-format.ts";
+
+const read = (path: string) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("subtitle FPS presets preserve exact NTSC fractional rates", () => {
+  assert.deepEqual(
+    SUBTITLE_FPS_PRESETS.map((preset) => preset.label),
+    ["23.976", "24", "25", "29.97", "30", "50", "59.94", "60"],
+  );
+  assert.equal(SUBTITLE_FPS_PRESETS[0].value, 24_000 / 1_001);
+  assert.equal(SUBTITLE_FPS_PRESETS[3].value, 30_000 / 1_001);
+  assert.equal(SUBTITLE_FPS_PRESETS[6].value, 60_000 / 1_001);
+});
+
+test("custom FPS accepts only finite values from 1 through 240", () => {
+  assert.deepEqual(validateSubtitleFps("23.976"), { ok: true, value: 23.976 });
+  assert.deepEqual(validateSubtitleFps(1), { ok: true, value: 1 });
+  assert.deepEqual(validateSubtitleFps(240), { ok: true, value: 240 });
+
+  for (const value of ["", " ", 0, 0.999, 240.001, Number.NaN, Infinity, true]) {
+    assert.equal(validateSubtitleFps(value).ok, false, String(value));
+  }
+});
+
+test("No correction maps to mpv's zero sentinel", () => {
+  assert.equal(subtitleFpsToMpvValue("default"), 0);
+  assert.equal(subtitleFpsToMpvValue(25), 25);
+  assert.throws(() => subtitleFpsToMpvValue(0), RangeError);
+});
+
+test("preset matching and formatting keep user-facing rates stable", () => {
+  assert.equal(matchingSubtitleFpsPreset(24_000 / 1_001), "23.976");
+  assert.equal(matchingSubtitleFpsPreset(24.981469), null);
+  assert.equal(formatSubtitleFps(24_000 / 1_001, 6), "23.976");
+  assert.equal(formatSubtitleFps(24.981469, 6), "24.981469");
+  assert.equal(formatSubtitleFps(null), "-");
+});
+
+test("manual control is available only for a selected text track in the primary mpv player", () => {
+  const valid = {
+    engine: "mpv" as const,
+    hasTrack: true,
+    textBased: true,
+    hasSecondary: false,
+    videoFps: 24_000 / 1_001,
+    nativeSupported: true,
+    autoSyncActive: false,
+  };
+  assert.deepEqual(subtitleFpsAvailability(valid), { enabled: true, reason: null });
+
+  const cases = [
+    [{ hasTrack: false }, "no-track"],
+    [{ engine: "html5" as const }, "html5"],
+    [{ textBased: false }, "not-text-based"],
+    [{ hasSecondary: true }, "secondary-active"],
+    [{ videoFps: null }, "video-fps-unavailable"],
+    [{ nativeSupported: false }, "native-unavailable"],
+    [{ autoSyncActive: true }, "auto-sync-active"],
+  ] as const;
+  for (const [override, reason] of cases) {
+    assert.deepEqual(subtitleFpsAvailability({ ...valid, ...override }), {
+      enabled: false,
+      reason,
+    });
+  }
+});
+
+test("recognized text formats are eligible and image formats are not", () => {
+  const track = (codec: string, title?: string) => ({
+    id: "1",
+    label: codec,
+    kind: "subtitle" as const,
+    selected: true,
+    codec,
+    title,
+  });
+  for (const codec of ["SUBRIP", "SRT", "WEBVTT", "ASS", "SSA", "MOV_TEXT"]) {
+    assert.equal(isTextSubTrack(track(codec)), true, codec);
+  }
+  for (const codec of ["HDMV_PGS_SUBTITLE", "DVD_SUBTITLE", "VOBSUB", "DVB_SUBTITLE"]) {
+    assert.equal(isTextSubTrack(track(codec)), false, codec);
+  }
+  assert.equal(isTextSubTrack(track("unknown", "external.srt")), true);
+  assert.equal(isTextSubTrack(track("unknown")), false);
+});
+
+test("FPS writes are serialized and transitions reset only an active correction", async () => {
+  const calls: number[] = [];
+  const coordinator = createSubtitleFpsCoordinator({
+    writeFps: async (value) => {
+      calls.push(value);
+    },
+  });
+
+  await Promise.all([coordinator.apply(25), coordinator.resetForTransition()]);
+  assert.deepEqual(calls, [25, 0]);
+  assert.equal(coordinator.isActive(), false);
+
+  await coordinator.resetForTransition();
+  assert.deepEqual(calls, [25, 0]);
+});
+
+test("a stale queued write cannot leak into a newer video or subtitle track", async () => {
+  const calls: number[] = [];
+  let current = true;
+  const coordinator = createSubtitleFpsCoordinator({
+    writeFps: async (value) => {
+      calls.push(value);
+      if (value === 25) current = false;
+    },
+  });
+
+  await assert.rejects(
+    coordinator.apply(25, () => current),
+    /context changed/,
+  );
+  assert.deepEqual(calls, [25, 0]);
+  assert.equal(coordinator.isActive(), false);
+});
+
+test("the latest rapid choice wins on the same subtitle track", async () => {
+  const calls: number[] = [];
+  let releaseFirstWrite: (() => void) | null = null;
+  let markFirstWriteStarted: (() => void) | null = null;
+  const firstWriteStarted = new Promise<void>((resolve) => {
+    markFirstWriteStarted = resolve;
+  });
+  let currentRequest = 1;
+  const coordinator = createSubtitleFpsCoordinator({
+    writeFps: async (value) => {
+      calls.push(value);
+      if (value === 25) {
+        markFirstWriteStarted?.();
+        await new Promise<void>((resolve) => {
+          releaseFirstWrite = resolve;
+        });
+      }
+    },
+  });
+
+  const first = coordinator.apply(25, () => currentRequest === 1);
+  await firstWriteStarted;
+  currentRequest = 2;
+  const second = coordinator.apply(24, () => currentRequest === 2);
+  releaseFirstWrite?.();
+
+  await assert.rejects(first, /context changed/);
+  await second;
+  assert.deepEqual(calls, [25, 0, 24]);
+  assert.equal(coordinator.isActive(), true);
+});
+
+test("a failed active reset blocks its transition and remains retryable", async () => {
+  let failReset = true;
+  const calls: number[] = [];
+  const coordinator = createSubtitleFpsCoordinator({
+    writeFps: async (value) => {
+      calls.push(value);
+      if (value === 0 && failReset) throw new Error("reset failed");
+    },
+  });
+
+  await coordinator.apply(25);
+  await assert.rejects(coordinator.resetForTransition(), /reset failed/);
+  assert.equal(coordinator.isActive(), true);
+  assert.deepEqual(calls, [25, 0]);
+
+  failReset = false;
+  await coordinator.resetForTransition();
+  assert.deepEqual(calls, [25, 0, 0]);
+  assert.equal(coordinator.isActive(), false);
+});
+
+test("native reads can wait for an in-flight subtitle FPS transition", async () => {
+  let releaseReset: (() => void) | null = null;
+  let markResetStarted: (() => void) | null = null;
+  const resetStarted = new Promise<void>((resolve) => {
+    markResetStarted = resolve;
+  });
+  const coordinator = createSubtitleFpsCoordinator({
+    writeFps: async (value) => {
+      if (value !== 0) return;
+      markResetStarted?.();
+      await new Promise<void>((resolve) => {
+        releaseReset = resolve;
+      });
+    },
+  });
+
+  await coordinator.apply(25);
+  const reset = coordinator.resetForTransition();
+  await resetStarted;
+
+  let settled = false;
+  const wait = coordinator.whenSettled().then(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  assert.equal(settled, false);
+
+  releaseReset?.();
+  await reset;
+  await wait;
+  assert.equal(settled, true);
+});
+
+test("the feature reuses Playback Stats FPS properties and only writes mpv sub-fps", () => {
+  const stats = read("src/components/player/stats-overlay.tsx");
+  const properties = read("src/lib/player/mpv-properties.ts");
+  assert.match(stats, /"estimated-vf-fps"/);
+  assert.match(stats, /"container-fps"/);
+  assert.match(properties, /"estimated-vf-fps"/);
+  assert.match(properties, /"container-fps"/);
+  assert.match(properties, /readMpvBoolean\("idle-active"\)/);
+  assert.match(properties, /"sub-fps"/);
+  assert.doesNotMatch(properties, /sub-delay|ffprobe|ffmpeg|MediaInfo/i);
+});
+
+test("manual FPS scope contains no calibration or delay ownership", () => {
+  const logic = read("src/lib/player/subtitle-fps.ts");
+  const panel = read("src/components/player/subtitle-menu/subtitle-fps-panel.tsx");
+  assert.doesNotMatch(logic, /calibr|sub-delay|SubtitleTimingPoint/i);
+  assert.doesNotMatch(panel, /calibr|early point|late point|manual offset|sub-delay/i);
+});
+
+test("the FPS control stays in the active main mpv player and does no per-frame work", () => {
+  const header = read("src/components/player/subtitle-menu/menu-header.tsx");
+  const menuTypes = read("src/components/player/subtitle-menu/types.ts");
+  const controls = read("src/components/player/subtitle-menu/subtitle-fps-control.tsx");
+  const panel = read("src/components/player/subtitle-menu/subtitle-fps-panel.tsx");
+  const renderer = read("src/components/player/transport/control-renderer.tsx");
+  const stremioRenderer = read("src/components/player/transport/control-renderer-stremio.tsx");
+  assert.match(header, /<SyncControl[\s\S]*<SubtitleFpsControl/);
+  assert.match(menuTypes, /engine\?: "html5" \| "mpv"/);
+  assert.match(renderer, /<SubtitleMenu[\s\S]*engine=\{ctx\.engine\}/);
+  assert.match(stremioRenderer, /<SubtitleMenu[\s\S]*engine=\{ctx\.engine\}/);
+  assert.match(controls, /getCurrentWindow\(\)\.label === "main"/);
+  assert.match(controls, /engine !== "mpv"/);
+  assert.match(controls, /triggerRef\.current\?\.focus\(\)/);
+  assert.match(controls, /listen<MpvPlaybackEvent>\("mpv:\/\/event"/);
+  for (const event of ["file-loaded", "end-file", "shutdown"]) {
+    assert.match(controls, new RegExp(`"${event}"`), event);
+  }
+  assert.match(controls, /SubtitleFpsPanel/);
+  assert.match(controls, /Subtitle FPS/);
+  assert.doesNotMatch(panel, /engine: "mpv"/);
+  assert.doesNotMatch(`${controls}\n${panel}`, /requestAnimationFrame|requestVideoFrameCallback/);
+  assert.doesNotMatch(read("src/components/player/subtitle-menu/sync-control.tsx"), /SubtitleFps/);
+});
+
+test("the FPS trigger uses the dedicated vector subtitle timing icon", () => {
+  const controls = read("src/components/player/subtitle-menu/subtitle-fps-control.tsx");
+  const icon = read("src/components/player/subtitle-menu/subtitle-fps-icon.tsx");
+
+  assert.match(controls, /<SubtitleFpsIcon/);
+  assert.doesNotMatch(controls, /\bGauge\b/);
+  assert.match(icon, /<svg/);
+  assert.match(icon, /currentColor/);
+  assert.match(icon, /aria-hidden="true"/);
+});
+
+test("the panel refreshes after Auto Sync or secondary subtitles reset the native value", () => {
+  const panel = read("src/components/player/subtitle-menu/subtitle-fps-panel.tsx");
+  assert.match(panel, /\[autoSyncActive, hasSecondary, track\?\.id\]/);
+  assert.match(panel, /resetByPlayer[\s\S]*autoSyncActive[\s\S]*hasSecondary/);
+});
+
+test("mpv lifecycle and Auto Sync boundaries reset only subtitle FPS", () => {
+  const properties = read("src/lib/player/mpv-properties.ts");
+  const autoSyncStore = read("src/components/player/autosync/autosync-store.ts");
+  const bridge = read("src/lib/player/mpv.ts");
+  const autoSync = read("src/views/player/hooks/use-auto-sync.ts");
+
+  assert.match(properties, /listen<MpvEvent>\("mpv:\/\/event"/);
+  for (const boundary of ["track-list", "file-loaded", "end-file", "shutdown"]) {
+    assert.match(properties, new RegExp(`"${boundary}"`), boundary);
+  }
+  assert.match(properties, /contextTrackId != null \|\| coordinator\.isActive\(\)/);
+  assert.match(properties, /pendingRequest === request/);
+  assert.match(properties, /await coordinator\.whenSettled\(\)/);
+  assert.match(autoSyncStore, /resetMpvSubtitleFpsForTransition/);
+  for (const action of ["run", "retry", "applyOffer"]) {
+    assert.match(autoSyncStore, new RegExp(`${action}: afterSubtitleFpsReset`), action);
+  }
+  assert.doesNotMatch(bridge, /mpv-properties|SubtitleFps/);
+  assert.doesNotMatch(autoSync, /mpv-properties|SubtitleFps|readMpvSubtitleDelay/);
+});


### PR DESCRIPTION
## Summary

- Add a manual **Subtitle source FPS** control beside the existing subtitle sync control.
- Use a dedicated lightweight subtitle-timing icon instead of a generic gauge, matching the control's actual purpose without adding an asset or dependency.
- Apply the selected rate through mpv's native `sub-fps` property without rewriting subtitle files.
- Read Video FPS from `estimated-vf-fps`, with `container-fps` as the same fallback used by Playback Stats.
- Pass the active player engine through both transport renderers, gate the control on an active, non-idle mpv session in the main Tauri window, and hide it again on mpv end/shutdown events.
- Reset an active correction when media or the primary subtitle track changes, secondary subtitles become active, the player shuts down, or Auto Sync starts or applies a result.
- Route HDR-overlay subtitle selection and subtitle addition back through the main `PlayerBridge`, with a media-identity guard so delayed actions from an old overlay cannot affect current playback.

## Why

A constant subtitle delay cannot fix timing that drifts progressively because the subtitle and video were authored at different frame rates. This control lets the user provide the subtitle's known source frame rate while Harbor keeps the video's frame rate, playback rate, and existing subtitle delay unchanged.

`No correction (default)` maps to mpv's `sub-fps=0`. It replaces the misleading idea of an automatic source-FPS detector: Harbor does not infer a subtitle source frame rate from timestamp-only subtitle data.

## Verification

- Fresh reviewer checkout: `pnpm install --frozen-lockfile` and the repository's `pnpm setup` completed successfully.
- `cargo check --manifest-path src-tauri/Cargo.toml`: passed after the official setup downloaded the bundled mpv runtime; two existing dead-code warnings remain in untouched Rust code.
- `vp fmt --check <all 23 changed files>`: passed.
- `vp check --no-fmt <all 23 changed files>`: passed with no warnings or lint errors.
- `pnpm exec tsc -b --pretty false`: passed.
- `node --test --experimental-strip-types tests/subtitle-fps.test.ts tests/autosync-switch-retrigger.test.ts`: 28/28 passed.
- `pnpm build`: passed; 4,706 modules transformed.
- Full repository suite: 296/302 passed. The exact base commit passes 271/277; the same six unrelated failures reproduce in both fresh checkouts, so this change adds 25 passing tests and no new failure.

Manual checks before merge:

- [ ] Select a known 25 FPS text subtitle over a 23.976 FPS video and confirm progressive drift is corrected during normal playback.
- [x] Apply a 25 FPS source value over 23.976 FPS Windows libmpv playback and confirm it is accepted without an error.
- [x] Switch the primary subtitle track and confirm the control returns to `No correction`.
- [ ] Switch media and confirm the previous source FPS does not carry over.
- [ ] Start Auto Sync and confirm the manual FPS correction is cleared first.
- [ ] Confirm bitmap and secondary-subtitle states show a disabled explanation instead of applying a correction.

## Platform Impact

The control is limited to desktop libmpv playback in the main player UI. Both the standard and Stremio transport renderers pass their actual engine to the subtitle menu. The control then verifies that mpv is running a loaded file through `idle-active` and follows `file-loaded`, `end-file`, and `shutdown` events so it does not remain available after playback stops. It is hidden in HTML5-only playback and separate modal player shells. Subtitle actions from Harbor's HDR overlay are forwarded to the main bridge with the originating media key, so delayed track or subtitle actions cannot cross a media boundary.

Text tracks classified as SRT/SubRip, ASS, SSA, WebVTT, or MOV_TEXT are supported by the code path. Embedded text tracks use the same path but still need runtime fixture coverage. Bitmap subtitles such as PGS, VobSub/DVD, DVB, and XSUB are intentionally unsupported. Secondary subtitles are intentionally unsupported because mpv's `sub-fps` property is global.

There are no Rust changes, new commands, dependencies, subtitle-file writes, playback-rate changes, or subtitle-delay changes.

## UI Changes

The subtitle menu header gains a compact subtitle-timing button beside Sync. Its custom vector icon combines subtitle lines and a clock, while inheriting the existing button's color and states. The panel shows Video FPS, a `No correction` default, standard source-FPS presets, and a validated custom value from 1 through 240.

**Header trigger with a selected text subtitle**

<img width="698" height="684" alt="Subtitle FPS trigger with a selected text subtitle" src="https://github.com/user-attachments/assets/50fc9eb6-1053-4e30-84f2-f7de152a2b0a" />

**Default timing**

<img width="674" height="617" alt="Subtitle FPS panel showing No correction and 23.976 video FPS" src="https://github.com/user-attachments/assets/c74c18ef-8150-4829-abc4-feaab9a3e0b0" />

**25 FPS subtitle source over 23.976 FPS video**

<img width="676" height="600" alt="Subtitle FPS panel applying a 25 FPS subtitle source over 23.976 FPS video" src="https://github.com/user-attachments/assets/495fa41c-0192-4487-b664-c72df926e405" />

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes. The current beta branch does not define this Vite+ task; the direct `pnpm exec tsc -b --pretty false` equivalent passed.
- [x] I ran the relevant Cargo checks after Rust changes. Not applicable: this pull request has no Rust changes.
- [x] I tested affected platforms when the change is platform-specific. Verified on Windows libmpv; macOS and Linux remain untested.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
