### PR TITLE
fix(player): defer resume seek until media is ready

### DIFF
--- a/src/views/player/hooks/use-bridge-load.ts
+++ b/src/views/player/hooks/use-bridge-load.ts
@@ -103,15 +103,6 @@ export function useBridgeLoad(params: {
           notWebReady: src.notWebReady,
           isLive,
           headers: src.headers,
-          startAtSec: guestInRoom
-            ? undefined
-            : eligibleForPrompt
-              ? undefined
-              : startSec > 5
-                ? startSec
-                : isFirstLoad
-                  ? undefined
-                  : 0,
         });
       } catch (e) {
         if (cancelled) return;
@@ -119,24 +110,6 @@ export function useBridgeLoad(params: {
         return;
       }
       if (cancelled) return;
-      if (!eligibleForPrompt && !guestInRoom && startSec > 5) {
-        let unsub: (() => void) | null = null;
-        let synced = false;
-        const stop = () => {
-          synced = true;
-          unsub?.();
-        };
-        unsub = bridge.subscribe((s) => {
-          if (cancelled) {
-            stop();
-            return;
-          }
-          if (s.durationSec <= 0) return;
-          stop();
-          if (startSec >= s.durationSec - 20) bridge.seek(0);
-        });
-        if (synced) unsub?.();
-      }
       if (eligibleForPrompt) {
         bridge.pause();
         setPendingResumeSec(startSec);
@@ -149,6 +122,13 @@ export function useBridgeLoad(params: {
             setPendingSeekSec(0);
           }
         };
+        return;
+      }
+      if (!guestInRoom && startSec > 5) {
+        // On Linux's embedded mpv renderer, supplying `start` during load can
+        // race the initial render context with a network seek. Load the first
+        // frame normally, then seek once the bridge reports a duration.
+        setPendingSeekSec(startSec);
         return;
       }
       if (!inRoomRef.current) {

--- a/src/views/player/hooks/use-pending-seek-apply.ts
+++ b/src/views/player/hooks/use-pending-seek-apply.ts
@@ -16,7 +16,7 @@ export function usePendingSeekApply(params: {
     if (!b) return;
     const target = pendingSeekSec;
     clearPendingSeek();
-    const t = target <= 5 ? 0 : Math.min(target, durationSec - 1);
+    const t = target <= 5 || target >= durationSec - 20 ? 0 : Math.min(target, durationSec - 1);
     b.seek(t);
     if (!inRoomRef.current) b.play().catch(() => {});
   }, [pendingSeekSec, durationSec, clearPendingSeek]);


### PR DESCRIPTION
## Summary

- Stop passing the saved resume position as an eager `startAtSec` load option.
- Queue the resume position through the existing pending-seek path.
- Apply the seek only after the bridge reports a valid media duration.
- Preserve start-over behavior when the saved position is within 20 seconds of the end.

## Why

Continue Watching could issue a network seek while the embedded mpv renderer was still initializing. On Linux this race could leave playback on a black frame, sometimes with audio, and make the player difficult to exit.

Loading the first frame normally and applying the saved position once duration is available keeps mpv as the playback-state source of truth and avoids that initialization race.

## Verification

- `vp lint src/views/player/hooks/use-bridge-load.ts src/views/player/hooks/use-pending-seek-apply.ts`
- `./node_modules/.bin/tsc -b --pretty false`
- `git diff --check origin/beta-branch...HEAD`
- Focused `vp check` was also attempted; it reports pre-existing formatting issues in `use-bridge-load.ts` outside this patch. The PR intentionally does not include unrelated formatting changes.

## Platform Impact

The loading path is shared, but this specifically addresses the Linux embedded-mpv Continue Watching regression.

Fixes #1214