### PR TITLE
feat(metadata): comprehensive metadata language and anime localization improvements

### DIFF
--- a/src/lib/providers/anime-detail.ts
+++ b/src/lib/providers/anime-detail.ts
@@ -1,6 +1,6 @@
 import type { Meta } from "@/lib/cinemeta";
 import { aniZipByKitsu } from "@/lib/providers/anizip";
-import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes } from "@/lib/providers/anime-episode-build";
+import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes, mergeTmdbEpisodes, isTextInLanguage } from "@/lib/providers/anime-episode-build";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import { kitsuToTvdb, kitsuToImdb, externalToKitsu, kitsuToAnilist } from "@/lib/providers/anime-mapping";
 import { anilistFranchise, type AnilistFranchiseNode } from "@/lib/anilist/relations";
@@ -22,7 +22,8 @@ import {
   type KitsuEpisode,
   type KitsuStreamer,
 } from "@/lib/providers/kitsu";
-import { tmdbAnimeLogo, tmdbDetails } from "@/lib/providers/tmdb";
+import { tmdbAnimeLogo, tmdbDetails, tmdbSeasonEpisodes } from "@/lib/providers/tmdb";
+import type { Episode as TmdbEpisode } from "@/lib/providers/tmdb/tmdb-details";
 import type { CastEntry, TmdbDetail } from "@/lib/providers/tmdb";
 import type { Settings } from "@/lib/settings";
 
@@ -36,7 +37,10 @@ export type FranchiseEntry = {
   isUpcoming: boolean;
 };
 
-export type AnimeDetailExtras = Partial<TmdbDetail>;
+export type AnimeDetailExtras = Partial<TmdbDetail> & {
+  /** Localized TMDB overviews keyed by TMDB season number (only populated when localization is active). */
+  seasonOverviews?: Record<number, string>;
+};
 
 export type AnimeDetailResult = {
   detail: TmdbDetail;
@@ -350,6 +354,10 @@ export async function animeDetails(
   const addonMeta = await animeKitsuMeta(`kitsu:${kitsuId}`).catch(() => null);
   if (!anime) return null;
 
+  const kind: "movie" | "tv" = anime.subtype === "movie" ? "movie" : "tv";
+  const iso1 = settings.tmdbLanguage || settings.uiLanguage || "en";
+  const localized = settings.localizeAnimeMetadata && iso1.split("-")[0]?.toLowerCase() !== "en";
+
   const franchisePromise = buildFranchise(kitsuId, anime).catch(() => [] as FranchiseEntry[]);
 
   const slugify = (s: string) =>
@@ -388,8 +396,21 @@ export async function animeDetails(
     ]);
 
   const episodes = buildKitsuEpisodes(addonMeta, kitsuRawEpisodes);
-  mergeAniZipEpisodes(episodes, aniZip);
-  mergeTvdbEpisodes(episodes, tvdbEpsRaw);
+  let tmdbEpsRaw: TmdbEpisode[] | null = null;
+  let tmdbEpisodesId = 0;
+  let tmdbEpisodesSeason = 0;
+  if (localized && settings.tmdbKey && kind === "tv") {
+    tmdbEpisodesId = Number(aniZip?.mappings?.themoviedb_id);
+    for (const az of Object.values(aniZip?.episodes ?? {})) {
+      if (az.seasonNumber != null && az.seasonNumber > tmdbEpisodesSeason) tmdbEpisodesSeason = az.seasonNumber;
+    }
+    if (tmdbEpisodesId > 0 && tmdbEpisodesSeason > 0) {
+      tmdbEpsRaw = await tmdbSeasonEpisodes(settings.tmdbKey, tmdbEpisodesId, tmdbEpisodesSeason, iso1).catch(() => null);
+    }
+  }
+  mergeAniZipEpisodes(episodes, aniZip, { lang: localized ? iso1 : undefined });
+  mergeTvdbEpisodes(episodes, tvdbEpsRaw, { lang: localized ? iso1 : undefined });
+  mergeTmdbEpisodes(episodes, tmdbEpsRaw, { lang: localized ? iso1 : undefined });
 
   let seriesImdb = aniZip?.mappings?.imdb_id ?? episodes.find((e) => e.imdbId)?.imdbId ?? null;
   if (!seriesImdb) seriesImdb = await kitsuToImdb(kitsuId).catch(() => null);
@@ -402,8 +423,6 @@ export async function animeDetails(
       ep.thumbnailFallback = `https://episodes.metahub.space/${seriesImdb}/${s}/${e}/w780.jpg`;
     }
   }
