### PR TITLE
feat(hotkeys): add configurable settings shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,12 @@ import { MangaFavoritesProvider } from "@/lib/manga-favorites";
 import { LocalWatchlistProvider } from "@/lib/local-watchlist";
 import { useSettings } from "@/lib/settings";
 import { torrentEngineSetOptions } from "@/lib/torrent/local-engine";
-import { effectiveBinding, eventToBinding, shouldHandleGlobalKeyboardEvent } from "@/lib/hotkeys";
+import {
+  effectiveBinding,
+  eventToBinding,
+  findHotkeyMatch,
+  shouldHandleGlobalKeyboardEvent,
+} from "@/lib/hotkeys";
 import { ViewProvider, useView, type Frame, type MetaFilter, type View } from "@/lib/view";
 import { requestOpenProfile, requestEditProfile } from "@/lib/social/open-profile";
 import { openNotificationCenter } from "@/lib/social/notification-open";
@@ -677,6 +682,7 @@ function Shell({ onReady }: { onReady?: () => void }) {
     picker,
     player,
     setView,
+    openSettings,
     canGoBack,
     goBack,
     canGoForward,
@@ -883,6 +889,14 @@ function Shell({ onReady }: { onReady?: () => void }) {
       if (!shouldHandleGlobalKeyboardEvent(e)) return;
       const binding = eventToBinding(e);
       const overrides = settings.hotkeys ?? {};
+      const globalMatch = findHotkeyMatch(e, overrides, "Global");
+      if (
+        globalMatch &&
+        globalMatch !== "globalUiScaleUp" &&
+        globalMatch !== "globalUiScaleDown" &&
+        globalMatch !== "globalUiScaleReset"
+      )
+        return;
       const uiScaleUpCustom = "globalUiScaleUp" in overrides;
       const uiScaleDownCustom = "globalUiScaleDown" in overrides;
       const uiScaleResetCustom = "globalUiScaleReset" in overrides;
@@ -950,6 +964,25 @@ function Shell({ onReady }: { onReady?: () => void }) {
       unbindWheel();
     };
   }, [player, settings.hotkeys, update]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!shouldHandleGlobalKeyboardEvent(e)) return;
+      if (findHotkeyMatch(e, settings.hotkeys ?? {}, "Global") !== "globalSettingsOpen")
+        return;
+      e.preventDefault();
+      if (
+        player ||
+        document.querySelector('[data-harbor-multiview-active="true"]')
+      )
+        return;
+      e.stopPropagation();
+      if (e.repeat) return;
+      openSettings();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [openSettings, player, settings.hotkeys]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -47,7 +47,8 @@ export type HotkeyId =
   | "globalUiScaleUp"
   | "globalUiScaleDown"
   | "globalUiScaleReset"
