### PR TITLE
fix(metadata): honor preferred metadata addon for localized overviews

### DIFF
--- a/src/lib/meta-resource.ts
+++ b/src/lib/meta-resource.ts
@@ -7,8 +7,24 @@ const ADDON_TIMEOUT_MS = 4000;
 
 function preferCustomMeta(): boolean {
   try {
-    const raw = localStorage.getItem("harbor.settings");
-    return raw ? JSON.parse(raw).preferCustomMetaAddon === true : false;
+    const profileState = JSON.parse(localStorage.getItem("harbor.profiles.v1") ?? "null") as {
+      activeId?: string | null;
+      profiles?: Array<{ id: string; settingsLinked?: boolean }>;
+    } | null;
+    const activeId = profileState?.activeId ?? "default";
+    const activeProfile = profileState?.profiles?.find((profile) => profile.id === activeId);
+    const preferredKey =
+      activeProfile?.settingsLinked === false
+        ? `harbor.settings.${activeId}`
+        : "harbor.settings.shared";
+
+    for (const key of [preferredKey, "harbor.settings.shared", "harbor.settings"]) {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      const value = (JSON.parse(raw) as { preferCustomMetaAddon?: unknown }).preferCustomMetaAddon;
+      if (typeof value === "boolean") return value;
+    }
+    return false;
   } catch {
     return false;
   }

--- a/src/lib/use-localized-overview.ts
+++ b/src/lib/use-localized-overview.ts
@@ -1,28 +1,63 @@
 import { useEffect, useState } from "react";
-import type { Meta } from "@/lib/cinemeta";
+import { narrowMediaType, type Meta } from "@/lib/cinemeta";
+import { useAuth } from "@/lib/auth";
+import { resolveMeta } from "@/lib/meta-resource";
+import { tmdbImdbId } from "@/lib/providers/tmdb";
 import { tmdbMetadataOverview } from "@/lib/providers/tmdb/tmdb-lite";
 import { useSettings } from "@/lib/settings";
 
 export function useLocalizedOverview(meta: Meta): string | undefined {
   const { settings } = useSettings();
+  const { authKey } = useAuth();
   const isTmdb = meta.id.startsWith("tmdb:");
   const [overview, setOverview] = useState<string | undefined>(
     isTmdb ? undefined : meta.description,
   );
+
   useEffect(() => {
-    if (!isTmdb || !settings.tmdbKey) {
-      setOverview(meta.description);
-      return;
-    }
-    setOverview(undefined);
     let alive = true;
-    void tmdbMetadataOverview(settings.tmdbKey, meta.id).then((o) => {
-      if (alive) setOverview(o ?? meta.description);
-    });
+
+    const load = async () => {
+      if (settings.preferCustomMetaAddon) {
+        let metadataId = meta.id;
+        if (isTmdb && settings.tmdbKey) {
+          metadataId = (await tmdbImdbId(settings.tmdbKey, meta.id).catch(() => null)) ?? meta.id;
+        }
+
+        const custom = await resolveMeta(authKey, narrowMediaType(meta.type), metadataId).catch(
+          () => null,
+        );
+
+        if (!alive) return;
+        if (custom?.addonOrigin && custom.description) {
+          setOverview(custom.description);
+          return;
+        }
+      }
+
+      if (!isTmdb || !settings.tmdbKey) {
+        setOverview(meta.description);
+        return;
+      }
+
+      setOverview(undefined);
+      const localized = await tmdbMetadataOverview(settings.tmdbKey, meta.id).catch(() => null);
+      if (alive) setOverview(localized ?? meta.description);
+    };
+
+    void load();
     return () => {
       alive = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [meta.id, settings.tmdbKey]);
+  }, [
+    authKey,
+    isTmdb,
+    meta.description,
+    meta.id,
+    meta.type,
+    settings.preferCustomMetaAddon,
+    settings.tmdbKey,
+  ]);
+
   return overview;
 }


### PR DESCRIPTION
## Résumé

Harbor propose l’option **Prefer my installed metadata addon**, mais le chemin partagé utilisé pour les synopsis localisés pouvait encore ignorer cette préférence et afficher les descriptions TMDB ou Cinemeta.

Cette modification :

- lit `preferCustomMetaAddon` depuis le stockage actuel partagé ou propre au profil, avec conservation du fallback historique ;
- résout si possible les identifiants `tmdb:*` vers IMDb avant d’interroger les addons metadata Stremio ;
- permet à l’addon metadata préféré de fournir le synopsis dans le chemin partagé des descriptions localisées ;
- conserve le fallback existant vers la description TMDB localisée ou la description originale lorsqu’aucune metadata exploitable n’est retournée.

L’implémentation reste indépendante de tout addon particulier.

## Validation

- `vp fmt --check src/lib/meta-resource.ts src/lib/use-localized-overview.ts`
- `vp check --no-fmt src/lib/meta-resource.ts src/lib/use-localized-overview.ts`
- `pnpm exec tsc -b --pretty false`
- `pnpm run build`
- `pnpm tauri:build:linux-system` : compilation native réussie ; packaging interrompu après génération du binaire et du paquet `.deb`, pendant la génération `.rpm` restée inactive.
