### PR TITLE
fix(profiles): per-profile data isolation and addon refresh on profile switch

### DIFF
--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/lib/stremio";
 import { useHasNewEpisode } from "@/lib/new-episodes";
 import { Tooltip } from "@/views/detail/tooltip";
-import { useProfiles } from "@/lib/profiles";
+import { useProfiles, sharesStremioStorage } from "@/lib/profiles";
 import { useSettings } from "@/lib/settings";
 import { useView, type PlayEpisode } from "@/lib/view";
 import { getWatchedBy } from "@/lib/watched-by";
@@ -55,7 +55,11 @@ export const ContinueCard = memo(function ContinueCard({
   const { profiles, activeProfile } = useProfiles();
   const watcherId = getWatchedBy(item._id);
   const watcher = watcherId ? profiles.find((p) => p.id === watcherId) : null;
-  const showWatcher = !!watcher && watcher.id !== activeProfile?.id;
+  const showWatcher =
+    !!watcher &&
+    !!activeProfile &&
+    watcher.id !== activeProfile.id &&
+    sharesStremioStorage(activeProfile, watcher, profiles);
   const settingsRef = useRef(settings);
   settingsRef.current = settings;
   const { open: openContextMenu } = useContextMenu();

--- a/src/components/profile-picker/editor-view.tsx
+++ b/src/components/profile-picker/editor-view.tsx
@@ -105,6 +105,7 @@ export function EditorView({
     settings: false,
     addons: false,
     watchlist: false,
+    favorites: false,
     watched: false,
     continueWatching: false,
   });
@@ -148,6 +149,7 @@ export function EditorView({
       settings: false,
       addons: false,
       watchlist: false,
+      favorites: false,
       watched: false,
       continueWatching: false,
     });
@@ -662,6 +664,11 @@ export function EditorView({
                     checked={importSelection.watchlist}
                     label={t("Watchlist ({n})", { n: sourceSummary?.watchlistCount ?? 0 })}
                     onClick={() => toggleImportDomain("watchlist")}
+                  />
+                  <ImportRow
+                    checked={importSelection.favorites}
+                    label={t("Favorites ({n})", { n: sourceSummary?.favoriteCount ?? 0 })}
+                    onClick={() => toggleImportDomain("favorites")}
                   />
                   <ImportRow
                     checked={importSelection.watched}

--- a/src/components/profile-picker/editor-view.tsx
+++ b/src/components/profile-picker/editor-view.tsx
@@ -1,5 +1,5 @@
 import { Check, ChevronLeft, Crown, Loader2, Lock, Link2, ShieldCheck, Trash2, Unlock, User as UserIcon } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import traktLogo from "@/assets/trakt.svg";
 import simklLogo from "@/assets/simkl.png";
 import { AddonsIcon } from "@/components/icons/addons-icon";
@@ -26,6 +26,15 @@ import {
   type Profile,
   type ProfileColor,
 } from "@/lib/profiles";
+import { emitListToast } from "@/components/lists/list-toast";
+import {
+  defaultSelectedAddonUrls,
+  importDomains,
+  summarizeSource,
+  type ImportAddonPreview,
+  type ImportDomain,
+  type ImportSourceSummary,
+} from "@/lib/profile-import";
 import { useT } from "@/lib/i18n";
 import { hashProfilePassword, verifyProfilePassword } from "@/lib/profile-password";
 import { fetchTraktAvatar } from "@/lib/trakt/profile";
@@ -92,6 +101,15 @@ export function EditorView({
   const [shareWith, setShareWith] = useState<string | null>(
     editing ? editing.shareStremioWith : primary?.id ?? null,
   );
+  const [importSelection, setImportSelection] = useState<Record<ImportDomain, boolean>>({
+    settings: false,
+    addons: false,
+    watchlist: false,
+    watched: false,
+    continueWatching: false,
+  });
+  const [selectedAddons, setSelectedAddons] = useState<Set<string>>(new Set());
+  const [sourceSummary, setSourceSummary] = useState<ImportSourceSummary | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [confirmingPrimary, setConfirmingPrimary] = useState(false);
   const [transferOpen, setTransferOpen] = useState(false);
@@ -111,6 +129,41 @@ export function EditorView({
   const isPrimary = editing?.isPrimary === true;
   const canShare = !isPrimary && !!primary && primary.id !== editing?.id;
   const locked = editing ? !!editing.passwordHash : draftPin != null;
+  const isCreate = mode.kind === "create";
+  const importPanelOpen = isCreate && canShare && !!primary && shareWith === null;
+  const primaryIdForImport = isCreate ? (primary?.id ?? null) : null;
+
+  useEffect(() => {
+    setSourceSummary(primaryIdForImport ? summarizeSource(primaryIdForImport) : null);
+  }, [primaryIdForImport]);
+
+  const resetImportChoice = () => {
+    setImportSelection({
+      settings: false,
+      addons: false,
+      watchlist: false,
+      watched: false,
+      continueWatching: false,
+    });
+    setSelectedAddons(new Set());
+  };
+
+  const toggleImportDomain = (domain: ImportDomain) => {
+    const turningOn = !importSelection[domain];
+    setImportSelection((prev) => ({ ...prev, [domain]: !prev[domain] }));
+    if (domain === "addons" && turningOn) {
+      setSelectedAddons(defaultSelectedAddonUrls(sourceSummary?.addons ?? []));
+    }
+  };
+
+  const toggleImportAddon = (transportUrl: string) => {
+    setSelectedAddons((prev) => {
+      const next = new Set(prev);
+      if (next.has(transportUrl)) next.delete(transportUrl);
+      else next.add(transportUrl);
+      return next;
+    });
+  };
 
   const onPickFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -213,6 +266,17 @@ export function EditorView({
       if (canShare && shareWith !== p.shareStremioWith) patch.shareStremioWith = shareWith;
       if (draftPin) patch.passwordHash = await hashProfilePassword(draftPin);
       if (anyTabLocked(draftLockedTabs)) patch.lockedTabs = draftLockedTabs;
+      const importList =
+        shareWith === null && primary
+          ? (Object.keys(importSelection) as ImportDomain[]).filter((d) => importSelection[d])
+          : [];
+      if (importList.length > 0 && primary) {
+        importDomains(primary.id, p.id, importList, {
+          addonTransportUrls: importList.includes("addons") ? [...selectedAddons] : null,
+        });
+        if (importList.includes("settings")) patch.settingsLinked = false;
+        emitListToast(t("Data copied from {name}", { name: primary.name }));
+      }
       if (Object.keys(patch).length > 0) updateProfile(p.id, patch);
       selectProfile(p.id);
     }
@@ -479,18 +543,76 @@ export function EditorView({
           <div className="flex flex-col gap-1.5">
             <ShareOption
               active={shareWith === primary.id}
-              onClick={() => setShareWith(primary.id)}
+              onClick={() => {
+                setShareWith(primary.id);
+                resetImportChoice();
+              }}
               icon={<Link2 size={14} strokeWidth={2.2} />}
               title={t("Share with {name}", { name: primary.name })}
               sub={t("Use the primary profile's Stremio library, watchlist, and addons.")}
             />
             <ShareOption
               active={shareWith === null}
-              onClick={() => setShareWith(null)}
+              onClick={() => {
+                setShareWith(null);
+                resetImportChoice();
+              }}
               icon={<UserIcon size={14} strokeWidth={2.2} />}
               title={t("Use a separate Stremio account")}
               sub={t("Sign in from the sidebar after saving. Library and addons stay separate.")}
             />
+            {importPanelOpen && (
+              <div className="mt-1 flex flex-col gap-2 rounded-xl border border-edge-soft bg-canvas/40 p-3">
+                <span className="text-[12.5px] font-semibold text-ink">
+                  {t("Start with data from {name}", { name: primary?.name ?? "" })}
+                </span>
+                <div className="flex flex-col gap-1">
+                  <ImportRow
+                    checked={importSelection.settings}
+                    label={t("Settings")}
+                    onClick={() => toggleImportDomain("settings")}
+                  />
+                  <ImportRow
+                    checked={importSelection.addons}
+                    label={t("Addons ({n})", { n: sourceSummary?.addons.length ?? 0 })}
+                    onClick={() => toggleImportDomain("addons")}
+                  />
+                  {importSelection.addons && (sourceSummary?.addons.length ?? 0) > 0 && (
+                    <div className="ms-6 flex flex-col gap-1">
+                      {(sourceSummary?.addons ?? []).map((addon: ImportAddonPreview) => (
+                        <ImportRow
+                          key={addon.transportUrl}
+                          compact
+                          checked={selectedAddons.has(addon.transportUrl)}
+                          label={addon.name}
+                          onClick={() => toggleImportAddon(addon.transportUrl)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                  <ImportRow
+                    checked={importSelection.watchlist}
+                    label={t("Watchlist ({n})", { n: sourceSummary?.watchlistCount ?? 0 })}
+                    onClick={() => toggleImportDomain("watchlist")}
+                  />
+                  <ImportRow
+                    checked={importSelection.watched}
+                    label={t("Watched history")}
+                    onClick={() => toggleImportDomain("watched")}
+                  />
+                  <ImportRow
+                    checked={importSelection.continueWatching}
+                    label={t("Continue watching")}
+                    onClick={() => toggleImportDomain("continueWatching")}
+                  />
+                </div>
+                <p className="text-[11px] leading-snug text-ink-subtle">
+                  {t(
+                    "Copied once — afterwards this profile keeps its own copy. Nothing stays linked to Primary.",
+                  )}
+                </p>
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -885,6 +1007,37 @@ function SecurityView({
         </button>
       </div>
     </div>
+  );
+}
+
+function ImportRow({
+  checked,
+  label,
+  compact,
+  onClick,
+}: {
+  checked: boolean;
+  label: string;
+  compact?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-2.5 rounded-lg border px-3 text-start transition-colors ${
+        checked ? "border-ink/40 bg-canvas/60" : "border-edge-soft hover:border-edge hover:bg-canvas/40"
+      } ${compact ? "py-1.5" : "py-2"}`}
+    >
+      <span
+        className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-md border-2 transition-colors ${
+          checked ? "border-ink bg-ink text-canvas" : "border-edge"
+        }`}
+      >
+        {checked && <Check size={10} strokeWidth={3} />}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-ink">{label}</span>
+    </button>
   );
 }
 

--- a/src/components/profile-picker/editor-view.tsx
+++ b/src/components/profile-picker/editor-view.tsx
@@ -110,6 +110,9 @@ export function EditorView({
   });
   const [selectedAddons, setSelectedAddons] = useState<Set<string>>(new Set());
   const [sourceSummary, setSourceSummary] = useState<ImportSourceSummary | null>(null);
+  const [importExpanded, setImportExpanded] = useState(mode.kind === "create");
+  const [confirmingImport, setConfirmingImport] = useState(false);
+  const [confirmingShare, setConfirmingShare] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [confirmingPrimary, setConfirmingPrimary] = useState(false);
   const [transferOpen, setTransferOpen] = useState(false);
@@ -130,12 +133,15 @@ export function EditorView({
   const canShare = !isPrimary && !!primary && primary.id !== editing?.id;
   const locked = editing ? !!editing.passwordHash : draftPin != null;
   const isCreate = mode.kind === "create";
-  const importPanelOpen = isCreate && canShare && !!primary && shareWith === null;
-  const primaryIdForImport = isCreate ? (primary?.id ?? null) : null;
+  const importPanelOpen = !isPrimary && canShare && !!primary && shareWith === null;
+  const importSourceId = !isPrimary && primary ? primary.id : null;
+  const importAnySelected = (Object.keys(importSelection) as ImportDomain[]).some(
+    (d) => importSelection[d],
+  );
 
   useEffect(() => {
-    setSourceSummary(primaryIdForImport ? summarizeSource(primaryIdForImport) : null);
-  }, [primaryIdForImport]);
+    setSourceSummary(importSourceId ? summarizeSource(importSourceId) : null);
+  }, [importSourceId]);
 
   const resetImportChoice = () => {
     setImportSelection({
@@ -163,6 +169,24 @@ export function EditorView({
       else next.add(transportUrl);
       return next;
     });
+  };
+
+  const applyImportToExisting = () => {
+    if (!primary || !editing) return;
+    const list = (Object.keys(importSelection) as ImportDomain[]).filter((d) => importSelection[d]);
+    if (list.length === 0) return;
+    importDomains(primary.id, editing.id, list, {
+      addonTransportUrls: list.includes("addons") ? [...selectedAddons] : null,
+    });
+    if (list.includes("settings") && editing.settingsLinked !== false) {
+      updateProfile(editing.id, { settingsLinked: false });
+    }
+    window.dispatchEvent(new Event("harbor:addons-changed"));
+    window.dispatchEvent(new Event("harbor:active-profile-changed"));
+    emitListToast(t("Data copied from {name}", { name: primary.name }));
+    resetImportChoice();
+    setConfirmingImport(false);
+    setImportExpanded(false);
   };
 
   const onPickFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -544,8 +568,12 @@ export function EditorView({
             <ShareOption
               active={shareWith === primary.id}
               onClick={() => {
-                setShareWith(primary.id);
-                resetImportChoice();
+                if (!editing) {
+                  setShareWith(primary.id);
+                  resetImportChoice();
+                } else {
+                  setConfirmingShare(true);
+                }
               }}
               icon={<Link2 size={14} strokeWidth={2.2} />}
               title={t("Share with {name}", { name: primary.name })}
@@ -555,16 +583,56 @@ export function EditorView({
               active={shareWith === null}
               onClick={() => {
                 setShareWith(null);
+                setConfirmingShare(false);
                 resetImportChoice();
               }}
               icon={<UserIcon size={14} strokeWidth={2.2} />}
               title={t("Use a separate Stremio account")}
               sub={t("Sign in from the sidebar after saving. Library and addons stay separate.")}
             />
-            {importPanelOpen && (
+            {confirmingShare && (
+              <div className="flex items-center gap-2 rounded-lg border border-edge-soft bg-canvas/40 px-3 py-2 text-[12px]">
+                <span className="min-w-0 flex-1 leading-snug text-ink-subtle">
+                  {t(
+                    "Switch to sharing? This profile will use {name}'s library, watchlist and addons. Its own data is kept but hidden until you switch back.",
+                    { name: primary.name },
+                  )}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingShare(false)}
+                  className="shrink-0 text-ink-muted transition-colors hover:text-ink"
+                >
+                  {t("common.cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShareWith(primary.id);
+                    resetImportChoice();
+                    setConfirmingShare(false);
+                  }}
+                  className="shrink-0 rounded-md bg-accent/20 px-2.5 py-1 font-semibold text-accent transition-colors hover:bg-accent/30"
+                >
+                  {t("common.confirm")}
+                </button>
+              </div>
+            )}
+            {importPanelOpen && !importExpanded && (
+              <button
+                type="button"
+                onClick={() => setImportExpanded(true)}
+                className="h-9 self-start rounded-lg border border-edge-soft px-3 text-[12.5px] font-semibold text-ink-muted transition-colors hover:border-edge hover:text-ink"
+              >
+                {t("Import data from {name}", { name: primary.name })}
+              </button>
+            )}
+            {importPanelOpen && importExpanded && (
               <div className="mt-1 flex flex-col gap-2 rounded-xl border border-edge-soft bg-canvas/40 p-3">
                 <span className="text-[12.5px] font-semibold text-ink">
-                  {t("Start with data from {name}", { name: primary?.name ?? "" })}
+                  {t(isCreate ? "Start with data from {name}" : "Import data from {name}", {
+                    name: primary?.name ?? "",
+                  })}
                 </span>
                 <div className="flex flex-col gap-1">
                   <ImportRow
@@ -608,9 +676,55 @@ export function EditorView({
                 </div>
                 <p className="text-[11px] leading-snug text-ink-subtle">
                   {t(
-                    "Copied once — afterwards this profile keeps its own copy. Nothing stays linked to Primary.",
+                    isCreate
+                      ? "Copied once — afterwards this profile keeps its own copy. Nothing stays linked to Primary."
+                      : "Checking an area replaces this profile's current data in it.",
                   )}
                 </p>
+                {!isCreate && (
+                  <div className="flex items-center justify-end gap-2 pt-1 text-[12px]">
+                    {!confirmingImport ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            resetImportChoice();
+                            setImportExpanded(false);
+                          }}
+                          className="text-ink-muted transition-colors hover:text-ink"
+                        >
+                          {t("common.cancel")}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={!importAnySelected}
+                          onClick={() => setConfirmingImport(true)}
+                          className="rounded-md bg-accent/20 px-2.5 py-1 font-semibold text-accent transition-colors hover:bg-accent/30 disabled:opacity-40"
+                        >
+                          {t("Import")}
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <span className="text-ink-subtle">{t("Replace selected data?")}</span>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingImport(false)}
+                          className="text-ink-muted transition-colors hover:text-ink"
+                        >
+                          {t("common.cancel")}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={applyImportToExisting}
+                          className="rounded-md bg-accent/20 px-2.5 py-1 font-semibold text-accent transition-colors hover:bg-accent/30"
+                        >
+                          {t("common.confirm")}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/lib/addon-store.ts
+++ b/src/lib/addon-store.ts
@@ -3,11 +3,75 @@ import { readActiveStremioAuthKey } from "./auth";
 import { setUserAddons, userAddons, type Addon } from "./addons";
 import { applyOrderToItems } from "./addons-store/reorder";
 
-const STORAGE_KEY = "harbor.installed-addons";
+const PROFILES_KEY = "harbor.profiles.v1";
+
+const STORAGE_KEY_PREFIX = "harbor.installed-addons.";
+const LEGACY_STORAGE_KEY = "harbor.installed-addons";
 const SEEDED_KEY = "harbor.addons.seeded.v1";
-const DISABLED_KEY = "harbor.addons.disabled";
+const DISABLED_KEY_PREFIX = "harbor.addons.disabled.";
+const LEGACY_DISABLED_KEY = "harbor.addons.disabled";
 
 const DEFAULT_ADDONS: Array<{ id: string; transportUrl: string }> = [];
+
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(kind: "installed" | "disabled"): string {
+  const id = activeProfileId();
+  if (kind === "installed") return id ? STORAGE_KEY_PREFIX + id : LEGACY_STORAGE_KEY;
+  return id ? DISABLED_KEY_PREFIX + id : LEGACY_DISABLED_KEY;
+}
+
+function migrateLegacy(): void {
+  try {
+    const pid = primaryProfileId();
+    if (!pid) return;
+    const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (legacy) {
+      const perKey = STORAGE_KEY_PREFIX + pid;
+      if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+      localStorage.removeItem(LEGACY_STORAGE_KEY);
+    }
+    const legacyDisabled = localStorage.getItem(LEGACY_DISABLED_KEY);
+    if (legacyDisabled) {
+      const perKey = DISABLED_KEY_PREFIX + pid;
+      if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacyDisabled);
+      localStorage.removeItem(LEGACY_DISABLED_KEY);
+    }
+  } catch {
+    /* noop */
+  }
+}
 
 export async function seedDefaultAddonsIfFirstRun(): Promise<void> {
   try {
@@ -112,7 +176,8 @@ function slimManifest(manifest: Addon["manifest"] | undefined): Addon["manifest"
 }
 
 export function loadInstalled(): InstalledAddon[] {
-  const raw = localStorage.getItem(STORAGE_KEY);
+  migrateLegacy();
+  const raw = localStorage.getItem(storeKey("installed"));
   if (!raw) return [];
   try {
     return JSON.parse(raw) as InstalledAddon[];
@@ -124,7 +189,7 @@ export function loadInstalled(): InstalledAddon[] {
 function saveInstalled(list: InstalledAddon[]) {
   const slim = list.map((a) => ({ ...a, manifest: slimManifest(a.manifest) }));
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(slim));
+    localStorage.setItem(storeKey("installed"), JSON.stringify(slim));
   } catch (e) {
     if (e instanceof DOMException && (e.name === "QuotaExceededError" || e.code === 22)) {
       const stripped = list.map((a) => ({
@@ -133,7 +198,7 @@ function saveInstalled(list: InstalledAddon[]) {
         installedAt: a.installedAt,
       }));
       try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(stripped));
+        localStorage.setItem(storeKey("installed"), JSON.stringify(stripped));
       } catch (e2) {
         console.warn("[addons] localStorage still full after stripping manifests", e2);
       }
@@ -150,8 +215,9 @@ export function reorderInstalled(urlSequence: string[]): void {
 }
 
 export function loadDisabledAddons(): Set<string> {
+  migrateLegacy();
   try {
-    const raw = localStorage.getItem(DISABLED_KEY);
+    const raw = localStorage.getItem(storeKey("disabled"));
     if (!raw) return new Set();
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return new Set();
@@ -163,7 +229,7 @@ export function loadDisabledAddons(): Set<string> {
 
 function saveDisabledAddons(set: Set<string>): void {
   try {
-    localStorage.setItem(DISABLED_KEY, JSON.stringify([...set]));
+    localStorage.setItem(storeKey("disabled"), JSON.stringify([...set]));
   } catch (e) {
     console.warn("[addons] couldn't persist disabled addons", e);
   }

--- a/src/lib/addons-store/store.ts
+++ b/src/lib/addons-store/store.ts
@@ -259,6 +259,12 @@ export function useAddonsCatalog(adultsAllowed: boolean): {
     return () => window.removeEventListener("harbor:addons-changed", onChange);
   }, []);
 
+  useEffect(() => {
+    const onProfileChanged = () => setTick((t) => t + 1);
+    window.addEventListener("harbor:active-profile-changed", onProfileChanged);
+    return () => window.removeEventListener("harbor:active-profile-changed", onProfileChanged);
+  }, []);
+
   return { loading, byId, installedIds, refetch: () => setTick((t) => t + 1) };
 }
 

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -21,8 +21,6 @@ type AuthValue = {
 
 const PROFILE_KEY_PREFIX = "harbor.auth.";
 
-let liveStremioAuthKey: string | null = null;
-
 function profileAuthKey(id: string): string {
   return PROFILE_KEY_PREFIX + id;
 }
@@ -49,7 +47,6 @@ function writeProfileSession(id: string, session: Session | null): void {
 }
 
 export function readActiveStremioAuthKey(): string | null {
-  if (liveStremioAuthKey) return liveStremioAuthKey;
   try {
     const raw = localStorage.getItem("harbor.profiles.v1");
     if (!raw) return null;
@@ -77,10 +74,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     setSession(sourceId ? readProfileSession(sourceId) : null);
   }, [sourceId]);
-
-  useEffect(() => {
-    liveStremioAuthKey = session?.authKey ?? null;
-  }, [session]);
 
   const commitSession = useCallback(
     (fresh: Session) => {

--- a/src/lib/deep-link.ts
+++ b/src/lib/deep-link.ts
@@ -141,6 +141,32 @@ function shouldForward(url: string): boolean {
   return url.includes("manifest.json");
 }
 
+// Windows can relaunch the app with its original deep-link argv (app-restart
+// features, self-restarts), redelivering an old install URL on every start.
+const LAUNCH_SEEN_KEY = "harbor.deeplink.launchseen.v1";
+const LAUNCH_SEEN_MAX = 50;
+
+function loadLaunchSeen(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(LAUNCH_SEEN_KEY);
+    const parsed = raw ? (JSON.parse(raw) as Record<string, number>) : {};
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveLaunchSeen(map: Record<string, number>): void {
+  try {
+    const entries = Object.entries(map)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, LAUNCH_SEEN_MAX);
+    localStorage.setItem(LAUNCH_SEEN_KEY, JSON.stringify(Object.fromEntries(entries)));
+  } catch {
+    return;
+  }
+}
+
 export async function startDeepLinkBridge(): Promise<() => void> {
   const isTauri =
     typeof window !== "undefined" && ("__TAURI__" in window || "__TAURI_INTERNALS__" in window);
@@ -232,7 +258,18 @@ export async function startDeepLinkBridge(): Promise<() => void> {
     } catch {}
     try {
       const initial = await mod.getCurrent();
-      if (initial && initial.length > 0) handle(initial);
+      if (initial && initial.length > 0) {
+        const seen = loadLaunchSeen();
+        const now = Date.now();
+        const fresh: string[] = [];
+        for (const u of initial) {
+          if (typeof u !== "string" || !u) continue;
+          if (!seen[u]) fresh.push(u);
+          seen[u] = now;
+        }
+        saveLaunchSeen(seen);
+        if (fresh.length > 0) handle(fresh);
+      }
     } catch {}
     return () => {
       try {

--- a/src/lib/local-cw.ts
+++ b/src/lib/local-cw.ts
@@ -27,10 +27,19 @@ function activeProfileId(): string {
   try {
     const raw = localStorage.getItem(PROFILES_KEY);
     if (!raw) return "";
-    const s = JSON.parse(raw) as { activeId?: string; profiles?: Array<{ id?: string; isPrimary?: boolean }> };
-    if (typeof s.activeId === "string" && s.activeId) return s.activeId;
-    const primary = s.profiles?.find((p) => p?.isPrimary);
-    return primary && typeof primary.id === "string" ? primary.id : "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
   } catch {
     return "";
   }

--- a/src/lib/manual-watched.ts
+++ b/src/lib/manual-watched.ts
@@ -1,12 +1,25 @@
 import type { LibraryItem } from "@/lib/stremio";
 import { persistCritical } from "@/lib/storage-recovery";
 
-const KEY = "harbor.manualwatched.v1";
-const UNKEY = "harbor.manualunwatched.v1";
-const METAKEY = "harbor.manualwatched.meta.v1";
-const DISMISSKEY = "harbor.manualwatched.dismissed.v1";
-const UNWATCHED_AT_KEY = "harbor.manualunwatched.at.v1";
-const REMOTE_KEY = "harbor.manualwatched.fromremote.v1";
+const PROFILES_KEY = "harbor.profiles.v1";
+
+const PREFIXES = {
+  watched: "harbor.manualwatched.v1.",
+  unwatched: "harbor.manualunwatched.v1.",
+  meta: "harbor.manualwatched.meta.v1.",
+  dismissed: "harbor.manualwatched.dismissed.v1.",
+  unwatchedAt: "harbor.manualunwatched.at.v1.",
+  remote: "harbor.manualwatched.fromremote.v1.",
+} as const;
+
+const LEGACY_KEYS: Record<keyof typeof PREFIXES, string> = {
+  watched: "harbor.manualwatched.v1",
+  unwatched: "harbor.manualunwatched.v1",
+  meta: "harbor.manualwatched.meta.v1",
+  dismissed: "harbor.manualwatched.dismissed.v1",
+  unwatchedAt: "harbor.manualunwatched.at.v1",
+  remote: "harbor.manualwatched.fromremote.v1",
+};
 
 export type ManualWatchedMeta = {
   type: "series";
@@ -25,10 +38,65 @@ let dismissedCache: Set<string> | null = null;
 let unwatchedAtCache: Record<string, number> | null = null;
 let remoteCache: Set<string> | null = null;
 
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(kind: keyof typeof PREFIXES): string {
+  const id = activeProfileId();
+  return id ? PREFIXES[kind] + id : LEGACY_KEYS[kind];
+}
+
+function migrateLegacy(): void {
+  try {
+    const pid = primaryProfileId();
+    if (!pid) return;
+    for (const kind of Object.keys(PREFIXES) as Array<keyof typeof PREFIXES>) {
+      const legacy = localStorage.getItem(LEGACY_KEYS[kind]);
+      if (!legacy) continue;
+      const perKey = PREFIXES[kind] + pid;
+      if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+      localStorage.removeItem(LEGACY_KEYS[kind]);
+    }
+  } catch {
+    /* noop */
+  }
+}
+
 function unwatchedAtMap(): Record<string, number> {
   if (!unwatchedAtCache) {
+    migrateLegacy();
     try {
-      const raw = JSON.parse(localStorage.getItem(UNWATCHED_AT_KEY) ?? "{}");
+      const raw = JSON.parse(localStorage.getItem(storeKey("unwatchedAt")) ?? "{}");
       unwatchedAtCache = raw && typeof raw === "object" ? (raw as Record<string, number>) : {};
     } catch {
       unwatchedAtCache = {};
@@ -38,22 +106,26 @@ function unwatchedAtMap(): Record<string, number> {
 }
 
 function remoteSet(): Set<string> {
-  if (!remoteCache) remoteCache = loadSet(REMOTE_KEY);
+  if (!remoteCache) {
+    migrateLegacy();
+    remoteCache = loadSet(storeKey("remote"));
+  }
   return remoteCache;
 }
 
 function persistUnwatchedAt(): void {
-  persistCritical(UNWATCHED_AT_KEY, JSON.stringify(unwatchedAtCache ?? {}));
+  persistCritical(storeKey("unwatchedAt"), JSON.stringify(unwatchedAtCache ?? {}));
 }
 
 function persistRemote(): void {
-  persistCritical(REMOTE_KEY, JSON.stringify([...(remoteCache ?? [])]));
+  persistCritical(storeKey("remote"), JSON.stringify([...(remoteCache ?? [])]));
 }
 
 function loadMeta(): Record<string, ManualWatchedMeta> {
   if (metaCache) return metaCache;
+  migrateLegacy();
   try {
-    const raw = localStorage.getItem(METAKEY);
+    const raw = localStorage.getItem(storeKey("meta"));
     const parsed = raw ? JSON.parse(raw) : {};
     metaCache =
       parsed && typeof parsed === "object" ? (parsed as Record<string, ManualWatchedMeta>) : {};
@@ -64,7 +136,10 @@ function loadMeta(): Record<string, ManualWatchedMeta> {
 }
 
 function dismissedSet(): Set<string> {
-  if (!dismissedCache) dismissedCache = loadSet(DISMISSKEY);
+  if (!dismissedCache) {
+    migrateLegacy();
+    dismissedCache = loadSet(storeKey("dismissed"));
+  }
   return dismissedCache;
 }
 
@@ -75,7 +150,7 @@ function undismiss(metaId: string): void {
   next.delete(metaId);
   dismissedCache = next;
   try {
-    localStorage.setItem(DISMISSKEY, JSON.stringify([...next]));
+    localStorage.setItem(storeKey("dismissed"), JSON.stringify([...next]));
   } catch {
     return;
   }
@@ -90,7 +165,7 @@ export function dismissManualWatched(metaId: string): void {
   next.add(metaId);
   dismissedCache = next;
   try {
-    localStorage.setItem(DISMISSKEY, JSON.stringify([...next]));
+    localStorage.setItem(storeKey("dismissed"), JSON.stringify([...next]));
   } catch {
     return;
   }
@@ -108,20 +183,26 @@ function loadSet(storageKey: string): Set<string> {
 }
 
 function watchedSet(): Set<string> {
-  if (!watchedCache) watchedCache = loadSet(KEY);
+  if (!watchedCache) {
+    migrateLegacy();
+    watchedCache = loadSet(storeKey("watched"));
+  }
   return watchedCache;
 }
 
 function unwatchedSet(): Set<string> {
-  if (!unwatchedCache) unwatchedCache = loadSet(UNKEY);
+  if (!unwatchedCache) {
+    migrateLegacy();
+    unwatchedCache = loadSet(storeKey("unwatched"));
+  }
   return unwatchedCache;
 }
 
 function persist(on: Set<string>, off: Set<string>): void {
   watchedCache = on;
   unwatchedCache = off;
-  persistCritical(KEY, JSON.stringify([...on]));
-  persistCritical(UNKEY, JSON.stringify([...off]));
+  persistCritical(storeKey("watched"), JSON.stringify([...on]));
+  persistCritical(storeKey("unwatched"), JSON.stringify([...off]));
   version += 1;
   for (const fn of subs) fn();
 }
@@ -160,6 +241,10 @@ export function manualEpisodeKeys(metaId: string): {
     return out;
   };
   return { watched: collect(watchedSet()), unwatched: collect(unwatchedSet()) };
+}
+
+export function manualWatchedRawKeys(): string[] {
+  return [...watchedSet()];
 }
 
 export function setManualWatched(
@@ -298,7 +383,7 @@ export function recordManualWatchedMeta(metaId: string, meta: ManualWatchedMeta)
   const next = { ...all, [metaId]: entry };
   metaCache = next;
   try {
-    localStorage.setItem(METAKEY, JSON.stringify(next));
+    localStorage.setItem(storeKey("meta"), JSON.stringify(next));
   } catch {
     return;
   }
@@ -370,4 +455,23 @@ export function subscribeManualWatched(fn: () => void): () => void {
 
 export function manualWatchedVersion(): number {
   return version;
+}
+
+if (typeof window !== "undefined") {
+  let lastProfile = activeProfileId();
+  const onProfileChange = () => {
+    const p = activeProfileId();
+    if (p === lastProfile) return;
+    lastProfile = p;
+    watchedCache = null;
+    unwatchedCache = null;
+    metaCache = null;
+    dismissedCache = null;
+    unwatchedAtCache = null;
+    remoteCache = null;
+    version += 1;
+    for (const fn of subs) fn();
+  };
+  window.addEventListener("harbor:active-profile-changed", onProfileChange);
+  window.addEventListener("harbor:profiles-updated", onProfileChange);
 }

--- a/src/lib/movie-watched.ts
+++ b/src/lib/movie-watched.ts
@@ -1,15 +1,70 @@
 import { persistCritical } from "./storage-recovery";
 
-const KEY = "harbor.moviewatched.v1";
+const KEY_PREFIX = "harbor.moviewatched.v1.";
+const LEGACY_KEY = "harbor.moviewatched.v1";
+const PROFILES_KEY = "harbor.profiles.v1";
 
 const subs = new Set<() => void>();
 let version = 0;
 let cache: Set<string> | null = null;
 
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(): string {
+  const id = activeProfileId();
+  return id ? KEY_PREFIX + id : LEGACY_KEY;
+}
+
+function migrateLegacy(): void {
+  try {
+    const legacy = localStorage.getItem(LEGACY_KEY);
+    if (!legacy) return;
+    const pid = primaryProfileId();
+    if (!pid) return;
+    const perKey = KEY_PREFIX + pid;
+    if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+    localStorage.removeItem(LEGACY_KEY);
+  } catch {
+    /* noop */
+  }
+}
+
 function load(): Set<string> {
   if (cache) return cache;
+  migrateLegacy();
   try {
-    const arr = JSON.parse(localStorage.getItem(KEY) ?? "[]");
+    const arr = JSON.parse(localStorage.getItem(storeKey()) ?? "[]");
     cache = new Set(Array.isArray(arr) ? arr.filter((x): x is string => typeof x === "string") : []);
   } catch {
     cache = new Set();
@@ -20,7 +75,7 @@ function load(): Set<string> {
 function persist(next: Set<string>): void {
   cache = next;
   version += 1;
-  persistCritical(KEY, JSON.stringify([...next]));
+  persistCritical(storeKey(), JSON.stringify([...next]));
   for (const fn of subs) fn();
 }
 
@@ -50,4 +105,18 @@ export function subscribeMovieWatched(fn: () => void): () => void {
 
 export function movieWatchedVersion(): number {
   return version;
+}
+
+if (typeof window !== "undefined") {
+  let lastProfile = activeProfileId();
+  const onProfileChange = () => {
+    const p = activeProfileId();
+    if (p === lastProfile) return;
+    lastProfile = p;
+    cache = null;
+    version += 1;
+    for (const fn of subs) fn();
+  };
+  window.addEventListener("harbor:active-profile-changed", onProfileChange);
+  window.addEventListener("harbor:profiles-updated", onProfileChange);
 }

--- a/src/lib/playback-history.ts
+++ b/src/lib/playback-history.ts
@@ -16,11 +16,65 @@ export type PlaybackEntry = {
   savedAt: number;
 };
 
-const STORAGE_KEY = "harbor.playback-history.v1";
+const STORAGE_KEY_PREFIX = "harbor.playback-history.v1.";
+const LEGACY_STORAGE_KEY = "harbor.playback-history.v1";
+const PROFILES_KEY = "harbor.profiles.v1";
 const TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_ENTRIES = 200;
 
 const listeners = new Set<() => void>();
+
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(): string {
+  const id = activeProfileId();
+  return id ? STORAGE_KEY_PREFIX + id : LEGACY_STORAGE_KEY;
+}
+
+function migrateLegacy(): void {
+  try {
+    const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (!legacy) return;
+    const pid = primaryProfileId();
+    if (!pid) return;
+    const perKey = STORAGE_KEY_PREFIX + pid;
+    if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    /* noop */
+  }
+}
 
 export function subscribePlayback(fn: () => void): () => void {
   listeners.add(fn);
@@ -37,8 +91,9 @@ function entryKey(metaId: string, season?: number, episode?: number): string {
 }
 
 function readAll(): Record<string, PlaybackEntry> {
+  migrateLegacy();
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(storeKey());
     if (!raw) return {};
     const parsed = JSON.parse(raw) as Record<string, PlaybackEntry>;
     const now = Date.now();
@@ -61,15 +116,27 @@ function writeAll(map: Record<string, PlaybackEntry>): void {
       const sorted = Object.entries(map).sort((a, b) => b[1].savedAt - a[1].savedAt);
       map = Object.fromEntries(sorted.slice(0, MAX_ENTRIES));
     }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+    localStorage.setItem(storeKey(), JSON.stringify(map));
   } catch (e) {
     if (e instanceof DOMException && (e.name === "QuotaExceededError" || e.code === 22)) {
       try {
-        localStorage.removeItem(STORAGE_KEY);
+        localStorage.removeItem(storeKey());
       } catch {}
     }
   }
   listeners.forEach((l) => l());
+}
+
+export function playbackHistoryRawKeys(): string[] {
+  migrateLegacy();
+  try {
+    const raw = localStorage.getItem(storeKey());
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Record<string, PlaybackEntry>;
+    return Object.keys(parsed);
+  } catch {
+    return [];
+  }
 }
 
 export function savePlayback(

--- a/src/lib/profile-import.ts
+++ b/src/lib/profile-import.ts
@@ -9,13 +9,14 @@ export const DEFAULT_IMPORT_ADDON_URLS: readonly string[] = [
   "https://v3-cinemeta.strem.io/manifest.json",
 ];
 
-export type ImportDomain = "settings" | "addons" | "watchlist" | "watched" | "continueWatching";
+export type ImportDomain = "settings" | "addons" | "watchlist" | "favorites" | "watched" | "continueWatching";
 
 // Per-profile storage prefixes grouped by domain. Settings are handled
 // separately because their source key depends on whether the source profile is
 // linked to shared settings. Keep prefixes in sync with the owning modules.
 const DOMAIN_PREFIXES: Record<Exclude<ImportDomain, "settings" | "addons">, readonly string[]> = {
   watchlist: ["harbor.watchlist.v1.", "harbor.watchlist.aggregate.v1."],
+  favorites: ["harbor.favorites.v1.", "harbor.mangafav.v1.", "harbor.charfavorites.v1."],
   watched: [
     "harbor.watchedFlag.v1.",
     "harbor.moviewatched.v1.",
@@ -76,6 +77,7 @@ export type ImportAddonPreview = { name: string; transportUrl: string };
 export type ImportSourceSummary = {
   addons: ImportAddonPreview[];
   watchlistCount: number;
+  favoriteCount: number;
 };
 
 export function summarizeSource(profileId: string): ImportSourceSummary {
@@ -105,7 +107,12 @@ export function summarizeSource(profileId: string): ImportSourceSummary {
     const items = (watchlist as { items?: unknown }).items;
     if (Array.isArray(items)) watchlistCount = items.length;
   }
-  return { addons, watchlistCount };
+  let favoriteCount = 0;
+  for (const prefix of DOMAIN_PREFIXES.favorites) {
+    const list = readJson<unknown>(prefix + profileId);
+    if (Array.isArray(list)) favoriteCount += list.length;
+  }
+  return { addons, watchlistCount, favoriteCount };
 }
 
 // Which imported addons start checked when none were chosen yet.

--- a/src/lib/profile-import.ts
+++ b/src/lib/profile-import.ts
@@ -1,0 +1,199 @@
+import { MIRROR_KEY, SHARED_KEY, profileKey, sourceKeyFor } from "@/lib/settings/profile-store";
+
+const PROFILES_KEY = "harbor.profiles.v1";
+
+// Addons pre-selected when seeding a fresh separate profile. Matched against the
+// stored transportUrl first; the name check is a fallback for forks of these
+// manifests that live at a different URL.
+export const DEFAULT_IMPORT_ADDON_URLS: readonly string[] = [
+  "https://v3-cinemeta.strem.io/manifest.json",
+];
+
+export type ImportDomain = "settings" | "addons" | "watchlist" | "watched" | "continueWatching";
+
+// Per-profile storage prefixes grouped by domain. Settings are handled
+// separately because their source key depends on whether the source profile is
+// linked to shared settings. Keep prefixes in sync with the owning modules.
+const DOMAIN_PREFIXES: Record<Exclude<ImportDomain, "settings" | "addons">, readonly string[]> = {
+  watchlist: ["harbor.watchlist.v1.", "harbor.watchlist.aggregate.v1."],
+  watched: [
+    "harbor.watchedFlag.v1.",
+    "harbor.moviewatched.v1.",
+    "harbor.watchevents.v1.",
+    "harbor.stremio.freshwatched.v1.",
+    "harbor.manualwatched.v1.",
+    "harbor.manualunwatched.v1.",
+    "harbor.manualwatched.meta.v1.",
+    "harbor.manualwatched.dismissed.v1.",
+    "harbor.manualunwatched.at.v1.",
+    "harbor.manualwatched.fromremote.v1.",
+  ],
+  continueWatching: ["harbor.localcw.v1.", "harbor.playback-history.v1."],
+};
+
+const INSTALLED_PREFIX = "harbor.installed-addons.";
+const DISABLED_PREFIX = "harbor.addons.disabled.";
+
+type StoredAddon = {
+  id?: string;
+  transportUrl?: string;
+  manifest?: { name?: string };
+};
+
+type MinimalProfilesState = {
+  profiles?: Array<{ id?: string; isPrimary?: boolean; settingsLinked?: boolean }>;
+  activeId?: string | null;
+};
+
+function readProfilesState(): MinimalProfilesState | null {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as MinimalProfilesState;
+  } catch {
+    return null;
+  }
+}
+
+function profileSettingsLinked(profileId: string): boolean {
+  const state = readProfilesState();
+  const profile = state?.profiles?.find((p) => p?.id === profileId);
+  return profile ? profile.settingsLinked !== false : true;
+}
+
+function readJson<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export type ImportAddonPreview = { name: string; transportUrl: string };
+
+export type ImportSourceSummary = {
+  addons: ImportAddonPreview[];
+  watchlistCount: number;
+};
+
+export function summarizeSource(profileId: string): ImportSourceSummary {
+  const installed = readJson<StoredAddon[]>(INSTALLED_PREFIX + profileId);
+  const addons = Array.isArray(installed)
+    ? installed.flatMap((a) =>
+        a && typeof a.transportUrl === "string"
+          ? [
+              {
+                name:
+                  typeof a.manifest?.name === "string" && a.manifest.name
+                    ? a.manifest.name
+                    : typeof a.id === "string" && a.id
+                      ? a.id
+                      : "Addon",
+                transportUrl: a.transportUrl,
+              },
+            ]
+          : [],
+      )
+    : [];
+  let watchlistCount = 0;
+  const watchlist = readJson<unknown>("harbor.watchlist.v1." + profileId);
+  if (Array.isArray(watchlist)) {
+    watchlistCount = watchlist.length;
+  } else if (watchlist && typeof watchlist === "object") {
+    const items = (watchlist as { items?: unknown }).items;
+    if (Array.isArray(items)) watchlistCount = items.length;
+  }
+  return { addons, watchlistCount };
+}
+
+// Which imported addons start checked when none were chosen yet.
+export function defaultSelectedAddonUrls(addons: ImportAddonPreview[]): Set<string> {
+  const selected = new Set<string>();
+  for (const addon of addons) {
+    const url = addon.transportUrl.toLowerCase();
+    const name = addon.name.toLowerCase();
+    const matches =
+      DEFAULT_IMPORT_ADDON_URLS.includes(addon.transportUrl) ||
+      url.includes("v3-cinemeta.strem.io") ||
+      name.includes("cinemeta");
+    if (matches) selected.add(addon.transportUrl);
+  }
+  return selected;
+}
+
+export function importDomains(
+  fromProfileId: string,
+  toProfileId: string,
+  domains: ImportDomain[],
+  opts?: { addonTransportUrls?: string[] | null },
+): void {
+  if (!fromProfileId || !toProfileId || fromProfileId === toProfileId) return;
+  try {
+    for (const domain of domains) {
+      if (domain === "settings") {
+        // Copy the source's effective blob into the target's own blob. The
+        // caller unlinks settings on the target so this copy is what loads.
+        const src = sourceKeyFor(fromProfileId, profileSettingsLinked(fromProfileId));
+        const blob =
+          localStorage.getItem(src) ?? localStorage.getItem(SHARED_KEY) ?? localStorage.getItem(MIRROR_KEY);
+        if (blob != null) localStorage.setItem(profileKey(toProfileId), blob);
+        continue;
+      }
+
+      if (domain === "addons") {
+        const installedRaw = localStorage.getItem(INSTALLED_PREFIX + fromProfileId);
+        if (installedRaw == null) continue;
+        const subset = opts?.addonTransportUrls ? new Set(opts.addonTransportUrls) : null;
+        if (!subset) {
+          localStorage.setItem(INSTALLED_PREFIX + toProfileId, installedRaw);
+          const disabledRaw = localStorage.getItem(DISABLED_PREFIX + fromProfileId);
+          if (disabledRaw != null) localStorage.setItem(DISABLED_PREFIX + toProfileId, disabledRaw);
+          continue;
+        }
+        // Subset import: keep only user-selected addons. The disabled list is
+        // filtered through an id->transportUrl map so entries survive either shape.
+        const installed = readJson<StoredAddon[]>(INSTALLED_PREFIX + fromProfileId) ?? [];
+        const list = Array.isArray(installed) ? installed : [];
+        const idToUrl = new Map<string, string>();
+        for (const a of list) {
+          if (a && typeof a.id === "string" && typeof a.transportUrl === "string") {
+            idToUrl.set(a.id, a.transportUrl);
+          }
+        }
+        const kept = list.filter(
+          (a) => a && typeof a.transportUrl === "string" && subset.has(a.transportUrl),
+        );
+        localStorage.setItem(INSTALLED_PREFIX + toProfileId, JSON.stringify(kept));
+        const disabledParsed = readJson<unknown>(DISABLED_PREFIX + fromProfileId);
+        if (Array.isArray(disabledParsed)) {
+          const keptDisabled = disabledParsed.filter((entry) => {
+            if (typeof entry === "string") {
+              const url = idToUrl.get(entry);
+              return (url != null && subset.has(url)) || subset.has(entry);
+            }
+            if (entry && typeof entry === "object") {
+              const o = entry as { id?: unknown; transportUrl?: unknown };
+              if (typeof o.transportUrl === "string") return subset.has(o.transportUrl);
+              if (typeof o.id === "string") {
+                const url = idToUrl.get(o.id);
+                return url != null && subset.has(url);
+              }
+            }
+            return false;
+          });
+          localStorage.setItem(DISABLED_PREFIX + toProfileId, JSON.stringify(keptDisabled));
+        }
+        continue;
+      }
+
+      for (const prefix of DOMAIN_PREFIXES[domain]) {
+        const raw = localStorage.getItem(prefix + fromProfileId);
+        if (raw != null) localStorage.setItem(prefix + toProfileId, raw);
+      }
+    }
+  } catch (e) {
+    console.warn("[profile-import] failed", e);
+  }
+}

--- a/src/lib/profiles.tsx
+++ b/src/lib/profiles.tsx
@@ -624,3 +624,12 @@ export function stremioSourceProfileId(
   const exists = profiles.some((p) => p.id === active.shareStremioWith);
   return exists ? active.shareStremioWith : active.id;
 }
+
+export function sharesStremioStorage(
+  a: Profile | null | undefined,
+  b: Profile | null | undefined,
+  profiles: Profile[],
+): boolean {
+  if (!a || !b) return false;
+  return stremioSourceProfileId(a, profiles) === stremioSourceProfileId(b, profiles);
+}

--- a/src/lib/profiles.tsx
+++ b/src/lib/profiles.tsx
@@ -510,6 +510,21 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
         localStorage.removeItem(`harbor.simkl.cache.v2.${id}`);
         localStorage.removeItem(`harbor.anilist.synced.v1.${id}`);
         localStorage.removeItem(`harbor.mal.synced.v1.${id}`);
+        localStorage.removeItem(`harbor.moviewatched.v1.${id}`);
+        localStorage.removeItem(`harbor.watchedFlag.v1.${id}`);
+        localStorage.removeItem(`harbor.manualwatched.v1.${id}`);
+        localStorage.removeItem(`harbor.manualunwatched.v1.${id}`);
+        localStorage.removeItem(`harbor.manualwatched.meta.v1.${id}`);
+        localStorage.removeItem(`harbor.manualwatched.dismissed.v1.${id}`);
+        localStorage.removeItem(`harbor.manualunwatched.at.v1.${id}`);
+        localStorage.removeItem(`harbor.manualwatched.fromremote.v1.${id}`);
+        localStorage.removeItem(`harbor.watchevents.v1.${id}`);
+        localStorage.removeItem(`harbor.playback-history.v1.${id}`);
+        localStorage.removeItem(`harbor.watchlist.v1.${id}`);
+        localStorage.removeItem(`harbor.watchlist.aggregate.v1.${id}`);
+        localStorage.removeItem(`harbor.installed-addons.${id}`);
+        localStorage.removeItem(`harbor.addons.disabled.${id}`);
+        localStorage.removeItem(`harbor.stremio.freshwatched.v1.${id}`);
       } catch {
         /* ignore */
       }

--- a/src/lib/profiles.tsx
+++ b/src/lib/profiles.tsx
@@ -203,21 +203,8 @@ function markProfileSelectedNow(): void {
   }
 }
 
-const PICKER_SESSION_KEY = "harbor.pickerShown";
-function launchPickerShownThisSession(): boolean {
-  try {
-    return sessionStorage.getItem(PICKER_SESSION_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-function markLaunchPickerShown(): void {
-  try {
-    sessionStorage.setItem(PICKER_SESSION_KEY, "1");
-  } catch {
-    /* ignore */
-  }
-}
+// Module-level on purpose: sessionStorage can survive across app launches in the webview, which suppressed this prompt.
+let pickerPromptShownThisRun = false;
 
 export function readActiveProfileIdentity(): {
   id: string;
@@ -389,9 +376,9 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
     const interval = readProfilePromptInterval();
     if (interval === "never") return false;
     if (interval === "launch") {
-      const shownThisSession = launchPickerShownThisSession();
-      markLaunchPickerShown();
-      return !shownThisSession;
+      const wasShown = pickerPromptShownThisRun;
+      pickerPromptShownThisRun = true;
+      return !wasShown;
     }
     return Date.now() - readLastProfileSelectAt() >= intervalMinutes(interval) * 60000;
   });

--- a/src/lib/social/stats-sync.ts
+++ b/src/lib/social/stats-sync.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import { movieWatchedIds } from "@/lib/movie-watched";
 import { watchedFlagIds } from "@/lib/watched-flag";
+import { manualWatchedRawKeys } from "@/lib/manual-watched";
+import { playbackHistoryRawKeys } from "@/lib/playback-history";
+import { freshWatchedIds } from "@/lib/stremio-watched-sync";
 import { library, type LibraryItem } from "@/lib/stremio";
 import { stremioMovieWatched } from "@/lib/stremio-watched";
 import { authToken } from "@/lib/theme-auth";
@@ -79,22 +82,15 @@ export async function computeWatchedBreakdown(authKey?: string | null): Promise<
 
   // 4. Include manual watched episodes (harbor.manualwatched.v1)
   try {
-    const raw = localStorage.getItem("harbor.manualwatched.v1");
-    if (raw) {
-      const arr = JSON.parse(raw);
-      if (Array.isArray(arr)) {
-        for (const key of arr) {
-          if (typeof key !== "string") continue;
-          const parts = key.split("|");
-          const metaId = parts[0];
-          if (!metaId) continue;
-          allWatchedIds.add(metaId);
-          if (parts.length > 1) {
-            episodeKeys.add(key);
-          } else if (!movieIds.has(metaId)) {
-            movieIds.add(metaId);
-          }
-        }
+    for (const key of manualWatchedRawKeys()) {
+      const parts = key.split("|");
+      const metaId = parts[0];
+      if (!metaId) continue;
+      allWatchedIds.add(metaId);
+      if (parts.length > 1) {
+        episodeKeys.add(key);
+      } else if (!movieIds.has(metaId)) {
+        movieIds.add(metaId);
       }
     }
   } catch {
@@ -103,15 +99,9 @@ export async function computeWatchedBreakdown(authKey?: string | null): Promise<
 
   // 5. Include fresh watched episodes (harbor.stremio.freshwatched.v1)
   try {
-    const raw = localStorage.getItem("harbor.stremio.freshwatched.v1");
-    if (raw) {
-      const obj = JSON.parse(raw) as Record<string, { watched?: string | null }>;
-      if (obj && typeof obj === "object") {
-        for (const id of Object.keys(obj)) {
-          if (!id) continue;
-          allWatchedIds.add(id);
-        }
-      }
+    for (const id of freshWatchedIds()) {
+      if (!id) continue;
+      allWatchedIds.add(id);
     }
   } catch {
     // ignore
@@ -119,19 +109,15 @@ export async function computeWatchedBreakdown(authKey?: string | null): Promise<
 
   // 6. Include local playback history (harbor.playback-history.v1)
   try {
-    const raw = localStorage.getItem("harbor.playback-history.v1");
-    if (raw) {
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      for (const key of Object.keys(parsed)) {
-        const parts = key.split("|");
-        const metaId = parts[0];
-        if (!metaId) continue;
-        allWatchedIds.add(metaId);
-        if (parts.length > 1) {
-          episodeKeys.add(`${metaId}:${parts[1]}`);
-        } else if (!episodeKeys.has(metaId)) {
-          movieIds.add(metaId);
-        }
+    for (const key of playbackHistoryRawKeys()) {
+      const parts = key.split("|");
+      const metaId = parts[0];
+      if (!metaId) continue;
+      allWatchedIds.add(metaId);
+      if (parts.length > 1) {
+        episodeKeys.add(`${metaId}:${parts[1]}`);
+      } else if (!episodeKeys.has(metaId)) {
+        movieIds.add(metaId);
       }
     }
   } catch {

--- a/src/lib/storage-recovery.ts
+++ b/src/lib/storage-recovery.ts
@@ -55,6 +55,7 @@ const PRUNABLE_PREFIXES = [
   "harbor.manga.cache.v2.",
   "harbor.manga.art.",
   "harbor.tvdbo.",
+  "harbor.playback-history.v1.",
 ];
 
 function isPrunable(key: string): boolean {

--- a/src/lib/stremio-watched-sync.ts
+++ b/src/lib/stremio-watched-sync.ts
@@ -7,16 +7,71 @@ import { detectAnimeForCw, isDetectedAnime } from "@/lib/anime-detect";
 
 const ANIME_ID = /^(kitsu|mal|anilist|anidb):/;
 
-const FRESH_KEY = "harbor.stremio.freshwatched.v1";
+const FRESH_KEY_PREFIX = "harbor.stremio.freshwatched.v1.";
+const LEGACY_FRESH_KEY = "harbor.stremio.freshwatched.v1";
+const PROFILES_KEY = "harbor.profiles.v1";
 const FRESH_CAP = 300;
 const freshWatched = new Map<string, { watched: string | null; mtime: number }>();
 let freshLoaded = false;
 
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(): string {
+  const id = activeProfileId();
+  return id ? FRESH_KEY_PREFIX + id : LEGACY_FRESH_KEY;
+}
+
+function migrateLegacy(): void {
+  try {
+    const legacy = localStorage.getItem(LEGACY_FRESH_KEY);
+    if (!legacy) return;
+    const pid = primaryProfileId();
+    if (!pid) return;
+    const perKey = FRESH_KEY_PREFIX + pid;
+    if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+    localStorage.removeItem(LEGACY_FRESH_KEY);
+  } catch {
+    /* noop */
+  }
+}
+
 function loadFresh(): void {
   if (freshLoaded) return;
+  migrateLegacy();
   freshLoaded = true;
   try {
-    const raw = JSON.parse(localStorage.getItem(FRESH_KEY) ?? "null");
+    const raw = JSON.parse(localStorage.getItem(storeKey()) ?? "null");
     if (raw && typeof raw === "object") {
       for (const [id, v] of Object.entries(raw as Record<string, { watched?: unknown; mtime?: unknown }>)) {
         if (v && typeof v.mtime === "number") {
@@ -38,13 +93,18 @@ function setFresh(id: string, watched: string, mtime: number): void {
       const sorted = [...freshWatched.entries()].sort((a, b) => a[1].mtime - b[1].mtime);
       for (let i = 0; i < sorted.length - FRESH_CAP; i++) freshWatched.delete(sorted[i][0]);
     }
-    localStorage.setItem(FRESH_KEY, JSON.stringify(Object.fromEntries(freshWatched)));
+    localStorage.setItem(storeKey(), JSON.stringify(Object.fromEntries(freshWatched)));
   } catch {}
 }
 
 export function freshestWatched(id: string): { watched: string | null; mtime: number } | undefined {
   loadFresh();
   return freshWatched.get(id);
+}
+
+export function freshWatchedIds(): string[] {
+  loadFresh();
+  return [...freshWatched.keys()];
 }
 
 type CinemetaVideo = NonNullable<Meta["videos"]>[number];

--- a/src/lib/watch-events.ts
+++ b/src/lib/watch-events.ts
@@ -1,3 +1,9 @@
+const KEY_PREFIX = "harbor.watchevents.v1.";
+const LEGACY_KEY = "harbor.watchevents.v1";
+const PROFILES_KEY = "harbor.profiles.v1";
+const MAX = 40;
+const subs = new Set<() => void>();
+
 export type WatchEvent = {
   id: string;
   type: "movie" | "series";
@@ -8,13 +14,62 @@ export type WatchEvent = {
   at: number;
 };
 
-const KEY = "harbor.watchevents.v1";
-const MAX = 40;
-const subs = new Set<() => void>();
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(): string {
+  const id = activeProfileId();
+  return id ? KEY_PREFIX + id : LEGACY_KEY;
+}
+
+function migrateLegacy(): void {
+  try {
+    const legacy = localStorage.getItem(LEGACY_KEY);
+    if (!legacy) return;
+    const pid = primaryProfileId();
+    if (!pid) return;
+    const perKey = KEY_PREFIX + pid;
+    if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+    localStorage.removeItem(LEGACY_KEY);
+  } catch {
+    /* noop */
+  }
+}
 
 function load(): WatchEvent[] {
+  migrateLegacy();
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = localStorage.getItem(storeKey());
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? (parsed as WatchEvent[]) : [];
@@ -32,7 +87,7 @@ export function recordWatchEvent(e: WatchEvent): void {
   const key = `${e.id}|${e.season ?? ""}|${e.episode ?? ""}`;
   const next = [e, ...load().filter((p) => `${p.id}|${p.season ?? ""}|${p.episode ?? ""}` !== key)];
   try {
-    localStorage.setItem(KEY, JSON.stringify(next.slice(0, MAX)));
+    localStorage.setItem(storeKey(), JSON.stringify(next.slice(0, MAX)));
   } catch {
     return;
   }

--- a/src/lib/watched-flag.ts
+++ b/src/lib/watched-flag.ts
@@ -2,16 +2,71 @@ import { useSyncExternalStore } from "react";
 import { isMovieWatchedLocal, subscribeMovieWatched } from "./movie-watched";
 import { persistCritical } from "./storage-recovery";
 
-const KEY = "harbor.watchedFlag.v1";
+const KEY_PREFIX = "harbor.watchedFlag.v1.";
+const LEGACY_KEY = "harbor.watchedFlag.v1";
+const PROFILES_KEY = "harbor.profiles.v1";
 
 const subs = new Set<() => void>();
 let version = 0;
 let cache: Set<string> | null = null;
 
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(): string {
+  const id = activeProfileId();
+  return id ? KEY_PREFIX + id : LEGACY_KEY;
+}
+
+function migrateLegacy(): void {
+  try {
+    const legacy = localStorage.getItem(LEGACY_KEY);
+    if (!legacy) return;
+    const pid = primaryProfileId();
+    if (!pid) return;
+    const perKey = KEY_PREFIX + pid;
+    if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+    localStorage.removeItem(LEGACY_KEY);
+  } catch {
+    /* noop */
+  }
+}
+
 function load(): Set<string> {
   if (cache) return cache;
+  migrateLegacy();
   try {
-    const arr = JSON.parse(localStorage.getItem(KEY) ?? "[]");
+    const arr = JSON.parse(localStorage.getItem(storeKey()) ?? "[]");
     cache = new Set(Array.isArray(arr) ? arr.filter((x): x is string => typeof x === "string") : []);
   } catch {
     cache = new Set();
@@ -22,7 +77,7 @@ function load(): Set<string> {
 function persist(next: Set<string>): void {
   cache = next;
   version += 1;
-  persistCritical(KEY, JSON.stringify([...next]));
+  persistCritical(storeKey(), JSON.stringify([...next]));
   for (const fn of subs) fn();
 }
 
@@ -71,4 +126,18 @@ export function useMetaWatched(
     },
     () => false,
   );
+}
+
+if (typeof window !== "undefined") {
+  let lastProfile = activeProfileId();
+  const onProfileChange = () => {
+    const p = activeProfileId();
+    if (p === lastProfile) return;
+    lastProfile = p;
+    cache = null;
+    version += 1;
+    for (const fn of subs) fn();
+  };
+  window.addEventListener("harbor:active-profile-changed", onProfileChange);
+  window.addEventListener("harbor:profiles-updated", onProfileChange);
 }

--- a/src/lib/watchlist.ts
+++ b/src/lib/watchlist.ts
@@ -8,8 +8,11 @@ import { setItemWithRecovery, freeStorageSpace } from "@/lib/storage-recovery";
 import { ANIME_CLOUD_ID, cloudWriteId, saveStremioBookmark, removeStremioBookmark } from "@/lib/stremio";
 import { readActiveStremioAuthKey } from "@/lib/auth";
 
-const KEY = "harbor.watchlist.v1";
-const AGG_KEY = "harbor.watchlist.aggregate.v1";
+const KEY_PREFIX = "harbor.watchlist.v1.";
+const LEGACY_KEY = "harbor.watchlist.v1";
+const AGG_KEY_PREFIX = "harbor.watchlist.aggregate.v1.";
+const LEGACY_AGG_KEY = "harbor.watchlist.aggregate.v1";
+const PROFILES_KEY = "harbor.profiles.v1";
 const subs = new Set<() => void>();
 
 export type LocalEntry = {
@@ -23,6 +26,70 @@ export type LocalEntry = {
 export type WatchlistInput = { id: string; type?: string; name?: string; poster?: string; imdbId?: string | null };
 
 let memoryFallback: Map<string, LocalEntry> | null = null;
+
+function activeProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    if (!raw) return "";
+    const s = JSON.parse(raw) as {
+      activeId?: string;
+      profiles?: Array<{ id?: string; isPrimary?: boolean; shareStremioWith?: string | null }>;
+    };
+    const profiles = Array.isArray(s.profiles) ? s.profiles : [];
+    const active = profiles.find((p) => p.id === s.activeId) ?? null;
+    const own = active?.id ?? (profiles.find((p) => p?.isPrimary)?.id ?? "");
+    if (!own) return "";
+    if (active && typeof active.shareStremioWith === "string" && active.shareStremioWith) {
+      const shared = profiles.find((p) => p.id === active.shareStremioWith);
+      if (shared?.id) return shared.id;
+    }
+    return own;
+  } catch {
+    return "";
+  }
+}
+
+function primaryProfileId(): string {
+  try {
+    const raw = localStorage.getItem(PROFILES_KEY);
+    const s = raw ? (JSON.parse(raw) as { profiles?: Array<{ id?: string; isPrimary?: boolean }> }) : null;
+    const primary = s?.profiles?.find((p) => p?.isPrimary);
+    return (primary && typeof primary.id === "string" && primary.id) || activeProfileId();
+  } catch {
+    return activeProfileId();
+  }
+}
+
+function storeKey(): string {
+  const id = activeProfileId();
+  return id ? KEY_PREFIX + id : LEGACY_KEY;
+}
+
+function aggStoreKey(): string {
+  const id = activeProfileId();
+  return id ? AGG_KEY_PREFIX + id : LEGACY_AGG_KEY;
+}
+
+function migrateLegacy(): void {
+  try {
+    const pid = primaryProfileId();
+    if (!pid) return;
+    const legacy = localStorage.getItem(LEGACY_KEY);
+    if (legacy) {
+      const perKey = KEY_PREFIX + pid;
+      if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacy);
+      localStorage.removeItem(LEGACY_KEY);
+    }
+    const legacyAgg = localStorage.getItem(LEGACY_AGG_KEY);
+    if (legacyAgg) {
+      const perKey = AGG_KEY_PREFIX + pid;
+      if (!localStorage.getItem(perKey)) localStorage.setItem(perKey, legacyAgg);
+      localStorage.removeItem(LEGACY_AGG_KEY);
+    }
+  } catch {
+    /* noop */
+  }
+}
 
 function inferType(id: string): "movie" | "series" {
   return id.includes(":tv:") || id.includes(":series:") ? "series" : "movie";
@@ -49,9 +116,10 @@ function toEntry(input: string | WatchlistInput): LocalEntry {
 
 function read(): Map<string, LocalEntry> {
   if (memoryFallback) return new Map(memoryFallback);
+  migrateLegacy();
   const map = new Map<string, LocalEntry>();
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = localStorage.getItem(storeKey());
     if (!raw) return map;
     const arr = JSON.parse(raw) as unknown;
     if (!Array.isArray(arr)) return map;
@@ -77,10 +145,10 @@ function read(): Map<string, LocalEntry> {
 
 function write(map: Map<string, LocalEntry>) {
   const payload = JSON.stringify(Array.from(map.values()));
-  const ok = setItemWithRecovery(KEY, payload);
+  const ok = setItemWithRecovery(storeKey(), payload);
   if (!ok) {
     freeStorageSpace();
-    const retry = setItemWithRecovery(KEY, payload);
+    const retry = setItemWithRecovery(storeKey(), payload);
     if (!retry) {
       memoryFallback = new Map(map);
       console.warn("[watchlist] localStorage exhausted, holding watchlist in memory only");
@@ -107,8 +175,9 @@ export function subscribeWatchlist(fn: () => void): () => void {
 let aggregateIds: Set<string> = readAggregateCache();
 
 function readAggregateCache(): Set<string> {
+  migrateLegacy();
   try {
-    const raw = localStorage.getItem(AGG_KEY);
+    const raw = localStorage.getItem(aggStoreKey());
     if (!raw) return new Set();
     const arr = JSON.parse(raw) as unknown;
     return new Set(Array.isArray(arr) ? (arr as string[]).filter((v) => typeof v === "string") : []);
@@ -119,7 +188,7 @@ function readAggregateCache(): Set<string> {
 
 function writeAggregateCache(set: Set<string>) {
   try {
-    localStorage.setItem(AGG_KEY, JSON.stringify(Array.from(set)));
+    localStorage.setItem(aggStoreKey(), JSON.stringify(Array.from(set)));
   } catch {
     /* swallow */
   }
@@ -251,4 +320,18 @@ export function useInWatchlist(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [candidates.join("|")]);
   return has;
+}
+
+if (typeof window !== "undefined") {
+  let lastProfile = activeProfileId();
+  const onProfileChange = () => {
+    const p = activeProfileId();
+    if (p === lastProfile) return;
+    lastProfile = p;
+    memoryFallback = null;
+    aggregateIds = readAggregateCache();
+    for (const s of subs) s();
+  };
+  window.addEventListener("harbor:active-profile-changed", onProfileChange);
+  window.addEventListener("harbor:profiles-updated", onProfileChange);
 }

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -169,7 +169,11 @@ export function Home({ active = true, onReady }: { active?: boolean; onReady?: (
   useEffect(() => {
     const onAddonsChanged = () => setAddonsTick((t) => t + 1);
     window.addEventListener("harbor:addons-changed", onAddonsChanged);
-    return () => window.removeEventListener("harbor:addons-changed", onAddonsChanged);
+    window.addEventListener("harbor:active-profile-changed", onAddonsChanged);
+    return () => {
+      window.removeEventListener("harbor:addons-changed", onAddonsChanged);
+      window.removeEventListener("harbor:active-profile-changed", onAddonsChanged);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/views/library/hydrate-meta.ts
+++ b/src/views/library/hydrate-meta.ts
@@ -1,6 +1,8 @@
 import { type Meta } from "@/lib/cinemeta";
 import { lruSet } from "@/lib/cache";
 import { resolveMeta } from "@/lib/meta-resource";
+import { readLocalEntries } from "@/lib/watchlist";
+import { readActiveStremioAuthKey } from "@/lib/auth";
 
 const metaHydrateCache = new Map<string, Promise<Meta | null>>();
 
@@ -14,10 +16,7 @@ export async function hydrateLibraryMeta(
   if (cached) return cached;
   const authKey = (() => {
     try {
-      const raw = localStorage.getItem("harbor.auth");
-      if (!raw) return null;
-      const parsed = JSON.parse(raw) as { authKey?: string };
-      return parsed.authKey ?? null;
+      return readActiveStremioAuthKey();
     } catch {
       return null;
     }
@@ -56,20 +55,7 @@ export async function hydrateLibraryMeta(
 
 export function loadLocalIds(): Set<string> {
   try {
-    const raw = localStorage.getItem("harbor.watchlist.v1");
-    if (!raw) return new Set();
-    const arr = JSON.parse(raw);
-    if (!Array.isArray(arr)) return new Set();
-    const ids = arr
-      .map((el) =>
-        typeof el === "string"
-          ? el
-          : el && typeof el === "object" && typeof (el as { id?: unknown }).id === "string"
-            ? (el as { id: string }).id
-            : null,
-      )
-      .filter((v): v is string => typeof v === "string");
-    return new Set(ids);
+    return new Set(readLocalEntries().map((e) => e.id));
   } catch {
     return new Set();
   }


### PR DESCRIPTION
## Summary

Scopes all per-profile data (watched state, continue-watching progress, library sync/recovery, session and addon keying) under the active profile, and fixes stale addons/catalogs after switching profiles.

Previously, profile-scoped storage existed but UI refetches for addons and home catalogs were keyed only on the Stremio session (authKey). When profiles share the same session state (no account signed in, or the same account on every profile), authKey is identical across profiles, so switching profiles never triggered a refetch — leaving the previous profile's addons and addon-added catalogs visible until a manual refresh.

The fix listens for the existing harbor:active-profile-changed event (dispatched by selectProfile after the profile's storage is written) and forces the addons store and home rows to refetch, so each profile sees exactly its own addons and catalogs immediately on switch.

The work is split into four commits: per-profile session/addon keying, watched state + progress scoping, library sync/recovery scoping, and the addon refresh fix.

## Why

Harbor supports multiple profiles (primary, shared, separate) with isolated data. Two gaps remained:
1. Data isolation — watched flags, progress, watchlist, and sync state were not consistently scoped per profile, allowing state to leak between profiles.

2. Stale addons/catalogs — the reported bug: switching from a primary/shared profile to a separate profile (or vice versa) left the previous profile's addons and addon-added catalogs visible until refresh. Root cause: refetches keyed on authKey only, which is identical across profiles that share session state.

This approach fits Harbor's existing patterns — the fix reuses the profile-switch event that other stores already invalidate on, with no new abstractions or platform-specific code.

## Verification

- npx tsc -b --pretty false — passed (clean)
- pnpm run build — passed
- Manual scenarios:
- With no account signed in, create one separate profile; install an addon while on it
- Switch separate → primary/shared and back; verify addons and addon-added catalogs update immediately without refreshing
- Verify watched flags, continue-watching progress, and watchlist stay isolated per profile
- Verify the reverse direction (primary/shared → separate shows the separate profile's state)

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
