### PR TITLE
fix(episodes): fill missing episode metadata from Cinemeta

### DIFF
--- a/src/lib/providers/anime-episode-cinemeta-merge.ts
+++ b/src/lib/providers/anime-episode-cinemeta-merge.ts
@@ -1,0 +1,46 @@
+import type { KitsuEpisode } from "./kitsu";
+
+export interface CinemetaEpisode {
+  season?: number;
+  episode?: number;
+  name?: string;
+  title?: string;
+  overview?: string;
+  description?: string;
+  thumbnail?: string;
+}
+
+export function mergeCinemetaEpisodes(episodes: KitsuEpisode[], videos: CinemetaEpisode[]): void {
+  const bySeasonEpisode = new Map<string, CinemetaEpisode>();
+  const byAbsolute = new Map<number, CinemetaEpisode>();
+  const ordered = videos
+    .filter((video) => video.season != null && video.episode != null)
+    .sort((a, b) => (a.season ?? 0) - (b.season ?? 0) || (a.episode ?? 0) - (b.episode ?? 0));
+  let position = 0;
+  for (const video of ordered) {
+    bySeasonEpisode.set(`${video.season}:${video.episode}`, video);
+    if ((video.season ?? 0) > 0) {
+      position += 1;
+      if (!byAbsolute.has(position)) byAbsolute.set(position, video);
+    }
+  }
+
+  for (const episode of episodes) {
+    const season = episode.imdbSeason ?? episode.seasonNumber ?? 1;
+    const episodeNumber = episode.imdbEpisode ?? episode.number;
+    const match =
+      bySeasonEpisode.get(`${season}:${episodeNumber}`) ??
+      byAbsolute.get(episode.absoluteNumber ?? episode.number);
+    if (!match) continue;
+
+    const title = match.name || match.title;
+    if (title && (!episode.title || episode.title === `Episode ${episode.number}`)) {
+      episode.title = title;
+    }
+    const synopsis = match.overview || match.description;
+    if (synopsis && !episode.synopsis) episode.synopsis = synopsis;
+    if (match.thumbnail && !episode.thumbnail) {
+      episode.thumbnail = match.thumbnail;
+    }
+  }
+}

--- a/src/lib/providers/anime-episode-enrich.ts
+++ b/src/lib/providers/anime-episode-enrich.ts
@@ -5,6 +5,7 @@ import { fetchTvdbThumbs } from "@/lib/providers/anime-tvdb-thumbs";
 import { meta as fetchCinemetaMeta } from "@/lib/cinemeta";
 import type { KitsuEpisode } from "@/lib/providers/kitsu";
 import type { Settings } from "@/lib/settings";
+import { mergeCinemetaEpisodes } from "./anime-episode-cinemeta-merge";
 
 async function enrichFiller(episodes: KitsuEpisode[], kitsuId: number): Promise<void> {
   if (episodes.some((ep) => ep.filler)) return;
@@ -18,36 +19,21 @@ async function enrichFiller(episodes: KitsuEpisode[], kitsuId: number): Promise<
   }
 }
 
