### PR TITLE
feat: add fullscreen in Live TV, chrome-hiding, and per-tile resizing to multiview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1007,23 +1007,35 @@ function Shell({ onReady }: { onReady?: () => void }) {
       {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "stremio" && (
         <StremioRail />
       )}
-      {!settingsTop && !playerActive && !pickerTop && layout === "topdock" && <TopDock />}
-      {!settingsTop && !playerActive && !pickerTop && layout === "cinematic" && (
+      {!settingsTop && !playerActive && !pickerTop && layout === "topdock" && !immersive && (
+        <TopDock />
+      )}
+      {!settingsTop && !playerActive && !pickerTop && layout === "cinematic" && !immersive && (
         <CinematicOverlay />
       )}
-      {!settingsTop && !playerActive && !pickerTop && layout === "royal" && <RoyalTopbar />}
-      {!settingsTop && !playerActive && !pickerTop && layout === "rail" && <SideRail />}
-      {!playerActive && !pickerTop && layout === "minui" && <MinUIDock />}
-      {!playerActive && !pickerTop && layout === "topdock" && <FloatingBack offsetTop={92} />}
-      {!playerActive && !pickerTop && layout === "cinematic" && <FloatingBack offsetTop={92} />}
-      {!playerActive && !pickerTop && layout === "royal" && <FloatingBack offsetTop={92} />}
-      {!playerActive && !pickerTop && layout === "rail" && (
+      {!settingsTop && !playerActive && !pickerTop && layout === "royal" && !immersive && (
+        <RoyalTopbar />
+      )}
+      {!settingsTop && !playerActive && !pickerTop && layout === "rail" && !immersive && (
+        <SideRail />
+      )}
+      {!playerActive && !pickerTop && layout === "minui" && !immersive && <MinUIDock />}
+      {!playerActive && !pickerTop && layout === "topdock" && !immersive && (
+        <FloatingBack offsetTop={92} />
+      )}
+      {!playerActive && !pickerTop && layout === "cinematic" && !immersive && (
+        <FloatingBack offsetTop={92} />
+      )}
+      {!playerActive && !pickerTop && layout === "royal" && !immersive && (
+        <FloatingBack offsetTop={92} />
+      )}
+      {!playerActive && !pickerTop && layout === "rail" && !immersive && (
         <FloatingBack offsetLeft={settings.sidebarCollapsed ? 88 : 220} offsetTop={28} />
       )}
-      {!playerActive && !pickerTop && layout === "custom" && (
+      {!playerActive && !pickerTop && layout === "custom" && !immersive && (
         <FloatingBack offsetLeft={20} offsetTop={20} />
       )}
-      {!playerActive && !pickerTop && layout === "custom" && (
+      {!playerActive && !pickerTop && layout === "custom" && !immersive && (
         <div className="fixed end-3 top-3 z-[120]">
           <WindowControls />
         </div>
@@ -1259,10 +1271,12 @@ function Shell({ onReady }: { onReady?: () => void }) {
             <WindowControls />
           </div>
         )}
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-x-0 top-0 z-30 h-24 bg-gradient-to-b from-canvas/85 via-canvas/40 to-transparent"
-        />
+        {!immersive && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 z-30 h-24 bg-gradient-to-b from-canvas/85 via-canvas/40 to-transparent"
+          />
+        )}
         {!immersive &&
           (themeHasTopbar || (settingsTop && layout !== "minui" && layout !== "custom")) && (
             <Topbar />

--- a/src/lib/multiview/store.ts
+++ b/src/lib/multiview/store.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { MAX_SLOTS } from "./bridge";
 
-export type Layout = "1" | "2" | "3" | "2x2";
+export type Layout = "1" | "2" | "2v" | "3" | "2x2";
 
 export type SlotChannel = { name: string; url: string; userAgent?: string };
 
@@ -9,18 +9,67 @@ export type MultiviewState = {
   slots: (SlotChannel | null)[];
   layout: Layout;
   audioFocus: number;
+  split: number;
+  splitRow: number;
+  splitRow2: number;
+  split3a: number;
+  split3b: number;
 };
 
 const LAYOUT_KEY = "harbor.multiview.layout";
+const SPLIT_KEY = "harbor.multiview.split";
+const SPLIT_ROW_KEY = "harbor.multiview.split-row";
+const SPLIT_ROW2_KEY = "harbor.multiview.split-row2";
+const SPLIT3A_KEY = "harbor.multiview.split3a";
+const SPLIT3B_KEY = "harbor.multiview.split3b";
+
+export const SPLIT_MIN = 28;
+export const SPLIT_MAX = 72;
+export const SPLIT_DEFAULT = 50;
+export const SPLIT3A_MIN = 20;
+export const SPLIT3A_MAX = 70;
+export const SPLIT3A_DEFAULT = 33.3;
+export const SPLIT3B_MIN = 25;
+export const SPLIT3B_MAX = 90;
+export const SPLIT3B_DEFAULT = 50;
+
+function clampNum(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+export function clampSplit(n: number): number {
+  if (!Number.isFinite(n)) return SPLIT_DEFAULT;
+  return clampNum(n, SPLIT_MIN, SPLIT_MAX);
+}
+
+export function clampSplitRow(n: number): number {
+  if (!Number.isFinite(n)) return SPLIT_DEFAULT;
+  return clampNum(n, SPLIT_MIN, SPLIT_MAX);
+}
+
+export function clampSplit3a(n: number): number {
+  if (!Number.isFinite(n)) return SPLIT3A_DEFAULT;
+  return clampNum(n, SPLIT3A_MIN, SPLIT3A_MAX);
+}
+
+export function clampSplit3b(n: number): number {
+  if (!Number.isFinite(n)) return SPLIT3B_DEFAULT;
+  return clampNum(n, SPLIT3B_MIN, SPLIT3B_MAX);
+}
+
+function readNum(key: string, fallback: number, clamp: (n: number) => number): number {
+  const v = typeof localStorage !== "undefined" ? localStorage.getItem(key) : null;
+  return v == null ? fallback : clamp(Number(v));
+}
 
 function initialLayout(): Layout {
   const v = typeof localStorage !== "undefined" ? localStorage.getItem(LAYOUT_KEY) : null;
-  return v === "1" || v === "2" || v === "3" || v === "2x2" ? v : "2x2";
+  return v === "1" || v === "2" || v === "2v" || v === "3" || v === "2x2" ? v : "2x2";
 }
 
 export function layoutSlotCount(l: Layout): number {
   if (l === "1") return 1;
-  if (l === "2") return 2;
+  if (l === "2" || l === "2v") return 2;
   if (l === "3") return 3;
   return 4;
 }
@@ -31,6 +80,30 @@ export function useMultiviewStore() {
   );
   const [layout, setLayoutState] = useState<Layout>(initialLayout);
   const [audioFocus, setAudioFocus] = useState(0);
+  const [split, setSplitState] = useState<number>(readNum(SPLIT_KEY, SPLIT_DEFAULT, clampSplit));
+  const [splitRow, setSplitRowState] = useState<number>(
+    readNum(SPLIT_ROW_KEY, SPLIT_DEFAULT, clampSplitRow),
+  );
+  const [splitRow2, setSplitRow2State] = useState<number>(
+    readNum(SPLIT_ROW2_KEY, SPLIT_DEFAULT, clampSplitRow),
+  );
+  const [split3a, setSplit3aState] = useState<number>(
+    readNum(SPLIT3A_KEY, SPLIT3A_DEFAULT, clampSplit3a),
+  );
+  const [split3b, setSplit3bState] = useState<number>(
+    readNum(SPLIT3B_KEY, SPLIT3B_DEFAULT, clampSplit3b),
+  );
+
+  const persist = useCallback(
+    (key: string) => (v: string) => {
+      try {
+        localStorage.setItem(key, v);
+      } catch {
+        /* noop */
+      }
+    },
+    [],
+  );
 
   const setSlot = useCallback((i: number, ch: SlotChannel | null) => {
     setSlots((cur) => {
@@ -40,14 +113,58 @@ export function useMultiviewStore() {
     });
   }, []);
 
-  const setLayout = useCallback((l: Layout) => {
-    setLayoutState(l);
-    try {
-      localStorage.setItem(LAYOUT_KEY, l);
-    } catch {
-      /* noop */
-    }
-  }, []);
+  const setLayout = useCallback(
+    (l: Layout) => {
+      setLayoutState(l);
+      persist(LAYOUT_KEY)(l);
+    },
+    [persist],
+  );
+
+  const setSplit = useCallback(
+    (n: number) => {
+      const c = clampSplit(n);
+      setSplitState(c);
+      persist(SPLIT_KEY)(String(c));
+    },
+    [persist],
+  );
+
+  const setSplitRow = useCallback(
+    (n: number) => {
+      const c = clampSplitRow(n);
+      setSplitRowState(c);
+      persist(SPLIT_ROW_KEY)(String(c));
+    },
+    [persist],
+  );
+
+  const setSplitRow2 = useCallback(
+    (n: number) => {
+      const c = clampSplitRow(n);
+      setSplitRow2State(c);
+      persist(SPLIT_ROW2_KEY)(String(c));
+    },
+    [persist],
+  );
+
+  const setSplit3a = useCallback(
+    (n: number) => {
+      const c = clampSplit3a(n);
+      setSplit3aState(c);
+      persist(SPLIT3A_KEY)(String(c));
+    },
+    [persist],
+  );
+
+  const setSplit3b = useCallback(
+    (n: number) => {
+      const c = clampSplit3b(n);
+      setSplit3bState(c);
+      persist(SPLIT3B_KEY)(String(c));
+    },
+    [persist],
+  );
 
   const reset = useCallback(() => {
     setSlots(Array.from({ length: MAX_SLOTS }, () => null));
@@ -58,9 +175,19 @@ export function useMultiviewStore() {
     slots,
     layout,
     audioFocus,
+    split,
+    splitRow,
+    splitRow2,
+    split3a,
+    split3b,
     setSlot,
     setLayout,
     setAudioFocus,
+    setSplit,
+    setSplitRow,
+    setSplitRow2,
+    setSplit3a,
+    setSplit3b,
     reset,
   };
 }

--- a/src/views/multiview.tsx
+++ b/src/views/multiview.tsx
@@ -1,7 +1,21 @@
-import { ChevronDown, ChevronUp, Grid2x2, Info, Square, StopCircle, X } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  Grid2x2,
+  Info,
+  Maximize,
+  Minimize,
+  Rows2,
+  Square,
+  StopCircle,
+  X,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { useMultiviewStore, type Layout } from "@/lib/multiview/store";
 import type { EpgIndex, IptvChannel, IptvPlaylist, IptvPlaylistSource } from "@/lib/iptv/types";
+import { WindowControls } from "@/chrome/window-controls";
+import { exitWindowFullscreen, toggleWindowFullscreen } from "@/lib/fullscreen-state";
+import { useWindowFullscreen } from "@/lib/use-window-fullscreen";
 import { Grid } from "./multiview/grid";
 import { ChannelPicker } from "./multiview/channel-picker";
 import { pushActivityHint } from "@/lib/discord/activity-hint";
@@ -9,6 +23,7 @@ import { pushActivityHint } from "@/lib/discord/activity-hint";
 const LAYOUTS: { id: Layout; label: string }[] = [
   { id: "1", label: "Single" },
   { id: "2", label: "Side by side" },
+  { id: "2v", label: "Stacked" },
   { id: "3", label: "Triple" },
   { id: "2x2", label: "Quad" },
 ];
@@ -31,6 +46,8 @@ export function MultiviewView({
   const store = useMultiviewStore();
   const [pickerSlot, setPickerSlot] = useState<number | null>(null);
   const [collapsed, setCollapsed] = useState(false);
+  const windowFullscreen = useWindowFullscreen();
+  const hideControls = collapsed || windowFullscreen;
   const [bannerHidden, setBannerHidden] = useState(() => {
     try {
       return localStorage.getItem("harbor.multiview.banner-dismissed") === "1";
@@ -48,31 +65,35 @@ export function MultiviewView({
   };
 
   useEffect(() => {
-    window.dispatchEvent(new CustomEvent("harbor:immersive", { detail: collapsed }));
-  }, [collapsed]);
+    window.dispatchEvent(new CustomEvent("harbor:immersive", { detail: hideControls }));
+  }, [hideControls]);
 
   useEffect(() => {
     if (!active) return;
     const n = store.slots.filter(Boolean).length;
-    const label = n > 0 ? `Watching ${n} stream${n === 1 ? "" : "s"} at once` : "Setting up Multiview";
+    const label =
+      n > 0 ? `Watching ${n} stream${n === 1 ? "" : "s"} at once` : "Setting up Multiview";
     return pushActivityHint({ details: label, state: "Multiview" });
   }, [active, store.slots]);
 
   useEffect(
     () => () => {
       window.dispatchEvent(new CustomEvent("harbor:immersive", { detail: false }));
+      void exitWindowFullscreen();
     },
     [],
   );
 
   useEffect(() => {
-    if (!collapsed) return;
+    if (!hideControls) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setCollapsed(false);
+      if (e.key !== "Escape") return;
+      if (windowFullscreen) void exitWindowFullscreen();
+      else setCollapsed(false);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [collapsed]);
+  }, [hideControls, windowFullscreen]);
 
   useEffect(() => {
     if (active) return;
@@ -89,8 +110,10 @@ export function MultiviewView({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className={`flex shrink-0 items-center gap-2 px-6 ${collapsed ? "py-1" : "pb-3 pt-1"}`}>
-        {!collapsed && (
+      <div
+        className={`flex shrink-0 items-center gap-2 px-6 ${hideControls ? "py-1" : "pb-3 pt-1"}`}
+      >
+        {!hideControls && (
           <>
             <div className="flex items-center gap-1 rounded-xl border border-edge-soft/55 bg-elevated p-1">
               {LAYOUTS.map((l) => {
@@ -104,8 +127,14 @@ export function MultiviewView({
                       isActive ? "bg-ink text-canvas" : "text-ink-muted hover:text-ink"
                     }`}
                   >
-                    {l.id === "2x2" ? <Grid2x2 size={13} /> : <Square size={12} />}
-                    {l.id === "2x2" ? "2x2" : l.id}
+                    {l.id === "2x2" ? (
+                      <Grid2x2 size={13} />
+                    ) : l.id === "2v" ? (
+                      <Rows2 size={13} />
+                    ) : (
+                      <Square size={12} />
+                    )}
+                    {l.id === "2x2" ? "2x2" : l.id === "2v" ? "Stacked" : l.id}
                   </button>
                 );
               })}
@@ -119,23 +148,34 @@ export function MultiviewView({
             </button>
           </>
         )}
-        <button
-          onClick={() => setCollapsed((c) => !c)}
-          title={collapsed ? "Show controls" : "Hide controls, full grid"}
-          aria-label={collapsed ? "Show controls" : "Hide controls"}
-          className="ms-auto flex h-8 w-8 items-center justify-center rounded-lg text-ink-subtle transition-colors hover:bg-elevated hover:text-ink"
-        >
-          {collapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
-        </button>
+        <div className="ms-auto flex items-center gap-1">
+          <button
+            onClick={() => void toggleWindowFullscreen()}
+            title={windowFullscreen ? "Exit fullscreen" : "Fullscreen split view"}
+            aria-label={windowFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-ink-subtle transition-colors hover:bg-elevated hover:text-ink"
+          >
+            {windowFullscreen ? <Minimize size={16} /> : <Maximize size={16} />}
+          </button>
+          <button
+            onClick={() => setCollapsed((c) => !c)}
+            title={collapsed ? "Show controls" : "Hide controls, full grid"}
+            aria-label={collapsed ? "Show controls" : "Hide controls"}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-ink-subtle transition-colors hover:bg-elevated hover:text-ink"
+          >
+            {collapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+          </button>
+          {hideControls && <WindowControls />}
+        </div>
       </div>
 
-      {!collapsed && !bannerHidden && (
+      {!hideControls && !bannerHidden && (
         <div className="mx-6 mb-3 flex items-start gap-2.5 rounded-xl border border-edge-soft/60 bg-elevated/30 px-3.5 py-2.5">
           <Info size={13} strokeWidth={2.2} className="mt-0.5 shrink-0 text-ink-subtle" />
           <p className="flex-1 text-[11.5px] leading-relaxed text-ink-muted">
-            Most IPTV providers cap simultaneous streams per account (commonly 1–2). If a tile
-            drops to "Stream offline" while others play, your provider may be throttling. Try
-            closing a stream and retrying.
+            Most IPTV providers cap simultaneous streams per account (commonly 1–2). If a tile drops
+            to "Stream offline" while others play, your provider may be throttling. Try closing a
+            stream and retrying.
           </p>
           <button
             type="button"
@@ -148,15 +188,25 @@ export function MultiviewView({
         </div>
       )}
 
-      <div className={`min-h-0 flex-1 px-6 ${collapsed ? "pb-3" : "pb-6"}`}>
+      <div className={`min-h-0 flex-1 px-6 ${hideControls ? "pb-3" : "pb-6"}`}>
         <Grid
           layout={store.layout}
           slots={store.slots}
           focusIndex={store.audioFocus}
+          split={store.split}
+          splitRow={store.splitRow}
+          splitRow2={store.splitRow2}
+          split3a={store.split3a}
+          split3b={store.split3b}
           onPick={(s) => setPickerSlot(s)}
           onClose={closeSlot}
           onFocus={(s) => store.setAudioFocus(s)}
           onMute={() => store.setAudioFocus(-1)}
+          onSplitChange={(pct) => store.setSplit(pct)}
+          onSplitRowChange={(pct) => store.setSplitRow(pct)}
+          onSplitRow2Change={(pct) => store.setSplitRow2(pct)}
+          onSplit3aChange={(pct) => store.setSplit3a(pct)}
+          onSplit3bChange={(pct) => store.setSplit3b(pct)}
         />
       </div>
 

--- a/src/views/multiview/grid.tsx
+++ b/src/views/multiview/grid.tsx
@@ -1,5 +1,5 @@
 import { Move } from "lucide-react";
-import { useRef, type RefObject } from "react";
+import { useRef, useState, type RefObject } from "react";
 import {
   SPLIT3A_MAX,
   SPLIT3A_MIN,
@@ -35,12 +35,14 @@ function Divider({
   min,
   max,
   onChange,
+  onDragStart,
 }: {
   axis: Axis;
   split: number;
   min: number;
   max: number;
   onChange: (pct: number) => void;
+  onDragStart?: () => void;
 }) {
   const dragRef = useRef<DividerDrag | null>(null);
   const isX = axis === "x";
@@ -82,6 +84,7 @@ function Divider({
         dragRef.current = { pointerId: event.pointerId, value: split };
         event.currentTarget.setPointerCapture(event.pointerId);
         event.preventDefault();
+        onDragStart?.();
       }}
       onPointerMove={(event) => {
         const drag = dragRef.current;
@@ -139,9 +142,11 @@ function Nexus({
   split,
   splitRow,
   splitRow2,
+  linked,
   onSplitChange,
   onSplitRowChange,
   onSplitRow2Change,
+  onAlign,
 }: {
   rootRef: RefObject<HTMLDivElement | null>;
   leftRef: RefObject<HTMLDivElement | null>;
@@ -150,9 +155,11 @@ function Nexus({
   split: number;
   splitRow: number;
   splitRow2: number;
+  linked: boolean;
   onSplitChange: (pct: number) => void;
   onSplitRowChange: (pct: number) => void;
   onSplitRow2Change: (pct: number) => void;
+  onAlign: () => void;
 }) {
   const handleRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<NexusDrag | null>(null);
@@ -200,7 +207,12 @@ function Nexus({
   return (
     <div
       ref={handleRef}
-      title="Drag to resize all four panels"
+      title={
+        linked
+          ? "Double-click to unlink rows"
+          : "Drag to resize all four panels · Double-click to align rows"
+      }
+      onDoubleClick={onAlign}
       onPointerDown={(event) => {
         if (event.button !== 0 || !event.isPrimary || dragRef.current || !rootRef.current) return;
         dragRef.current = {
@@ -234,7 +246,12 @@ function Nexus({
       onPointerCancel={(event) => {
         if (dragRef.current?.pointerId === event.pointerId) finish();
       }}
-      className="absolute z-20 flex h-8 w-8 -translate-x-1/2 -translate-y-1/2 cursor-grab touch-none select-none items-center justify-center rounded-full border border-edge-soft bg-elevated/95 text-ink-muted shadow-[0_3px_14px_rgba(0,0,0,0.28)] transition-colors hover:border-accent hover:bg-accent hover:text-black active:cursor-grabbing"
+      className={
+        "absolute z-20 flex h-8 w-8 -translate-x-1/2 -translate-y-1/2 cursor-grab touch-none select-none items-center justify-center rounded-full border shadow-[0_3px_14px_rgba(0,0,0,0.28)] transition-colors active:cursor-grabbing " +
+        (linked
+          ? "border-accent bg-accent text-black"
+          : "border-edge-soft bg-elevated/95 text-ink-muted hover:border-accent hover:bg-accent hover:text-black")
+      }
       style={{
         left: "calc(" + split + "% + " + HANDLE_CENTER_OFFSET + ")",
         top: "calc(" + center + "% + " + HANDLE_CENTER_OFFSET + ")",
@@ -286,6 +303,14 @@ export function Grid({
   const leftRef = useRef<HTMLDivElement>(null);
   const leftTopRef = useRef<HTMLDivElement>(null);
   const rightTopRef = useRef<HTMLDivElement>(null);
+  const [rowsLinked, setRowsLinked] = useState(false);
+  const alignRows = () => {
+    const avg = (splitRow + splitRow2) / 2;
+    onSplitRowChange(avg);
+    onSplitRow2Change(avg);
+    setRowsLinked(true);
+  };
+  const unlinkRows = () => setRowsLinked(false);
   const count = layoutSlotCount(layout);
   const renderCell = (index: number) => (
     <Cell
@@ -377,6 +402,7 @@ export function Grid({
             min={SPLIT_MIN}
             max={SPLIT_MAX}
             onChange={onSplitRowChange}
+            onDragStart={unlinkRows}
           />
           <div className="flex h-full min-h-0 flex-1">{renderCell(1)}</div>
         </div>
@@ -395,6 +421,7 @@ export function Grid({
             min={SPLIT_MIN}
             max={SPLIT_MAX}
             onChange={onSplitRow2Change}
+            onDragStart={unlinkRows}
           />
           <div className="flex h-full min-h-0 flex-1">{renderCell(3)}</div>
         </div>
@@ -406,9 +433,11 @@ export function Grid({
           split={split}
           splitRow={splitRow}
           splitRow2={splitRow2}
+          linked={rowsLinked}
           onSplitChange={onSplitChange}
           onSplitRowChange={onSplitRowChange}
           onSplitRow2Change={onSplitRow2Change}
+          onAlign={alignRows}
         />
       </div>
     );

--- a/src/views/multiview/grid.tsx
+++ b/src/views/multiview/grid.tsx
@@ -1,45 +1,422 @@
+import { Move } from "lucide-react";
+import { useRef, type RefObject } from "react";
+import {
+  SPLIT3A_MAX,
+  SPLIT3A_MIN,
+  SPLIT3B_MAX,
+  SPLIT3B_MIN,
+  SPLIT_MAX,
+  SPLIT_MIN,
+  layoutSlotCount,
+  type Layout,
+  type SlotChannel,
+} from "@/lib/multiview/store";
 import { Cell } from "./cell";
-import { layoutSlotCount, type Layout, type SlotChannel } from "@/lib/multiview/store";
 
-const GRID: Record<Layout, string> = {
-  "1": "grid-cols-1 grid-rows-1",
-  "2": "grid-cols-2 grid-rows-1",
-  "3": "grid-cols-3 grid-rows-1",
-  "2x2": "grid-cols-2 grid-rows-2",
+const HANDLE_CENTER_OFFSET = "0.875rem";
+
+type Axis = "x" | "y";
+type DividerDrag = { pointerId: number; value: number };
+type NexusValue = { split: number; row: number; row2: number };
+type NexusDrag = NexusValue & {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  value: NexusValue;
 };
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+function Divider({
+  axis,
+  split,
+  min,
+  max,
+  onChange,
+}: {
+  axis: Axis;
+  split: number;
+  min: number;
+  max: number;
+  onChange: (pct: number) => void;
+}) {
+  const dragRef = useRef<DividerDrag | null>(null);
+  const isX = axis === "x";
+
+  const valueAt = (target: HTMLDivElement, clientX: number, clientY: number) => {
+    const parent = target.parentElement;
+    if (!parent) return null;
+    const rect = parent.getBoundingClientRect();
+    const size = isX ? rect.width : rect.height;
+    if (size === 0) return null;
+    const position = isX ? clientX - rect.left : clientY - rect.top;
+    return clamp((position / size) * 100, min, max);
+  };
+
+  const preview = (target: HTMLDivElement, value: number) => {
+    const panel = target.previousElementSibling;
+    if (!(panel instanceof HTMLElement)) return;
+    if (isX) panel.style.width = value + "%";
+    else panel.style.height = value + "%";
+  };
+
+  const finish = () => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    dragRef.current = null;
+    if (drag.value !== split) onChange(drag.value);
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation={isX ? "vertical" : "horizontal"}
+      aria-valuenow={Math.round(split)}
+      aria-valuemin={Math.round(min)}
+      aria-valuemax={Math.round(max)}
+      tabIndex={0}
+      onPointerDown={(event) => {
+        if (event.button !== 0 || !event.isPrimary || dragRef.current) return;
+        dragRef.current = { pointerId: event.pointerId, value: split };
+        event.currentTarget.setPointerCapture(event.pointerId);
+        event.preventDefault();
+      }}
+      onPointerMove={(event) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== event.pointerId) return;
+        const value = valueAt(event.currentTarget, event.clientX, event.clientY);
+        if (value == null) return;
+        drag.value = value;
+        preview(event.currentTarget, value);
+      }}
+      onPointerUp={(event) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== event.pointerId) return;
+        const value = valueAt(event.currentTarget, event.clientX, event.clientY);
+        if (value != null) {
+          drag.value = value;
+          preview(event.currentTarget, value);
+        }
+        finish();
+        try {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        } catch {
+          /* ignore */
+        }
+      }}
+      onPointerCancel={(event) => {
+        if (dragRef.current?.pointerId === event.pointerId) finish();
+      }}
+      onKeyDown={(event) => {
+        const increase = event.key === "ArrowRight" || event.key === "ArrowDown";
+        const decrease = event.key === "ArrowLeft" || event.key === "ArrowUp";
+        if (!increase && !decrease) return;
+        event.preventDefault();
+        onChange(clamp(split + (increase ? 2.5 : -2.5), min, max));
+      }}
+      className={
+        "group relative z-10 shrink-0 touch-none outline-none " +
+        (isX ? "w-3 cursor-col-resize" : "h-3 cursor-row-resize")
+      }
+    >
+      <div
+        className={
+          "rounded-full bg-edge-soft/70 transition-colors group-hover:bg-accent group-focus-visible:bg-accent group-active:bg-accent " +
+          (isX ? "mx-auto h-full w-[3px]" : "mx-auto h-[3px] w-full")
+        }
+      />
+    </div>
+  );
+}
+
+function Nexus({
+  rootRef,
+  leftRef,
+  leftTopRef,
+  rightTopRef,
+  split,
+  splitRow,
+  splitRow2,
+  onSplitChange,
+  onSplitRowChange,
+  onSplitRow2Change,
+}: {
+  rootRef: RefObject<HTMLDivElement | null>;
+  leftRef: RefObject<HTMLDivElement | null>;
+  leftTopRef: RefObject<HTMLDivElement | null>;
+  rightTopRef: RefObject<HTMLDivElement | null>;
+  split: number;
+  splitRow: number;
+  splitRow2: number;
+  onSplitChange: (pct: number) => void;
+  onSplitRowChange: (pct: number) => void;
+  onSplitRow2Change: (pct: number) => void;
+}) {
+  const handleRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<NexusDrag | null>(null);
+
+  const preview = (value: NexusValue) => {
+    if (leftRef.current) leftRef.current.style.width = value.split + "%";
+    if (leftTopRef.current) leftTopRef.current.style.height = value.row + "%";
+    if (rightTopRef.current) rightTopRef.current.style.height = value.row2 + "%";
+    if (handleRef.current) {
+      handleRef.current.style.left = "calc(" + value.split + "% + " + HANDLE_CENTER_OFFSET + ")";
+      handleRef.current.style.top =
+        "calc(" + (value.row + value.row2) / 2 + "% + " + HANDLE_CENTER_OFFSET + ")";
+    }
+  };
+
+  const valueAt = (clientX: number, clientY: number) => {
+    const drag = dragRef.current;
+    const root = rootRef.current;
+    if (!drag || !root) return null;
+    const rect = root.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return drag.value;
+
+    const value = {
+      split: clamp(drag.split + ((clientX - drag.startX) / rect.width) * 100, SPLIT_MIN, SPLIT_MAX),
+      row: clamp(drag.row + ((clientY - drag.startY) / rect.height) * 100, SPLIT_MIN, SPLIT_MAX),
+      row2: clamp(drag.row2 + ((clientY - drag.startY) / rect.height) * 100, SPLIT_MIN, SPLIT_MAX),
+    };
+    drag.value = value;
+    return value;
+  };
+
+  const finish = (value?: NexusValue) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const next = value ?? drag.value;
+    preview(next);
+    dragRef.current = null;
+    if (next.split !== split) onSplitChange(next.split);
+    if (next.row !== splitRow) onSplitRowChange(next.row);
+    if (next.row2 !== splitRow2) onSplitRow2Change(next.row2);
+  };
+
+  const center = (splitRow + splitRow2) / 2;
+
+  return (
+    <div
+      ref={handleRef}
+      title="Drag to resize all four panels"
+      onPointerDown={(event) => {
+        if (event.button !== 0 || !event.isPrimary || dragRef.current || !rootRef.current) return;
+        dragRef.current = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startY: event.clientY,
+          split,
+          row: splitRow,
+          row2: splitRow2,
+          value: { split, row: splitRow, row2: splitRow2 },
+        };
+        event.currentTarget.setPointerCapture(event.pointerId);
+        event.preventDefault();
+      }}
+      onPointerMove={(event) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== event.pointerId) return;
+        const value = valueAt(event.clientX, event.clientY);
+        if (value) preview(value);
+      }}
+      onPointerUp={(event) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== event.pointerId) return;
+        finish(valueAt(event.clientX, event.clientY) ?? undefined);
+        try {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        } catch {
+          /* ignore */
+        }
+      }}
+      onPointerCancel={(event) => {
+        if (dragRef.current?.pointerId === event.pointerId) finish();
+      }}
+      className="absolute z-20 flex h-8 w-8 -translate-x-1/2 -translate-y-1/2 cursor-grab touch-none select-none items-center justify-center rounded-full border border-edge-soft bg-elevated/95 text-ink-muted shadow-[0_3px_14px_rgba(0,0,0,0.28)] transition-colors hover:border-accent hover:bg-accent hover:text-black active:cursor-grabbing"
+      style={{
+        left: "calc(" + split + "% + " + HANDLE_CENTER_OFFSET + ")",
+        top: "calc(" + center + "% + " + HANDLE_CENTER_OFFSET + ")",
+      }}
+    >
+      <Move aria-hidden size={15} strokeWidth={2.2} />
+    </div>
+  );
+}
 
 export function Grid({
   layout,
   slots,
   focusIndex,
+  split,
+  splitRow,
+  splitRow2,
+  split3a,
+  split3b,
   onPick,
   onClose,
   onFocus,
   onMute,
+  onSplitChange,
+  onSplitRowChange,
+  onSplitRow2Change,
+  onSplit3aChange,
+  onSplit3bChange,
 }: {
   layout: Layout;
   slots: (SlotChannel | null)[];
   focusIndex: number;
+  split: number;
+  splitRow: number;
+  splitRow2: number;
+  split3a: number;
+  split3b: number;
   onPick: (slot: number) => void;
   onClose: (slot: number) => void;
   onFocus: (slot: number) => void;
   onMute: () => void;
+  onSplitChange: (pct: number) => void;
+  onSplitRowChange: (pct: number) => void;
+  onSplitRow2Change: (pct: number) => void;
+  onSplit3aChange: (pct: number) => void;
+  onSplit3bChange: (pct: number) => void;
 }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const leftRef = useRef<HTMLDivElement>(null);
+  const leftTopRef = useRef<HTMLDivElement>(null);
+  const rightTopRef = useRef<HTMLDivElement>(null);
   const count = layoutSlotCount(layout);
-  return (
-    <div className={`grid h-full w-full gap-2 ${GRID[layout]}`}>
-      {Array.from({ length: count }, (_, i) => (
-        <Cell
-          key={i}
-          slot={i}
-          channel={slots[i] ?? null}
-          focused={focusIndex === i}
-          onPick={() => onPick(i)}
-          onClose={() => onClose(i)}
-          onFocus={() => onFocus(i)}
-          onMute={onMute}
+  const renderCell = (index: number) => (
+    <Cell
+      key={index}
+      slot={index}
+      channel={slots[index] ?? null}
+      focused={focusIndex === index}
+      onPick={() => onPick(index)}
+      onClose={() => onClose(index)}
+      onFocus={() => onFocus(index)}
+      onMute={onMute}
+    />
+  );
+
+  if (layout === "2") {
+    return (
+      <div className="flex h-full w-full gap-2">
+        <div className="flex h-full min-w-0" style={{ width: split + "%" }}>
+          {renderCell(0)}
+        </div>
+        <Divider axis="x" split={split} min={SPLIT_MIN} max={SPLIT_MAX} onChange={onSplitChange} />
+        <div className="flex h-full min-w-0 flex-1">{renderCell(1)}</div>
+      </div>
+    );
+  }
+
+  if (layout === "2v") {
+    return (
+      <div className="flex h-full w-full flex-col gap-2">
+        <div className="flex h-full min-h-0" style={{ height: splitRow + "%" }}>
+          {renderCell(0)}
+        </div>
+        <Divider
+          axis="y"
+          split={splitRow}
+          min={SPLIT_MIN}
+          max={SPLIT_MAX}
+          onChange={onSplitRowChange}
         />
-      ))}
+        <div className="flex h-full min-h-0 flex-1">{renderCell(1)}</div>
+      </div>
+    );
+  }
+
+  if (layout === "3") {
+    return (
+      <div className="flex h-full w-full gap-2">
+        <div className="flex h-full min-w-0" style={{ width: split3a + "%" }}>
+          {renderCell(0)}
+        </div>
+        <Divider
+          axis="x"
+          split={split3a}
+          min={SPLIT3A_MIN}
+          max={SPLIT3A_MAX}
+          onChange={onSplit3aChange}
+        />
+        <div className="flex h-full min-w-0 flex-1 gap-2">
+          <div className="flex h-full min-w-0" style={{ width: split3b + "%" }}>
+            {renderCell(1)}
+          </div>
+          <Divider
+            axis="x"
+            split={split3b}
+            min={SPLIT3B_MIN}
+            max={SPLIT3B_MAX}
+            onChange={onSplit3bChange}
+          />
+          <div className="flex h-full min-w-0 flex-1">{renderCell(2)}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (layout === "2x2") {
+    return (
+      <div ref={rootRef} className="relative flex h-full w-full gap-2">
+        <div
+          ref={leftRef}
+          className="flex h-full min-w-0 flex-col gap-2"
+          style={{ width: split + "%" }}
+        >
+          <div ref={leftTopRef} className="flex h-full min-h-0" style={{ height: splitRow + "%" }}>
+            {renderCell(0)}
+          </div>
+          <Divider
+            axis="y"
+            split={splitRow}
+            min={SPLIT_MIN}
+            max={SPLIT_MAX}
+            onChange={onSplitRowChange}
+          />
+          <div className="flex h-full min-h-0 flex-1">{renderCell(1)}</div>
+        </div>
+        <Divider axis="x" split={split} min={SPLIT_MIN} max={SPLIT_MAX} onChange={onSplitChange} />
+        <div className="flex h-full min-w-0 flex-1 flex-col gap-2">
+          <div
+            ref={rightTopRef}
+            className="flex h-full min-h-0"
+            style={{ height: splitRow2 + "%" }}
+          >
+            {renderCell(2)}
+          </div>
+          <Divider
+            axis="y"
+            split={splitRow2}
+            min={SPLIT_MIN}
+            max={SPLIT_MAX}
+            onChange={onSplitRow2Change}
+          />
+          <div className="flex h-full min-h-0 flex-1">{renderCell(3)}</div>
+        </div>
+        <Nexus
+          rootRef={rootRef}
+          leftRef={leftRef}
+          leftTopRef={leftTopRef}
+          rightTopRef={rightTopRef}
+          split={split}
+          splitRow={splitRow}
+          splitRow2={splitRow2}
+          onSplitChange={onSplitChange}
+          onSplitRowChange={onSplitRowChange}
+          onSplitRow2Change={onSplitRow2Change}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid h-full w-full grid-cols-1 grid-rows-1">
+      {Array.from({ length: count }, (_, index) => renderCell(index))}
     </div>
   );
 }


### PR DESCRIPTION
### Multiview layout controls: fullscreen, chrome hiding, and resizable tiles

**Summary**

Improves the Multiview screen-split experience under Live TV with full control over how the split grid is displayed and sized.

**Changes**

- Fullscreen split view: New button (and Escape to exit) toggles the whole split grid to fullscreen.


- Hide top bar: The collapse button hides the app nav bar and shows only the window controls (minimize/maximize/close) while collapsed or in fullscreen.

- Resizable tiles: Drag dividers in every layout — side-by-side, stacked, triple, and quad. Each split (including left/right columns in the quad layout) is independent, so resizing one tile never moves the others.

- Align rows in quad layout: Double-click the center handle to snap both row dividers to the same position and link them together (handle highlights while linked). Dragging any row divider unlinks it so each side can be resized independently. Double-click again to re-align.

- Persisted layout: Split positions are saved per layout in localStorage and restored on next launch.


Where
Accessible from Live TV → Multiview, the split grid layout bar.