### PR TITLE
feat: persist addon origin in saved items and fall back to alternate stream types

### DIFF
--- a/src/components/context-menu.tsx
+++ b/src/components/context-menu.tsx
@@ -193,6 +193,8 @@ export function ContextMenu() {
         name: meta.name,
         poster: meta.poster,
         imdbId: targetImdb,
+        addonOrigin: meta.addonOrigin,
+        videos: meta.videos,
       });
       close();
     };
@@ -239,7 +241,14 @@ export function ContextMenu() {
         icon={<Heart size={14} strokeWidth={2} fill={isFav ? "currentColor" : "none"} />}
         label={isFav ? "Favorited" : "Favorite"}
         onClick={() => {
-          toggleFavorite({ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster });
+          toggleFavorite({
+            id: meta.id,
+            type: meta.type,
+            name: meta.name,
+            poster: meta.poster,
+            addonOrigin: meta.addonOrigin,
+            videos: meta.videos,
+          });
           close();
         }}
         accent={isFav}
@@ -248,7 +257,14 @@ export function ContextMenu() {
     items.push(
       <MyListSubmenu
         key="local-list"
-        item={{ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster }}
+        item={{
+          id: meta.id,
+          type: meta.type,
+          name: meta.name,
+          poster: meta.poster,
+          addonOrigin: meta.addonOrigin,
+          videos: meta.videos,
+        }}
         onClose={close}
       />,
     );

--- a/src/components/context-menu/my-list-submenu.tsx
+++ b/src/components/context-menu/my-list-submenu.tsx
@@ -44,7 +44,14 @@ export function MyListSubmenu({ item, onClose }: { item: ListItemInput; onClose:
   };
 
   const toggleDefault = () => {
-    local.toggle({ id: item.id, type: item.type, name: item.name, poster: item.poster });
+    local.toggle({
+      id: item.id,
+      type: item.type,
+      name: item.name,
+      poster: item.poster,
+      addonOrigin: item.addonOrigin,
+      videos: item.videos,
+    });
     emitListToast(inDefault ? t("Removed from My List") : t("Added to My List"));
   };
   const toggleCustom = (listId: string, name: string) => {

--- a/src/components/feed-hero.tsx
+++ b/src/components/feed-hero.tsx
@@ -157,7 +157,7 @@ export function FeedHero({
             <SecondaryAction
               icon={saved ? <BookmarkCheck size={18} /> : <Bookmark size={18} />}
               label={saved ? t("Saved") : t("Save")}
-              onClick={() => toggleWatchlist({ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster, imdbId: resolvedImdb })}
+              onClick={() => toggleWatchlist({ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster, imdbId: resolvedImdb, addonOrigin: meta.addonOrigin, videos: meta.videos })}
               active={saved}
             />
             <SecondaryAction

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -473,6 +473,8 @@ export const Hero = memo(function Hero({
                     name: meta.name,
                     poster: meta.poster,
                     imdbId: resolvedImdb,
+                    addonOrigin: meta.addonOrigin,
+                    videos: meta.videos,
                   });
                 }}
                 className={`flex h-12 items-center gap-2.5 ${actionRadius} border border-edge bg-canvas/55 px-6 text-[15px] font-medium text-ink shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition-colors duration-200 hover:border-ink-subtle hover:bg-canvas/75`}

--- a/src/components/hover-preview/block.tsx
+++ b/src/components/hover-preview/block.tsx
@@ -54,7 +54,7 @@ function WatchlistToggle({ data }: { data: PreviewData }) {
       onPointerDown={(e) => e.stopPropagation()}
       onClick={(e) => {
         e.stopPropagation();
-        toggleWatchlist({ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster, imdbId: alt ?? undefined });
+        toggleWatchlist({ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster, imdbId: alt ?? undefined, addonOrigin: meta.addonOrigin, videos: meta.videos });
       }}
       className="flex h-7 w-7 items-center justify-center rounded-md text-ink-subtle transition-colors duration-150 hover:bg-raised hover:text-ink"
     >

--- a/src/components/hover-preview/marquee.tsx
+++ b/src/components/hover-preview/marquee.tsx
@@ -236,6 +236,8 @@ function MarqueeBlock({
               name: meta.name,
               poster: meta.poster,
               imdbId: alt ?? undefined,
+              addonOrigin: meta.addonOrigin,
+              videos: meta.videos,
             });
           }}
         >

--- a/src/components/pick-card/elegant-hover.tsx
+++ b/src/components/pick-card/elegant-hover.tsx
@@ -68,7 +68,7 @@ export function ElegantHoverActions({
           title={inWatchlist ? t("Remove from watchlist") : t("Add to watchlist")}
           onClick={(e) =>
             act(e, () => {
-              toggleWatchlist({ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster });
+              toggleWatchlist({ id: meta.id, type: meta.type, name: meta.name, poster: meta.poster, addonOrigin: meta.addonOrigin, videos: meta.videos });
             })
           }
           className={`${btn} flex h-9 w-9 items-center justify-center rounded-full text-white transition-transform hover:scale-110`}

--- a/src/lib/addon-store.ts
+++ b/src/lib/addon-store.ts
@@ -194,18 +194,26 @@ export function transportUrlFor(id: string): string | null {
   return loadInstalled().find((a) => a.id === id)?.transportUrl ?? null;
 }
 
-function transportHost(url: string): string | null {
+// Identifies an addon instance by host + base path, ignoring manifest.json /
+// configure suffixes and query strings, so distinct manifests on the same host
+// (e.g. /p/1/manifest.json vs /p/2/manifest.json) stay separate addons.
+function transportBaseKey(url: string): string | null {
   try {
-    return new URL(url).host.toLowerCase();
+    const u = new URL(url);
+    const path = u.pathname
+      .replace(/\/manifest\.json$/i, "")
+      .replace(/\/configure$/i, "")
+      .replace(/\/+$/, "");
+    return `${u.host.toLowerCase()}${path}`;
   } catch {
     return null;
   }
 }
 
 export function findHostnameMatch(transportUrl: string): InstalledAddon | null {
-  const host = transportHost(transportUrl);
-  if (!host) return null;
-  return loadInstalled().find((a) => transportHost(a.transportUrl) === host) ?? null;
+  const base = transportBaseKey(transportUrl);
+  if (!base) return null;
+  return loadInstalled().find((a) => transportBaseKey(a.transportUrl) === base) ?? null;
 }
 
 export type AddonUrlParse =

--- a/src/lib/cinemeta.ts
+++ b/src/lib/cinemeta.ts
@@ -52,6 +52,17 @@ export type Meta = {
   }>;
 };
 
+export function cappedEmbeddedVideos(videos: Meta["videos"]): Meta["videos"] {
+  if (!videos || videos.length === 0 || videos.length > 40) return undefined;
+  if (!videos.some((v) => Array.isArray(v.streams) && v.streams.length > 0)) return undefined;
+  try {
+    if (JSON.stringify(videos).length > 64000) return undefined;
+  } catch {
+    return undefined;
+  }
+  return videos;
+}
+
 export function isAddonNativeMeta(meta: Meta): boolean {
   if (meta.type === "tv" || meta.type === "channel") return true;
   if (!meta.addonOrigin) return false;

--- a/src/lib/custom-lists.ts
+++ b/src/lib/custom-lists.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { setItemWithRecovery, freeStorageSpace } from "@/lib/storage-recovery";
 import { randomUuid } from "@/lib/uuid";
+import { cappedEmbeddedVideos, type Meta } from "@/lib/cinemeta";
 
 const KEY = "harbor.customlists.v1";
 const PROFILES_KEY = "harbor.profiles.v1";
@@ -37,9 +38,18 @@ export type ListItem = {
   name: string;
   poster?: string;
   addedAt: number;
+  addonOrigin?: Meta["addonOrigin"];
+  videos?: Meta["videos"];
 };
 
-export type ListItemInput = { id: string; type?: string; name?: string; poster?: string };
+export type ListItemInput = {
+  id: string;
+  type?: string;
+  name?: string;
+  poster?: string;
+  addonOrigin?: Meta["addonOrigin"];
+  videos?: Meta["videos"];
+};
 
 export type ListBgMode = "auto" | "custom";
 
@@ -79,6 +89,8 @@ function toItem(input: ListItemInput): ListItem {
     name: input.name ?? "",
     poster: input.poster,
     addedAt: Date.now(),
+    addonOrigin: input.addonOrigin,
+    videos: cappedEmbeddedVideos(input.videos),
   };
 }
 
@@ -107,6 +119,13 @@ function read(): CustomList[] {
             name: typeof it.name === "string" ? it.name : "",
             poster: typeof it.poster === "string" ? it.poster : undefined,
             addedAt: typeof it.addedAt === "number" ? it.addedAt : 0,
+            addonOrigin:
+              it.addonOrigin &&
+              typeof it.addonOrigin === "object" &&
+              typeof (it.addonOrigin as { id?: unknown }).id === "string"
+                ? (it.addonOrigin as Meta["addonOrigin"])
+                : undefined,
+            videos: Array.isArray(it.videos) ? (it.videos as Meta["videos"]) : undefined,
           });
         }
       }

--- a/src/lib/media-list-store.tsx
+++ b/src/lib/media-list-store.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useProfiles } from "./profiles";
+import { cappedEmbeddedVideos, type Meta } from "./cinemeta";
 
 export type MediaEntry = {
   id: string;
@@ -7,9 +8,18 @@ export type MediaEntry = {
   name: string;
   poster?: string;
   addedAt: number;
+  addonOrigin?: Meta["addonOrigin"];
+  videos?: Meta["videos"];
 };
 
-export type MediaInput = { id: string; type?: string; name?: string; poster?: string };
+export type MediaInput = {
+  id: string;
+  type?: string;
+  name?: string;
+  poster?: string;
+  addonOrigin?: Meta["addonOrigin"];
+  videos?: Meta["videos"];
+};
 
 export type MediaListStore = {
   ids: Set<string>;
@@ -44,6 +54,13 @@ function readMap(key: string): Map<string, MediaEntry> {
           name: typeof el.name === "string" ? el.name : "",
           poster: typeof el.poster === "string" ? el.poster : undefined,
           addedAt: typeof el.addedAt === "number" ? el.addedAt : 0,
+          addonOrigin:
+            el.addonOrigin &&
+            typeof el.addonOrigin === "object" &&
+            typeof (el.addonOrigin as { id?: unknown }).id === "string"
+              ? (el.addonOrigin as Meta["addonOrigin"])
+              : undefined,
+          videos: Array.isArray(el.videos) ? (el.videos as Meta["videos"]) : undefined,
         });
       }
     }
@@ -102,6 +119,8 @@ export function createMediaListStore(prefix: string) {
               name: input.name ?? "",
               poster: input.poster,
               addedAt: Date.now(),
+              addonOrigin: input.addonOrigin,
+              videos: cappedEmbeddedVideos(input.videos),
             });
           }
           writeMap(keyFor(pid), next);
