### PR TITLE
feat: add controller cursor, keyboard, and manga enhancements

### DIFF
--- a/src/components/gamepad-runner.tsx
+++ b/src/components/gamepad-runner.tsx
@@ -1,6 +1,206 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { HarborMark } from "@/components/icons/harbor-mark";
+import { tvHover } from "@/lib/keyboard-navigation";
+import { useLiveGamepad } from "@/lib/gamepad/live";
 import { useGamepad } from "@/lib/gamepad/use-gamepad";
+import { useSettings } from "@/lib/settings";
+
+function hoverCss(rules: CSSRuleList): string {
+  return Array.from(rules).map((rule) => rule instanceof CSSStyleRule && rule.selectorText.includes(":hover")
+    ? `${rule.selectorText.replaceAll(":hover", "[data-gamepad-hover]")}{${rule.style.cssText}${hoverCss(rule.cssRules)}}`
+    : "cssRules" in rule ? `${rule.cssText.slice(0, rule.cssText.indexOf("{"))}{${hoverCss((rule as CSSGroupingRule).cssRules)}}` : "").join("");
+}
+
+type TextField = HTMLInputElement | HTMLTextAreaElement;
+const isTextField = (el: unknown): el is TextField => el instanceof HTMLTextAreaElement || el instanceof HTMLInputElement && ["text", "search", "email", "url", "tel", "password", "number"].includes(el.type);
 
 export function GamepadRunner() {
   useGamepad();
-  return null;
+  const live = useLiveGamepad();
+  const { settings } = useSettings();
+  const cursor = useRef<HTMLDivElement>(null);
+  const position = useRef({ x: innerWidth / 2, y: innerHeight / 2 });
+  const axes = useRef(live.axes);
+  const active = useRef(false);
+  const hovered = useRef<HTMLElement>(null);
+  const hoverPath = useRef<HTMLElement[]>([]);
+  const controllerField = useRef<TextField | null>(null);
+  const [keyboard, setKeyboard] = useState<TextField | null>(null);
+  axes.current = live.axes;
+
+  useEffect(() => {
+    const style = document.createElement("style");
+    style.setAttribute("data-gamepad-hover-styles", "");
+    document.head.appendChild(style);
+    const apply = () => {
+      style.textContent = Array.from(document.styleSheets).filter((sheet) => sheet.ownerNode !== style).map((sheet) => {
+        try { return hoverCss(sheet.cssRules); } catch { return ""; }
+      }).join("");
+    };
+    apply();
+    const observer = new MutationObserver(apply);
+    observer.observe(document.head, { childList: true });
+    return () => { observer.disconnect(); style.remove(); };
+  }, []);
+
+  useEffect(() => {
+    let frame = 0;
+    let previous = performance.now();
+    let refreshHover = false;
+    const refresh = () => { refreshHover = true; };
+    window.addEventListener("blur", refresh);
+    const tick = (now: number) => {
+      const dt = Math.min((now - previous) / 1000, 0.05);
+      previous = now;
+      const { ly, rx, ry } = axes.current;
+      const deadzone = settings.controllerDeadzone;
+      const x = Math.abs(rx) < deadzone ? 0 : rx;
+      const y = Math.abs(ry) < deadzone ? 0 : ry;
+      if (x || y) {
+        active.current = true;
+        position.current.x = Math.max(0, Math.min(innerWidth, position.current.x + x * settings.controllerCursorSpeed * dt));
+        position.current.y = Math.max(0, Math.min(innerHeight, position.current.y + y * settings.controllerCursorSpeed * dt));
+        const hit = document.elementFromPoint(position.current.x, position.current.y) as HTMLElement | null;
+        if (refreshHover || hit !== hoverPath.current[0]) {
+          refreshHover = false;
+          const previousHit = hoverPath.current[0];
+          for (const el of hoverPath.current) el.removeAttribute("data-gamepad-hover");
+          hoverPath.current = [];
+          for (let el = hit; el; el = el.parentElement) hoverPath.current.push(el);
+          for (const el of hoverPath.current) el.setAttribute("data-gamepad-hover", "");
+          previousHit?.dispatchEvent(new PointerEvent("pointerout", { bubbles: true, relatedTarget: hit }));
+          previousHit?.dispatchEvent(new PointerEvent("pointerleave", { relatedTarget: hit }));
+          previousHit?.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: hit }));
+          previousHit?.dispatchEvent(new MouseEvent("mouseleave", { relatedTarget: hit }));
+          hit?.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, relatedTarget: previousHit }));
+          hit?.dispatchEvent(new PointerEvent("pointerenter", { relatedTarget: previousHit }));
+          hit?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, relatedTarget: previousHit }));
+          hit?.dispatchEvent(new MouseEvent("mouseenter", { relatedTarget: previousHit }));
+        }
+        hit?.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: position.current.x, clientY: position.current.y }));
+        hit?.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: position.current.x, clientY: position.current.y }));
+        const target = hit?.closest<HTMLElement>("a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1']),[data-focusable='true']") ?? null;
+        if (target && document.activeElement !== target) target.focus({ preventScroll: true });
+        if (target !== hovered.current) {
+          tvHover(hovered.current = target);
+        }
+      }
+      cursor.current?.style.setProperty("opacity", active.current && !(document.documentElement.hasAttribute("data-player-chrome-mounted") && !document.documentElement.hasAttribute("data-player-chrome-visible")) ? "1" : "0");
+      cursor.current?.style.setProperty("transform", `translate(${position.current.x}px,${position.current.y}px) translate(-50%,-50%)`);
+      if (Math.abs(ly) >= deadzone) {
+        let el = document.elementFromPoint(position.current.x, position.current.y) as HTMLElement | null;
+        while (el && el !== document.body && (!/(auto|scroll)/.test(getComputedStyle(el).overflowY) || el.scrollHeight <= el.clientHeight)) el = el.parentElement;
+        (el ?? document.scrollingElement)?.scrollBy({ top: ly * 600 * dt });
+      }
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => { cancelAnimationFrame(frame); window.removeEventListener("blur", refresh); };
+  }, [settings.controllerDeadzone, settings.controllerCursorSpeed]);
+
+  useEffect(() => {
+    if (!live.buttons.south) return;
+    const selectedField = document.activeElement === controllerField.current ? controllerField.current : null;
+    if (!active.current && !selectedField) return;
+    if (keyboard && document.activeElement instanceof HTMLButtonElement && document.activeElement.closest("[data-controller-keyboard]")) {
+      document.activeElement.click();
+      return;
+    }
+    const target = document.elementFromPoint(position.current.x, position.current.y);
+    const field = isTextField(target) ? target : selectedField;
+    if (field) { setKeyboard(field); return; }
+    const seek = target?.closest<HTMLElement>("[data-player-seekbar]");
+    if (seek) {
+      seek.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: position.current.x, clientY: position.current.y }));
+      return;
+    }
+    const stage = target?.closest<HTMLElement>("[data-player-click-stage]");
+    if (stage) {
+      stage.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, clientX: position.current.x, clientY: position.current.y }));
+      window.dispatchEvent(new MouseEvent("mouseup", { button: 0, clientX: position.current.x, clientY: position.current.y }));
+      return;
+    }
+    const clickable = target?.closest<HTMLElement>("button,a,input,select,textarea,[role='button'],[tabindex]");
+    (clickable ?? (target instanceof HTMLElement ? target : null))?.click();
+  }, [live.buttons.south]);
+
+  useEffect(() => {
+    if (live.buttons.west && keyboard) typeInto(keyboard, "Backspace");
+  }, [live.buttons.west, keyboard]);
+
+  useEffect(() => {
+    if (live.buttons.north && keyboard) typeInto(keyboard, " ");
+  }, [live.buttons.north, keyboard]);
+
+  useEffect(() => {
+    if (!keyboard) return;
+    const close = (e: KeyboardEvent) => { if (e.key === "Escape") setKeyboard(null); };
+    const observer = new MutationObserver(() => { if (!keyboard.isConnected) setKeyboard(null); });
+    window.addEventListener("keydown", close);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => { window.removeEventListener("keydown", close); observer.disconnect(); };
+  }, [keyboard]);
+
+  useEffect(() => {
+    const select = (e: Event) => { controllerField.current = isTextField(e.target) ? e.target : null; };
+    document.addEventListener("harbor-controller-focus", select);
+    return () => document.removeEventListener("harbor-controller-focus", select);
+  }, []);
+
+  useEffect(() => {
+    if (live.buttons.west && !keyboard && document.documentElement.hasAttribute("data-player-chrome-mounted"))
+      document.querySelector<HTMLElement>("[data-player-subtitles]")?.click();
+  }, [live.buttons.west, keyboard]);
+
+  return createPortal(
+    <>
+      {keyboard?.isConnected && <ControllerKeyboard input={keyboard} size={settings.controllerKeyboardSize} onClose={() => setKeyboard(null)} />}
+      <div ref={cursor} className="pointer-events-none fixed left-0 top-0 z-[2147483647] h-10 w-10 text-accent opacity-0 drop-shadow-lg">
+        <HarborMark className="h-full w-full" />
+      </div>
+    </>,
+    document.body,
+  );
+}
+
+const KEYS = {
+  English: ["QWERTYUIOP", "ASDFGHJKL", "ZXCVBNM"],
+  العربية: ["ضصثقفغعهخحجد", "شسيبلاتنمكط", "ئءؤرلاىةوزظ"],
+};
+
+function ControllerKeyboard({ input, size, onClose }: { input: TextField; size: number; onClose: () => void }) {
+  const [language, setLanguage] = useState<keyof typeof KEYS>("English");
+  const [pressed, setPressed] = useState("");
+  const flash = (key: string) => {
+    setPressed(key);
+    window.setTimeout(() => setPressed(""), 120);
+  };
+  const tap = (key: string) => {
+    flash(key);
+    typeInto(input, key);
+  };
+  return <div data-controller-keyboard className="fixed inset-x-0 bottom-0 z-[2147483646] flex flex-col items-center gap-2 border-t border-edge bg-canvas/95 p-4 shadow-2xl backdrop-blur-xl" style={{ transform: `scale(${size / 100})`, transformOrigin: "bottom center" }}>
+    <div className="flex gap-2">{"1234567890".split("").map((key) => <button key={key} onClick={() => tap(key)} className={`h-12 w-12 rounded-full bg-elevated text-lg font-semibold text-ink transition hover:bg-accent/20 hover:ring-4 hover:ring-accent/30 ${pressed === key ? "scale-75 bg-accent text-canvas" : ""}`}>{key}</button>)}</div>
+    {KEYS[language].map((row) => <div key={row} className="flex gap-2">{[...row].map((key) => <button key={key} onClick={() => tap(key)} className={`h-12 w-12 rounded-full bg-elevated text-lg font-semibold text-ink transition hover:bg-accent/20 hover:ring-4 hover:ring-accent/30 ${pressed === key ? "scale-75 bg-accent text-canvas" : ""}`}>{key}</button>)}</div>)}
+    <div className="flex gap-2">
+      <button onClick={() => { flash("Language"); setLanguage(language === "English" ? "العربية" : "English"); }} className={`h-12 px-6 rounded-xl bg-elevated font-semibold text-ink transition hover:bg-raised focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/50 ${pressed === "Language" ? "scale-90 bg-accent text-canvas" : ""}`}>{language === "English" ? "العربية" : "English"}</button>
+      <button onClick={() => tap(" ")} className={`h-12 w-64 rounded-xl bg-elevated font-semibold text-ink transition hover:bg-raised focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/50 ${pressed === " " ? "scale-90 bg-accent text-canvas" : ""}`}>Space</button>
+      <button onClick={() => tap("Backspace")} className={`h-12 px-6 rounded-xl bg-elevated font-semibold text-ink transition hover:bg-raised focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/50 ${pressed === "Backspace" ? "scale-90 bg-accent text-canvas" : ""}`}>Backspace</button>
+      <button onClick={() => tap("Enter")} className={`h-12 px-6 rounded-xl bg-accent font-semibold text-canvas transition focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white/50 ${pressed === "Enter" ? "scale-90 brightness-75" : ""}`}>Search</button>
+      <button onClick={onClose} className="h-12 px-6 rounded-xl bg-elevated font-semibold text-ink transition hover:bg-raised focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/50 active:scale-90">Close</button>
+    </div>
+  </div>;
+}
+
+function typeInto(input: TextField, key: string) {
+  if (key === "Enter") input.dispatchEvent(new KeyboardEvent("keydown", { key, code: key, bubbles: true }));
+  else {
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? start;
+    const value = key === "Backspace" ? input.value.slice(0, Math.max(0, start - 1)) + input.value.slice(end) : input.value.slice(0, start) + key + input.value.slice(end);
+    Object.getOwnPropertyDescriptor(input instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype, "value")?.set?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.setSelectionRange(key === "Backspace" ? Math.max(0, start - 1) : start + key.length, key === "Backspace" ? Math.max(0, start - 1) : start + key.length);
+  }
 }

