### PR TITLE
fix(anime): episode ratings

### DIFF
--- a/src/lib/providers/anime-episode-enrich.ts
+++ b/src/lib/providers/anime-episode-enrich.ts
@@ -83,7 +83,13 @@ async function enrichHarborImdb(episodes: KitsuEpisode[], imdbId: string | null)
   for (const ep of episodes) {
     const season = ep.imdbSeason ?? ep.seasonNumber ?? 1;
     const num = ep.imdbEpisode ?? ep.number;
-    const real = map.get(`${season}:${num}`);
+    let real = map.get(`${season}:${num}`);
+    if (real == null) {
+      const abs = ep.absoluteNumber ?? ep.number;
+      if (abs != null) {
+        real = map.get(`1:${abs}`) ?? map.get(`0:${abs}`);
+      }
+    }
     if (real != null && real > 0) {
       ep.rating = real;
       ep.ratingIsImdb = true;

--- a/src/lib/providers/anime-franchise-episodes.ts
+++ b/src/lib/providers/anime-franchise-episodes.ts
@@ -1,5 +1,6 @@
 import { aniZipByKitsu } from "@/lib/providers/anizip";
 import { buildKitsuEpisodes, mergeAniZipEpisodes, mergeTvdbEpisodes, mergeTmdbEpisodes } from "@/lib/providers/anime-episode-build";
+import { enrichEpisodes } from "@/lib/providers/anime-episode-enrich";
 import { animeKitsuMeta } from "@/lib/providers/anime-kitsu-addon";
 import { kitsuEpisodes, type KitsuEpisode } from "@/lib/providers/kitsu";
 import { kitsuToTvdb } from "@/lib/providers/anime-mapping";
@@ -86,6 +87,8 @@ export function fetchEntryEpisodes(kitsuId: number, settings: Settings): Promise
       if (tvdbRaw?.en) mergeTvdbEpisodes(eps, tvdbRaw.en);
       if (tmdbEnRaw) mergeTmdbEpisodes(eps, tmdbEnRaw);
     }
+    const imdbId = aniZip?.mappings?.imdb_id ?? eps.find((e) => e.imdbId)?.imdbId ?? null;
+    await enrichEpisodes(eps, settings, kitsuId, imdbId).catch(() => {});
     const sourceMetaId = `kitsu:${kitsuId}`;
     const out: KitsuEpisode[] = [];
     for (const ep of eps) {

--- a/src/views/detail/anime-episodes/use-anime-tvdb-panel.ts
+++ b/src/views/detail/anime-episodes/use-anime-tvdb-panel.ts
@@ -14,6 +14,7 @@ import {
 import { tmdbLanguageIso } from "@/lib/providers/tmdb/tmdb-client";
 import { pickLocalizedText } from "@/lib/localized-text";
 import { fetchTvdbOrderBySeriesId, seasonDateRange, type TvdbOrder } from "@/lib/providers/tvdb-order";
+import { harborImdbEpisodesCached } from "@/lib/providers/harbor-imdb";
 import type { PickerItem } from "../series-episodes/season-arc-picker";
 
 export type AnimeTvdbPanel = {
@@ -171,6 +172,7 @@ export function useAnimeTvdbPanel(
     const subset = new Map<string, KitsuEpisode[]>();
     const claimed = new Set<number>();
     const claimedExtras = new Set<string>();
+    const imdbMap = imdbId ? harborImdbEpisodesCached(imdbId) : undefined;
     for (const s of ordering.seasons) {
       if (s.seasonNumber < 0) continue;
       const bucket = ordering.bySeason.get(s.seasonNumber) ?? [];
@@ -225,6 +227,9 @@ export function useAnimeTvdbPanel(
           }
         }
 
+        const imdbRating =
+          imdbMap?.get(`${e.seasonNumber}:${e.episodeNumber}`) ??
+          (abs != null ? imdbMap?.get(`1:${abs}`) : undefined);
 
         const ep: KitsuEpisode = match
           ? {
@@ -232,6 +237,9 @@ export function useAnimeTvdbPanel(
               thumbnail: !match.thumbnail && img ? img : match.thumbnail,
               ...(title != null ? { title } : {}),
               ...(synopsis != null ? { synopsis } : {}),
+              ...(match.rating == null && imdbRating != null
+                ? { rating: imdbRating, ratingIsImdb: true }
+                : {}),
             }
           : {
               id: -e.id,
@@ -253,6 +261,8 @@ export function useAnimeTvdbPanel(
               absoluteNumber: abs ?? undefined,
               tvdbEpisodeId: e.id > 0 ? e.id : undefined,
               streamId,
+              rating: imdbRating,
+              ratingIsImdb: imdbRating != null ? true : undefined,
             };
         if (seenId.has(ep.id)) continue;
         seenId.add(ep.id);


### PR DESCRIPTION
## Summary

Fixes missing IMDb episode ratings and badges across subsequent anime seasons, specials, and franchise entries in the episode dropdown menu.
- Enriches franchise episodes in `fetchEntryEpisodes` with official IMDb ratings, MAL filler flags, and fallback thumbnails.
- Adds an absolute episode number fallback (`ep.absoluteNumber`) in `enrichHarborImdb` to support long-running anime that index flatly on IMDb.
- Injects cached IMDb ratings into synthetic fallback episodes in `useAnimeTvdbPanel`.
## Why

Previously, `enrichEpisodes()` was only executed for the initial anchor season during `animeDetails()`. When a user switched to another season or franchise entry via the episode dropdown menu:
- The background-fetched episodes in `fetchEntryEpisodes()` mapped AniZip and TVDB data but never ran `enrichHarborImdb()`.

- Because `ep.ratingIsImdb` remained `false`/`undefined`, `EpisodeRatingBadge` fell back to rendering yellow Star icons with Kitsu's community score instead of official IMDb ratings.

- Calling `enrichEpisodes()` during franchise episode fetching and supporting absolute numbering fallbacks ensures consistent IMDb ratings and badges across all seasons.

## Verification

pnpm run typecheck tsc -b --pretty false > no errors
Verified that switching seasons in the episode dropdown menu displays the IMDb badge and score consistently across all seasons.
## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