-  | "globalSearchFocus";
+  | "globalSearchFocus"
+  | "globalSettingsOpen";
 
 export type HotkeyDef = {
   id: HotkeyId;
@@ -63,6 +64,7 @@ export const HOTKEYS: HotkeyDef[] = [
   { id: "globalUiScaleUp", scope: "Global", group: "Interface", label: "Increase interface scale", description: "Make Harbor's interface larger.", defaultBinding: "ctrl+=" },
   { id: "globalUiScaleDown", scope: "Global", group: "Interface", label: "Decrease interface scale", description: "Make Harbor's interface smaller.", defaultBinding: "ctrl+-" },
   { id: "globalUiScaleReset", scope: "Global", group: "Interface", label: "Reset interface scale", description: "Restore Harbor's interface scale to 100%.", defaultBinding: "ctrl+0" },
+  { id: "globalSettingsOpen", scope: "Global", group: "Navigation", label: "Open settings", description: "Open Harbor's settings outside playback.", defaultBinding: "ctrl+s" },
 
   { id: "playerClose", scope: "Player", group: "Playback", label: "Close player", description: "Exit playback and return to the previous view.", defaultBinding: "Escape" },
   { id: "playerPlayPause", scope: "Player", group: "Playback", label: "Play / pause", description: "Toggle playback.", defaultBinding: "Space" },

--- a/src/lib/i18n/locales/ar/settings.ts
+++ b/src/lib/i18n/locales/ar/settings.ts
@@ -1011,6 +1011,7 @@ const settings: Record<string, string> = {
   "Press a key…": "اضغط على مفتاح…",
   "Focus search": "التركيز على البحث",
   "Jump to the top-bar search from anywhere.": "الانتقال إلى شريط البحث العلوي من أي مكان.",
+  "Open Harbor's settings outside playback.": "فتح إعدادات Harbor خارج وضع التشغيل.",
   "Your face in Watch Together rooms, sessions, and chat. Sits on top of your Stremio account.": "صورتك في غرف المشاهدة المشتركة والجلسات والدردشة. تُبنى فوق حسابك في Stremio.",
   "Use my AniList avatar as my Harbor avatar": "استخدام صورتي الرمزية في AniList كصورة رمزية في Harbor",
   "Use my Trakt avatar as my Harbor avatar": "استخدام صورتي الرمزية في Trakt كصورة رمزية في Harbor",

--- a/src/lib/i18n/locales/pt/settings.ts
+++ b/src/lib/i18n/locales/pt/settings.ts
@@ -624,6 +624,7 @@ const settings: Record<string, string> = {
   "Press a key…": "Pressione uma tecla…",
   "Focus search": "Focar busca",
   "Jump to the top-bar search from anywhere.": "Vá para a busca da barra superior de qualquer lugar.",
+  "Open Harbor's settings outside playback.": "Abra as configurações do Harbor fora da reprodução.",
   "Your face in Watch Together rooms, sessions, and chat. Sits on top of your Stremio account.": "Seu rosto nas salas, sessões e chat do Assistir Juntos. Fica em cima da sua conta Stremio.",
   "Use my AniList avatar as my Harbor avatar": "Usar meu avatar do AniList como avatar do Harbor",
   "Use my Trakt avatar as my Harbor avatar": "Usar meu avatar do Trakt como avatar do Harbor",

--- a/src/lib/i18n/locales/ru/settings.ts
+++ b/src/lib/i18n/locales/ru/settings.ts
@@ -624,6 +624,7 @@ const settings: Record<string, string> = {
   "Press a key…": "Нажмите клавишу…",
   "Focus search": "Перейти к поиску",
   "Jump to the top-bar search from anywhere.": "Переход к поиску в верхней панели из любого места.",
+  "Open Harbor's settings outside playback.": "Открывайте настройки Harbor вне режима воспроизведения.",
   "Your face in Watch Together rooms, sessions, and chat. Sits on top of your Stremio account.": "Ваше лицо в комнатах Watch Together, сессиях и чате. Поверх вашего аккаунта Stremio.",
   "Use my AniList avatar as my Harbor avatar": "Использовать аватар AniList как аватар Harbor",
   "Use my Trakt avatar as my Harbor avatar": "Использовать аватар Trakt как аватар Harbor",

--- a/src/views/multiview.tsx
+++ b/src/views/multiview.tsx
@@ -88,7 +88,10 @@ export function MultiviewView({
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div
+      data-harbor-multiview-active={active ? "true" : undefined}
+      className="flex h-full min-h-0 flex-col"
+    >
       <div className={`flex shrink-0 items-center gap-2 px-6 ${collapsed ? "py-1" : "pb-3 pt-1"}`}>
         {!collapsed && (
           <>

--- a/src/views/settings/nav.tsx
+++ b/src/views/settings/nav.tsx
@@ -1099,6 +1099,7 @@ const SETTINGS_OPTIONS: SettingsOption[] = [
   { label: "Seek step", section: "hotkeys", anchorTitle: "Behavior", keywords: ["arrow jump", "seek amount", "skip seconds", "back forward step", "10 seconds", "jump length"] },
   { label: "Global", section: "hotkeys", anchorTitle: "Global", keywords: ["global shortcuts", "app wide keys", "anywhere shortcuts", "keyboard"] },
   { label: "Focus search", section: "hotkeys", anchorTitle: "Global", keywords: ["search shortcut", "slash key", "jump to search", "find", "quick search"] },
+  { label: "Open settings", section: "hotkeys", anchorTitle: "Global", keywords: ["settings shortcut", "settings hotkey", "ctrl s", "preferences"] },
   { label: "Increase interface scale", section: "hotkeys", anchorTitle: "Global", keywords: ["zoom in", "bigger ui", "ctrl plus", "scale up", "enlarge"] },
   { label: "Decrease interface scale", section: "hotkeys", anchorTitle: "Global", keywords: ["zoom out", "smaller ui", "ctrl minus", "scale down", "shrink"] },
   { label: "Reset interface scale", section: "hotkeys", anchorTitle: "Global", keywords: ["reset zoom", "100 percent", "ctrl zero", "default scale"] },

--- a/tests/settings-search.test.ts
+++ b/tests/settings-search.test.ts
@@ -1,6 +1,8 @@
 // @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
 import assert from "node:assert/strict";
 // @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
 import test from "node:test";
 import { matchesSettingsSearch } from "../src/views/settings/search-match.ts";
 
@@ -15,4 +17,26 @@ test("settings search matches translated labels without losing source-language m
   assert.equal(matchesSettingsSearch("conta", ["Account"], translate), true);
   assert.equal(matchesSettingsSearch("languages", ["Languages"], translate), true);
   assert.equal(matchesSettingsSearch("player", ["Languages"], translate), false);
+});
+
+test("settings search indexes open settings under Global", () => {
+  const nav = readFileSync(
+    new URL("../src/views/settings/nav.tsx", import.meta.url),
+    "utf8",
+  );
+  const entries = [
+    ...nav.matchAll(
+      /\{\s*label: "Open settings",\s*section: "hotkeys",\s*anchorTitle: "Global",\s*keywords: \[([^\]]+)\],?\s*\}/g,
+    ),
+  ];
+  assert.equal(entries.length, 1, "exactly one Open settings search entry");
+  assert.equal(
+    entries[0][1],
+    '"settings shortcut", "settings hotkey", "ctrl s", "preferences"',
+  );
+
+  const focusAt = nav.indexOf('{ label: "Focus search"');
+  const settingsAt = nav.indexOf('{ label: "Open settings"');
+  const scaleAt = nav.indexOf('{ label: "Increase interface scale"');
+  assert.equal(focusAt < settingsAt && settingsAt < scaleAt, true);
 });

--- a/tests/settings-shortcut.test.ts
+++ b/tests/settings-shortcut.test.ts
@@ -1,0 +1,164 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+import arSettings from "../src/lib/i18n/locales/ar/settings.ts";
+import ptSettings from "../src/lib/i18n/locales/pt/settings.ts";
+import ruSettings from "../src/lib/i18n/locales/ru/settings.ts";
+import {
+  HOTKEYS,
+  findHotkeyMatch,
+  shouldHandleGlobalKeyboardEvent,
+} from "../src/lib/hotkeys.ts";
+
+function keyboardEvent(
+  key: string,
+  init: Partial<KeyboardEvent> = {},
+): KeyboardEvent {
+  return {
+    key,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ...init,
+  } as KeyboardEvent;
+}
+
+test("open settings is a configurable Global Ctrl+S command", () => {
+  const command = HOTKEYS.find((entry) => entry.id === "globalSettingsOpen");
+  assert.deepEqual(command, {
+    id: "globalSettingsOpen",
+    scope: "Global",
+    group: "Navigation",
+    label: "Open settings",
+    description: "Open Harbor's settings outside playback.",
+    defaultBinding: "ctrl+s",
+  });
+});
+
+test("open settings follows Global priority and effective binding rules", () => {
+  const ctrlS = keyboardEvent("s", { ctrlKey: true });
+  const ctrlShiftS = keyboardEvent("S", { ctrlKey: true, shiftKey: true });
+  const metaS = keyboardEvent("s", { metaKey: true });
+  const altP = keyboardEvent("p", { altKey: true });
+
+  assert.equal(findHotkeyMatch(ctrlS, {}, "Global"), "globalSettingsOpen");
+  assert.equal(findHotkeyMatch(ctrlShiftS, {}, "Global"), "globalSettingsOpen");
+  assert.equal(findHotkeyMatch(metaS, {}, "Global"), null);
+  assert.equal(
+    findHotkeyMatch(ctrlS, { globalSearchFocus: "ctrl+s" }, "Global"),
+    "globalSearchFocus",
+  );
+  assert.equal(
+    findHotkeyMatch(altP, { globalSettingsOpen: "alt+p" }, "Global"),
+    "globalSettingsOpen",
+  );
+  assert.equal(
+    findHotkeyMatch(ctrlS, { globalSettingsOpen: "alt+p" }, "Global"),
+    null,
+  );
+});
+
+test("supported catalogs translate the open-settings description", () => {
+  const source = "Open Harbor's settings outside playback.";
+  for (const [locale, catalog] of [
+    ["ar", arSettings],
+    ["pt", ptSettings],
+    ["ru", ruSettings],
+  ] as const) {
+    assert.equal(typeof catalog[source], "string", locale);
+    assert.notEqual(catalog[source]?.trim(), "", locale);
+    assert.notEqual(catalog[source], source, locale);
+  }
+});
+
+function effectContaining(source: string, needle: string): string {
+  const needleAt = source.indexOf(needle);
+  assert.notEqual(needleAt, -1, "expected Shell effect marker");
+  const start = source.lastIndexOf("  useEffect(() => {", needleAt);
+  const end = source.indexOf("\n  useEffect(() => {", needleAt);
+  assert.notEqual(start, -1, "expected Shell effect start");
+  assert.notEqual(end, -1, "expected Shell effect end");
+  return source.slice(start, end);
+}
+
+test("typing targets retain ownership of the global shortcut", () => {
+  const input = {
+    nodeType: 1,
+    tagName: "INPUT",
+    isContentEditable: false,
+    getAttribute: () => null,
+  };
+  const event = keyboardEvent("s", {
+    ctrlKey: true,
+    target: input as unknown as EventTarget,
+    isComposing: false,
+  });
+  assert.equal(shouldHandleGlobalKeyboardEvent(event), false);
+});
+
+test("Shell consumes save before playback guards and navigates only outside playback", () => {
+  const app = readFileSync(new URL("../src/App.tsx", import.meta.url), "utf8");
+  const effect = effectContaining(app, '"globalSettingsOpen"');
+  const order = [
+    effect.indexOf("shouldHandleGlobalKeyboardEvent(e)"),
+    effect.indexOf('"globalSettingsOpen"'),
+    effect.indexOf("e.preventDefault();"),
+    effect.indexOf("player ||"),
+    effect.indexOf('document.querySelector(\'[data-harbor-multiview-active="true"]\')'),
+    effect.indexOf("e.stopPropagation();"),
+    effect.indexOf("if (e.repeat) return;"),
+    effect.indexOf("openSettings();"),
+  ];
+
+  assert.equal(order.every((index) => index >= 0), true, order.join(","));
+  assert.equal(
+    order.every((index, position) => position === 0 || order[position - 1] < index),
+    true,
+    order.join(","),
+  );
+  assert.match(effect, /window\.addEventListener\("keydown", onKey, true\);/);
+  assert.match(effect, /window\.removeEventListener\("keydown", onKey, true\);/);
+  assert.match(effect, /\[openSettings, player, settings\.hotkeys\]/);
+});
+
+test("Shell defers implicit zoom aliases owned by a Settings rebind", () => {
+  const settingsRebind = keyboardEvent("=", { metaKey: true });
+  assert.equal(
+    findHotkeyMatch(
+      settingsRebind,
+      { globalSettingsOpen: "meta+=" },
+      "Global",
+    ),
+    "globalSettingsOpen",
+  );
+
+  const app = readFileSync(new URL("../src/App.tsx", import.meta.url), "utf8");
+  const effect = effectContaining(app, "const isDefaultUiScaleUp");
+  const guard = effect.indexOf('findHotkeyMatch(e, overrides, "Global")');
+  const implicitAlias = effect.indexOf("isDefaultUiScaleUp(e)");
+
+  assert.ok(guard >= 0, "expected UI-scale Global ownership guard");
+  assert.ok(
+    guard < implicitAlias,
+    "expected the guard before implicit zoom alias matching",
+  );
+  assert.match(
+    effect,
+    /globalMatch !== "globalUiScaleUp"[\s\S]*globalMatch !== "globalUiScaleDown"[\s\S]*globalMatch !== "globalUiScaleReset"/,
+  );
+});
+
+test("Multiview marks only its active mounted root", () => {
+  const multiview = readFileSync(
+    new URL("../src/views/multiview.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    multiview,
+    /data-harbor-multiview-active=\{active \? "true" : undefined\}/,
+  );
+});


### PR DESCRIPTION
## Summary
- Adds configurable **Global → Navigation → Open settings** with a default `Ctrl+S` binding.
- Opens Settings through Harbor's existing navigation path; existing Global command priority and configured overrides remain authoritative.
- Suppresses the command during standard playback and active Live Multiview, adds Settings-search discovery, and adds Arabic, Portuguese, and Russian descriptions.

## Why
Keyboard access is available without bypassing Harbor's override priority, Player event ownership, or Live keep-alive behavior.

## Verification
- `node --test tests/settings-shortcut.test.ts tests/settings-search.test.ts`: 9 passed, 0 failed.
- `node --test tests/i18n-coverage.test.ts`: documented baseline retained — 2 passed, 1 failed; exactly 13 unrelated Portuguese strings remain missing, with no new Settings shortcut omission.
- `pnpm exec tsc -b --pretty false`: exit 0.
- `pnpm build`: exit 0.
- `git diff --check origin/beta-branch...HEAD`: exit 0.
- `vp fmt --check …`: exit 1. This repository reports `This project does not use vite-plus` and has no Vite+ config, so Vite+ used defaults and reported formatting differences in all nine scoped files; no auto-formatting was applied to this reviewed branch.
- `vp check --no-fmt …`: exit 0, 0 errors and 1 existing warning in `src/App.tsx` (`unicorn(no-useless-fallback-in-spread)`).

## Platform impact
Focused automated coverage was run on Windows. **Manual desktop verification pending** for default/rebound/reset bindings, typing targets, playback and both Multiview states, Live Home/Grid/Guide, priority conflicts, and repeat suppression. macOS, Linux, and TV input have not been manually verified.

## UI changes
No personal screenshots were uploaded. Interaction capture is pending.