### PR TITLE
fix(player): keep context menu open in fullscreen

### DIFF
--- a/src/components/context-menu.tsx
+++ b/src/components/context-menu.tsx
@@ -516,7 +516,17 @@ export function ContextMenu() {
 
   return (
     <>
-      <div aria-hidden className="fixed inset-0 z-[144]" onClick={close} onWheel={close} />
+      <div
+        aria-hidden
+        className="fixed inset-0 z-[144]"
+        // In fullscreen, some WebViews dispatch the secondary click after the
+        // contextmenu event. Dismiss on a new primary press instead so that
+        // event cannot immediately close the menu it just opened.
+        onMouseDown={(e) => {
+          if (e.button === 0) close();
+        }}
+        onWheel={close}
+      />
       <div
         ref={ref}
         role="menu"

--- a/src/lib/context-menu.tsx
+++ b/src/lib/context-menu.tsx
@@ -40,7 +40,9 @@ export function ContextMenuProvider({ children }: { children: ReactNode }) {
       if (t instanceof Element && t.closest("[data-harbor-player]")) return;
       close();
     };
-    const onResize = () => close();
+    // Fullscreen window chrome can briefly resize while opening a context menu.
+    // Keep the menu open and let its viewport-clamped position update instead.
+    const onResize = () => setState((current) => (current ? { ...current } : null));
     document.addEventListener("scroll", onScroll, true);
     window.addEventListener("resize", onResize);
     return () => {


### PR DESCRIPTION
## Summary

Fixed the right-click context menu from auto-closing in fullscreen

## Why

The context menu closes in a blink when right-click is pressed in fullscreen.

## Verification

Tested the build after the change and verified that the issue is gone and the elements of the context menu are working as intended.


## Checklist

- [✅ ] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [✅] I ran the relevant Cargo checks after Rust changes. (No Rust Changes)
- [✅] I tested affected platforms when the change is platform-specific.
- [✅] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [✅] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
