### PR TITLE
fix(localization): keep localized search results and posters from falling back to English

### DIFF
--- a/src/components/pick-card.tsx
+++ b/src/components/pick-card.tsx
@@ -240,7 +240,7 @@ const PosterCard = memo(function PosterCard({
 
   const [imgIdx, setImgIdx] = useState(0);
   const [hydratedPoster, setHydratedPoster] = useState<string | undefined>();
-  const localizedPoster = useLocalizedPoster(meta.id);
+  const { url: localizedPoster, localizing: posterLocalizing } = useLocalizedPoster(meta.id);
   const wantTmdbPoster = needsTmdbForPoster(settings.rpdbKey, meta.id);
   const resolvedTmdb = useTmdbIdFromImdb(wantTmdbPoster ? meta.id : undefined);
   const animeTmdb = useTmdbIdFromImdb(animeImdb) ?? undefined;
@@ -257,6 +257,7 @@ const PosterCard = memo(function PosterCard({
   const pinnedPoster = useTitlePoster(meta.id);
   const posterCandidates = useMemo(() => {
     if (posterPending && !pinnedPoster) return [];
+    if (posterLocalizing) return pinnedPoster ? [pinnedPoster] : [];
     const base = localizedPoster ?? meta.poster;
     const seen = new Set<string>();
     const out: string[] = [];
@@ -274,7 +275,7 @@ const PosterCard = memo(function PosterCard({
       out.push(u);
     }
     return out;
-  }, [settings.rpdbKey, meta.id, posterAltId, meta.poster, meta.background, hydratedPoster, animeImdb, animeTvdb, animeTmdb, localizedPoster, posterPending, pinnedPoster]);
+  }, [settings.rpdbKey, meta.id, posterAltId, meta.poster, meta.background, hydratedPoster, animeImdb, animeTvdb, animeTmdb, localizedPoster, posterLocalizing, posterPending, pinnedPoster]);
   const posterSrc = posterCandidates[imgIdx];
 
   useEffect(() => {

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -16,27 +16,39 @@ import { useProxiedImageSrc } from "@/lib/remote-image-proxy";
 
 type Ratio = "portrait" | "landscape" | "wide";
 
-export function useLocalizedPoster(metaId: string): string | undefined {
+export function useLocalizedPoster(metaId: string): { url: string | undefined; localizing: boolean } {
   const { settings } = useSettings();
   const [url, setUrl] = useState<string | undefined>(undefined);
+  const [localizing, setLocalizing] = useState<boolean>(() => {
+    const canResolve = metaId.startsWith("tmdb:") || metaId.startsWith("tt");
+    return !!settings.tmdbKey && canResolve && shouldLocalizePosters();
+  });
   useEffect(() => {
     setUrl(undefined);
     const canResolve = metaId.startsWith("tmdb:") || metaId.startsWith("tt");
-    if (!settings.tmdbKey || !canResolve || !shouldLocalizePosters()) return;
+    const active = !!settings.tmdbKey && canResolve && shouldLocalizePosters();
+    setLocalizing(active);
+    if (!active) return;
     let alive = true;
     void (async () => {
       const tmdbId = metaId.startsWith("tmdb:")
         ? metaId
         : await tmdbIdFromImdb(settings.tmdbKey, metaId);
-      if (!tmdbId) return;
+      if (!alive) return;
+      if (!tmdbId) {
+        setLocalizing(false);
+        return;
+      }
       const localized = await tmdbLocalizedPoster(settings.tmdbKey, tmdbId);
-      if (alive && localized) setUrl(localized);
+      if (!alive) return;
+      if (localized) setUrl(localized);
+      setLocalizing(false);
     })();
     return () => {
       alive = false;
     };
   }, [metaId, settings.tmdbKey]);
-  return url;
+  return { url, localizing };
 }
 
 export function useRpdbAltId(
@@ -112,21 +124,23 @@ export function usePosterChain(
 ) {
   const { altId, pending } = useRpdbAltId(rpdbKey, metaId, type);
   const { animeImdb, animeTvdb, animeTmdb } = useAnimeRpdbIds(rpdbKey, metaId);
-  const localized = useLocalizedPoster(metaId);
+  const { url: localized, localizing } = useLocalizedPoster(metaId);
   const pinned = useTitlePoster(metaId);
   const candidates = useMemo(() => {
     if (pending && !pinned) return [];
     const base = localized ?? metaPoster;
     const out: string[] = [];
     const seen = new Set<string>();
-    for (const u of [
-      pinned,
+    // While the localized poster is being resolved, hold the artwork instead of flashing the
+    // original-language (e.g. Japanese) search poster, which then swaps to English once resolved.
+    const fallbacks = localizing ? [pinned] : [
       animeImdb ? rpdbPoster(rpdbKey, animeImdb, base, animeTmdb) : undefined,
       animeTvdb ? rpdbPoster(rpdbKey, `tvdb:${animeTvdb}`, base) : undefined,
       rpdbPoster(rpdbKey, metaId, base, altId),
       localized,
       metaPoster,
-    ]) {
+    ];
+    for (const u of [pinned, ...fallbacks]) {
       if (u && !seen.has(u)) {
         seen.add(u);
         out.push(u);
@@ -142,6 +156,7 @@ export function usePosterChain(
     animeTvdb,
     animeTmdb,
     localized,
+    localizing,
     pending,
     pinned,
   ]);

--- a/src/lib/providers/anime-episode-build.ts
+++ b/src/lib/providers/anime-episode-build.ts
@@ -79,6 +79,12 @@ const EPISODE_NUMBER_WORDS = [
   "aflevering",
   "avsnitt",
   "tập",
+  "episod",
+  "epizoda",
+  "epizod",
+  "dil",
+  "resz",
+  "jakso",
 ];
 
 export function isGenericEpisodeName(text: string | null | undefined): boolean {
@@ -89,7 +95,12 @@ export function isGenericEpisodeName(text: string | null | undefined): boolean {
   // Compact CJK forms like 第18話 / 第18集 / 18화
   if (/^第\s*\d+\s*[話话集]$/.test(t)) return true;
   if (/^\d+\s*화$/.test(t)) return true;
-  const lower = t.toLowerCase();
+  // Fold accents (Épisode→episode, Bölüm→bolum, Rész→resz) so one ASCII list
+  // covers every locale's "Episode N" placeholder regardless of diacritics.
+  const lower = t
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
   for (const word of EPISODE_NUMBER_WORDS) {
     if (!lower.includes(word)) continue;
     const rest = lower.replace(word, "").replace(/[\s\-–—:.,()\[\]'"،،]/g, "");

--- a/src/lib/providers/tmdb.ts
+++ b/src/lib/providers/tmdb.ts
@@ -62,6 +62,7 @@ export {
 export {
   tmdbDetails,
   tmdbSeasonEpisodes,
+  tmdbSeasonEpisodesPair,
   type CastEntry,
   type CrewEntry,
   type Season,

--- a/src/lib/providers/tmdb/tmdb-details.ts
+++ b/src/lib/providers/tmdb/tmdb-details.ts
@@ -447,6 +447,21 @@ export async function tmdbDetails(key: string, meta: Meta, lang?: string): Promi
   };
 }
 
+function toSeasonEpisodes(d: any): Episode[] {
+  if (!d?.episodes) return [];
+  return d.episodes.map((e: any) => ({
+    id: e.id,
+    episodeNumber: e.episode_number,
+    seasonNumber: e.season_number,
+    name: e.name ?? "",
+    overview: e.overview ?? "",
+    stillPath: e.still_path ?? null,
+    airDate: e.air_date ?? null,
+    runtime: e.runtime ?? null,
+    voteAverage: e.vote_average ?? null,
+  }));
+}
+
 export async function tmdbSeasonEpisodes(
   key: string,
   tvId: number,
@@ -458,20 +473,7 @@ export async function tmdbSeasonEpisodes(
   const data = await get<any>(key, `tv/${tvId}/season/${seasonNumber}`, {
     language: requested,
   });
-  if (!data?.episodes) return [];
-  const toEpisodes = (d: any): Episode[] =>
-    d.episodes.map((e: any) => ({
-      id: e.id,
-      episodeNumber: e.episode_number,
-      seasonNumber: e.season_number,
-      name: e.name ?? "",
-      overview: e.overview ?? "",
-      stillPath: e.still_path ?? null,
-      airDate: e.air_date ?? null,
-      runtime: e.runtime ?? null,
-      voteAverage: e.vote_average ?? null,
-    }));
-  const episodes = toEpisodes(data);
+  const episodes = toSeasonEpisodes(data);
   const base = requested.split("-")[0]?.toLowerCase() ?? "";
   const wantsEnglishFallback = base !== "" && base !== "en" && base !== "ja";
   const japanese = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF]/;
@@ -479,7 +481,28 @@ export async function tmdbSeasonEpisodes(
     episodes.some((e) => japanese.test(e.name) || japanese.test(e.overview));
   if (fellBackToJapanese) {
     const en = await get<any>(key, `tv/${tvId}/season/${seasonNumber}`, { language: "en-US" });
-    if (en?.episodes) return toEpisodes(en);
+    if (en?.episodes) return toSeasonEpisodes(en);
   }
   return episodes;
+}
+
+/// Returns episodes in the requested language together with the en-US list, so callers can
+/// detect silent fallback: a title/overview identical to the English one means TMDB had no
+/// translation for that field, even when scripts can't tell the two apart (tr/de/vi…).
+export async function tmdbSeasonEpisodesPair(
+  key: string,
+  tvId: number,
+  seasonNumber: number,
+  lang?: string,
+): Promise<{ episodes: Episode[]; en: Episode[] }> {
+  if (!key) return { episodes: [], en: [] };
+  const requested = lang ?? (effectiveTmdbLanguage() || "en");
+  const isEn = requested.split("-")[0]?.toLowerCase() === "en";
+  const [locData, enData] = await Promise.all([
+    get<any>(key, `tv/${tvId}/season/${seasonNumber}`, { language: requested }),
+    isEn
+      ? Promise.resolve(null)
+      : get<any>(key, `tv/${tvId}/season/${seasonNumber}`, { language: "en-US" }).catch(() => null),
+  ]);
+  return { episodes: toSeasonEpisodes(locData), en: toSeasonEpisodes(enData) };
 }

--- a/src/lib/providers/tmdb/tmdb-image-lang.ts
+++ b/src/lib/providers/tmdb/tmdb-image-lang.ts
@@ -55,5 +55,10 @@ export function pickedImageLangs(): string[] {
 
 export function shouldLocalizePosters(): boolean {
   const top = imageRequestLang();
-  return !!top && top !== "en";
+  if (!!top && top !== "en") return true;
+  // Posters should also follow the metadata language (search returns the original-language
+  // poster when the requested translation has none), falling back to English downstream.
+  const meta = loadStoredSettings().tmdbLanguage;
+  const base = (meta ?? "").split("-")[0]?.toLowerCase() ?? "";
+  return base !== "" && base !== "en";
 }

--- a/src/lib/providers/tmdb/tmdb-images.ts
+++ b/src/lib/providers/tmdb/tmdb-images.ts
@@ -1,5 +1,6 @@
 import { lruSet } from "@/lib/cache";
 import { registerCache } from "@/lib/memory-profiler";
+import { loadStoredSettings } from "@/lib/settings/load";
 import { get, IMG } from "./tmdb-client";
 import { imageLangParam, imageLangRank, pickedImageLangs } from "./tmdb-image-lang";
 
@@ -55,16 +56,24 @@ export const pickLogo = (logos: LogoEntry[], originalLang?: string | null): stri
 };
 
 export async function tmdbLocalizedPoster(key: string, metaId: string): Promise<string | undefined> {
-  const picks = pickedImageLangs();
-  if (!picks.length) return undefined;
-  const assets = await fetchMovieAssets(key, metaId);
-  const posters = (assets?.posters ?? []).filter(
-    (p) => typeof p.iso_639_1 === "string" && picks.includes(p.iso_639_1),
-  );
+  const st = loadStoredSettings();
+  const metaBase = (st.tmdbLanguage ?? "").split("-")[0]?.toLowerCase() ?? "";
+  // Prefer the metadata language, then configured image languages, then English, then original —
+  // so a missing localized poster falls back to English rather than the original-language (e.g. Japanese).
+  const want: string[] = [];
+  const add = (c: string | null) => {
+    if (c && !want.includes(c)) want.push(c);
+  };
+  if (metaBase && metaBase !== "en") add(metaBase);
+  for (const c of pickedImageLangs()) add(c);
+  add("en");
+  if (want.length === 0) return undefined;
+  const assets = await fetchMovieAssets(key, metaId, want[0] ?? null);
+  const posters = assets?.posters ?? [];
   if (!posters.length) return undefined;
   const rank = (iso?: string | null) => {
-    const i = picks.indexOf(iso ?? "");
-    return i === -1 ? -1 : picks.length - i;
+    const i = want.indexOf(iso ?? "");
+    return i === -1 ? -1 : want.length - i;
   };
   const best = [...posters].sort(
     (a, b) => rank(b.iso_639_1) - rank(a.iso_639_1) || (b.vote_average ?? 0) - (a.vote_average ?? 0),

--- a/src/lib/providers/tmdb/tmdb-meta-mappers.ts
+++ b/src/lib/providers/tmdb/tmdb-meta-mappers.ts
@@ -72,19 +72,26 @@ function genresFromIds(ids: number[] | undefined, kind: "movie" | "tv"): string[
   return names.length > 0 ? names : undefined;
 }
 
-export const movieMeta = (m: RawMovie, englishName?: string): Meta => {
+export const movieMeta = (
+  m: RawMovie,
+  english?: { name?: string; overview?: string },
+): Meta => {
   const st = loadStoredSettings();
   const translate = st.translateTitles;
   const anime = isAnimeItem(m);
   let name = translate ? m.title : anime ? m.title : m.original_title || m.title;
-  if (anime && translate && englishName && JAPANESE_SCRIPT.test(name)) name = englishName;
+  if (anime && translate && english?.name && JAPANESE_SCRIPT.test(name)) name = english.name;
+  // TMDB returns a blank or original-language value when the requested language has no
+  // translation; fall back to English so non-localized titles still show readable info.
+  if (translate && (!name.trim() || JAPANESE_SCRIPT.test(name)) && english?.name) name = english.name;
+  const description = (translate && !m.overview?.trim() && english?.overview) ? english.overview : m.overview;
   return {
     id: `tmdb:movie:${m.id}`,
     type: "movie",
     name,
     poster: poster(m.poster_path),
     background: back(m.backdrop_path),
-    description: m.overview,
+    description,
     originalLanguage: m.original_language,
     releaseInfo: year(m.release_date),
     releaseDate: m.release_date,
@@ -94,19 +101,24 @@ export const movieMeta = (m: RawMovie, englishName?: string): Meta => {
   };
 };
 
-export const seriesMeta = (s: RawSeries, englishName?: string): Meta => {
+export const seriesMeta = (
+  s: RawSeries,
+  english?: { name?: string; overview?: string },
+): Meta => {
   const st = loadStoredSettings();
   const translate = st.translateTitles;
   const anime = isAnimeItem(s);
   let name = translate ? s.name : anime ? s.name : s.original_name || s.name;
-  if (anime && translate && englishName && JAPANESE_SCRIPT.test(name)) name = englishName;
+  if (anime && translate && english?.name && JAPANESE_SCRIPT.test(name)) name = english.name;
+  if (translate && (!name.trim() || JAPANESE_SCRIPT.test(name)) && english?.name) name = english.name;
+  const description = (translate && !s.overview?.trim() && english?.overview) ? english.overview : s.overview;
   return {
     id: `tmdb:tv:${s.id}`,
     type: "series",
     name,
     poster: poster(s.poster_path),
     background: back(s.backdrop_path),
-    description: s.overview,
+    description,
     originalLanguage: s.original_language,
     releaseInfo: year(s.first_air_date),
     releaseDate: s.first_air_date,

--- a/src/lib/providers/tvdb.ts
+++ b/src/lib/providers/tvdb.ts
@@ -308,10 +308,12 @@ export async function tvdbEpisodes(
   lang?: string,
 ): Promise<TvdbEpisode[]> {
   if (!seriesId) return [];
-  const langSeg = lang ? `&language=${lang}` : "";
+  // Language must be a path segment on this endpoint — TVDB ignores `language=` as a
+  // query param here and silently serves the series' original language instead.
+  const langSeg = lang ? `/${lang}` : "";
   const data = await getJson<any>(
     apiKey,
-    `/series/${seriesId}/episodes/default?season=${season}${langSeg}`,
+    `/series/${seriesId}/episodes/default${langSeg}?season=${season}`,
   );
   const arr = data?.episodes ?? [];
   return (arr as any[])

--- a/src/lib/search-context.tsx
+++ b/src/lib/search-context.tsx
@@ -101,20 +101,6 @@ function normShow(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
-function sameShow(a: string, b: string): boolean {
-  const x = normShow(a);
-  return x.length > 0 && x === normShow(b);
-}
-
-function animeKindFromFormat(
-  format: string | null,
-  fallback: "movie" | "series",
-): "movie" | "series" {
-  const fmt = (format ?? "").toUpperCase();
-  if (!fmt) return fallback;
-  return fmt === "MOVIE" ? "movie" : "series";
-}
-
 function loadRecent(): string[] {
   try {
     const raw = localStorage.getItem(RECENT_KEY);
@@ -302,33 +288,10 @@ export function SearchProvider({ children }: { children: ReactNode }) {
         const dedupedGroups = acc.groups
           .map((g) => ({ ...g, metas: dropAnime(g.metas.filter((m) => !shown.has(m.id))) }))
           .filter((g) => g.metas.length > 0);
-        const animeTop = acc.anime[0];
-        const animeTopKind: "movie" | "series" = animeTop
-          ? animeKindFromFormat(animeTop.format, base.topMatch?.kind ?? "series")
-          : "series";
-        const topMatch =
-          animeTop && base.topMatch && sameShow(base.topMatch.meta.name, animeTop.name)
-            ? {
-                kind: animeTopKind,
-                meta: {
-                  id: animeTop.kitsuId
-                    ? `kitsu:${animeTop.kitsuId}`
-                    : animeTop.malId
-                      ? `mal:${animeTop.malId}`
-                      : `anilist:${animeTop.anilistId}`,
-                  type: animeTopKind,
-                  name: animeTop.name,
-                  poster: animeTop.poster ?? base.topMatch.meta.poster,
-                  background: animeTop.background ?? undefined,
-                  description: animeTop.overview || undefined,
-                  releaseInfo: animeTop.year ?? undefined,
-                },
-                popularity: base.topMatch.popularity,
-                backdrop: animeTop.background ?? base.topMatch.backdrop,
-                overview: animeTop.overview || base.topMatch.overview,
-                voteAverage: base.topMatch.voteAverage,
-              }
-            : base.topMatch;
+        // Keep the top match as the localized TMDB entry. Replacing it with the anime
+        // (MAL/Kitsu) version changed its id and poster, which flickered the localized
+        // result to the English/MAL artwork once the anime search resolved.
+        const topMatch = base.topMatch;
         setResults({
           ...base,
           topMatch: settings.hideContent.anime && topMatch && metaLooksAnime(topMatch.meta) ? null : topMatch,

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -284,7 +284,7 @@ export async function searchAll(
     };
   }
   const metaBase = effectiveTmdbLanguage().split("-")[0]?.toLowerCase() ?? "";
-  let enNameById: Map<number, string> | null = null;
+  let enById: Map<number, { name?: string; overview?: string }> | null = null;
   if (loadStoredSettings().translateTitles && metaBase !== "" && metaBase !== "en" && metaBase !== "ja") {
     const en = await get<Page<MultiItem>>(key, "search/multi", {
       query: trimmed,
@@ -292,10 +292,11 @@ export async function searchAll(
       language: "en-US",
     });
     if (en?.results) {
-      enNameById = new Map();
+      enById = new Map();
       for (const r of en.results) {
         const n = (r as { title?: string; name?: string }).title ?? (r as { name?: string }).name;
-        if (n && typeof r.id === "number") enNameById.set(r.id, n);
+        const o = (r as { overview?: string }).overview;
+        if (typeof r.id === "number" && (n || o)) enById.set(r.id, { name: n, overview: o });
       }
     }
   }
@@ -318,14 +319,14 @@ export async function searchAll(
 
   for (const r of results) {
     if (r.media_type === "movie" && r.poster_path) {
-      movies.push(movieMeta(r, enNameById?.get(r.id)));
+      movies.push(movieMeta(r, enById?.get(r.id)));
       const pop = r.popularity ?? 0;
       if (pop > topPop) {
         topRaw = r;
         topPop = pop;
       }
     } else if (r.media_type === "tv" && r.poster_path) {
-      series.push(seriesMeta(r, enNameById?.get(r.id)));
+      series.push(seriesMeta(r, enById?.get(r.id)));
       const pop = r.popularity ?? 0;
       if (pop > topPop) {
         topRaw = r;
@@ -363,8 +364,8 @@ export async function searchAll(
     topMatch = {
       kind: isMovie ? "movie" : "series",
       meta: isMovie
-        ? movieMeta(winner as RawMovie, enNameById?.get(winner.id))
-        : seriesMeta(winner as RawSeries, enNameById?.get(winner.id)),
+        ? movieMeta(winner as RawMovie, enById?.get(winner.id))
+        : seriesMeta(winner as RawSeries, enById?.get(winner.id)),
       popularity: winner.popularity ?? 0,
       backdrop: winner.backdrop_path ? `https://image.tmdb.org/t/p/w1280${winner.backdrop_path}` : undefined,
       overview: winner.overview,

--- a/src/views/detail/series-episodes.tsx
+++ b/src/views/detail/series-episodes.tsx
@@ -262,16 +262,22 @@ export function SeriesEpisodes({
     }
     return orderedEpsRaw.map((ep) => {
       const tmdbEp = airedLike ? tmdbByKey.get(`${ep.seasonNumber}:${ep.episodeNumber}`) : undefined;
+      // TMDB cache holds episodes fetched with the requested metadata language, so its text is
+      // canonical; script ranking can't separate e.g. Turkish from English, so a length
+      // tie-break must never let longer TVDB English overwrite a real translation.
+      const tmdbName = (tmdbEp?.name ?? "").trim();
       const name =
-        pickLocalizedText(
-          [{ text: ep.name }, { text: ep.nameEn ?? "" }, { text: tmdbEp?.name ?? "" }],
+        tmdbName ||
+        (pickLocalizedText(
+          [{ text: ep.name }, { text: ep.nameEn ?? "" }],
           { forName: true, lang },
-        ) ?? ep.name;
+        ) ??
+          ep.name);
+      const tmdbOverview = (tmdbEp?.overview ?? "").trim();
       const overview =
-        pickLocalizedText(
-          [{ text: ep.overview }, { text: ep.overviewEn ?? "" }, { text: tmdbEp?.overview ?? "" }],
-          { lang },
-        ) ?? ep.overview;
+        tmdbOverview ||
+        (pickLocalizedText([{ text: ep.overview }, { text: ep.overviewEn ?? "" }], { lang }) ??
+          ep.overview);
       let next = { ...ep, name, overview };
       if (ep.imdbRating == null) {
         const r = imdbRatings.get(`${ep.seasonNumber}:${ep.episodeNumber}`);

--- a/src/views/detail/series-episodes.tsx
+++ b/src/views/detail/series-episodes.tsx
@@ -112,6 +112,10 @@ export function SeriesEpisodes({
     return s;
   }, [stremioWatched, simklWatched, traktWatched, meta.id, mwVersion]);
   const cache = useRef<Map<number, Episode[]>>(new Map());
+  // Bumped whenever a TMDB season lands in `cache`. The ordered-episodes merge reads the cache
+  // for its localized-name candidates, but refs don't trigger re-renders — without this counter
+  // an ordering that resolves before the fetch would stay on TVDB's (often English) names forever.
+  const [tmdbCacheVersion, setTmdbCacheVersion] = useState(0);
 
   const traktKey = imdbId ?? meta.id;
 
@@ -213,6 +217,7 @@ export function SeriesEpisodes({
         const m = cache.current;
         m.delete(season);
         m.set(season, eps);
+        setTmdbCacheVersion((v) => v + 1);
         while (m.size > 2) {
           const oldest = m.keys().next().value;
           if (oldest === undefined) break;
@@ -274,7 +279,7 @@ export function SeriesEpisodes({
       }
       return next;
     });
-  }, [orderedEpsRaw, imdbRatings, orderActive, orderSeasonEff, settings.tvdbSeasonType]);
+  }, [orderedEpsRaw, imdbRatings, orderActive, orderSeasonEff, settings.tvdbSeasonType, tmdbCacheVersion]);
   const visibleOrderedEps = useMemo(
     () =>
       hideActive && hiddenSet.size > 0

--- a/src/views/detail/series-episodes.tsx
+++ b/src/views/detail/series-episodes.tsx
@@ -12,11 +12,11 @@ import { useHiddenEpisodes } from "@/lib/hidden-episodes";
 import type { Meta } from "@/lib/cinemeta";
 import { getEpisodeProgress, resumeDefaultSeason } from "@/lib/episode-progress";
 import { scrollToDataEp } from "@/lib/episode-scroll";
-import { tmdbSeasonEpisodes, type Episode, type Season } from "@/lib/providers/tmdb";
+import { tmdbSeasonEpisodesPair, type Episode, type Season } from "@/lib/providers/tmdb";
 import { tmdbLanguageIso } from "@/lib/providers/tmdb/tmdb-client";
 import type { OrderedEpisode } from "@/lib/providers/tvdb-order";
 import { pickLocalizedText } from "@/lib/localized-text";
-import { isGenericEpisodeName } from "@/lib/providers/anime-episode-build";
+import { isGenericEpisodeName, isUsableLocalizedText } from "@/lib/providers/anime-episode-build";
 import { useSettings } from "@/lib/settings";
 import { effectiveOrderProvider, tvdbPanelEnabled } from "@/lib/settings/episode-order";
 import { useTrakt } from "@/lib/trakt/provider";
@@ -113,6 +113,9 @@ export function SeriesEpisodes({
     return s;
   }, [stremioWatched, simklWatched, traktWatched, meta.id, mwVersion]);
   const cache = useRef<Map<number, Episode[]>>(new Map());
+  // English counterparts for the cached seasons; used to detect TMDB's silent
+  // fallback (localized text identical to en-US ⇒ no real translation exists).
+  const enCache = useRef<Map<number, Episode[]>>(new Map());
   // Bumped whenever a TMDB season lands in `cache`. The ordered-episodes merge reads the cache
   // for its localized-name candidates, but refs don't trigger re-renders — without this counter
   // an ordering that resolves before the fetch would stay on TVDB's (often English) names forever.
@@ -147,6 +150,7 @@ export function SeriesEpisodes({
     imdbId,
     tvdbKey: settings.tvdbKey,
     omdbKey: settings.omdbKey,
+    enEpisodes: enCache.current.get(active),
   });
   const tvdbStills = useSeriesTvdbStills(imdbId, enrichedBase.length, settings.tvdbSeasonType);
   const enrichedEpisodes = useMemo(() => {
@@ -213,16 +217,22 @@ export function SeriesEpisodes({
   useEffect(() => {
     let cancelled = false;
     const load = (season: number): Promise<Episode[]> =>
-      tmdbSeasonEpisodes(settings.tmdbKey, tvId, season).then((eps) => {
+      tmdbSeasonEpisodesPair(settings.tmdbKey, tvId, season).then(({ episodes: eps, en }) => {
         if (cancelled || eps.length === 0) return [];
         const m = cache.current;
         m.delete(season);
         m.set(season, eps);
+        if (en.length > 0) {
+          const em = enCache.current;
+          em.delete(season);
+          em.set(season, en);
+        }
         setTmdbCacheVersion((v) => v + 1);
         while (m.size > 2) {
           const oldest = m.keys().next().value;
           if (oldest === undefined) break;
           m.delete(oldest);
+          enCache.current.delete(oldest);
         }
         return eps;
       });
@@ -263,10 +273,21 @@ export function SeriesEpisodes({
     }
     return orderedEpsRaw.map((ep) => {
       const tmdbEp = airedLike ? tmdbByKey.get(`${ep.seasonNumber}:${ep.episodeNumber}`) : undefined;
-      // Same placeholder rule as the enrich path: generic localized titles ("2. Bölüm",
-      // "الحلقة 1") count as missing so real TVDB/English names still win.
+      const tmdbEpEn = airedLike
+        ? enCache.current.get(orderSeasonEff)?.find(
+            (e) =>
+              `${e.seasonNumber}:${e.episodeNumber}` ===
+              `${ep.seasonNumber}:${ep.episodeNumber}`,
+          )
+        : undefined;
+      // Same rules as the enrich path: generic placeholders AND silent fallback (localized
+      // text identical to its en-US counterpart) count as missing so real translations win.
       const tmdbName = (tmdbEp?.name ?? "").trim();
-      const usableTmdbName = tmdbName && !isGenericEpisodeName(tmdbName) ? tmdbName : "";
+      const tmdbNameIsFallback = lang !== "" && tmdbName === (tmdbEpEn?.name ?? "").trim();
+      const usableTmdbName =
+        tmdbName && !isGenericEpisodeName(tmdbName) && !tmdbNameIsFallback && isUsableLocalizedText(tmdbName, lang)
+          ? tmdbName
+          : "";
       const name =
         usableTmdbName ||
         (pickLocalizedText(
@@ -275,11 +296,26 @@ export function SeriesEpisodes({
         ) ??
           ep.name);
       const tmdbOverview = (tmdbEp?.overview ?? "").trim();
+      const tmdbOverviewIsFallback =
+        lang !== "" && tmdbOverview === (tmdbEpEn?.overview ?? "").trim();
       const overview =
-        tmdbOverview ||
-        (pickLocalizedText([{ text: ep.overview }, { text: ep.overviewEn ?? "" }], { lang }) ??
-          ep.overview);
+        tmdbOverview && !tmdbOverviewIsFallback && isUsableLocalizedText(tmdbOverview, lang)
+          ? tmdbOverview
+          : (pickLocalizedText([{ text: ep.overview }, { text: ep.overviewEn ?? "" }], { lang }) ??
+            ep.overview);
       let next = { ...ep, name, overview };
+      // Inside the order pair, a requested-language string differing from its English twin
+      // is a genuine translation — script ranking can't separate them for Latin targets
+      // and the length tie-break lets longer English win. TMDB keeps precedence when it
+      // also verified as real.
+      const ordName = (ep.name ?? "").trim();
+      const ordNameIsReal = lang !== "" && ordName !== "" && ordName !== (ep.nameEn ?? "").trim();
+      const ordOverview = (ep.overview ?? "").trim();
+      const ordOverviewIsReal =
+        lang !== "" && ordOverview !== "" && ordOverview !== (ep.overviewEn ?? "").trim();
+      if (ordNameIsReal && !usableTmdbName) next = { ...next, name: ordName };
+      if (ordOverviewIsReal && !(tmdbOverview && isUsableLocalizedText(tmdbOverview, lang)))
+        next = { ...next, overview: ordOverview };
       if (ep.imdbRating == null) {
         const r = imdbRatings.get(`${ep.seasonNumber}:${ep.episodeNumber}`);
         if (r != null && r > 0) next = { ...next, imdbRating: r };

--- a/src/views/detail/series-episodes.tsx
+++ b/src/views/detail/series-episodes.tsx
@@ -16,6 +16,7 @@ import { tmdbSeasonEpisodes, type Episode, type Season } from "@/lib/providers/t
 import { tmdbLanguageIso } from "@/lib/providers/tmdb/tmdb-client";
 import type { OrderedEpisode } from "@/lib/providers/tvdb-order";
 import { pickLocalizedText } from "@/lib/localized-text";
+import { isGenericEpisodeName } from "@/lib/providers/anime-episode-build";
 import { useSettings } from "@/lib/settings";
 import { effectiveOrderProvider, tvdbPanelEnabled } from "@/lib/settings/episode-order";
 import { useTrakt } from "@/lib/trakt/provider";
@@ -262,12 +263,12 @@ export function SeriesEpisodes({
     }
     return orderedEpsRaw.map((ep) => {
       const tmdbEp = airedLike ? tmdbByKey.get(`${ep.seasonNumber}:${ep.episodeNumber}`) : undefined;
-      // TMDB cache holds episodes fetched with the requested metadata language, so its text is
-      // canonical; script ranking can't separate e.g. Turkish from English, so a length
-      // tie-break must never let longer TVDB English overwrite a real translation.
+      // Same placeholder rule as the enrich path: generic localized titles ("2. Bölüm",
+      // "الحلقة 1") count as missing so real TVDB/English names still win.
       const tmdbName = (tmdbEp?.name ?? "").trim();
+      const usableTmdbName = tmdbName && !isGenericEpisodeName(tmdbName) ? tmdbName : "";
       const name =
-        tmdbName ||
+        usableTmdbName ||
         (pickLocalizedText(
           [{ text: ep.name }, { text: ep.nameEn ?? "" }],
           { forName: true, lang },

--- a/src/views/detail/series-episodes/use-episode-enrich.ts
+++ b/src/views/detail/series-episodes/use-episode-enrich.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { isGenericEpisodeName } from "@/lib/providers/anime-episode-build";
 import { harborImdbEpisodes } from "@/lib/providers/harbor-imdb";
 import { omdbSeasonRatings } from "@/lib/providers/omdb";
 import type { Episode } from "@/lib/providers/tmdb";
@@ -73,12 +74,15 @@ export function useEpisodeEnrich({
       let next: Episode = ep;
       const tv = tvdbForSeason?.get(ep.episodeNumber);
       if (tv) {
-        // TMDB episodes were fetched with the requested metadata language, making them the
-        // canonical localized source (their own fallback chain ends in English/original).
-        // Script ranking can't separate Turkish-style Latin text from English, so a length
-        // tie-break there would randomly overwrite real translations with longer TVDB English;
-        // TVDB therefore only fills fields TMDB left empty.
-        const name = (next.name ?? "").trim() ? next.name : tv.name ?? next.name;
+        // TMDB text is canonical for the requested language, but contributors fill
+        // untranslated episodes with generic placeholders ("2. Bölüm", "الحلقة 1") —
+        // treat those as missing so real titles from other sources still win.
+        const tmdbTitle = (next.name ?? "").trim();
+        const tvTitle = (tv.name ?? "").trim();
+        const name =
+          (tmdbTitle && !isGenericEpisodeName(tmdbTitle) ? tmdbTitle : undefined) ??
+          (tvTitle && !isGenericEpisodeName(tvTitle) ? tvTitle : undefined) ??
+          next.name;
         const overview = (next.overview ?? "").trim() ? next.overview : tv.overview ?? next.overview;
         next = {
           ...next,

--- a/src/views/detail/series-episodes/use-episode-enrich.ts
+++ b/src/views/detail/series-episodes/use-episode-enrich.ts
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react";
-import { pickLocalizedText } from "@/lib/localized-text";
 import { harborImdbEpisodes } from "@/lib/providers/harbor-imdb";
 import { omdbSeasonRatings } from "@/lib/providers/omdb";
 import type { Episode } from "@/lib/providers/tmdb";
@@ -74,14 +73,13 @@ export function useEpisodeEnrich({
       let next: Episode = ep;
       const tv = tvdbForSeason?.get(ep.episodeNumber);
       if (tv) {
-        // pickLocalizedText keys script tests by ISO-1 ("ko"), not TVDB codes ("kor").
-        const lang = tmdbLanguageIso();
-        const name =
-          pickLocalizedText([{ text: tv.name ?? "" }, { text: next.name }], { forName: true, lang }) ??
-          next.name;
-        const overview =
-          pickLocalizedText([{ text: tv.overview ?? "" }, { text: next.overview }], { lang }) ??
-          next.overview;
+        // TMDB episodes were fetched with the requested metadata language, making them the
+        // canonical localized source (their own fallback chain ends in English/original).
+        // Script ranking can't separate Turkish-style Latin text from English, so a length
+        // tie-break there would randomly overwrite real translations with longer TVDB English;
+        // TVDB therefore only fills fields TMDB left empty.
+        const name = (next.name ?? "").trim() ? next.name : tv.name ?? next.name;
+        const overview = (next.overview ?? "").trim() ? next.overview : tv.overview ?? next.overview;
         next = {
           ...next,
           name,

--- a/src/views/detail/series-episodes/use-episode-enrich.ts
+++ b/src/views/detail/series-episodes/use-episode-enrich.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { isGenericEpisodeName } from "@/lib/providers/anime-episode-build";
+import { isGenericEpisodeName, isUsableLocalizedText } from "@/lib/providers/anime-episode-build";
 import { harborImdbEpisodes } from "@/lib/providers/harbor-imdb";
 import { omdbSeasonRatings } from "@/lib/providers/omdb";
 import type { Episode } from "@/lib/providers/tmdb";
@@ -12,12 +12,15 @@ export function useEpisodeEnrich({
   imdbId,
   tvdbKey,
   omdbKey,
+  enEpisodes,
 }: {
   episodes: Episode[];
   active: number;
   imdbId: string | null;
   tvdbKey: string;
   omdbKey: string;
+  /** en-US counterparts for `episodes`; used to detect TMDB's silent language fallback. */
+  enEpisodes?: Episode[];
 }): { episodes: Episode[]; imdbRatings: Map<string, number> } {
   const [tvdbBySeason, setTvdbBySeason] = useState<Map<number, Map<number, TvdbEpisode>>>(new Map());
   const [omdbBySeason, setOmdbBySeason] = useState<Map<number, Map<number, number>>>(new Map());
@@ -70,20 +73,32 @@ export function useEpisodeEnrich({
   const omdbForSeason = omdbBySeason.get(active);
   const enriched = useMemo<Episode[]>(() => {
     if (!tvdbForSeason && !omdbForSeason && harborImdb.size === 0) return episodes;
+    const lang = tmdbLanguageIso();
+    // A localized candidate only counts as real if it differs from its en-US counterpart:
+    // equality means TMDB had no translation and silently served English.
+    const usable = (text: string | null | undefined, enText?: string | null) => {
+      const t = (text ?? "").trim();
+      if (!t || isGenericEpisodeName(t) || !isUsableLocalizedText(t, lang)) return false;
+      const e = (enText ?? "").trim();
+      return !(lang && e && t === e);
+    };
+    const enByNumber = new Map<number, Episode>();
+    for (const e of enEpisodes ?? []) enByNumber.set(e.episodeNumber, e);
     return episodes.map((ep): Episode => {
       let next: Episode = ep;
       const tv = tvdbForSeason?.get(ep.episodeNumber);
+      const en = enByNumber.get(ep.episodeNumber);
       if (tv) {
-        // TMDB text is canonical for the requested language, but contributors fill
-        // untranslated episodes with generic placeholders ("2. Bölüm", "الحلقة 1") —
-        // treat those as missing so real titles from other sources still win.
-        const tmdbTitle = (next.name ?? "").trim();
-        const tvTitle = (tv.name ?? "").trim();
+        // Precedence: verified-localized TMDB, then TVDB (its requested-language fetch can
+        // also carry genuine translations TMDB lacks), then raw TMDB as last resort.
         const name =
-          (tmdbTitle && !isGenericEpisodeName(tmdbTitle) ? tmdbTitle : undefined) ??
-          (tvTitle && !isGenericEpisodeName(tvTitle) ? tvTitle : undefined) ??
+          (usable(next.name, en?.name) ? next.name : undefined) ??
+          (usable(tv.name) ? tv.name : undefined) ??
           next.name;
-        const overview = (next.overview ?? "").trim() ? next.overview : tv.overview ?? next.overview;
+        const overview =
+          (usable(next.overview, en?.overview) ? next.overview : undefined) ??
+          (usable(tv.overview) ? tv.overview : undefined) ??
+          next.overview;
         next = {
           ...next,
           name,
@@ -99,6 +114,6 @@ export function useEpisodeEnrich({
       }
       return next;
     });
-  }, [episodes, tvdbForSeason, omdbForSeason, harborImdb, active]);
+  }, [episodes, tvdbForSeason, omdbForSeason, harborImdb, active, enEpisodes]);
   return { episodes: enriched, imdbRatings: harborImdb };
 }


### PR DESCRIPTION
## Summary

Makes Harbor honor the user's selected metadata language consistently across search results, posters, and episode metadata. Titles, overviews, episode names, and artwork now follow the configured language with an English fallback, instead of defaulting to the original-language (e.g. Japanese) or English values that previously slipped through in different flows.

## Why

Localization was inconsistent across entry points and surfaces:

- Search was requested in the metadata language, but for titles without a translation TMDB returned blank or original-language (Japanese) info, and the localized result could be overridden by the English MAL/AniList entry once the anime search resolved causing a localized→English flicker and blank info.
- Posters fell back to the original Japanese artwork when the metadata-language poster was unavailable, instead of English.
- Anime/series episode metadata picked the first available language rather than the requested one, so episode titles/overviews ignored the metadata language (and Japanese leaked through when the language was English).

This approach fits Harbor by fixing the root cause, a language-first text picker and consistent English fallback in shared metadata/artwork logic — rather than patching individual views. It applies uniformly to search, anime, and series content.

## Verification

- npx tsc -b --pretty false — clean, exit 0 (after the TypeScript changes)
- pnpm run build — success (only pre-existing chunk-size warning)
- node --test — search-display-state, search-request-guard, and poster-backdrop-expansion tests pass
- Manual scenarios: search for a title without a localized translation (English fallback shown, no blank info); anime search keeps the localized result instead of swapping to English/MAL; posters fall back to English, not Japanese; anime/series episode names & overviews in the metadata language; English metadata language no longer shows Japanese episode text.

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