--- a/src/components/player/subtitle-menu.tsx
+++ b/src/components/player/subtitle-menu.tsx
@@ -137,6 +137,7 @@ export function SubtitleMenu(props: Props) {
     <div ref={wrap} className="relative">
       <Tooltip label={t("Subtitles")}>
         <button
+          data-player-subtitles
           type="button"
           onClick={handleClick}
           aria-label={t("Subtitles")}

--- a/src/components/player/transport-kids.tsx
+++ b/src/components/player/transport-kids.tsx
@@ -181,6 +181,8 @@ function KidsSeekBar({
   return (
     <div
       ref={ref}
+      data-player-seekbar
+      onClick={(e) => { if (!e.isTrusted && duration > 0) onSeek(fromX(e.clientX) * duration); }}
       onPointerDown={(e) => {
         e.currentTarget.setPointerCapture(e.pointerId);
         setDrag(fromX(e.clientX));

--- a/src/components/player/transport/live-controls.tsx
+++ b/src/components/player/transport/live-controls.tsx
@@ -119,10 +119,12 @@ export function LiveSeekBar({
     <div className="pointer-events-auto group/seek relative h-12">
       <div
         ref={ref}
+        data-player-seekbar
         onPointerMove={onMove}
         onPointerLeave={onLeave}
         onPointerDown={onDown}
         onPointerUp={onUp}
+        onClick={(e) => { if (!e.isTrusted) onSeek(fromEvent(e.clientX)); }}
         className="absolute inset-x-0 top-1/2 -translate-y-1/2 cursor-pointer"
       >
         <SeekBarVisual

--- a/src/components/player/transport/seek-bar.tsx
+++ b/src/components/player/transport/seek-bar.tsx
@@ -140,11 +140,19 @@ export function SeekBar({
     <div dir="ltr" className="pointer-events-auto group/seek relative h-12">
       <div
         ref={ref}
+        data-player-seekbar
         onPointerMove={onMove}
         onPointerLeave={onLeave}
         onPointerDown={onDown}
         onPointerUp={onUp}
         onPointerCancel={onCancel}
+        onClick={(e) => {
+          if (e.isTrusted) return;
+          const seek = fromEvent(e.clientX);
+          setPending(seek);
+          pendingAtRef.current = Date.now();
+          onSeek(seek);
+        }}
         className="absolute inset-x-0 top-1/2 -translate-y-1/2 cursor-pointer"
       >
         <SeekBarVisual

--- a/src/lib/gamepad/mapping.ts
+++ b/src/lib/gamepad/mapping.ts
@@ -1,4 +1,4 @@
-import type { GpAxis, GpButton } from "./protocol";
+import type { GpButton } from "./protocol";
 
 export type NavAction = "up" | "down" | "left" | "right" | "select" | "back" | "home";
 export type PlayerKey = { key: string; code: string };
@@ -8,7 +8,6 @@ export const NAV_BUTTON: Partial<Record<GpButton, NavAction>> = {
   ddown: "down",
   dleft: "left",
   dright: "right",
-  south: "select",
   east: "back",
   start: "home",
   guide: "home",
@@ -16,20 +15,13 @@ export const NAV_BUTTON: Partial<Record<GpButton, NavAction>> = {
 
 export const NAV_REPEATABLE = new Set<GpButton>(["dup", "ddown", "dleft", "dright"]);
 
-export const NAV_AXIS: Partial<Record<GpAxis, { neg: NavAction; pos: NavAction }>> = {
-  lx: { neg: "left", pos: "right" },
-  ly: { neg: "up", pos: "down" },
-};
-
 const ARROW_LEFT: PlayerKey = { key: "ArrowLeft", code: "ArrowLeft" };
 const ARROW_RIGHT: PlayerKey = { key: "ArrowRight", code: "ArrowRight" };
 const ARROW_UP: PlayerKey = { key: "ArrowUp", code: "ArrowUp" };
 const ARROW_DOWN: PlayerKey = { key: "ArrowDown", code: "ArrowDown" };
 
 export const PLAYER_BUTTON: Partial<Record<GpButton, PlayerKey>> = {
-  south: { key: " ", code: "Space" },
   east: { key: "Escape", code: "Escape" },
-  west: { key: "s", code: "KeyS" },
   north: { key: "i", code: "KeyI" },
   lb: { key: "b", code: "KeyB" },
   rb: { key: "n", code: "KeyN" },
@@ -42,7 +34,3 @@ export const PLAYER_BUTTON: Partial<Record<GpButton, PlayerKey>> = {
 };
 
 export const PLAYER_REPEATABLE = new Set<GpButton>(["dleft", "dright", "dup", "ddown"]);
-
-export const PLAYER_AXIS: Partial<Record<GpAxis, { neg: PlayerKey; pos: PlayerKey }>> = {
-  ry: { neg: ARROW_UP, pos: ARROW_DOWN },
-};

--- a/src/lib/gamepad/use-gamepad.ts
+++ b/src/lib/gamepad/use-gamepad.ts
@@ -8,12 +8,10 @@ import { dispatchTvNav } from "@/lib/keyboard-navigation";
 import { publishGamepads } from "./store";
 import { resetLiveGamepad, setLiveAxis, setLiveButton } from "./live";
 import { startWebGamepadSource } from "./web-source";
-import type { GamepadEventPayload, GamepadInfo, GpAxis, GpButton } from "./protocol";
+import type { GamepadEventPayload, GamepadInfo, GpButton } from "./protocol";
 import {
-  NAV_AXIS,
   NAV_BUTTON,
   NAV_REPEATABLE,
-  PLAYER_AXIS,
   PLAYER_BUTTON,
   PLAYER_REPEATABLE,
   type PlayerKey,
@@ -25,6 +23,29 @@ function synthKey({ key, code }: PlayerKey): void {
   const init = { key, code, bubbles: true, cancelable: true };
   window.dispatchEvent(new KeyboardEvent("keydown", init));
   window.dispatchEvent(new KeyboardEvent("keyup", init));
+}
+
+function keyboardNav(dir: string): boolean {
+  const root = document.querySelector<HTMLElement>("[data-controller-keyboard]");
+  if (!root || !["up", "down", "left", "right"].includes(dir)) return false;
+  const keys = [...root.querySelectorAll<HTMLButtonElement>("button:not([disabled])")];
+  const current = root.contains(document.activeElement) ? document.activeElement as HTMLButtonElement : null;
+  if (!current) { keys[0]?.focus({ preventScroll: true }); return true; }
+  const a = current.getBoundingClientRect(), ax = a.left + a.width / 2, ay = a.top + a.height / 2;
+  let candidates = keys.filter((key) => key !== current).map((key) => {
+    const b = key.getBoundingClientRect(), dx = b.left + b.width / 2 - ax, dy = b.top + b.height / 2 - ay;
+    const valid = dir === "left" ? dx < 0 : dir === "right" ? dx > 0 : dir === "up" ? dy < 0 : dy > 0;
+    const primary = dir === "left" || dir === "right" ? Math.abs(dx) : Math.abs(dy);
+    const cross = dir === "left" || dir === "right" ? Math.abs(dy) : Math.abs(dx);
+    return { key, valid, primary, cross };
+  }).filter((x) => x.valid);
+  if (dir === "left" || dir === "right") {
+    const sameRow = candidates.filter((x) => x.cross < a.height / 2);
+    if (sameRow.length) candidates = sameRow;
+  }
+  const next = candidates.sort((x, y) => x.primary + x.cross * 2 - y.primary - y.cross * 2)[0];
+  next?.key.focus({ preventScroll: true });
+  return true;
 }
 
 let nativePads: GamepadInfo[] = [];
@@ -54,12 +75,10 @@ export function useGamepad(): void {
   }, [backgroundInput]);
 
   const cfgRef = useRef({
-    deadzone: settings.controllerDeadzone,
     repeatMs: settings.controllerRepeatMs,
     initialDelayMs: settings.controllerInitialDelayMs,
   });
   cfgRef.current = {
-    deadzone: settings.controllerDeadzone,
     repeatMs: settings.controllerRepeatMs,
     initialDelayMs: settings.controllerInitialDelayMs,
   };
@@ -71,8 +90,6 @@ export function useGamepad(): void {
     if (!isTauri || !enabled) return;
 
     const repeats = new Map<string, { delay: number | null; interval: number | null }>();
-    const axisDir = new Map<GpAxis, "neg" | "pos" | null>();
-
     const stopRepeat = (id: string) => {
       const r = repeats.get(id);
       if (!r) return;
@@ -101,17 +118,10 @@ export function useGamepad(): void {
         return;
       }
       const nav = NAV_BUTTON[button];
-      if (nav) dispatchTvNav(nav);
-    };
-
-    const fireAxis = (axis: GpAxis, dir: "neg" | "pos") => {
-      if (playerRef.current) {
-        const key = PLAYER_AXIS[axis]?.[dir];
-        if (key) synthKey(key);
-        return;
+      if (nav && !keyboardNav(nav)) {
+        dispatchTvNav(nav);
+        document.activeElement?.dispatchEvent(new CustomEvent("harbor-controller-focus", { bubbles: true }));
       }
-      const nav = NAV_AXIS[axis]?.[dir];
-      if (nav) dispatchTvNav(nav);
     };
 
     const onButton = (button: GpButton, pressed: boolean) => {
@@ -124,22 +134,6 @@ export function useGamepad(): void {
         : NAV_REPEATABLE.has(button);
       if (repeatable) startRepeat(`btn:${button}`, () => fireButton(button));
       else fireButton(button);
-    };
-
-    const onAxis = (axis: GpAxis, value: number) => {
-      const mapped = playerRef.current ? PLAYER_AXIS[axis] : NAV_AXIS[axis];
-      const dz = Math.max(0.05, cfgRef.current.deadzone);
-      const dir: "neg" | "pos" | null = !mapped
-        ? null
-        : value <= -dz
-          ? "neg"
-          : value >= dz
-            ? "pos"
-            : null;
-      if ((axisDir.get(axis) ?? null) === dir) return;
-      axisDir.set(axis, dir);
-      stopRepeat(`axis:${axis}`);
-      if (dir) startRepeat(`axis:${axis}`, () => fireAxis(axis, dir));
     };
 
     let unlisten: (() => void) | undefined;
@@ -164,7 +158,6 @@ export function useGamepad(): void {
           break;
         case "axis":
           setLiveAxis(p.axis, p.value);
-          onAxis(p.axis, p.value);
           break;
       }
     }).then((raw) => {
@@ -180,7 +173,6 @@ export function useGamepad(): void {
       },
       onAxis: (axis, value) => {
         setLiveAxis(axis, value);
-        onAxis(axis, value);
       },
       onPads: (pads) => {
         webPads = pads;
@@ -192,7 +184,6 @@ export function useGamepad(): void {
       cancelled = true;
       stopAll();
       stopWebSource();
-      axisDir.clear();
       webPads = [];
       resetLiveGamepad();
       unlisten?.();

--- a/src/lib/keyboard-navigation.ts
+++ b/src/lib/keyboard-navigation.ts
@@ -46,10 +46,18 @@ export function dispatchTvNav(action: Dir | "select" | "back" | "home"): void {
     if (active && !isEditable(active)) active.click();
     return;
   }
+  const anchor = action !== "back" ? hoveredEl : null;
+  const fromHover = !!anchor;
+  if (anchor) {
+    anchor.focus({ preventScroll: true });
+    hoveredEl = null;
+  }
   const key = TV_NAV_KEY[action];
+  suppressFocusScroll = fromHover;
   window.dispatchEvent(
     new KeyboardEvent("keydown", { key, code: key, bubbles: true, cancelable: true }),
   );
+  suppressFocusScroll = false;
 }
 
 let focusStylesInjected = false;
@@ -71,9 +79,16 @@ function ensureFocusStyles() {
 }
 
 let lastFocusedEl: HTMLElement | null = null;
+let hoveredEl: HTMLElement | null = null;
+let suppressFocusScroll = false;
 
 export function tvFocus(el: HTMLElement) {
   focusElement(el);
+}
+
+export function tvHover(el: HTMLElement | null) {
+  clearTvFocusRing();
+  hoveredEl = el;
 }
 
 function clearTvFocusRing() {
@@ -120,6 +135,7 @@ function focusElement(el: HTMLElement) {
   lastFocusedEl = el;
 
   el.focus({ preventScroll: true });
+  if (suppressFocusScroll) return;
   if (isInHero(el)) {
     const scroller = getScrollParent(el);
     if (scroller) scroller.scrollTo({ top: 0, left: 0, behavior: "smooth" });

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -93,6 +93,8 @@ export const DEFAULT: Settings = {
   controllerSupportEnabled: true,
   controllerBackgroundInput: false,
   controllerDeadzone: 0.35,
+  controllerCursorSpeed: 900,
+  controllerKeyboardSize: 100,
   controllerRepeatMs: 140,
   controllerInitialDelayMs: 400,
   trailerQuality: "auto",

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -143,6 +143,8 @@ export type Settings = {
   controllerSupportEnabled: boolean;
   controllerBackgroundInput: boolean;
   controllerDeadzone: number;
+  controllerCursorSpeed: number;
+  controllerKeyboardSize: number;
   controllerRepeatMs: number;
   controllerInitialDelayMs: number;
   trailerQuality: "auto" | "360p" | "720p" | "1080p" | "best";

--- a/src/views/manga/manga-browse.tsx
+++ b/src/views/manga/manga-browse.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Search, Star } from "lucide-react";
+import { BookCheck, Clock3, Loader2, Search, Sparkles, Star } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
 import { Poster } from "@/components/poster";
@@ -17,6 +17,8 @@ import { BrowseEmpty, BrowseError, SkeletonGrid } from "./manga-browse/states";
 import { CollectionBadges } from "./collection-badge";
 
 type Status = "loading" | "ready" | "error";
+type SortMode = "latest" | "new" | "chapters";
+type StatusFilter = "all" | "completed" | "ongoing";
 
 const GRID = "repeat(auto-fill, minmax(150px, 1fr))";
 
@@ -30,6 +32,8 @@ export function MangaBrowse({
   const t = useT();
   const [query, setQuery] = useState("");
   const [tagId, setTagId] = useState("");
+  const [sortMode, setSortMode] = useState<SortMode>("latest");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const { items: favItems } = useMangaFavorites();
   const [items, setItems] = useState<MangaSummary[]>([]);
   const [status, setStatus] = useState<Status>("loading");
@@ -130,19 +134,23 @@ export function MangaBrowse({
   }, [status, hasMore, items.length, fetchPage]);
 
   const displayItems = useMemo(() => {
+    let list: MangaSummary[];
     if (tagId === FAVORITES) {
       const qf = query.trim().toLowerCase();
       const favs = [...favItems.values()]
         .sort((a, b) => b.addedAt - a.addedAt)
         .map((e) => ({ id: e.id, title: e.title, cover: e.cover }));
-      return qf ? favs.filter((m) => m.title.toLowerCase().includes(qf)) : favs;
+      list = qf ? favs.filter((m) => m.title.toLowerCase().includes(qf)) : favs;
+    } else {
+      const favs: MangaSummary[] = [], rest: MangaSummary[] = [];
+      for (const m of items) (favItems.has(m.id) ? favs : rest).push(m);
+      list = favs.length ? [...favs, ...rest] : items;
     }
-    if (favItems.size === 0) return items;
-    const favs: MangaSummary[] = [];
-    const rest: MangaSummary[] = [];
-    for (const m of items) (favItems.has(m.id) ? favs : rest).push(m);
-    return favs.length ? [...favs, ...rest] : items;
-  }, [items, favItems, tagId, query]);
+    if (statusFilter !== "all") list = list.filter((m) => mangaStatus(m.status) === statusFilter);
+    if (sortMode === "new") return [...list].sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+    if (sortMode === "chapters") return [...list].sort((a, b) => chapterNumber(b.lastChapter) - chapterNumber(a.lastChapter));
+    return list;
+  }, [items, favItems, tagId, query, sortMode, statusFilter]);
 
   const loadMore = useCallback(() => {
     if (loadingMore || status !== "ready" || !hasMore) return;
@@ -200,6 +208,14 @@ export function MangaBrowse({
         <SourceDropdown onManageSources={onManageSources} />
         <TagDropdown tagId={tagId} onSelect={setTagId} />
       </div>
+      <div className="-mt-3 flex flex-wrap items-center gap-2 border-b border-edge-soft/60 pb-4">
+        <FilterButton active={sortMode === "latest"} onClick={() => setSortMode("latest")} icon={<Clock3 size={14} />} label={t("Latest")} />
+        <FilterButton active={sortMode === "new"} onClick={() => setSortMode("new")} icon={<Sparkles size={14} />} label={t("New releases")} />
+        <FilterButton active={sortMode === "chapters"} onClick={() => setSortMode("chapters")} icon={<BookCheck size={14} />} label={t("Latest chapters")} />
+        <span className="mx-1 h-5 w-px bg-edge-soft" />
+        <FilterButton active={statusFilter === "completed"} onClick={() => setStatusFilter(statusFilter === "completed" ? "all" : "completed")} label={t("Completed")} />
+        <FilterButton active={statusFilter === "ongoing"} onClick={() => setStatusFilter(statusFilter === "ongoing" ? "all" : "ongoing")} label={t("Ongoing")} />
+      </div>
 
       {status === "loading" ? (
         <SkeletonGrid />
@@ -229,6 +245,21 @@ export function MangaBrowse({
       )}
     </div>
   );
+}
+
+function chapterNumber(value?: string): number {
+  return Number(value?.match(/\d+(?:\.\d+)?/)?.[0]) || 0;
+}
+
+function mangaStatus(value?: string): StatusFilter {
+  const status = value?.toLowerCase() ?? "";
+  if (/complete|finished|ended/.test(status)) return "completed";
+  if (/ongoing|publishing|releasing|serialization/.test(status)) return "ongoing";
+  return "all";
+}
+
+function FilterButton({ active, onClick, icon, label }: { active: boolean; onClick: () => void; icon?: React.ReactNode; label: string }) {
+  return <button type="button" onClick={onClick} className={`inline-flex h-9 items-center gap-1.5 rounded-full px-3.5 text-[12.5px] font-semibold transition-colors ${active ? "bg-ink text-canvas" : "bg-elevated/40 text-ink-muted ring-1 ring-edge-soft/60 hover:bg-elevated hover:text-ink"}`}>{icon}{label}</button>;
 }
 
 function MangaCard({ manga, onOpen }: { manga: MangaSummary; onOpen: (id: string) => void }) {

--- a/src/views/manga/manga-browse/filters.tsx
+++ b/src/views/manga/manga-browse/filters.tsx
@@ -149,7 +149,7 @@ export function TagDropdown({
 
   const active = tags.find((t) => t.id === tagId);
   const sourceMode = tags.length > 0 && tags.every((tg) => tg.group === "Sources");
-  const allLabel = sourceMode ? "All sources" : "All tags";
+  const allLabel = sourceMode ? "All sources" : "Categories";
   const shown = useMemo(() => {
     const q = filter.trim().toLowerCase();
     const list = q ? tags.filter((t) => t.name.toLowerCase().includes(q)) : tags;

--- a/src/views/manga/manga-detail/chapter-list.tsx
+++ b/src/views/manga/manga-detail/chapter-list.tsx
@@ -49,11 +49,7 @@ function relativeDate(iso?: string): string | null {
   if (hours < 24) return t("{n}h ago", { n: hours });
   const days = Math.round(hours / 24);
   if (days < 7) return t("{n}d ago", { n: days });
-  const weeks = Math.round(days / 7);
-  if (weeks < 5) return t("{n}w ago", { n: weeks });
-  const months = Math.round(days / 30);
-  if (months < 12) return t("{n}mo ago", { n: months });
-  return t("{n}y ago", { n: Math.round(days / 365) });
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(then);
 }
 
 function chapterLabel(chapter: string | null): string {
@@ -386,6 +382,7 @@ export function ChapterList({
   const [view, setView] = useState<ChapterView>(readView);
   const [range, setRange] = useState<number | null>(null);
   const [sourceFilter, setSourceFilter] = useState("");
+  const [sourceChoice, setSourceChoice] = useState<MangaChapter | null>(null);
   const batch = useMangaDownloadBatch(mangaId ?? "");
 
   useEffect(() => {
@@ -412,11 +409,34 @@ export function ChapterList({
     if (sourceFilter && !sourceOptions.some((o) => o.id === sourceFilter)) setSourceFilter("");
   }, [sourceOptions, sourceFilter]);
 
-  const scoped = useMemo(
+  const rawScoped = useMemo(
     () =>
       sourceFilter ? chapters.filter((c) => chapterSourceId(c.id) === sourceFilter) : chapters,
     [chapters, sourceFilter],
   );
+
+  const chapterGroups = useMemo(() => {
+    const groups = new Map<string, MangaChapter[]>();
+    for (const c of rawScoped) {
+      const number = c.chapter == null ? NaN : Number(c.chapter);
+      const identity = Number.isFinite(number) ? String(number) : c.chapter ?? c.title?.trim().toLowerCase() ?? "oneshot";
+      const key = `${c.language}|${identity}`;
+      groups.set(key, [...(groups.get(key) ?? []), c]);
+    }
+    const list: MangaChapter[] = [], options = new Map<string, MangaChapter[]>();
+    for (const group of groups.values()) {
+      const sources = new Set(group.map((c) => chapterSourceId(c.id)).filter(Boolean));
+      if (sources.size < 2) {
+        for (const c of group) { list.push(c); options.set(c.id, [c]); }
+        continue;
+      }
+      const sorted = [...group].sort((a, b) => new Date(b.publishAt ?? 0).getTime() - new Date(a.publishAt ?? 0).getTime());
+      list.push(sorted[0]);
+      options.set(sorted[0].id, sorted);
+    }
+    return { list, options };
+  }, [rawScoped]);
+  const scoped = chapterGroups.list;
 
   const animeEndId = useMemo(() => {
     if (animeEndChapter == null) return null;
@@ -475,6 +495,12 @@ export function ChapterList({
     () => (sort === "newest" ? [...ascending].reverse() : ascending),
     [ascending, sort],
   );
+  const readChapter = (chapter: MangaChapter, selected = chapter) => {
+    const options = chapterGroups.options.get(chapter.id) ?? [chapter];
+    if (selected === chapter && options.length > 1) { setSourceChoice(chapter); return; }
+    const list = ascending.map((c) => c.id === chapter.id ? selected : c);
+    onRead(list, list.findIndex((c) => c.id === selected.id));
+  };
 
   if (chapters.length === 0) {
     return (
@@ -665,12 +691,7 @@ export function ChapterList({
               <button
                 key={c.id}
                 type="button"
-                onClick={() =>
-                  onRead(
-                    ascending,
-                    ascending.findIndex((x) => x.id === c.id),
-                  )
-                }
+                onClick={() => readChapter(c)}
                 className={`group flex min-h-[64px] w-full items-center justify-between gap-4 border-b border-edge-soft/60 px-5 py-3.5 text-start transition-colors last:border-b-0 hover:bg-elevated/40 ${
                   cur ? "bg-accent/5" : ""
                 }`}
@@ -719,12 +740,7 @@ export function ChapterList({
               <button
                 key={c.id}
                 type="button"
-                onClick={() =>
-                  onRead(
-                    ascending,
-                    ascending.findIndex((x) => x.id === c.id),
-                  )
-                }
+                onClick={() => readChapter(c)}
                 className={`group flex min-h-[64px] flex-col justify-between gap-2 rounded-xl border bg-surface/60 px-4 py-3.5 text-start transition-colors hover:bg-elevated/60 ${
                   cur ? "border-accent/70" : "border-edge-soft hover:border-edge"
                 }`}
@@ -764,6 +780,26 @@ export function ChapterList({
               </button>
             );
           })}
+        </div>
+      )}
+      {sourceChoice && (
+        <div className="fixed inset-0 z-[80] grid place-items-center bg-black/65 p-6 backdrop-blur-sm" onClick={() => setSourceChoice(null)}>
+          <div className="w-full max-w-md overflow-hidden rounded-2xl border border-edge bg-elevated shadow-[0_24px_80px_rgba(0,0,0,0.65)]" onClick={(e) => e.stopPropagation()}>
+            <div className="border-b border-edge-soft px-5 py-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-ink-subtle">{t("Choose source")}</p>
+              <h3 className="mt-1 text-[18px] font-semibold text-ink">{chapterLabel(sourceChoice.chapter)}</h3>
+            </div>
+            <div className="max-h-[55vh] overflow-y-auto p-2">
+              {(chapterGroups.options.get(sourceChoice.id) ?? [sourceChoice]).map((option) => {
+                const source = sourceOptions.find((s) => s.id === chapterSourceId(option.id));
+                return <button key={option.id} type="button" onClick={() => { setSourceChoice(null); readChapter(sourceChoice, option); }} className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-start transition-colors hover:bg-raised">
+                  <SourceIcon iconUrl={source?.iconUrl} />
+                  <span className="min-w-0 flex-1"><span className="block truncate text-[14px] font-semibold text-ink">{source?.name ?? option.group ?? t("Source")}</span><span className="block truncate text-[12px] text-ink-subtle">{relativeDate(option.publishAt) ?? option.group}</span></span>
+                  <BookOpen size={17} className="text-ink-subtle" />
+                </button>;
+              })}
+            </div>
+          </div>
         </div>
       )}
     </section>

--- a/src/views/player/drag-click-stage.tsx
+++ b/src/views/player/drag-click-stage.tsx
@@ -8,6 +8,7 @@ export function DragClickStage(props: {
   const { drawMode, pipMode, onClick, onDoubleClick, onWheelVolume } = props;
   return (
     <div
+      data-player-click-stage
       className="pointer-events-auto absolute inset-0 z-[3]"
       onWheel={(e) => {
         if (drawMode || pipMode) return;

--- a/src/views/player/hooks/use-chrome-visibility.ts
+++ b/src/views/player/hooks/use-chrome-visibility.ts
@@ -19,6 +19,12 @@ export function useChromeVisibility(params: {
   const chromeVisibleRef = useRef(false);
   useEffect(() => {
     chromeVisibleRef.current = chromeVisible;
+    document.documentElement.toggleAttribute("data-player-chrome-visible", chromeVisible);
+    document.documentElement.setAttribute("data-player-chrome-mounted", "");
+    return () => {
+      document.documentElement.removeAttribute("data-player-chrome-visible");
+      document.documentElement.removeAttribute("data-player-chrome-mounted");
+    };
   }, [chromeVisible]);
 
   const hideTimer = useRef<number | null>(null);

--- a/src/views/settings/controllers-panel.tsx
+++ b/src/views/settings/controllers-panel.tsx
@@ -7,17 +7,21 @@ import { ControllerPreview } from "./controllers-panel/controller-preview";
 
 const BROWSE_MAP: Array<{ control: string; action: string }> = [
   { control: "D-pad", action: "Move focus" },
-  { control: "A / Cross", action: "Select" },
+  { control: "A / Cross", action: "Click cursor" },
+  { control: "Right stick", action: "Move cursor" },
+  { control: "Left stick", action: "Scroll" },
   { control: "B / Circle", action: "Back" },
   { control: "Menu / Options", action: "Home" },
 ];
 
 const PLAYER_MAP: Array<{ control: string; action: string }> = [
-  { control: "A / Cross", action: "Play or pause" },
+  { control: "A / Cross", action: "Click cursor" },
+  { control: "Right stick", action: "Move cursor" },
+  { control: "Left stick", action: "Scroll" },
   { control: "X / Square", action: "Subtitles" },
   { control: "Y / Triangle", action: "Stats overlay" },
   { control: "Bumpers (LB / RB)", action: "Previous or next episode" },
-  { control: "Triggers (LT / RT)", action: "Seek back or forward" },
+  { control: "D-pad left / right", action: "Seek back or forward" },
   { control: "D-pad up / down", action: "Volume up or down" },
   { control: "B / Circle", action: "Exit player" },
 ];
@@ -115,6 +119,26 @@ export function ControllersPanel() {
           value={settings.controllerDeadzone}
           display={`${Math.round(settings.controllerDeadzone * 100)}%`}
           onChange={(v) => update({ controllerDeadzone: v })}
+        />
+        <SliderRow
+          label={t("Cursor speed")}
+          sub={t("How quickly the Harbor cursor moves with the right stick.")}
+          min={300}
+          max={1500}
+          step={100}
+          value={settings.controllerCursorSpeed}
+          display={t("{n} px/s", { n: settings.controllerCursorSpeed })}
+          onChange={(v) => update({ controllerCursorSpeed: v })}
+        />
+        <SliderRow
+          label={t("Keyboard size")}
+          sub={t("Size of the controller on-screen keyboard.")}
+          min={70}
+          max={130}
+          step={5}
+          value={settings.controllerKeyboardSize}
+          display={`${settings.controllerKeyboardSize}%`}
+          onChange={(v) => update({ controllerKeyboardSize: v })}
         />
         <SliderRow
           label={t("Repeat speed")}


### PR DESCRIPTION
## Summary
- add a Harbor-branded controller cursor driven by the right stick, with hover, click, player, seek-bar, and left-stick scrolling support
- add a controller on-screen keyboard with D-pad navigation, language/numeric layouts, shortcuts, and configurable cursor speed and keyboard size
- add manga browsing filters, relative release times, deduplicated chapters, and source selection

## Controller mappings
- Right stick: move Harbor cursor
- Left stick: scroll vertically
- A / Cross: activate the element beneath the cursor
- X / Square: subtitles in the player and backspace on the controller keyboard
- Y / Triangle: space on the controller keyboard
- D-pad: context-aware navigation, including the controller keyboard

## Testing
- manually exercised the controller cursor, hover states, scrolling, on-screen keyboard, and player interactions in the desktop app