### PR TITLE
fix(discover): apply configured region to movie discovery queries

### DIFF
--- a/src/lib/feed/locale.ts
+++ b/src/lib/feed/locale.ts
@@ -98,19 +98,11 @@ export function preferredLangCodes(settings: Settings): string[] {
   return [...out];
 }
 
-function alreadyLocalized(floor: Record<string, string>): boolean {
-  return "with_original_language" in floor || "with_origin_country" in floor;
-}
-
 export function localizeFloor(
   floor: Record<string, string>,
   settings: Settings,
   mediaType: "movie" | "tv",
 ): Record<string, string> {
-  if (!settings.feedLocaleBias) return floor;
-  if (alreadyLocalized(floor)) return floor;
-  const codes = preferredLangCodes(settings);
-  if (codes.length === 0) return floor;
   if (mediaType !== "movie" || !settings.region) return floor;
   return { ...floor, region: settings.region };
 }


### PR DESCRIPTION
## Summary

The configured **Region & language** value already participates in Discover cache scoping, but `settings.region` is currently added to movie discovery queries only when the optional locale-bias feature is enabled and its language conditions match.

That couples two independent settings.

This change applies the configured region to TMDB movie discovery queries independently of `feedLocaleBias`, while leaving the language/ranking bias behavior unchanged.

This makes Discover consistently respect the same region used for streaming availability and release windows.