-
-  const kind: "movie" | "tv" = anime.subtype === "movie" ? "movie" : "tv";
 
   const toCast = (chars: typeof characters): CastEntry[] =>
     chars.map((c, i) => ({
@@ -514,13 +533,15 @@ export async function animeDetails(
         : settings.fanartKey && kind === "tv" && tvdbId
           ? fanartTv(settings.fanartKey, tvdbId).catch(() => null)
           : Promise.resolve(null);
+    const tmdbFullId = Number(aniZip?.mappings?.themoviedb_id) || tmdbHit?.tmdbId || 0;
+    const tmdbFullFromMapping = Number(aniZip?.mappings?.themoviedb_id) > 0;
     const tmdbFullPromise =
-      settings.tmdbKey && tmdbHit?.tmdbId
+      settings.tmdbKey && tmdbFullId
         ? tmdbDetails(settings.tmdbKey, {
-            id: `tmdb:${kind === "movie" ? "movie" : "tv"}:${tmdbHit.tmdbId}`,
+            id: `tmdb:${kind === "movie" ? "movie" : "tv"}:${tmdbFullId}`,
             type: kind === "movie" ? "movie" : "series",
             name: anime.title,
-          } as Meta).catch(() => null)
+          } as Meta, localized ? iso1 : undefined).catch(() => null)
         : Promise.resolve(null);
     const [fa, fullRaw] = await Promise.all([fanartPromise, tmdbFullPromise]);
     if (fa) {
@@ -532,9 +553,14 @@ export async function animeDetails(
     const backdrops = gallery;
     let tmdbFull: TmdbDetail | null = null;
     if (fullRaw) {
-      const ay = Number(anime.year);
-      const ty = Number(fullRaw.year);
-      if (!Number.isFinite(ay) || !Number.isFinite(ty) || Math.abs(ty - ay) <= 1) tmdbFull = fullRaw;
+      // AniZip's themoviedb_id is authoritative per entry; the title-search id can false-positive, so it keeps the year gate.
+      if (tmdbFullFromMapping) {
+        tmdbFull = fullRaw;
+      } else {
+        const ay = Number(anime.year);
+        const ty = Number(fullRaw.year);
+        if (!Number.isFinite(ay) || !Number.isFinite(ty) || Math.abs(ty - ay) <= 1) tmdbFull = fullRaw;
+      }
     }
     const patch: AnimeDetailExtras = {
       logo,
@@ -557,6 +583,19 @@ export async function animeDetails(
       editor: tmdbFull?.editor ?? [],
       keywords: tmdbFull?.keywords ?? [],
     };
+    if (localized && tmdbFull) {
+      const overviewOk = !!tmdbFull.overview && isTextInLanguage(tmdbFull.overview, iso1);
+      const titleOk = !!tmdbFull.title && isTextInLanguage(tmdbFull.title, iso1);
+      if (overviewOk) patch.overview = tmdbFull.overview;
+      if (titleOk) patch.title = tmdbFull.title;
+      // TMDB's tv/{id} response carries per-season localized overviews; surface them so the season
+      // hero can vary per season instead of showing the static series overview everywhere.
+      const seasonOverviews: Record<number, string> = {};
+      for (const s of tmdbFull.seasons ?? []) {
+        if (s.overview && isTextInLanguage(s.overview, iso1)) seasonOverviews[s.seasonNumber] = s.overview;
+      }
+      patch.seasonOverviews = seasonOverviews;
+    }
     if (cast.length === 0) {
       let fallback: CastEntry[] | undefined;
       for (const k of castKeys) {

--- a/src/lib/providers/anime-episode-build.ts
+++ b/src/lib/providers/anime-episode-build.ts
@@ -1,7 +1,95 @@
-import { pickEpisodeTitle, type AniZipMapping } from "@/lib/providers/anizip";
+import { pickEpisodeTitle, pickLocalizedTitle, type AniZipMapping } from "@/lib/providers/anizip";
 import type { AnimeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import type { KitsuEpisode } from "@/lib/providers/kitsu";
 import type { TvdbEpisode } from "@/lib/providers/tvdb";
+import type { Episode as TmdbEpisode } from "@/lib/providers/tmdb/tmdb-details";
+
+export type EpisodeLocalizeOptions = { lang?: string | null };
+
+// Opt-in gate: localized text applies only for non-English languages; English/empty keeps the old merge behavior.
+function wantsLocalized(opts?: EpisodeLocalizeOptions): boolean {
+  const lang = opts?.lang?.trim();
+  if (!lang) return false;
+  const base = lang.split("-")[0]?.toLowerCase() ?? "";
+  return base !== "" && base !== "en";
+}
+
+// TMDB/TVDB return original-language text (Japanese for most anime) when the requested
+// translation is missing, so only accept text written in the target language's script.
+const SCRIPT_TEST: Record<string, RegExp> = {
+  ar: /[\u0600-\u06FF\u0750-\u077F]/,
+  fa: /[\u0600-\u06FF\u0750-\u077F]/,
+  ur: /[\u0600-\u06FF\u0750-\u077F]/,
+  ru: /[\u0400-\u04FF]/,
+  uk: /[\u0400-\u04FF]/,
+  bg: /[\u0400-\u04FF]/,
+  sr: /[\u0400-\u04FF]/,
+  mk: /[\u0400-\u04FF]/,
+  be: /[\u0400-\u04FF]/,
+  el: /[\u0370-\u03FF]/,
+  hi: /[\u0900-\u097F]/,
+  mr: /[\u0900-\u097F]/,
+  ne: /[\u0900-\u097F]/,
+  th: /[\u0E00-\u0E7F]/,
+  he: /[\u0590-\u05FF]/,
+  yi: /[\u0590-\u05FF]/,
+  ko: /[\uAC00-\uD7AF\u1100-\u11FF]/,
+  zh: /[\u3400-\u4DBF\u4E00-\u9FFF]/,
+  ja: /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF]/,
+};
+
+const FOREIGN_SCRIPT =
+  /[\u0600-\u06FF\u0750-\u077F\u0400-\u04FF\u0370-\u03FF\u0900-\u097F\u0E00-\u0E7F\u0590-\u05FF\uAC00-\uD7AF\u1100-\u11FF\u3400-\u4DBF\u4E00-\u9FFF\u3040-\u30FF]/;
+
+export function isTextInLanguage(text: string | null | undefined, lang: string | null | undefined): boolean {
+  if (!text) return false;
+  const base = lang?.trim().split("-")[0]?.toLowerCase() ?? "";
+  if (!base || base === "en") return true;
+  const range = SCRIPT_TEST[base];
+  if (range) return range.test(text);
+  return !FOREIGN_SCRIPT.test(text);
+}
+
+// "Episode N" words in various languages: providers ship such placeholders when a real
+// translated title is missing, and they must not be merged in as if they were titles.
+const EPISODE_NUMBER_WORDS = [
+  "episode", "ep",
+  "الحلقة", "الحلقه", "حلقة", "حلقه",
+  "قسمت", "اپیزود", "اپيسود",
+  "قسط",
+  "серия", "эпизод", "серія", "епізод", "епизод", "епизода", "серыя", "эпізод",
+  "επεισόδιο",
+  "एपिसोड", "भाग",
+  "ตอน",
+  "פרק", "פּרק",
+  "에피소드",
+  "episodio", "capítulo", "capitulo", "cap",
+  "épisode",
+  "folge",
+  "puntata",
+  "bölüm", "bolum",
+  "odcinek",
+  "aflevering",
+  "avsnitt",
+  "tập",
+];
+
+export function isGenericEpisodeName(text: string | null | undefined): boolean {
+  if (!text) return false;
+  const t = text.trim();
+  if (!t) return false;
+  if (/^\d+[\s.,-]*$/.test(t)) return true;
+  // Compact CJK forms like 第18話 / 第18集 / 18화
+  if (/^第\s*\d+\s*[話话集]$/.test(t)) return true;
+  if (/^\d+\s*화$/.test(t)) return true;
+  const lower = t.toLowerCase();
+  for (const word of EPISODE_NUMBER_WORDS) {
+    if (!lower.includes(word)) continue;
+    const rest = lower.replace(word, "").replace(/[\s\-–—:.,()\[\]'"،،]/g, "");
+    if (/^\d*$/.test(rest)) return true;
+  }
+  return false;
+}
 
 export function buildKitsuEpisodes(
   addonMeta: AnimeKitsuMeta | null,
@@ -29,17 +117,31 @@ export function buildKitsuEpisodes(
   });
 }
 
-export function mergeAniZipEpisodes(episodes: KitsuEpisode[], aniZip: AniZipMapping | null): void {
+export function mergeAniZipEpisodes(
+  episodes: KitsuEpisode[],
+  aniZip: AniZipMapping | null,
+  opts?: EpisodeLocalizeOptions,
+): void {
   if (!aniZip?.episodes) return;
   const azImdb = aniZip.mappings?.imdb_id;
+  const localized = wantsLocalized(opts);
   for (const ep of episodes) {
     const az = aniZip.episodes[String(ep.number)];
     if (!az) continue;
-    const enrichedTitle = pickEpisodeTitle(az);
-    if (enrichedTitle && (!ep.title || ep.title === `Episode ${ep.number}`)) {
-      ep.title = enrichedTitle;
+    if (localized) {
+      const localizedTitle = pickLocalizedTitle(az, opts?.lang);
+      if (localizedTitle && !isGenericEpisodeName(localizedTitle) && isTextInLanguage(localizedTitle, opts?.lang)) {
+        ep.title = localizedTitle;
+      }
+    } else {
+      const enrichedTitle = pickEpisodeTitle(az);
+      if (enrichedTitle && !isGenericEpisodeName(enrichedTitle) && (!ep.title || ep.title === `Episode ${ep.number}`)) {
+        ep.title = enrichedTitle;
+      }
     }
-    if (az.overview && !ep.synopsis) ep.synopsis = az.overview;
+    if (az.overview && !ep.synopsis && (!localized || isTextInLanguage(az.overview, opts?.lang))) {
+      ep.synopsis = az.overview;
+    }
     if (az.image) {
       if (ep.thumbnail && ep.thumbnail !== az.image && !ep.thumbnailFallback) {
         ep.thumbnailFallback = ep.thumbnail;
@@ -63,8 +165,13 @@ export function mergeAniZipEpisodes(episodes: KitsuEpisode[], aniZip: AniZipMapp
   }
 }
 
-export function mergeTvdbEpisodes(episodes: KitsuEpisode[], tvdbEps: TvdbEpisode[] | null): void {
+export function mergeTvdbEpisodes(
+  episodes: KitsuEpisode[],
+  tvdbEps: TvdbEpisode[] | null,
+  opts?: EpisodeLocalizeOptions,
+): void {
   if (!tvdbEps || tvdbEps.length === 0) return;
+  const localized = wantsLocalized(opts);
   const tvdbById = new Map<number, TvdbEpisode>();
   const tvdbByAbsolute = new Map<number, TvdbEpisode>();
   const tvdbBySeasonAndEpisode = new Map<string, TvdbEpisode>();
@@ -87,11 +194,17 @@ export function mergeTvdbEpisodes(episodes: KitsuEpisode[], tvdbEps: TvdbEpisode
     if (!tvdbEp) tvdbEp = tvdbByAbsolute.get(ep.number);
 
     if (tvdbEp) {
-      if (tvdbEp.name && (!ep.title || ep.title === `Episode ${ep.number}`)) {
-        ep.title = tvdbEp.name;
+      if (tvdbEp.name && !isGenericEpisodeName(tvdbEp.name) && (localized || !ep.title || ep.title === `Episode ${ep.number}`)) {
+        if (!localized || isTextInLanguage(tvdbEp.name, opts?.lang)) {
+          ep.title = tvdbEp.name;
+        }
       }
       if (tvdbEp.aired) ep.airdate = tvdbEp.aired;
-      if (tvdbEp.overview && !ep.synopsis) ep.synopsis = tvdbEp.overview;
+      if (tvdbEp.overview && (localized || !ep.synopsis)) {
+        if (!localized || isTextInLanguage(tvdbEp.overview, opts?.lang)) {
+          ep.synopsis = tvdbEp.overview;
+        }
+      }
       if (tvdbEp.image) {
         if (ep.thumbnail && ep.thumbnail !== tvdbEp.image && !ep.thumbnailFallback) {
           ep.thumbnailFallback = ep.thumbnail;
@@ -99,6 +212,33 @@ export function mergeTvdbEpisodes(episodes: KitsuEpisode[], tvdbEps: TvdbEpisode
         ep.thumbnail = tvdbEp.image;
       }
       if (tvdbEp.runtime && !ep.length) ep.length = tvdbEp.runtime;
+    }
+  }
+}
+
+export function mergeTmdbEpisodes(
+  episodes: KitsuEpisode[],
+  tmdbEps: TmdbEpisode[] | null,
+  opts?: EpisodeLocalizeOptions,
+): void {
+  if (!tmdbEps || tmdbEps.length === 0) return;
+  const localized = wantsLocalized(opts);
+  const byNumber = new Map<number, TmdbEpisode>();
+  for (const e of tmdbEps) byNumber.set(e.episodeNumber, e);
+  for (const ep of episodes) {
+    // Kitsu restarts numbering per season entry, so prefer AniZip's TMDB episode number
+    // (imdbEpisode) to keep split-season parts matched to the correct TMDB episodes.
+    const tmdbEp = byNumber.get(ep.imdbEpisode ?? ep.number);
+    if (!tmdbEp) continue;
+    if (tmdbEp.name && !isGenericEpisodeName(tmdbEp.name) && (localized || !ep.title || ep.title === `Episode ${ep.number}`)) {
+      if (!localized || isTextInLanguage(tmdbEp.name, opts?.lang)) {
+        ep.title = tmdbEp.name;
+      }
+    }
+    if (tmdbEp.overview && (localized || !ep.synopsis)) {
+      if (!localized || isTextInLanguage(tmdbEp.overview, opts?.lang)) {
+        ep.synopsis = tmdbEp.overview;
+      }
     }
   }
 }

--- a/src/lib/providers/anime-franchise-episodes.ts
+++ b/src/lib/providers/anime-franchise-episodes.ts
@@ -1,9 +1,11 @@
 import { aniZipByKitsu } from "@/lib/providers/anizip";
-import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes } from "@/lib/providers/anime-episode-build";
+import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes, mergeTmdbEpisodes } from "@/lib/providers/anime-episode-build";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import { kitsuEpisodes, type KitsuEpisode } from "@/lib/providers/kitsu";
 import { kitsuToTvdb } from "@/lib/providers/anime-mapping";
 import { tvdbEpisodesByType, tvdbEpisodesAbsolute, tvdbLangFromIso1 } from "@/lib/providers/tvdb";
+import { tmdbSeasonEpisodes } from "@/lib/providers/tmdb/tmdb-details";
+import type { Episode as TmdbEpisode } from "@/lib/providers/tmdb/tmdb-details";
 import type { Settings } from "@/lib/settings";
 
 const cache = new Map<string, Promise<KitsuEpisode[]>>();
@@ -15,7 +17,9 @@ function isPlayable(ep: KitsuEpisode): boolean {
 
 export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise<KitsuEpisode[]> {
   const lang = tvdbLangFromIso1(settings.tmdbLanguage || settings.uiLanguage);
-  const cacheKey = `${kitsuId}:${lang}`;
+  const iso1 = settings.tmdbLanguage || settings.uiLanguage || "en";
+  const localized = settings.localizeAnimeMetadata && iso1.split("-")[0]?.toLowerCase() !== "en";
+  const cacheKey = `${kitsuId}:${lang}:${localized ? "loc" : "std"}`;
   const cached = cache.get(cacheKey);
   if (cached) return cached;
   const p = (async () => {
@@ -37,9 +41,22 @@ export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise
         })
         .catch(() => null),
     ]);
+    let tmdbEpsRaw: TmdbEpisode[] | null = null;
+    let tmdbId = 0;
+    let tmdbSeason = 0;
+    if (localized && settings.tmdbKey) {
+      tmdbId = Number(aniZip?.mappings?.themoviedb_id);
+      for (const az of Object.values(aniZip?.episodes ?? {})) {
+        if (az.seasonNumber != null && az.seasonNumber > tmdbSeason) tmdbSeason = az.seasonNumber;
+      }
+      if (tmdbId > 0 && tmdbSeason > 0) {
+        tmdbEpsRaw = await tmdbSeasonEpisodes(settings.tmdbKey, tmdbId, tmdbSeason, iso1).catch(() => null);
+      }
+    }
     const eps = buildKitsuEpisodes(addonMeta, raw);
-    mergeAniZipEpisodes(eps, aniZip);
-    mergeTvdbEpisodes(eps, tvdbEpsRaw);
+    mergeAniZipEpisodes(eps, aniZip, { lang: localized ? iso1 : undefined });
+    mergeTvdbEpisodes(eps, tvdbEpsRaw, { lang: localized ? iso1 : undefined });
+    mergeTmdbEpisodes(eps, tmdbEpsRaw, { lang: localized ? iso1 : undefined });
     const sourceMetaId = `kitsu:${kitsuId}`;
     const out: KitsuEpisode[] = [];
     for (const ep of eps) {

--- a/src/lib/providers/anizip.ts
+++ b/src/lib/providers/anizip.ts
@@ -119,3 +119,17 @@ export function pickEpisodeTitle(ep: AniZipEpisode | undefined): string | null {
   if (!ep?.titles) return null;
   return ep.titles.en ?? ep.titles["x-jat"] ?? ep.titles.ja ?? null;
 }
+
+export function pickLocalizedTitle(
+  ep: AniZipEpisode | undefined,
+  lang: string | null | undefined,
+): string | null {
+  if (!ep?.titles) return null;
+  if (lang) {
+    const exact = lang.trim();
+    if (ep.titles[exact]) return ep.titles[exact];
+    const base = exact.split("-")[0]?.toLowerCase() ?? "";
+    if (base && ep.titles[base]) return ep.titles[base];
+  }
+  return ep.titles.en ?? ep.titles["x-jat"] ?? ep.titles.ja ?? null;
+}

--- a/src/lib/providers/kitsu.ts
+++ b/src/lib/providers/kitsu.ts
@@ -254,7 +254,8 @@ export async function kitsuSimilarByGenres(
   limit = 18,
 ): Promise<Meta[]> {
   if (genreSlugs.length === 0) return [];
-  const slug = genreSlugs.slice(0, 4).join(",");
+  // Kitsu 400s when the comma-joined genres filter is combined with the multi-value ageRating filter, so match on the primary genre only.
+  const slug = genreSlugs[0];
   const ageFilter = adultContentHidden() ? "&filter[ageRating]=G,PG,R" : "";
   const params = `filter[genres]=${encodeURIComponent(slug)}${ageFilter}&sort=-userCount&page[limit]=${limit + 6}`;
   const j = await get<Doc<Resource<KitsuAnimeAttrs>[]>>(`/anime?${params}`);

--- a/src/lib/providers/tmdb/tmdb-catalogs.ts
+++ b/src/lib/providers/tmdb/tmdb-catalogs.ts
@@ -7,6 +7,13 @@ import {
   type RawMovie,
   type RawSeries,
 } from "./tmdb-meta-mappers";
+import { loadStoredSettings } from "../../settings/load";
+
+// When "Translate titles" is off, request TMDB in English so row titles are
+// the untranslated English names instead of the original language.
+function titleRequestLanguage(): string | undefined {
+  return loadStoredSettings().translateTitles ? undefined : "en-US";
+}
 
 export async function tmdbMovieRow(
   key: string,
@@ -15,9 +22,11 @@ export async function tmdbMovieRow(
   page = 1,
 ): Promise<Meta[]> {
   if (endpoint === "now_playing") return tmdbInCinema(key, region, page);
+  const lang = titleRequestLanguage();
   const data = await get<Page<RawMovie>>(key, `movie/${endpoint}`, {
     region,
     page: String(page),
+    ...(lang ? { language: lang } : {}),
   });
   return (data?.results ?? []).map(movieMeta);
 }
@@ -25,6 +34,7 @@ export async function tmdbMovieRow(
 async function tmdbInCinema(key: string, region: string, page = 1): Promise<Meta[]> {
   const day = 24 * 60 * 60 * 1000;
   const fmt = (t: number) => new Date(t).toISOString().slice(0, 10);
+  const lang = titleRequestLanguage();
   const data = await get<Page<RawMovie>>(key, "discover/movie", {
     region,
     with_release_type: "3",
@@ -33,6 +43,7 @@ async function tmdbInCinema(key: string, region: string, page = 1): Promise<Meta
     "with_runtime.gte": "60",
     sort_by: "popularity.desc",
     page: String(page),
+    ...(lang ? { language: lang } : {}),
   });
   return (data?.results ?? []).map((m) => ({ ...movieMeta(m), inTheaters: true }));
 }
@@ -42,7 +53,11 @@ export async function tmdbSeriesRow(
   endpoint: "popular" | "top_rated" | "airing_today" | "on_the_air",
   page = 1,
 ): Promise<Meta[]> {
-  const data = await get<Page<RawSeries>>(key, `tv/${endpoint}`, { page: String(page) });
+  const lang = titleRequestLanguage();
+  const data = await get<Page<RawSeries>>(key, `tv/${endpoint}`, {
+    page: String(page),
+    ...(lang ? { language: lang } : {}),
+  });
   return (data?.results ?? []).map(seriesMeta);
 }
 
@@ -52,8 +67,10 @@ export async function tmdbTrending(
   window: "day" | "week" = "week",
   page = 1,
 ): Promise<Meta[]> {
+  const lang = titleRequestLanguage();
   const data = await get<Page<RawMovie | RawSeries>>(key, `trending/${type}/${window}`, {
     page: String(page),
+    ...(lang ? { language: lang } : {}),
   });
   const results = data?.results ?? [];
   return type === "movie"
@@ -67,7 +84,11 @@ export async function tmdbDiscover(
   params: Record<string, string>,
 ): Promise<Meta[]> {
   if (!key) return [];
-  const data = await get<Page<RawMovie | RawSeries>>(key, `discover/${type}`, params);
+  const lang = titleRequestLanguage();
+  const data = await get<Page<RawMovie | RawSeries>>(key, `discover/${type}`, {
+    ...params,
+    ...(lang ? { language: lang } : {}),
+  });
   const results = data?.results ?? [];
   return type === "movie"
     ? (results as RawMovie[]).map(movieMeta)
@@ -80,8 +101,10 @@ export async function tmdbSearchMovie(
   year?: number,
 ): Promise<Meta | null> {
   if (!key || !query.trim()) return null;
+  const lang = titleRequestLanguage();
   const params: Record<string, string> = { query, include_adult: "false" };
   if (year) params.year = String(year);
+  if (lang) params.language = lang;
   const data = await get<Page<RawMovie>>(key, "search/movie", params);
   const hit = (data?.results ?? [])[0];
   return hit ? movieMeta(hit) : null;
@@ -94,15 +117,18 @@ export async function tmdbSearchTitle(
   year?: number,
 ): Promise<Meta | null> {
   if (!key || !query.trim()) return null;
+  const lang = titleRequestLanguage();
   if (type === "movie") {
     const params: Record<string, string> = { query, include_adult: "false" };
     if (year) params.year = String(year);
+    if (lang) params.language = lang;
     const data = await get<Page<RawMovie>>(key, "search/movie", params);
     const hit = (data?.results ?? [])[0];
     return hit ? movieMeta(hit) : null;
   }
   const params: Record<string, string> = { query, include_adult: "false" };
   if (year) params.first_air_date_year = String(year);
+  if (lang) params.language = lang;
   const data = await get<Page<RawSeries>>(key, "search/tv", params);
   const hit = (data?.results ?? [])[0];
   return hit ? seriesMeta(hit) : null;

--- a/src/lib/providers/tmdb/tmdb-details.ts
+++ b/src/lib/providers/tmdb/tmdb-details.ts
@@ -5,6 +5,7 @@ import { pickLogo, fetchMovieAssets } from "./tmdb-images";
 import { imageLangParam, imageLangRank } from "./tmdb-image-lang";
 import { pickTrailers, type Video } from "./tmdb-trailers";
 import type { PersonRef } from "./tmdb-people";
+import { isAnimeItem } from "./tmdb-meta-mappers";
 
 export type CastEntry = {
   id: number;
@@ -340,11 +341,14 @@ export async function tmdbDetails(key: string, meta: Meta, lang?: string): Promi
   let tagline = raw.tagline ?? "";
   // Explicit per-call languages (anime localization) bypass the global "Translate overviews"
   // toggle, which is meant for regular TMDB content only.
+  const enTrans = raw.translations?.translations?.find((t: any) => t.iso_639_1 === "en")?.data;
   if (!settings.translateDescriptions && !lang) {
-    const enTrans = raw.translations?.translations?.find((t: any) => t.iso_639_1 === "en")?.data;
     if (enTrans?.overview) overview = enTrans.overview;
     if (enTrans?.tagline) tagline = enTrans.tagline;
   }
+  // "Translate titles" off means English titles; prefer the English translation over the
+  // requested-language title and the original-language title.
+  const enTitle = enTrans?.title || enTrans?.name;
 
   let finalPosterPath = raw.poster_path;
   if (!settings.posterBaseUrl && posterSource?.length) {
@@ -356,13 +360,18 @@ export async function tmdbDetails(key: string, meta: Meta, lang?: string): Promi
     if (best) finalPosterPath = best.file_path;
   }
 
+  const anime = isAnimeItem(raw);
+  const useEnglishForAnime = !settings.translateTitles && anime;
+
   return {
     kind,
     id: raw.id,
     imdbId: raw.external_ids?.imdb_id ?? null,
     title: settings.translateTitles
       ? (raw.title || raw.name)
-      : (raw.original_title || raw.original_name || raw.title || raw.name),
+      : useEnglishForAnime
+        ? (enTitle || raw.title || raw.name)
+        : (raw.original_title || raw.original_name || raw.title || raw.name),
     originalTitle: raw.original_title ?? raw.original_name ?? "",
     tagline,
     overview,

--- a/src/lib/providers/tmdb/tmdb-details.ts
+++ b/src/lib/providers/tmdb/tmdb-details.ts
@@ -165,7 +165,7 @@ const uniqByName = (entries: Array<{ id: number; name: string }>): PersonRef[] =
   return out;
 };
 
-export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail | null> {
+export async function tmdbDetails(key: string, meta: Meta, lang?: string): Promise<TmdbDetail | null> {
   if (!key) return null;
   let kind: "movie" | "tv";
   let id: string;
@@ -192,13 +192,40 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   }
 
   const settings = loadStoredSettings();
-  const metaLang = effectiveTmdbLanguage() || "en";
+  const metaLang = lang ?? (effectiveTmdbLanguage() || "en");
   const raw = await get<any>(key, `${kind}/${id}`, {
     append_to_response: "credits,aggregate_credits,recommendations,similar,videos,external_ids,images,keywords,translations",
     language: metaLang,
     include_image_language: imageLangParam(),
   });
   if (!raw) return null;
+
+  // TMDB returns a person's name in the requested language only when a translation
+  // exists; otherwise it falls back to the original name (e.g. Japanese for anime
+  // staff). Fetch English credits as a fallback so untranslated names stay readable.
+  const metaLangBase = metaLang.split("-")[0]?.toLowerCase() ?? "";
+  let enNameById: Map<number, string> | null = null;
+  if (metaLangBase && metaLangBase !== "en") {
+    const [enCredits, enAgg] = await Promise.all([
+      get<any>(key, `${kind}/${id}/credits`, { language: "en-US" }),
+      get<any>(key, `${kind}/${id}/aggregate_credits`, { language: "en-US" }),
+    ]);
+    enNameById = new Map();
+    for (const list of [enCredits?.cast, enCredits?.crew, enAgg?.cast, enAgg?.crew]) {
+      for (const p of list ?? []) {
+        if (p?.id != null && typeof p.name === "string" && p.name && !enNameById.has(p.id)) {
+          enNameById.set(p.id, p.name);
+        }
+      }
+    }
+  }
+  const displayName = (c: any): string => {
+    const localized = typeof c?.name === "string" ? c.name : "";
+    if (!enNameById) return localized;
+    const original = typeof c?.original_name === "string" ? c.original_name : "";
+    if (original && localized === original) return enNameById.get(c.id) ?? localized;
+    return localized;
+  };
 
   const origLang = typeof raw.original_language === "string" ? raw.original_language : "";
   let logo = pickLogo(raw.images?.logos ?? [], origLang);
@@ -231,7 +258,7 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   const castSrc = aggCast.length > 0 ? aggCast : flatCast;
   const cast: CastEntry[] = castSrc.map((c: any) => ({
     id: c.id,
-    name: c.name,
+    name: displayName(c),
     character:
       c.character ??
       (c.roles?.length ? c.roles.map((r: any) => r.character).filter(Boolean).join(", ") : ""),
@@ -244,7 +271,7 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   const crewSrc = aggCrew.length > 0 ? aggCrew : flatCrew;
   const crew: CrewEntry[] = crewSrc.map((c: any) => ({
     id: c.id,
-    name: c.name,
+    name: displayName(c),
     job: c.job ?? c.jobs?.[0]?.job ?? "",
     department: c.department ?? "",
     profilePath: c.profile_path ?? null,
@@ -253,7 +280,11 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   const jobsOf = (e: any): string[] =>
     e.jobs?.length ? e.jobs.map((j: any) => j.job).filter(Boolean) : e.job ? [e.job] : [];
   const byJob = (test: (job: string) => boolean) =>
-    uniqByName(crewSrc.filter((c: any) => jobsOf(c).some(test)));
+    uniqByName(
+      crewSrc
+        .filter((c: any) => jobsOf(c).some(test))
+        .map((c: any) => ({ id: c.id, name: displayName(c) })),
+    );
 
   const directors = byJob((j) => j === "Director");
   const writers = byJob((j) => WRITER_JOBS.has(j));
@@ -261,7 +292,10 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
   const composer = byJob((j) => j === "Original Music Composer" || j === "Music");
   const cinematography = byJob((j) => j === "Director of Photography" || j === "Cinematography");
   const editor = byJob((j) => j === "Editor");
-  const creators: PersonRef[] = (raw.created_by ?? []).map((c: any) => ({ id: c.id, name: c.name }));
+  const creators: PersonRef[] = (raw.created_by ?? []).map((c: any) => ({
+    id: c.id,
+    name: displayName(c),
+  }));
 
   const toMeta = (r: any): Meta => ({
     id: kind === "movie" ? `tmdb:movie:${r.id}` : `tmdb:tv:${r.id}`,
@@ -304,7 +338,9 @@ export async function tmdbDetails(key: string, meta: Meta): Promise<TmdbDetail |
 
   let overview = raw.overview ?? "";
   let tagline = raw.tagline ?? "";
-  if (!settings.translateDescriptions) {
+  // Explicit per-call languages (anime localization) bypass the global "Translate overviews"
+  // toggle, which is meant for regular TMDB content only.
+  if (!settings.translateDescriptions && !lang) {
     const enTrans = raw.translations?.translations?.find((t: any) => t.iso_639_1 === "en")?.data;
     if (enTrans?.overview) overview = enTrans.overview;
     if (enTrans?.tagline) tagline = enTrans.tagline;
@@ -400,10 +436,11 @@ export async function tmdbSeasonEpisodes(
   key: string,
   tvId: number,
   seasonNumber: number,
+  lang?: string,
 ): Promise<Episode[]> {
   if (!key) return [];
   const data = await get<any>(key, `tv/${tvId}/season/${seasonNumber}`, {
-    language: effectiveTmdbLanguage() || "en",
+    language: lang ?? (effectiveTmdbLanguage() || "en"),
   });
   if (!data?.episodes) return [];
   return data.episodes.map((e: any) => ({

--- a/src/lib/providers/tmdb/tmdb-meta-mappers.ts
+++ b/src/lib/providers/tmdb/tmdb-meta-mappers.ts
@@ -3,6 +3,20 @@ import { MOVIE_GENRES, TV_GENRES } from "../../feed/tags";
 import { loadStoredSettings } from "../../settings/load";
 import { IMG } from "./tmdb-client";
 
+export function isAnimeItem(item: {
+  genre_ids?: number[];
+  genres?: any[];
+  original_language?: string;
+  origin_country?: string[];
+}): boolean {
+  const hasAnim =
+    (item.genre_ids ?? []).includes(16) ||
+    (item.genres ?? []).some((g: any) => g === "Animation" || g?.id === 16);
+  const isJp =
+    item.original_language === "ja" || (item.origin_country ?? []).includes("JP");
+  return hasAnim && isJp;
+}
+
 export type RawMovie = {
   id: number;
   title: string;
@@ -59,10 +73,12 @@ function genresFromIds(ids: number[] | undefined, kind: "movie" | "tv"): string[
 export const movieMeta = (m: RawMovie): Meta => {
   const st = loadStoredSettings();
   const translate = st.translateTitles;
+  const anime = isAnimeItem(m);
+  const name = translate ? m.title : anime ? m.title : m.original_title || m.title;
   return {
     id: `tmdb:movie:${m.id}`,
     type: "movie",
-    name: translate ? m.title : m.original_title || m.title,
+    name,
     poster: poster(m.poster_path),
     background: back(m.backdrop_path),
     description: m.overview,
@@ -78,10 +94,12 @@ export const movieMeta = (m: RawMovie): Meta => {
 export const seriesMeta = (s: RawSeries): Meta => {
   const st = loadStoredSettings();
   const translate = st.translateTitles;
+  const anime = isAnimeItem(s);
+  const name = translate ? s.name : anime ? s.name : s.original_name || s.name;
   return {
     id: `tmdb:tv:${s.id}`,
     type: "series",
-    name: translate ? s.name : s.original_name || s.name,
+    name,
     poster: poster(s.poster_path),
     background: back(s.backdrop_path),
     description: s.overview,

--- a/src/lib/providers/tmdb/tmdb-people.ts
+++ b/src/lib/providers/tmdb/tmdb-people.ts
@@ -145,11 +145,23 @@ export async function tmdbPerson(key: string, personId: number): Promise<PersonD
 }
 
 async function fetchPerson(key: string, personId: number): Promise<PersonDetail | null> {
+  const lang = effectiveTmdbLanguage();
+  const langBase = lang.split("-")[0]?.toLowerCase() ?? "";
   const raw = await get<any>(key, `person/${personId}`, {
     append_to_response: "combined_credits,external_ids",
-    language: effectiveTmdbLanguage() || "en",
+    language: lang || "en",
   });
   if (!raw) return null;
+
+  // TMDB falls back to the original-language name (e.g. Japanese for anime staff) when
+  // the requested language has no translation, so prefer the English name in that case.
+  const localized = typeof raw.name === "string" ? raw.name : "";
+  const original = typeof raw.original_name === "string" ? raw.original_name : "";
+  let name = localized;
+  if (langBase && langBase !== "en" && original && localized === original) {
+    const enRaw = await get<any>(key, `person/${personId}`, { language: "en-US" });
+    if (typeof enRaw?.name === "string" && enRaw.name) name = enRaw.name;
+  }
 
   const toCredit = (c: any): PersonCredit => ({
     id: c.id,
@@ -174,7 +186,7 @@ async function fetchPerson(key: string, personId: number): Promise<PersonDetail 
 
   const detail: PersonDetail = {
     id: raw.id,
-    name: raw.name ?? "",
+    name,
     biography: raw.biography ?? "",
     birthday: raw.birthday ?? null,
     deathday: raw.deathday ?? null,

--- a/src/lib/providers/tmdb/tmdb-title-credits.ts
+++ b/src/lib/providers/tmdb/tmdb-title-credits.ts
@@ -1,5 +1,5 @@
 import { lruSet } from "../../cache";
-import { get } from "./tmdb-client";
+import { get, effectiveTmdbLanguage } from "./tmdb-client";
 
 export type TitleCreditPerson = {
   id: number;
@@ -26,10 +26,16 @@ function cacheKey(kind: "movie" | "tv", id: number): string {
   return `${kind}:${id}`;
 }
 
-function toPerson(raw: any): TitleCreditPerson {
+function toPerson(raw: any, enNameById: Map<number, string> | null): TitleCreditPerson {
+  // TMDB returns the original-language name (e.g. Japanese for anime staff) when no
+  // translation exists for the requested language, so fall back to the English name.
+  const localized = typeof raw.name === "string" ? raw.name : "";
+  const original = typeof raw.original_name === "string" ? raw.original_name : "";
+  const name =
+    enNameById && original && localized === original ? enNameById.get(raw.id) ?? localized : localized;
   return {
     id: raw.id,
-    name: raw.name ?? "",
+    name,
     profilePath: raw.profile_path ?? null,
     popularity: typeof raw.popularity === "number" ? raw.popularity : 0,
     order: typeof raw.order === "number" ? raw.order : undefined,
@@ -37,9 +43,9 @@ function toPerson(raw: any): TitleCreditPerson {
   };
 }
 
-function parse(raw: any): TitleCredits {
+function parse(raw: any, enNameById: Map<number, string> | null): TitleCredits {
   const cast: TitleCreditPerson[] = (raw?.cast ?? [])
-    .map(toPerson)
+    .map((c: any) => toPerson(c, enNameById))
     .sort(
       (a: TitleCreditPerson, b: TitleCreditPerson) =>
         (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER),
@@ -47,7 +53,7 @@ function parse(raw: any): TitleCredits {
     .slice(0, KEEP_CAST);
   const crew: TitleCreditPerson[] = (raw?.crew ?? [])
     .filter((c: any) => c?.department === "Directing" || c?.department === "Writing")
-    .map(toPerson)
+    .map((c: any) => toPerson(c, enNameById))
     .slice(0, KEEP_CREW);
   return { cast, crew };
 }
@@ -72,7 +78,24 @@ export async function tmdbTitleCredits(
   if (pending) return pending;
   const p = (async () => {
     const raw = await get<any>(key, `${kind}/${id}/credits`);
-    const parsed = raw ? parse(raw) : null;
+    if (!raw) {
+      lruSet(cache, k, null, CACHE_MAX);
+      return null;
+    }
+    const langBase = effectiveTmdbLanguage().split("-")[0]?.toLowerCase() ?? "";
+    let enNameById: Map<number, string> | null = null;
+    if (langBase && langBase !== "en") {
+      const en = await get<any>(key, `${kind}/${id}/credits`, { language: "en-US" });
+      enNameById = new Map();
+      for (const list of [en?.cast, en?.crew]) {
+        for (const p of list ?? []) {
+          if (p?.id != null && typeof p.name === "string" && p.name && !enNameById.has(p.id)) {
+            enNameById.set(p.id, p.name);
+          }
+        }
+      }
+    }
+    const parsed = parse(raw, enNameById);
     lruSet(cache, k, parsed, CACHE_MAX);
     return parsed;
   })().finally(() => inflight.delete(k));

--- a/src/lib/search-context.tsx
+++ b/src/lib/search-context.tsx
@@ -218,6 +218,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
       const tmdbCacheKey = [
         settings.tmdbKey,
         settings.tmdbLanguage,
+        settings.translateTitles,
         excludeGenres.join(","),
         normalizedQuery,
       ].join("\0");
@@ -399,7 +400,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
         debounceRef.current = null;
       }
     };
-  }, [query, aiHold, settings.tmdbKey, settings.tmdbLanguage, settings.iptvPlaylists, excludeGenres, hiddenTabs.anime, settings.hideContent.anime, hiddenTabs.liveTv, settings.mangaEnabled, settings.hideContent.manga, authKey]);
+  }, [query, aiHold, settings.tmdbKey, settings.tmdbLanguage, settings.translateTitles, settings.iptvPlaylists, excludeGenres, hiddenTabs.anime, settings.hideContent.anime, hiddenTabs.liveTv, settings.mangaEnabled, settings.hideContent.manga, authKey]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -7,6 +7,7 @@ import type { AddonHit } from "@/lib/search-addon-index";
 import { getCachedPlaylist } from "@/lib/iptv/store";
 import { arabicAwareMatch } from "@/lib/iptv/rtl";
 import type { Settings } from "@/lib/settings";
+import { loadStoredSettings } from "@/lib/settings/load";
 import { safeFetch } from "@/lib/safe-fetch";
 import { anilistAnimeSearch } from "@/lib/anilist/browse";
 import type { MangaSummary } from "@/lib/manga/model";
@@ -263,6 +264,7 @@ export async function searchAll(
   const data = await get<Page<MultiItem>>(key, "search/multi", {
     query: trimmed,
     include_adult: "false",
+    ...(loadStoredSettings().translateTitles ? {} : { language: "en-US" }),
   });
   if (!data) {
     return {

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -503,6 +503,7 @@ export const DEFAULT: Settings = {
   pauseListStatusOnPause: false,
   translateTitles: true,
   translateDescriptions: true,
+  localizeAnimeMetadata: false,
   letterboxd: {
     enabled: false,
     mode: "public",

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -592,6 +592,7 @@ export type Settings = {
   pauseListStatusOnPause: boolean;
   translateTitles: boolean;
   translateDescriptions: boolean;
+  localizeAnimeMetadata: boolean;
   letterboxd: LetterboxdSettings;
   adSkipEnabled: boolean;
   adReportAlwaysShow: boolean;

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { Check, HardDrive, Heart, Layers, Pencil, Play, Plus, RotateCcw } from "lucide-react";
-import { animeDetails, type FranchiseEntry } from "@/lib/providers/anime-detail";
+import { animeDetails, type AnimeDetailExtras, type FranchiseEntry } from "@/lib/providers/anime-detail";
+import { isTextInLanguage } from "@/lib/providers/anime-episode-build";
 import { peekAnimeArt, saveAnimeArt } from "@/lib/providers/anime-art-cache";
 import { imdbToKitsu, tmdbTvToKitsu } from "@/lib/providers/anime-mapping";
 import { kitsuAnime, kitsuMainTvSeries } from "@/lib/providers/kitsu";
@@ -186,7 +187,7 @@ export function DetailView({
   const contentDrag = useContentDrag();
   const settingsRef = useRef(settings);
   settingsRef.current = settings;
-  const [detail, setDetail] = useState<TmdbDetail | null>(null);
+  const [detail, setDetail] = useState<(TmdbDetail & Pick<AnimeDetailExtras, "seasonOverviews">) | null>(null);
   const [animeEpisodes, setAnimeEpisodes] = useState<KitsuEpisode[]>([]);
   const [franchise, setFranchise] = useState<FranchiseEntry[]>([]);
   const [animeCanonicalId, setAnimeCanonicalId] = useState<string | null>(null);
@@ -233,6 +234,13 @@ export function DetailView({
     },
     [],
   );
+  // Season picker swaps franchise seasons in-place without re-running animeDetails, so the
+  // localized TMDB series overview must be passed down for the season hero description.
+  const localizedAnimeOverview = useMemo(() => {
+    if (!settings.localizeAnimeMetadata || !detail?.overview) return undefined;
+    const iso1 = settings.tmdbLanguage || settings.uiLanguage || "en";
+    return isTextInLanguage(detail.overview, iso1) ? detail.overview : undefined;
+  }, [settings.localizeAnimeMetadata, settings.tmdbLanguage, settings.uiLanguage, detail?.overview]);
   const pinnedBackdrop = useTitleBackdrop(meta.id);
   const pinnedBackdropHi = pinnedBackdrop
     ? pinnedBackdrop.replace(/\/t\/p\/w\d+\//, "/t/p/original/")
@@ -1622,6 +1630,8 @@ export function DetailView({
               (meta.id.startsWith("tt") ? meta.id : null)
             }
             onSeasonArt={handleSeasonArt}
+            localizedOverview={localizedAnimeOverview}
+            seasonOverviews={detail.seasonOverviews}
           />
           </FadeInUp>
         )}

--- a/src/views/detail/anime-episodes.tsx
+++ b/src/views/detail/anime-episodes.tsx
@@ -52,6 +52,8 @@ export function AnimeEpisodes({
   trackId,
   imdbId,
   episodeHint,
+  localizedOverview,
+  seasonOverviews,
   onSeasonArt,
 }: {
   meta: Meta;
@@ -62,6 +64,8 @@ export function AnimeEpisodes({
   trackId?: string;
   imdbId?: string | null;
   episodeHint?: { season: number; episode: number };
+  localizedOverview?: string;
+  seasonOverviews?: Record<number, string>;
   onSeasonArt?: (
     sel:
       | { background?: string; description?: string; logo?: string; name?: string; entryId: string }
@@ -194,19 +198,40 @@ export function AnimeEpisodes({
     () => mapSeasonToEntry(tvdbActiveSeason, franchise, currentId),
     [tvdbActiveSeason, franchise, currentId],
   );
+  // The matched franchise entry's episodes carry their TMDB season number (AniZip), which selects
+  // the right localized per-season overview so the hero changes per season instead of staying static.
+  const seasonOverview = useMemo(() => {
+    if (!seasonEntry || !seasonOverviews) return undefined;
+    const counts = new Map<number, number>();
+    for (const ep of franchiseEpisodes) {
+      if (ep.sourceMetaId !== seasonEntry.meta.id || ep.imdbSeason == null) continue;
+      counts.set(ep.imdbSeason, (counts.get(ep.imdbSeason) ?? 0) + 1);
+    }
+    let best: number | null = null;
+    let bestN = 0;
+    for (const [s, n] of counts) {
+      if (n > bestN) {
+        best = s;
+        bestN = n;
+      }
+    }
+    return best != null ? seasonOverviews[best] : undefined;
+  }, [seasonEntry, seasonOverviews, franchiseEpisodes]);
   useEffect(() => {
     onSeasonArtRef.current?.(
       seasonEntry
         ? {
             background: seasonEntry.meta.background,
-            description: seasonEntry.meta.description,
+            // Prefer the localized per-season TMDB overview, then the localized series overview,
+            // over the franchise entry's Kitsu synopsis (localized* is only set when localization is active).
+            description: seasonOverview ?? localizedOverview ?? seasonEntry.meta.description,
             logo: seasonEntry.meta.logo,
             name: seasonEntry.meta.name,
             entryId: seasonEntry.meta.id,
           }
         : null,
     );
-  }, [seasonEntry]);
+  }, [seasonEntry, localizedOverview, seasonOverview]);
   useEffect(() => () => onSeasonArtRef.current?.(null), []);
   const proxyImages = useTvdbProxyImages(
     parseKitsuId(meta.id),

--- a/src/views/settings/language-panel.tsx
+++ b/src/views/settings/language-panel.tsx
@@ -165,7 +165,7 @@ export function LanguagePanel() {
       )}
       <ToggleRow
         label={t("Translate titles")}
-        sub={t("On shows titles in your metadata language (English by default). Off keeps each title's original language, so anime and foreign films show their native names.")}
+        sub={t("On shows titles in your metadata language (English by default). Off keeps titles in English.")}
         value={settings.translateTitles}
         onChange={(v) => update({ translateTitles: v })}
       />

--- a/src/views/settings/language-panel.tsx
+++ b/src/views/settings/language-panel.tsx
@@ -1,6 +1,6 @@
-import {  } from "lucide-react";
+import { RotateCw } from "lucide-react";
 import { GitHubIcon } from "@/components/github-icon";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Dropdown, type DropdownOption } from "@/components/dropdown";
 import { useSettings } from "@/lib/settings";
 import { useT } from "@/lib/i18n";
@@ -39,6 +39,10 @@ export function LanguagePanel() {
   const { settings, update } = useSettings();
   const t = useT();
   const [blockDraft, setBlockDraft] = useState(settings.trackBlockWords.join(", "));
+  const [langDraft, setLangDraft] = useState(settings.tmdbLanguage);
+  useEffect(() => {
+    setLangDraft(settings.tmdbLanguage);
+  }, [settings.tmdbLanguage]);
   return (
     <>
     <DisplayLanguageSection />
@@ -130,18 +134,42 @@ export function LanguagePanel() {
       subtitle={t("Titles, overviews, and taglines from TMDB display in this language when a translation exists. Needs a TMDB key.")}
     >
       <Dropdown
-        value={settings.tmdbLanguage}
-        onChange={(v) => update({ tmdbLanguage: v })}
+        value={langDraft}
+        onChange={setLangDraft}
         options={[{ value: "", label: t("English (default)") }, ...TMDB_LANGUAGES]}
         className="w-full max-w-[340px]"
       />
+      {langDraft !== settings.tmdbLanguage && (
+        <div className="flex max-w-[340px] flex-col gap-2.5 rounded-xl border border-edge-soft bg-canvas/30 p-3.5">
+          <p className="text-[12.5px] leading-relaxed text-ink-muted">
+            {t("Changing the metadata language reloads Harbor so the new language takes effect. Apply when you're done with the options below.")}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => update({ tmdbLanguage: langDraft })}
+              className="flex items-center gap-1.5 rounded-full bg-ink px-4 py-2 text-[12.5px] font-semibold text-canvas transition-transform hover:scale-[1.02] active:scale-[0.97]"
+            >
+              <RotateCw size={13} strokeWidth={2.2} />
+              {t("Apply and reload")}
+            </button>
+            <button
+              type="button"
+              onClick={() => setLangDraft(settings.tmdbLanguage)}
+              className="rounded-full border border-edge-soft px-4 py-2 text-[12.5px] font-semibold text-ink-muted transition-colors hover:border-edge hover:text-ink"
+            >
+              {t("Cancel")}
+            </button>
+          </div>
+        </div>
+      )}
       <ToggleRow
         label={t("Translate titles")}
         sub={t("On shows titles in your metadata language (English by default). Off keeps each title's original language, so anime and foreign films show their native names.")}
         value={settings.translateTitles}
         onChange={(v) => update({ translateTitles: v })}
       />
-      {settings.tmdbLanguage !== "" && (
+      {langDraft !== "" && (
         <ToggleRow
           label={t("Translate overviews")}
           sub={t("Translate plot descriptions and taglines into the language above. Turn off to keep English overviews.")}

--- a/src/views/settings/language-panel.tsx
+++ b/src/views/settings/language-panel.tsx
@@ -149,6 +149,12 @@ export function LanguagePanel() {
           onChange={(v) => update({ translateDescriptions: v })}
         />
       )}
+      <ToggleRow
+        label={t("Localize anime metadata")}
+        sub={t("Applies the metadata language to anime as well: series overviews and episode names come from TMDB and TVDB translations when available, instead of Kitsu's English synopses. Needs a TMDB or TVDB key. Off keeps anime on Kitsu data.")}
+        value={settings.localizeAnimeMetadata}
+        onChange={(v) => update({ localizeAnimeMetadata: v })}
+      />
     </Section>
 
     <Section


### PR DESCRIPTION
## Summary

- Anime Metadata Localization: Localizes anime metadata from TMDB and TVDB (063b7681), falls back gracefully to English names when translations are missing (15d4f6a3), and uses primary genre for similar titles (d06b7fc2).

- Settings UX: Adds explicit apply-and-reload controls for metadata language changes (ff88d8e1).

- Smart Title Fallback for Translate Titles: When "Translate titles" is disabled, anime correctly shows English titles while non-anime movies and TV shows preserve their native original language (original_title).

## Why

Improves multi-language metadata handling and anime localization across Harbor. Users can now choose their preferred metadata language with an explicit apply flow, and anime items correctly display English titles when title translation is turned off while keeping foreign film native titles intact.

## Verification

- Ran TypeScript type checking (npx tsc -b --pretty false), exiting with 0 errors.

- Verified metadata language settings workflow, search bar behavior, catalog rails, and detail pages.

## Platform Impact

None

## UI Changes

- Added draft-apply buttons to the Language settings panel for metadata language changes.

- Updated the "Translate titles" toggle description to accurately reflect English title fallback for anime.

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/b2d6aae5-9ce5-4346-a2cf-570660ded277" alt="image" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/56ffd1e5-24de-4ae9-a54e-7ad0a7547085" alt="image" width="100%" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/80799b2a-5a10-43dc-9afa-8c2710e9876f" alt="image" width="100%" /></td>
    <td><img src="https://github.com/user-attachments/assets/affaed1e-a05e-41fc-9e77-ac99c10f18f7" alt="image" width="100%" /></td>
  </tr>
</table>


## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