@@ -145,6 +164,8 @@ export function createMediaListStore(prefix: string) {
         name: input.name ?? "",
         poster: input.poster,
         addedAt: Date.now(),
+        addonOrigin: input.addonOrigin,
+        videos: cappedEmbeddedVideos(input.videos),
       });
     } else {
       map.delete(input.id);

--- a/src/lib/streams/addons.ts
+++ b/src/lib/streams/addons.ts
@@ -55,26 +55,39 @@ export async function fetchAddonStreams(
     }
     const forcedId = forcedBases.get(addon.transportUrl.replace(/\/manifest\.json$/, ""));
     const ids = forcedId != null ? [forcedId] : pickIds(addon, req.type, req.ids);
-    if (ids.length === 0) {
+    if (ids.length > 0) {
+      for (const id of ids) {
+        // Local lists only persist movie/series, which can drop the type an addon's
+        // catalog declared for non-standard id schemes. Retry the other declared
+        // types when the primary query comes back empty.
+        const altTypes =
+          forcedId != null || !hasStandardIdScheme(id)
+            ? alternateStreamTypes(addon, req.type, id)
+            : [];
+        const name = ids.length > 1 ? `${addon.manifest.name}[${idScheme(id)}]` : addon.manifest.name;
+        namedTasks.push({
+          name,
+          p: fetchOne(addon, req.type, id, signal, timeoutMs, altTypes).then((ss) =>
+            ss.map((s, idx) => ({ ...s, addonPriority: priority, addonReturnIdx: idx })),
+          ),
+        });
+      }
+      continue;
+    }
+    // No (type, id) pair matched the request, but a non-standard id may still be
+    // served under a type the catalog declared. Query those types directly.
+    const anyType = pickIdByDeclaredTypes(addon, req.ids);
+    if (anyType == null) {
       skipped.push(`${addon.manifest.name}(no-matching-id)`);
       continue;
     }
-    for (const id of ids) {
-      // Local lists only persist movie/series, which can drop the type an addon's
-      // catalog declared for non-standard id schemes. Retry the other declared
-      // types when the primary query comes back empty.
-      const altTypes =
-        forcedId != null || !hasStandardIdScheme(id)
-          ? alternateStreamTypes(addon, req.type, id)
-          : [];
-      const name = ids.length > 1 ? `${addon.manifest.name}[${idScheme(id)}]` : addon.manifest.name;
-      namedTasks.push({
-        name,
-        p: fetchOne(addon, req.type, id, signal, timeoutMs, altTypes).then((ss) =>
-          ss.map((s, idx) => ({ ...s, addonPriority: priority, addonReturnIdx: idx })),
-        ),
-      });
-    }
+    const { id, types } = anyType;
+    namedTasks.push({
+      name: `${addon.manifest.name}[${idScheme(id)}]`,
+      p: fetchOne(addon, types[0], id, signal, timeoutMs, types.slice(1)).then((ss) =>
+        ss.map((s, idx) => ({ ...s, addonPriority: priority, addonReturnIdx: idx })),
+      ),
+    });
   }
   if (skipped.length > 0) console.info(`[addons] skipped: ${skipped.join(", ")}`);
   console.info(`[addons] querying ${namedTasks.length}: ${namedTasks.map((t) => t.name).join(", ")}`);
@@ -143,6 +156,44 @@ function pickIds(addon: Addon, type: string, ids: string[]): string[] {
   return [accepted[0]];
 }
 
+function pickIdByDeclaredTypes(
+  addon: Addon,
+  ids: string[],
+): { id: string; types: string[] } | null {
+  const sorted = [...ids].sort((a, b) => idPriority(a) - idPriority(b));
+  for (const id of sorted) {
+    const types = streamTypesAcceptingId(addon, id);
+    if (types.length > 0) return { id, types };
+  }
+  return null;
+}
+
+function streamTypesAcceptingId(addon: Addon, id: string): string[] {
+  const m = addon.manifest;
+  const resources = m.resources ?? [];
+  const streamResources = resources.filter(
+    (r): r is { name: string; types?: string[]; idPrefixes?: string[] } =>
+      typeof r === "object" && r.name === "stream",
+  );
+  const out = new Set<string>();
+  if (streamResources.length > 0) {
+    for (const r of streamResources) {
+      const idOk =
+        !r.idPrefixes ||
+        r.idPrefixes.length === 0 ||
+        r.idPrefixes.some((p) => id.startsWith(p));
+      if (!idOk) continue;
+      for (const t of r.types ?? []) out.add(t);
+    }
+    return Array.from(out);
+  }
+  if (!resources.some((r) => r === "stream")) return [];
+  const idOk =
+    !m.idPrefixes || m.idPrefixes.length === 0 || m.idPrefixes.some((p) => id.startsWith(p));
+  if (!idOk) return [];
+  return Array.from(m.types ?? []);
+}
+
 function addonAcceptsId(addon: Addon, type: string, id: string): boolean {
   const m = addon.manifest;
   const resources = m.resources ?? [];
@@ -169,23 +220,7 @@ function addonAcceptsId(addon: Addon, type: string, id: string): boolean {
 }
 
 function alternateStreamTypes(addon: Addon, type: string, id: string): string[] {
-  const resources = addon.manifest.resources ?? [];
-  const streamResources = resources.filter(
-    (r): r is { name: string; types?: string[]; idPrefixes?: string[] } =>
-      typeof r === "object" && r.name === "stream",
-  );
-  const out = new Set<string>();
-  for (const r of streamResources) {
-    const idOk =
-      !r.idPrefixes ||
-      r.idPrefixes.length === 0 ||
-      r.idPrefixes.some((p) => id.startsWith(p));
-    if (!idOk) continue;
-    for (const t of r.types ?? []) {
-      if (t !== type) out.add(t);
-    }
-  }
-  return Array.from(out);
+  return streamTypesAcceptingId(addon, id).filter((t) => t !== type);
 }
 
 async function fetchOne(

--- a/src/lib/streams/addons.ts
+++ b/src/lib/streams/addons.ts
@@ -41,7 +41,9 @@ export async function fetchAddonStreams(
   onProgress?: (settled: number, total: number) => void,
   timeoutMs = TIMEOUT_MS_SLOW,
   ranks?: AddonRankFn | null,
+  forced?: Array<{ base: string; id: string }>,
 ): Promise<Stream[]> {
+  const forcedBases = new Map((forced ?? []).map((f) => [f.base, f.id]));
   const namedTasks: Array<{ name: string; p: Promise<Stream[]> }> = [];
   const skipped: string[] = [];
   for (let i = 0; i < addons.length; i++) {
@@ -51,16 +53,24 @@ export async function fetchAddonStreams(
       skipped.push(`${addon.manifest.name}(status-addon)`);
       continue;
     }
-    const ids = pickIds(addon, req.type, req.ids);
+    const forcedId = forcedBases.get(addon.transportUrl.replace(/\/manifest\.json$/, ""));
+    const ids = forcedId != null ? [forcedId] : pickIds(addon, req.type, req.ids);
     if (ids.length === 0) {
       skipped.push(`${addon.manifest.name}(no-matching-id)`);
       continue;
     }
     for (const id of ids) {
+      // Local lists only persist movie/series, which can drop the type an addon's
+      // catalog declared for non-standard id schemes. Retry the other declared
+      // types when the primary query comes back empty.
+      const altTypes =
+        forcedId != null || !hasStandardIdScheme(id)
+          ? alternateStreamTypes(addon, req.type, id)
+          : [];
       const name = ids.length > 1 ? `${addon.manifest.name}[${idScheme(id)}]` : addon.manifest.name;
       namedTasks.push({
         name,
-        p: fetchOne(addon, req.type, id, signal, timeoutMs).then((ss) =>
+        p: fetchOne(addon, req.type, id, signal, timeoutMs, altTypes).then((ss) =>
           ss.map((s, idx) => ({ ...s, addonPriority: priority, addonReturnIdx: idx })),
         ),
       });
@@ -113,8 +123,14 @@ function pickId(addon: Addon, type: string, ids: string[]): string | null {
 
 const ANIME_SCHEMES = ["kitsu", "mal", "anidb", "anilist"];
 
+const STANDARD_ID_SCHEMES = ["tt", "tmdb:", "kitsu:", "mal:", "anidb:", "anilist:", "tvdb:", "simkl:"];
+
 function idScheme(id: string): string {
   return id.startsWith("tt") ? "imdb" : id.split(":")[0];
+}
+
+function hasStandardIdScheme(id: string): boolean {
+  return STANDARD_ID_SCHEMES.some((p) => id.startsWith(p));
 }
 
 function pickIds(addon: Addon, type: string, ids: string[]): string[] {
@@ -152,75 +168,107 @@ function addonAcceptsId(addon: Addon, type: string, id: string): boolean {
   return true;
 }
 
+function alternateStreamTypes(addon: Addon, type: string, id: string): string[] {
+  const resources = addon.manifest.resources ?? [];
+  const streamResources = resources.filter(
+    (r): r is { name: string; types?: string[]; idPrefixes?: string[] } =>
+      typeof r === "object" && r.name === "stream",
+  );
+  const out = new Set<string>();
+  for (const r of streamResources) {
+    const idOk =
+      !r.idPrefixes ||
+      r.idPrefixes.length === 0 ||
+      r.idPrefixes.some((p) => id.startsWith(p));
+    if (!idOk) continue;
+    for (const t of r.types ?? []) {
+      if (t !== type) out.add(t);
+    }
+  }
+  return Array.from(out);
+}
+
 async function fetchOne(
   addon: Addon,
   type: string,
   id: string,
   signal: AbortSignal,
   timeoutMs: number,
+  altTypes: string[] = [],
 ): Promise<Stream[]> {
   const base = addon.transportUrl.replace(/\/manifest\.json$/, "");
-  const url = `${base}/stream/${type}/${id}.json`;
   const limit = timeoutFor(addon, timeoutMs);
-  const ac = new AbortController();
-  let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    ac.abort();
-  }, limit);
-  const onParentAbort = () => ac.abort();
-  signal.addEventListener("abort", onParentAbort);
-  const startedAt = performance.now();
-  try {
-    const res = await fetch(url, {
-      headers: {
-        Accept: "application/json, text/plain, */*",
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
-      },
-      signal: ac.signal,
-    });
-    if (!res.ok) {
-      dwarn(`[addons] ${addon.manifest.name} returned ${res.status} for ${type}/${id}`);
-      return [];
-    }
-    const json = (await res.json()) as { streams?: RawStream[] };
-    const list = json.streams ?? [];
-    const ranked = isAddonRanked(addon);
-    return list.map((s) => {
-      const mapped = {
-        ...s,
-        infoHash: s.infoHash?.toLowerCase(),
-        addonId: addon.manifest.id,
-        addonName: addon.manifest.name,
-        addonUrl: addon.transportUrl,
-        addonRanked: ranked,
-      };
-      if (!mapped.infoHash && hasUncachedMarker(s)) {
-        const fromUrl = s.url ? infoHashFromUrl(s.url) : null;
-        const hash = fromUrl?.infoHash ?? infoHashFromSources(s.sources);
-        if (hash) {
-          mapped.infoHash = hash;
-          if (mapped.fileIdx == null && fromUrl?.fileIdx != null) mapped.fileIdx = fromUrl.fileIdx;
-        }
+
+  const queryOnce = async (t: string): Promise<Stream[] | null> => {
+    const url = `${base}/stream/${t}/${id}.json`;
+    const ac = new AbortController();
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      ac.abort();
+    }, limit);
+    const onParentAbort = () => ac.abort();
+    signal.addEventListener("abort", onParentAbort);
+    const startedAt = performance.now();
+    try {
+      const res = await fetch(url, {
+        headers: {
+          Accept: "application/json, text/plain, */*",
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+        },
+        signal: ac.signal,
+      });
+      if (!res.ok) {
+        dwarn(`[addons] ${addon.manifest.name} returned ${res.status} for ${t}/${id}`);
+        return null;
       }
-      return mapped;
-    });
-  } catch (e) {
-    if (timedOut) {
-      dwarn(`[addons] ${addon.manifest.name} timed out after ${limit}ms — dropped`);
-    } else if (!signal.aborted) {
-      dwarn(`[addons] ${addon.manifest.name} failed`, e);
+      const json = (await res.json()) as { streams?: RawStream[] };
+      const list = json.streams ?? [];
+      const ranked = isAddonRanked(addon);
+      return list.map((s) => {
+        const mapped = {
+          ...s,
+          infoHash: s.infoHash?.toLowerCase(),
+          addonId: addon.manifest.id,
+          addonName: addon.manifest.name,
+          addonUrl: addon.transportUrl,
+          addonRanked: ranked,
+        };
+        if (!mapped.infoHash && hasUncachedMarker(s)) {
+          const fromUrl = s.url ? infoHashFromUrl(s.url) : null;
+          const hash = fromUrl?.infoHash ?? infoHashFromSources(s.sources);
+          if (hash) {
+            mapped.infoHash = hash;
+            if (mapped.fileIdx == null && fromUrl?.fileIdx != null) mapped.fileIdx = fromUrl.fileIdx;
+          }
+        }
+        return mapped;
+      });
+    } catch (e) {
+      if (timedOut) {
+        dwarn(`[addons] ${addon.manifest.name} timed out after ${limit}ms — dropped`);
+      } else if (!signal.aborted) {
+        dwarn(`[addons] ${addon.manifest.name} failed`, e);
+      }
+      return null;
+    } finally {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onParentAbort);
+      const elapsed = Math.round(performance.now() - startedAt);
+      if (elapsed > 2500 && !timedOut) {
+        dlog(`[addons] ${addon.manifest.name} took ${elapsed}ms`);
+      }
     }
-    return [];
-  } finally {
-    clearTimeout(timer);
-    signal.removeEventListener("abort", onParentAbort);
-    const elapsed = Math.round(performance.now() - startedAt);
-    if (elapsed > 2500 && !timedOut) {
-      dlog(`[addons] ${addon.manifest.name} took ${elapsed}ms`);
-    }
+  };
+
+  const primary = await queryOnce(type);
+  if (primary == null || primary.length > 0 || altTypes.length === 0) return primary ?? [];
+  const settled = await Promise.allSettled(altTypes.map((t) => queryOnce(t)));
+  for (const r of settled) {
+    if (r.status === "fulfilled" && r.value && r.value.length > 0) return r.value;
   }
+  return [];
 }
 
 function dedupeStreams(streams: Stream[]): Stream[] {

--- a/src/lib/streams/episode-pipeline-input.ts
+++ b/src/lib/streams/episode-pipeline-input.ts
@@ -91,6 +91,7 @@ export function buildEpisodePipelineInput(params: {
     presetStreams: embedded.length > 0 ? embedded : undefined,
     addonTimeoutMs: Math.max(8, Math.min(120, settings.addonTimeoutSec ?? 30)) * 1000,
     addonRanks: resolveAddonRanks(addons, settings.streamPriority),
+    forcedAddonBases: meta.addonOrigin?.base ? [{ base: meta.addonOrigin.base, id: meta.id }] : undefined,
     trust: {
       kind: episode ? "series" : meta.type === "series" ? "series" : "movie",
       expectedTitle: meta.name,

--- a/src/lib/streams/pipeline.ts
+++ b/src/lib/streams/pipeline.ts
@@ -74,6 +74,7 @@ export type PipelineInput = {
   presetStreams?: Stream[];
   addonTimeoutMs?: number;
   addonRanks?: AddonRankFn | null;
+  forcedAddonBases?: Array<{ base: string; id: string }>;
 };
 
 export type DebridError = { slug: string; name: string; code: string };
@@ -132,7 +133,7 @@ export async function runPipeline(
     }),
     presets.length > 0
       ? Promise.resolve(presets)
-      : fetchAddonStreams(input.addons, input.request, signal, emitPartial, onAddonProgress, input.addonTimeoutMs, input.addonRanks),
+      : fetchAddonStreams(input.addons, input.request, signal, emitPartial, onAddonProgress, input.addonTimeoutMs, input.addonRanks, input.forcedAddonBases),
   ]);
   if (librarySettled.status === "fulfilled") library = librarySettled.value;
   const addonStreams = addonSettled.status === "fulfilled" ? addonSettled.value : [];

--- a/src/lib/watchlist.ts
+++ b/src/lib/watchlist.ts
@@ -7,6 +7,7 @@ import { isAuthenticated as simklConnected } from "@/lib/simkl/session";
 import { setItemWithRecovery, freeStorageSpace } from "@/lib/storage-recovery";
 import { ANIME_CLOUD_ID, cloudWriteId, saveStremioBookmark, removeStremioBookmark } from "@/lib/stremio";
 import { readActiveStremioAuthKey } from "@/lib/auth";
+import { cappedEmbeddedVideos, type Meta } from "@/lib/cinemeta";
 
 const KEY = "harbor.watchlist.v1";
 const AGG_KEY = "harbor.watchlist.aggregate.v1";
@@ -18,9 +19,19 @@ export type LocalEntry = {
   name: string;
   poster?: string;
   addedAt: number;
+  addonOrigin?: Meta["addonOrigin"];
+  videos?: Meta["videos"];
 };
 
-export type WatchlistInput = { id: string; type?: string; name?: string; poster?: string; imdbId?: string | null };
+export type WatchlistInput = {
+  id: string;
+  type?: string;
+  name?: string;
+  poster?: string;
+  imdbId?: string | null;
+  addonOrigin?: Meta["addonOrigin"];
+  videos?: Meta["videos"];
+};
 
 let memoryFallback: Map<string, LocalEntry> | null = null;
 
@@ -44,6 +55,8 @@ function toEntry(input: string | WatchlistInput): LocalEntry {
     name: input.name ?? "",
     poster: input.poster,
     addedAt: Date.now(),
+    addonOrigin: input.addonOrigin,
+    videos: cappedEmbeddedVideos(input.videos),
   };
 }
 
@@ -59,13 +72,28 @@ function read(): Map<string, LocalEntry> {
       if (typeof el === "string") {
         map.set(el, { id: el, type: inferType(el), name: "", addedAt: 0 });
       } else if (el && typeof el === "object" && typeof (el as { id?: unknown }).id === "string") {
-        const e = el as { id: string; type?: string; name?: string; poster?: string; addedAt?: number };
+        const e = el as {
+          id: string;
+          type?: string;
+          name?: string;
+          poster?: string;
+          addedAt?: number;
+          addonOrigin?: unknown;
+          videos?: unknown;
+        };
         map.set(e.id, {
           id: e.id,
           type: e.type === "series" ? "series" : "movie",
           name: typeof e.name === "string" ? e.name : "",
           poster: typeof e.poster === "string" ? e.poster : undefined,
           addedAt: typeof e.addedAt === "number" ? e.addedAt : 0,
+          addonOrigin:
+            e.addonOrigin &&
+            typeof e.addonOrigin === "object" &&
+            typeof (e.addonOrigin as { id?: unknown }).id === "string"
+              ? (e.addonOrigin as Meta["addonOrigin"])
+              : undefined,
+          videos: Array.isArray(e.videos) ? (e.videos as Meta["videos"]) : undefined,
         });
       }
     }

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -772,6 +772,8 @@ export function DetailView({
     type: meta.type,
     name: title || meta.name,
     poster: meta.poster ?? detail?.poster,
+    addonOrigin: meta.addonOrigin,
+    videos: meta.videos,
   };
   const overview =
     seasonArt?.description || (detail?.overview ?? (meta.id.startsWith("tmdb:") ? "" : meta.description) ?? "");
@@ -1386,6 +1388,8 @@ export function DetailView({
                           name: title || meta.name,
                           poster: meta.poster ?? detail?.poster,
                           imdbId: detail?.imdbId,
+                          addonOrigin: meta.addonOrigin,
+                          videos: meta.videos,
                         })
                       }
                       className={`flex h-12 items-center gap-2.5 whitespace-nowrap rounded-full border px-6 text-[15px] font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] transition-[transform,background-color,border-color] duration-200 active:scale-[0.98] ${
@@ -1440,6 +1444,8 @@ export function DetailView({
                         type: meta.type,
                         name: title || meta.name,
                         poster: meta.poster ?? detail?.poster,
+                        addonOrigin: meta.addonOrigin,
+                        videos: meta.videos,
                       })
                     }
                     hasTrailer={!!trailerCandidate}
@@ -1458,6 +1464,8 @@ export function DetailView({
                         name: title || meta.name,
                         poster: meta.poster ?? detail?.poster,
                         imdbId: detail?.imdbId,
+                        addonOrigin: meta.addonOrigin,
+                        videos: meta.videos,
                       })
                     }
                     simkl={{
@@ -1481,6 +1489,8 @@ export function DetailView({
                             type: meta.type,
                             name: title || meta.name,
                             poster: meta.poster ?? detail?.poster,
+                            addonOrigin: meta.addonOrigin,
+                            videos: meta.videos,
                           })
                         }
                         aria-label={isFav ? t("Remove from favorites") : t("Add to favorites")}

--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -669,7 +669,14 @@ export function Home({ active = true, onReady }: { active?: boolean; onReady?: (
     const toMetas = (m: Map<string, MediaEntry>): Meta[] =>
       [...m.values()]
         .sort((a, b) => b.addedAt - a.addedAt)
-        .map((e) => ({ id: e.id, type: e.type, name: e.name, poster: e.poster }));
+        .map((e) => ({
+          id: e.id,
+          type: e.type,
+          name: e.name,
+          poster: e.poster,
+          addonOrigin: e.addonOrigin,
+          videos: e.videos,
+        }));
     const out: HomeRow[] = [];
     if (favItems.size > 0) {
       out.push({ key: "harbor-favorites", type: "movie", name: "Favorites", metas: toMetas(favItems), page: 1, hasMore: false, noDedup: true });

--- a/src/views/library/favorites-tab.tsx
+++ b/src/views/library/favorites-tab.tsx
@@ -13,7 +13,7 @@ import { Grid, WatchlistCard } from "./shared";
 const ANIME_ID = /^(kitsu|mal|anilist|anidb|simkl):/;
 
 function toMeta(e: MediaEntry): Meta {
-  return { id: e.id, type: e.type, name: e.name, poster: e.poster };
+  return { id: e.id, type: e.type, name: e.name, poster: e.poster, addonOrigin: e.addonOrigin, videos: e.videos };
 }
 
 export function FavoritesTab() {

--- a/src/views/library/hydrate-meta.ts
+++ b/src/views/library/hydrate-meta.ts
@@ -1,6 +1,7 @@
 import { type Meta } from "@/lib/cinemeta";
 import { lruSet } from "@/lib/cache";
 import { resolveMeta } from "@/lib/meta-resource";
+import { fetchAddonMeta } from "@/lib/addons";
 
 const metaHydrateCache = new Map<string, Promise<Meta | null>>();
 
@@ -8,8 +9,9 @@ export async function hydrateLibraryMeta(
   id: string,
   type: "movie" | "series",
   tmdbKey: string | null,
+  origin?: Meta["addonOrigin"],
 ): Promise<Meta | null> {
-  const cacheKey = `${type}:${id}`;
+  const cacheKey = `${type}:${id}:${origin?.base ?? ""}`;
   const cached = metaHydrateCache.get(cacheKey);
   if (cached) return cached;
   const authKey = (() => {
@@ -23,6 +25,14 @@ export async function hydrateLibraryMeta(
     }
   })();
   const p = (async () => {
+    if (origin?.base) {
+      try {
+        const addonMeta = await fetchAddonMeta(origin.base, type, id);
+        if (addonMeta) return addonMeta;
+      } catch {
+        /* fall through to the existing resolve logic */
+      }
+    }
     if (id.startsWith("tmdb:") && tmdbKey) {
       const isTv = id.startsWith("tmdb:tv:") || id.startsWith("tmdb:series:");
       const tmdbType = isTv ? "tv" : "movie";

--- a/src/views/library/list-detail.tsx
+++ b/src/views/library/list-detail.tsx
@@ -10,7 +10,7 @@ import { ListSettingsMenu } from "./list-detail/list-settings-menu";
 import { Grid } from "./shared";
 
 function itemToMeta(it: ListItem): Meta {
-  return { id: it.id, type: it.type, name: it.name, poster: it.poster };
+  return { id: it.id, type: it.type, name: it.name, poster: it.poster, addonOrigin: it.addonOrigin, videos: it.videos };
 }
 
 export function ListDetail({ listId, onBack }: { listId: string; onBack: () => void }) {

--- a/src/views/library/list-detail/add-title-search.tsx
+++ b/src/views/library/list-detail/add-title-search.tsx
@@ -68,7 +68,7 @@ export function AddTitleSearch({ list }: { list: CustomList }) {
       emitListToast(t("This list is full ({max} items)", { max: MAX_ITEMS }));
       return;
     }
-    addToList(list.id, { id: m.id, type: m.type, name: m.name, poster: m.poster });
+    addToList(list.id, { id: m.id, type: m.type, name: m.name, poster: m.poster, addonOrigin: m.addonOrigin, videos: m.videos });
     emitListToast(t('Added to "{name}"', { name: list.name }));
   };
 

--- a/src/views/library/watchlist-card.tsx
+++ b/src/views/library/watchlist-card.tsx
@@ -28,7 +28,8 @@ export function WatchlistCard({ meta, onRemove }: { meta: Meta; onRemove?: () =>
     setPosterFailed(true);
   }, []);
   useEffect(() => {
-    if (meta.poster && meta.name && !posterFailed) {
+    const needsAddonHydration = !!meta.addonOrigin?.base && !meta.videos?.length;
+    if (meta.poster && meta.name && !posterFailed && !needsAddonHydration) {
       setHydrated(null);
       return;
     }
@@ -36,7 +37,12 @@ export function WatchlistCard({ meta, onRemove }: { meta: Meta; onRemove?: () =>
     if (!el) return;
     let cancelled = false;
     const run = () => {
-      hydrateLibraryMeta(meta.id, narrowMediaType(meta.type), settings.tmdbKey ?? null)
+      hydrateLibraryMeta(
+        meta.id,
+        narrowMediaType(meta.type),
+        settings.tmdbKey ?? null,
+        meta.addonOrigin,
+      )
         .then((full) => {
           if (cancelled || !full) return;
           setHydrated(full);
@@ -57,8 +63,26 @@ export function WatchlistCard({ meta, onRemove }: { meta: Meta; onRemove?: () =>
       cancelled = true;
       io.disconnect();
     };
-  }, [meta.id, meta.type, meta.poster, meta.name, settings.tmdbKey, posterFailed]);
-  const display: Meta = hydrated ? { ...meta, ...hydrated, id: meta.id, type: meta.type } : meta;
+  }, [
+    meta.id,
+    meta.type,
+    meta.poster,
+    meta.name,
+    settings.tmdbKey,
+    posterFailed,
+    meta.addonOrigin?.base,
+    meta.videos?.length,
+  ]);
+  const display: Meta = hydrated
+    ? {
+        ...meta,
+        ...hydrated,
+        id: meta.id,
+        type: meta.type,
+        addonOrigin: meta.addonOrigin ?? hydrated.addonOrigin,
+        videos: hydrated.videos ?? meta.videos,
+      }
+    : meta;
   const open = () => openMeta(display);
   const poster = usePosterChain(
     settings.rpdbKey,

--- a/src/views/library/watchlist-tab.tsx
+++ b/src/views/library/watchlist-tab.tsx
@@ -291,7 +291,14 @@ function mergeWatchlist(
     if (nameKey && byKey.has(nameKey)) continue;
     byKey.set(nameKey ?? `local:${e.id}`, {
       key: e.id,
-      meta: { id: e.id, type: e.type, name: e.name || e.id, poster: e.poster },
+      meta: {
+        id: e.id,
+        type: e.type,
+        name: e.name || e.id,
+        poster: e.poster,
+        addonOrigin: e.addonOrigin,
+        videos: e.videos,
+      },
       date: e.addedAt || null,
     });
   }

--- a/src/views/mobile/mobile-anime.tsx
+++ b/src/views/mobile/mobile-anime.tsx
@@ -249,7 +249,7 @@ function AnimeHeroMobile({
           <button
             type="button"
             aria-label={inWl ? "In My List" : "Add to My List"}
-            onClick={() => toggleWatchlist({ id: current.id, type: current.type, name: current.name, poster: current.poster })}
+            onClick={() => toggleWatchlist({ id: current.id, type: current.type, name: current.name, poster: current.poster, addonOrigin: current.addonOrigin, videos: current.videos })}
             className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-full border border-edge bg-canvas/55 text-ink transition-transform duration-150 active:scale-[0.94]"
           >
             {inWl ? <Check size={20} strokeWidth={2.6} className="text-accent" /> : <Plus size={21} strokeWidth={2.2} />}

--- a/src/views/mobile/mobile-hero.tsx
+++ b/src/views/mobile/mobile-hero.tsx
@@ -214,7 +214,7 @@ export function MobileHero({ slides, onOpenDetail }: { slides: Meta[]; onOpenDet
                 type="button"
                 aria-label={inWl ? "In My List" : "Add to My List"}
                 onClick={() =>
-                  toggleWatchlist({ id: current.id, type: current.type, name: current.name, poster: current.poster })
+                  toggleWatchlist({ id: current.id, type: current.type, name: current.name, poster: current.poster, addonOrigin: current.addonOrigin, videos: current.videos })
                 }
                 className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-full border border-white/25 bg-black/35 text-white backdrop-blur-sm transition-transform duration-150 active:scale-[0.94]"
               >


### PR DESCRIPTION
## Summary

Saving an item to the watchlist, favorites, or a custom list only persisted id, type, name, and poster. The type was normalized to movie/series, which can drop the type an addon's catalog actually declared for non-standard id schemes. On replay, the pipeline queried /stream/<movie|series>/<id>.json, and addons that only serve that id under a different declared type returned an empty result — so saved items from those catalogs showed zero streams. The saved entries also never recorded their source addon (addonOrigin), so the pipeline could not route the query back to the origin addon.

This change does two things:

Persist source metadata — addonOrigin and embedded videos are now carried through watchlist, favorites, and custom-list entries (types, read/write, hydration, and every toggle call site), so a saved item remembers which addon served it.
Recover from collapsed types — fetchAddonStreams now retries the addon's other manifest-declared stream types when the primary query returns no streams. This runs on the forced origin-addon path and on the normal id-matching path for non-standard id schemes (where stored movie/series is unreliable). Standard schemes (tt, tmdb:, kitsu:, ...) are untouched, so no extra requests for normal content.

## Why

Old entries saved before this fix lack addonOrigin, so the origin-addon route alone was not enough. The fallback must also work through normal id-matching for non-standard id schemes — otherwise re-adding every saved item would be required. The approach is fully manifest-driven: it reads the addon's declared stream types and id prefixes rather than special-casing any content category.

## Verification

- tsc -b --pretty false — passes (exit 0).

- Reproduced against a real addon whose catalog declares additional stream types: the type the addon actually serves the id  under returns a stream list, while the collapsed movie type returns {"streams":[]} — confirming the type-collapse root cause.

- Confirmed from a fresh backup that the failing saved entries lack addonOrigin (saved pre-fix), while the one re-added item that worked carries it.

- Console trace before fix: [addons] querying 2: AIOStreams, AIOStreams then 0 streams twice. After this change the alternate declared types are retried, so a non-empty result is expected

## Platform Impact

None

## UI Changes

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
