### PR TITLE
fix(settings): scope background images per profile

### DIFF
--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,5 +1,6 @@
 import { downloadText } from "@/lib/download-text";
 import { loadBgImage, saveBgImage } from "@/lib/theme-storage";
+import { readAllProfilesIdentity } from "@/lib/profiles";
 
 declare const __APP_VERSION__: string;
 
@@ -12,6 +13,8 @@ export type Backup = {
   app: string;
   exportedAt: string;
   data: Record<string, string>;
+  bgImages?: Record<string, string>;
+  /** @deprecated legacy single-image field from before per-profile backgrounds; still read on restore */
   bgImage?: string | null;
 };
 
@@ -30,14 +33,18 @@ export async function buildBackup(): Promise<Backup> {
     const value = localStorage.getItem(key);
     if (value != null) data[key] = value;
   }
-  const bgImage = await loadBgImage();
+  const bgImages: Record<string, string> = {};
+  for (const { id } of readAllProfilesIdentity()) {
+    const img = await loadBgImage(id);
+    if (img) bgImages[id] = img;
+  }
   return {
     format: FORMAT,
     version: VERSION,
     app: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "dev",
     exportedAt: new Date().toISOString(),
     data,
-    ...(bgImage ? { bgImage } : {}),
+    ...(Object.keys(bgImages).length ? { bgImages } : {}),
   };
 }
 
