### PR TITLE
fix(ui): update handle cooldown message from 30 to 14 days

### DIFF
--- a/src/lib/account/error-messages.ts
+++ b/src/lib/account/error-messages.ts
@@ -14,7 +14,7 @@ const BY_CODE: Record<string, string> = {
   handle_too_long: "That handle is too long. Use at most 24 characters.",
   handle_invalid: "Handles can use letters, numbers, and single hyphens only.",
   handle_taken: "That handle is already taken. Try one of the suggestions.",
-  handle_cooldown_other: "Someone released that handle recently. It frees up 30 days after they dropped it.",
+  handle_cooldown_other: "Someone released that handle recently. It frees up 14 days after they dropped it.",
   handle_cooldown: "You changed your handle recently. You can change it again after the cooldown.",
   stremio_already_bound: "That Stremio account is already linked to a different Harbor account. Unlink it there first.",
   stremio_key_invalid: "That Stremio sign-in did not go through. Try again.",


### PR DESCRIPTION
## Summary
- Update the `handle_cooldown_other` error message in `src/lib/account/error-messages.ts`
  from "30 days" to "14 days" so it matches the backend's handle-change cooldown
  (`COOLDOWN_MS` in `handle-rules.js`, corrected from 30 to 14 days in a companion
  backend change).
- No other frontend copy needed changing — the existing "once every 14 days" /
  "...for 14 days" strings in `handle-claim-card.tsx` and `handle-change-confirm.tsx`
  were already correct; the backend was the side that disagreed with them.

## Context
Users were seeing a message implying a 14-day handle-change cooldown, but the
backend enforced 30 days, so a user who waited 15 days was still rejected.
This PR is the frontend half of the fix; it must land together with the backend
change that lowers `COOLDOWN_MS` to 14 days and starts returning
`handleChangeAvailableAt`, or the copy will be accurate again but the UI lock
card still won't render correctly.