-async function enrichCinemetaThumbs(episodes: KitsuEpisode[], imdbId: string | null): Promise<void> {
+async function enrichCinemetaEpisodes(
+  episodes: KitsuEpisode[],
+  imdbId: string | null,
+): Promise<void> {
   if (!imdbId || !imdbId.startsWith("tt")) return;
-  if (episodes.every((ep) => ep.thumbnail)) return;
+  if (
+    episodes.every(
+      (ep) => ep.thumbnail && ep.synopsis && ep.title && ep.title !== `Episode ${ep.number}`,
+    )
+  )
+    return;
   const m = await fetchCinemetaMeta("series", imdbId).catch(() => null);
   const videos = m?.videos ?? [];
   if (videos.length === 0) return;
-
-  const bySeasonEpisode = new Map<string, string>();
-  const byAbsolute = new Map<number, string>();
-  const ordered = videos
-    .filter((v) => v.thumbnail && v.season != null && v.episode != null)
-    .sort((a, b) => (a.season ?? 0) - (b.season ?? 0) || (a.episode ?? 0) - (b.episode ?? 0));
-  let pos = 0;
-  for (const v of ordered) {
-    const thumb = v.thumbnail as string;
-    bySeasonEpisode.set(`${v.season}:${v.episode}`, thumb);
-    if ((v.season ?? 0) > 0) {
-      pos += 1;
-      if (!byAbsolute.has(pos)) byAbsolute.set(pos, thumb);
-    }
-  }
-
-  for (const ep of episodes) {
-    if (ep.thumbnail) continue;
-    const season = ep.imdbSeason ?? ep.seasonNumber ?? 1;
-    const epNum = ep.imdbEpisode ?? ep.number;
-    const hit =
-      bySeasonEpisode.get(`${season}:${epNum}`) ?? byAbsolute.get(ep.absoluteNumber ?? ep.number);
-    if (hit) ep.thumbnail = hit;
-  }
+  mergeCinemetaEpisodes(episodes, videos);
 }
 
 async function enrichTvdbThumbs(
@@ -59,9 +45,7 @@ async function enrichTvdbThumbs(
   if (episodes.every((ep) => ep.thumbnail)) return;
   const tvdbId = await kitsuToTvdb(kitsuId).catch(() => null);
   if (!tvdbId) return;
-  const seasons = Array.from(
-    new Set(episodes.map((ep) => ep.imdbSeason ?? ep.seasonNumber ?? 1)),
-  );
+  const seasons = Array.from(new Set(episodes.map((ep) => ep.imdbSeason ?? ep.seasonNumber ?? 1)));
   const index = await fetchTvdbThumbs(settings.tvdbKey, tvdbId, seasons).catch(() => null);
   if (!index) return;
   for (const ep of episodes) {
@@ -101,7 +85,7 @@ export async function enrichEpisodes(
     enrichFiller(episodes, kitsuId),
     enrichHarborImdb(episodes, imdbId),
     (async () => {
-      await enrichCinemetaThumbs(episodes, imdbId);
+      await enrichCinemetaEpisodes(episodes, imdbId);
       await enrichTvdbThumbs(episodes, settings, kitsuId);
     })(),
   ]);

--- a/tests/anime-episode-cinemeta-enrich.test.ts
+++ b/tests/anime-episode-cinemeta-enrich.test.ts
@@ -1,0 +1,55 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import { mergeCinemetaEpisodes } from "../src/lib/providers/anime-episode-cinemeta-merge.ts";
+import type { KitsuEpisode } from "../src/lib/providers/kitsu.ts";
+
+test("fills a generic anime episode title from Cinemeta without overwriting valid metadata", () => {
+  const episodes: KitsuEpisode[] = [
+    {
+      id: 7,
+      number: 7,
+      seasonNumber: 1,
+      title: "Episode 7",
+      synopsis: "",
+      thumbnail: null,
+      airdate: null,
+      length: null,
+    },
+    {
+      id: 8,
+      number: 8,
+      seasonNumber: 1,
+      title: "Existing title",
+      synopsis: "Existing synopsis",
+      thumbnail: "https://example.test/existing.jpg",
+      airdate: null,
+      length: null,
+    },
+  ];
+
+  mergeCinemetaEpisodes(episodes, [
+    {
+      season: 1,
+      episode: 7,
+      name: "Golden Raana Farming",
+      overview: "Episode seven overview",
+      thumbnail: "https://example.test/7.jpg",
+    },
+    {
+      season: 1,
+      episode: 8,
+      name: "Replacement title",
+      overview: "Replacement synopsis",
+      thumbnail: "https://example.test/8.jpg",
+    },
+  ]);
+
+  assert.equal(episodes[0].title, "Golden Raana Farming");
+  assert.equal(episodes[0].synopsis, "Episode seven overview");
+  assert.equal(episodes[0].thumbnail, "https://example.test/7.jpg");
+  assert.equal(episodes[1].title, "Existing title");
+  assert.equal(episodes[1].synopsis, "Existing synopsis");
+  assert.equal(episodes[1].thumbnail, "https://example.test/existing.jpg");
+});


### PR DESCRIPTION
## Summary

Harbor now consistently replaces generic labels such as `Episode 7` with available Cinemeta titles across episodic shows.

Standard series already render Cinemeta video metadata directly. This patch closes the remaining gap for series routed through the Kitsu/AniZip enrichment path by merging Cinemeta titles, synopsis, and artwork there as well. Existing valid metadata is preserved.

## Why

Generic episode labels are not specific to anime as a user-facing problem. Harbor has two relevant episode-metadata paths:

- Standard series consume Cinemeta episode videos directly.
- Kitsu/AniZip-backed series use Harbor's enriched episode model.

The second path previously used Cinemeta only for thumbnails, so it could retain a generic title even when Cinemeta had the correct IMDb season/episode title. With this fallback in place, both paths expose available episode titles consistently.

## Verification

- `node --test tests/anime-episode-cinemeta-enrich.test.ts`
- `pnpm typecheck`
- `pnpm exec vp check --no-fmt src/lib/providers/anime-episode-enrich.ts src/lib/providers/anime-episode-cinemeta-merge.ts tests/anime-episode-cinemeta-enrich.test.ts`
- Enriched-path regression: `tt33334216` S1E7 resolves from `Episode 7` to `Golden Raana Farming`.
- Standard-series visual regression: *Mike Tyson Mysteries* S4E16 renders `Shop 'Til You Drop`, confirming ordinary series retain their Cinemeta episode titles.

## Platform Impact

None. This changes shared episode metadata enrichment only and does not alter playback or platform-specific behavior.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes. (No Rust changes.)
- [x] I tested affected platforms when the change is platform-specific. (Not platform-specific.)
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