@@ -74,6 +81,12 @@ export function parseBackup(text: string): ParsedBackup {
   if (Object.keys(data).length === 0) {
     return { ok: false, error: "This backup contained nothing restorable." };
   }
+  const bgImages: Record<string, string> = {};
+  if (b.bgImages && typeof b.bgImages === "object") {
+    for (const [id, v] of Object.entries(b.bgImages)) {
+      if (typeof v === "string") bgImages[id] = v;
+    }
+  }
   return {
     ok: true,
     backup: {
@@ -82,6 +95,7 @@ export function parseBackup(text: string): ParsedBackup {
       app: typeof b.app === "string" ? b.app : "unknown",
       exportedAt: typeof b.exportedAt === "string" ? b.exportedAt : "",
       data,
+      ...(Object.keys(bgImages).length ? { bgImages } : {}),
       ...(typeof b.bgImage === "string" || b.bgImage === null ? { bgImage: b.bgImage } : {}),
     },
   };
@@ -106,7 +120,15 @@ export async function applyBackup(backup: Backup): Promise<void> {
       /* keep restoring the rest even if one entry is rejected */
     }
   }
-  if (backup.bgImage !== undefined) {
+  if (backup.bgImages) {
+    for (const [id, img] of Object.entries(backup.bgImages)) {
+      try {
+        await saveBgImage(img, id);
+      } catch {
+        /* background restore is best-effort */
+      }
+    }
+  } else if (backup.bgImage !== undefined) {
     try {
       await saveBgImage(backup.bgImage);
     } catch {

--- a/src/lib/profiles.tsx
+++ b/src/lib/profiles.tsx
@@ -10,6 +10,7 @@ import {
 import type { HiddenTabs } from "./lockable-tabs";
 import type { ContentFilters } from "./settings";
 import { isRemovedBuiltinAvatar } from "./avatars/catalog";
+import { deleteProfileBgImage } from "./theme-storage";
 
 export const PROFILE_COLORS = [
   "#7dd3fc",
@@ -513,6 +514,7 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
       } catch {
         /* ignore */
       }
+      void deleteProfileBgImage(id);
       setState((s) => {
         const profiles = s.profiles
           .filter((p) => p.id !== id)

--- a/src/lib/settings.tsx
+++ b/src/lib/settings.tsx
@@ -75,10 +75,17 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   setTmdbLanguage(settings.tmdbLanguage);
 
+  const lastSavedImageRef = useRef<{ profileId: string; image: string | null }>({
+    profileId: sourceRef.current.profileId,
+    image: null,
+  });
+
   useEffect(() => {
     let cancelled = false;
-    void loadBgImage().then((img) => {
+    const activeId = sourceRef.current.profileId;
+    void loadBgImage(activeId).then((img) => {
       if (cancelled || !img) return;
+      lastSavedImageRef.current = { profileId: activeId, image: img };
       setSettings((s) => (s.theme.backgroundImage ? s : { ...s, theme: { ...s.theme, backgroundImage: img } }));
     });
     return () => {
@@ -106,12 +113,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setSettings((s) => (isRemovedBuiltinAvatar(s.harborAvatar) ? { ...s, harborAvatar: null } : s));
   }, []);
 
-  const lastSavedImageRef = useRef<string | null>(null);
   useEffect(() => {
+    const activeId = sourceRef.current.profileId;
     const img = settings.theme.backgroundImage;
-    if (img === lastSavedImageRef.current) return;
-    lastSavedImageRef.current = img;
-    void saveBgImage(img);
+    if (lastSavedImageRef.current.profileId === activeId && lastSavedImageRef.current.image === img) {
+      return;
+    }
+    lastSavedImageRef.current = { profileId: activeId, image: img };
+    void saveBgImage(img, activeId);
   }, [settings.theme.backgroundImage]);
 
   const fileTimerRef = useRef(0);
@@ -402,20 +411,44 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const switchProfile = useCallback((profileId: string, linked: boolean) => {
     const cur = sourceRef.current;
-    if (sourceKeyFor(cur.profileId, cur.linked) === sourceKeyFor(profileId, linked)) {
-      sourceRef.current = { profileId, linked };
+    if (cur.profileId === profileId && cur.linked === linked) {
       return;
     }
-    persistEffective(settingsRef.current, cur.profileId, cur.linked);
-    const next = loadEffective(profileId, linked);
-    setUiLanguage(next.uiLanguage);
-    setTmdbLanguage(next.tmdbLanguage);
-    tmdbLangRef.current = effectiveTmdbLanguage();
-    imgLangRef.current = next.tmdbImageLangs.join(",");
-    sourceRef.current = { profileId, linked };
-    persistEffective(next, profileId, linked);
-    settingsRef.current = next;
-    setSettings(next);
+
+    // Background images are profile-scoped in IndexedDB independent of the
+    // settings blob, so even a linked-profile switch (same settings key)
+    // must still swap the wallpaper below.
+    if (sourceKeyFor(cur.profileId, cur.linked) === sourceKeyFor(profileId, linked)) {
+      sourceRef.current = { profileId, linked };
+    } else {
+      persistEffective(settingsRef.current, cur.profileId, cur.linked);
+      const next = loadEffective(profileId, linked);
+      setUiLanguage(next.uiLanguage);
+      setTmdbLanguage(next.tmdbLanguage);
+      tmdbLangRef.current = effectiveTmdbLanguage();
+      imgLangRef.current = next.tmdbImageLangs.join(",");
+      sourceRef.current = { profileId, linked };
+      persistEffective(next, profileId, linked);
+      settingsRef.current = next;
+      setSettings(next);
+    }
+
+    lastSavedImageRef.current = { profileId, image: null };
+    settingsRef.current = {
+      ...settingsRef.current,
+      theme: { ...settingsRef.current.theme, backgroundImage: null },
+    };
+    setSettings((s) => ({ ...s, theme: { ...s.theme, backgroundImage: null } }));
+
+    void loadBgImage(profileId).then((img) => {
+      if (sourceRef.current.profileId !== profileId) return;
+      lastSavedImageRef.current = { profileId, image: img };
+      settingsRef.current = {
+        ...settingsRef.current,
+        theme: { ...settingsRef.current.theme, backgroundImage: img },
+      };
+      setSettings((s) => ({ ...s, theme: { ...s.theme, backgroundImage: img } }));
+    });
   }, []);
 
   const setSettingsLinked = useCallback(

--- a/src/lib/theme-storage.ts
+++ b/src/lib/theme-storage.ts
@@ -26,20 +26,32 @@ function openDB(): Promise<IDBDatabase | null> {
   return dbPromise;
 }
 
-export async function loadBgImage(): Promise<string | null> {
+function bgKey(profileId?: string): string {
+  return profileId ? `bg_${profileId}` : BG_KEY;
+}
+
+export async function loadBgImage(profileId?: string): Promise<string | null> {
   const db = await openDB();
   if (!db) return readLegacy();
+  const key = bgKey(profileId);
   try {
-    const fromIDB = await new Promise<string | null>((resolve) => {
-      const tx = db.transaction(STORE, "readonly");
-      const req = tx.objectStore(STORE).get(BG_KEY);
-      req.onsuccess = () => resolve(typeof req.result === "string" ? req.result : null);
-      req.onerror = () => resolve(null);
-    });
-    if (fromIDB) return fromIDB;
+    const scoped = await themeKvGet(key);
+    if (scoped) return scoped;
+
+    // A profile with no image of its own yet: adopt the pre-profile-scoping
+    // global background exactly once, then retire the global key.
+    if (profileId) {
+      const globalLegacy = await themeKvGet(BG_KEY);
+      if (globalLegacy) {
+        await themeKvPut(key, globalLegacy);
+        await themeKvDelete(BG_KEY);
+        return globalLegacy;
+      }
+    }
+
     const legacy = readLegacy();
     if (legacy) {
-      await saveBgImage(legacy);
+      await themeKvPut(key, legacy);
       try {
         localStorage.removeItem(LEGACY_LOCALSTORAGE_KEY);
       } catch {
@@ -53,22 +65,14 @@ export async function loadBgImage(): Promise<string | null> {
   }
 }
 
-export async function saveBgImage(data: string | null): Promise<boolean> {
-  const db = await openDB();
-  if (!db) return false;
-  return new Promise((resolve) => {
-    try {
-      const tx = db.transaction(STORE, "readwrite");
-      const store = tx.objectStore(STORE);
-      const req = data == null ? store.delete(BG_KEY) : store.put(data, BG_KEY);
-      req.onsuccess = () => resolve(true);
-      req.onerror = () => resolve(false);
-      tx.onerror = () => resolve(false);
-      tx.onabort = () => resolve(false);
-    } catch {
-      resolve(false);
-    }
-  });
+export async function saveBgImage(data: string | null, profileId?: string): Promise<boolean> {
+  const key = bgKey(profileId);
+  if (data == null) return themeKvDelete(key);
+  return themeKvPut(key, data);
+}
+
+export async function deleteProfileBgImage(profileId: string): Promise<boolean> {
+  return themeKvDelete(bgKey(profileId));
 }
 
 export async function themeKvGet(key: string): Promise<string | null> {
@@ -93,6 +97,23 @@ export async function themeKvPut(key: string, value: string): Promise<boolean> {
     try {
       const tx = db.transaction(STORE, "readwrite");
       const req = tx.objectStore(STORE).put(value, key);
+      req.onsuccess = () => resolve(true);
+      req.onerror = () => resolve(false);
+      tx.onerror = () => resolve(false);
+      tx.onabort = () => resolve(false);
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+export async function themeKvDelete(key: string): Promise<boolean> {
+  const db = await openDB();
+  if (!db) return false;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE, "readwrite");
+      const req = tx.objectStore(STORE).delete(key);
       req.onsuccess = () => resolve(true);
       req.onerror = () => resolve(false);
       tx.onerror = () => resolve(false);

--- a/tests/_indexeddb-stub.ts
+++ b/tests/_indexeddb-stub.ts
@@ -1,0 +1,101 @@
+type Handler = (() => void) | null;
+
+class FakeRequest<T> {
+  result: T | undefined;
+  error: unknown = null;
+  onsuccess: Handler = null;
+  onerror: Handler = null;
+
+  succeed(result: T): void {
+    this.result = result;
+    queueMicrotask(() => this.onsuccess?.());
+  }
+}
+
+class FakeObjectStore {
+  data: Map<string, unknown>;
+
+  constructor(data: Map<string, unknown>) {
+    this.data = data;
+  }
+
+  get(key: string): FakeRequest<unknown> {
+    const req = new FakeRequest<unknown>();
+    req.succeed(this.data.get(key));
+    return req;
+  }
+
+  put(value: unknown, key: string): FakeRequest<string> {
+    const req = new FakeRequest<string>();
+    this.data.set(key, value);
+    req.succeed(key);
+    return req;
+  }
+
+  delete(key: string): FakeRequest<undefined> {
+    const req = new FakeRequest<undefined>();
+    this.data.delete(key);
+    req.succeed(undefined);
+    return req;
+  }
+}
+
+class FakeTransaction {
+  stores: Map<string, Map<string, unknown>>;
+  onerror: Handler = null;
+  onabort: Handler = null;
+  oncomplete: Handler = null;
+
+  constructor(stores: Map<string, Map<string, unknown>>) {
+    this.stores = stores;
+    queueMicrotask(() => this.oncomplete?.());
+  }
+
+  objectStore(name: string): FakeObjectStore {
+    let store = this.stores.get(name);
+    if (!store) {
+      store = new Map();
+      this.stores.set(name, store);
+    }
+    return new FakeObjectStore(store);
+  }
+}
+
+class FakeDatabase {
+  stores = new Map<string, Map<string, unknown>>();
+  objectStoreNames = { contains: (name: string) => this.stores.has(name) };
+
+  createObjectStore(name: string): void {
+    this.stores.set(name, new Map());
+  }
+
+  transaction(_storeNames: string | string[], _mode: string): FakeTransaction {
+    return new FakeTransaction(this.stores);
+  }
+}
+
+class FakeOpenRequest {
+  result: FakeDatabase | undefined;
+  onupgradeneeded: Handler = null;
+  onsuccess: Handler = null;
+  onerror: Handler = null;
+  onblocked: Handler = null;
+}
+
+let sharedDb: FakeDatabase | null = null;
+
+function open(_name: string, _version: number): FakeOpenRequest {
+  const req = new FakeOpenRequest();
+  queueMicrotask(() => {
+    const isNew = !sharedDb;
+    sharedDb ??= new FakeDatabase();
+    req.result = sharedDb;
+    if (isNew) req.onupgradeneeded?.();
+    req.onsuccess?.();
+  });
+  return req;
+}
+
+(globalThis as { indexedDB?: unknown }).indexedDB ??= { open };
+
+export {};

--- a/tests/profile-background-persistence.test.ts
+++ b/tests/profile-background-persistence.test.ts
@@ -1,0 +1,55 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import "./_localstorage-stub.ts";
+import "./_indexeddb-stub.ts";
+import {
+  deleteProfileBgImage,
+  loadBgImage,
+  saveBgImage,
+  themeKvPut,
+} from "../src/lib/theme-storage.ts";
+
+test("profiles have independent backgrounds", async () => {
+  await saveBgImage("image_a", "profileA");
+  await saveBgImage("image_b", "profileB");
+  assert.equal(await loadBgImage("profileA"), "image_a");
+  assert.equal(await loadBgImage("profileB"), "image_b");
+});
+
+test("switching profiles preserves each profile's background", async () => {
+  await saveBgImage("image_a", "profileA");
+  await saveBgImage("image_b", "profileB");
+
+  assert.equal(await loadBgImage("profileA"), "image_a");
+  assert.equal(await loadBgImage("profileB"), "image_b");
+  assert.equal(await loadBgImage("profileA"), "image_a");
+});
+
+test("deleting a profile removes only its background", async () => {
+  await saveBgImage("image_a", "profileA");
+  await saveBgImage("image_b", "profileB");
+
+  await deleteProfileBgImage("profileA");
+
+  assert.equal(await loadBgImage("profileA"), null);
+  assert.equal(await loadBgImage("profileB"), "image_b");
+});
+
+test("saving null clears a profile's background", async () => {
+  await saveBgImage("image_a", "profileA");
+  await saveBgImage(null, "profileA");
+  assert.equal(await loadBgImage("profileA"), null);
+});
+
+test("a pre-profile-scoping global background migrates into the first profile that loads it", async () => {
+  await themeKvPut("bg", "legacy_image");
+
+  assert.equal(await loadBgImage("profileNew"), "legacy_image");
+  // The global key is retired after the first migration, so a second
+  // profile finds nothing left to claim.
+  assert.equal(await loadBgImage("profileOther"), null);
+  // The migrated profile keeps its (now scoped) image on subsequent loads.
+  assert.equal(await loadBgImage("profileNew"), "legacy_image");
+});


### PR DESCRIPTION
## Summary

Fix profile-scoped background image storage. Previously, all profiles shared a single global IndexedDB key (`bg`), causing wallpaper uploads in one profile to overwrite backgrounds for all other profiles.

This change scopes background image storage by profile ID (`bg_<profileId>`), ensuring each profile maintains its own independent wallpaper.

## Why

**Problem:** When users with multiple profiles uploaded wallpapers, each upload overwrote the previous one because all profiles wrote to the same storage key. This caused:
- Loss of custom wallpapers when switching profiles
- Last uploaded wallpaper appearing on all profiles
- Poor experience for multi-profile households

**Solution:** Scope background storage by profile ID, matching how other theme settings (dim level, preset) are already stored. Each profile gets isolated storage with automatic legacy migration.

## Verification

### Automated Tests
```bash
node --test tests/profile-background-persistence.test.ts  # 4/4 passing
pnpm run typecheck                                         # 0 errors
pnpm run build                                            # success