### PR TITLE
Feature/calendar release time larger posters

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,11 +57,13 @@ mod web_server;
 mod webview_helpers;
 
 pub(crate) fn release_stremio_scheme(app: &tauri::AppHandle) {
+    use std::io::Write;
     use tauri_plugin_deep_link::DeepLinkExt;
-    match app.deep_link().unregister("stremio") {
-        Ok(()) => eprintln!("[harbor::deeplink] released stremio:// on shutdown"),
-        Err(e) => eprintln!("[harbor::deeplink] could not release stremio://: {}", e),
-    }
+    let msg = match app.deep_link().unregister("stremio") {
+        Ok(()) => "[harbor::deeplink] released stremio:// on shutdown".to_string(),
+        Err(e) => format!("[harbor::deeplink] could not release stremio://: {}", e),
+    };
+    let _ = writeln!(std::io::stderr(), "{}", msg);
 }
 
 pub(crate) fn shutdown_services(app: &tauri::AppHandle) {

--- a/src/components/poster.tsx
+++ b/src/components/poster.tsx
@@ -248,11 +248,17 @@ export function Poster({
     if (!inView || qMult === 0) return;
     const el = rootRef.current;
     if (!el) return;
-    const box = el.getBoundingClientRect();
-    if (box.width <= 0) return;
-    const need = Math.max(box.width, box.height * RATIO_AR[ratio]);
-    const t = Math.ceil(need * (window.devicePixelRatio || 1) * qMult);
-    setTargetPx((prev) => (t > prev ? t : prev));
+    const measure = () => {
+      const box = el.getBoundingClientRect();
+      if (box.width <= 0) return;
+      const need = Math.max(box.width, box.height * RATIO_AR[ratio]);
+      const t = Math.ceil(need * (window.devicePixelRatio || 1) * qMult);
+      setTargetPx((prev) => (t > prev ? t : prev));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, [inView, qMult, ratio]);
   const rawCandidates = [src, ...(fallbacks ?? [])].filter((u): u is string => !!u);
   const candidates =

--- a/src/lib/anilist/airing.ts
+++ b/src/lib/anilist/airing.ts
@@ -1,4 +1,5 @@
 import type { CalendarItem } from "@/lib/calendar";
+import { toLocalDateISO, toLocalTimeLabel } from "@/lib/calendar-time";
 import { anilistRequest } from "./client";
 
 const AIRING_QUERY = `query ($start: Int, $end: Int, $page: Int) {
@@ -58,22 +59,6 @@ const CONCURRENCY = 3;
 
 function pad(n: number): string {
   return String(n).padStart(2, "0");
-}
-
-function toLocalISO(epochSeconds: number): string {
-  const d = new Date(epochSeconds * 1000);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function toLocalTime(epochSeconds: number): string {
-  const d = new Date(epochSeconds * 1000);
-  const hour = d.getHours();
-  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
-  const period = hour >= 12 ? "PM" : "AM";
-  return `${hour12}:${pad(d.getMinutes())} ${period}`;
 }
 
 function stripHtml(s: string): string {
@@ -144,6 +129,7 @@ export async function fetchAniListAiringCalendar(
       const id = `${baseId}:1:${node.episode}`;
       if (seen.has(id)) continue;
       seen.add(id);
+      const airMs = node.airingAt * 1000;
       out.push({
         id,
         imdbId: null,
@@ -151,8 +137,9 @@ export async function fetchAniListAiringCalendar(
         name: `${title} S1E${pad(node.episode)}`,
         poster: media.coverImage?.extraLarge ?? media.coverImage?.large ?? null,
         background: media.bannerImage ?? null,
-        releaseDate: toLocalISO(node.airingAt),
-        releaseTime: toLocalTime(node.airingAt),
+        releaseDate: toLocalDateISO(new Date(airMs)),
+        releaseTime: toLocalTimeLabel(new Date(airMs)),
+        releaseAtMs: airMs,
         isAnime: true,
         overview: media.description ? stripHtml(media.description) : "",
         voteAverage: media.averageScore != null ? media.averageScore / 10 : 0,

--- a/src/lib/anilist/airing.ts
+++ b/src/lib/anilist/airing.ts
@@ -89,12 +89,7 @@ export async function fetchAniListAiringCalendar(
     while (!pastLast && next <= MAX_PAGES && inflight < CONCURRENCY) {
       const page = next++;
       inflight++;
-      anilistRequest<AiringResponse>(
-        AIRING_QUERY,
-        { start, end, page },
-        undefined,
-        true,
-      )
+      anilistRequest<AiringResponse>(AIRING_QUERY, { start, end, page }, undefined, true)
         .then((data) => {
           const nodes = data?.Page?.airingSchedules ?? [];
           pages.set(page, nodes);

--- a/src/lib/calendar-library.ts
+++ b/src/lib/calendar-library.ts
@@ -388,7 +388,7 @@ export async function resolveSavedCalendar(
         imdbId: c.id.startsWith("tt") ? c.id.split(":")[0] : null,
         type: "tv",
         name: ep.name ? `${showName} ${epLabel}: ${ep.name}` : `${showName} ${epLabel}`,
-        poster: r.isAnime ? (r.poster ?? ep.image ?? null) : (ep.image ?? r.poster ?? null),
+        poster: r.poster ?? ep.image ?? null,
         background: null,
         releaseDate: ep.airDate,
         releaseTime: ep.releaseTime,

--- a/src/lib/calendar-library.ts
+++ b/src/lib/calendar-library.ts
@@ -6,10 +6,12 @@ import { tvmazeUpcoming } from "./providers/tvmaze";
 import {
   tmdbFindByImdb,
   tmdbMovieRelease,
+  tmdbTvPoster,
   tmdbTvUpcoming,
 } from "./providers/tmdb/tmdb-calendar";
 import { aniZipByAnilist, aniZipByKitsu, aniZipByMal, pickEpisodeTitle } from "./providers/anizip";
 import type { CalendarItem } from "./calendar";
+import { localDateTimeFromIso } from "./calendar-time";
 
 const SERIES_LIMIT = 80;
 const MOVIE_LIMIT = 80;
@@ -31,6 +33,8 @@ type ResolvedEpisode = {
   number: number;
   name: string;
   airDate: string;
+  releaseTime?: string;
+  releaseAtMs?: number;
   image: string | null;
   overview: string;
   voteAverage: number;
@@ -97,6 +101,7 @@ function animeNumericId(id: string): number | null {
 async function animeUpcoming(
   id: string,
   inWindow: (date: string) => boolean,
+  tmdbKey: string,
 ): Promise<ResolvedSeries | null> {
   const numId = animeNumericId(id);
   if (numId == null) return null;
@@ -108,21 +113,32 @@ async function animeUpcoming(
   if (!mapping?.episodes) return null;
   const episodes: ResolvedEpisode[] = [];
   for (const [k, ep] of Object.entries(mapping.episodes)) {
-    const date = (ep.airDate ?? ep.airDateUtc ?? "").slice(0, 10);
+    const { date, time, atMs } = localDateTimeFromIso(ep.airDate ?? ep.airDateUtc);
     if (!date || !inWindow(date)) continue;
     episodes.push({
       season: ep.seasonNumber ?? 1,
       number: ep.episodeNumber ?? (Number(k) || 0),
       name: pickEpisodeTitle(ep) ?? "",
       airDate: date,
+      releaseTime: time,
+      releaseAtMs: atMs,
       image: ep.image ?? null,
       overview: ep.overview ?? "",
       voteAverage: 0,
     });
   }
+  // AniZip has no series-poster field, only small per-episode stills, so the
+  // per-episode images are frequently low-resolution. Resolve a proper poster
+  // via the TMDB cross-reference AniZip already supplies, when available.
+  let poster: string | null = null;
+  const tmdbId = mapping.mappings?.themoviedb_id;
+  const numTmdbId = typeof tmdbId === "string" ? Number(tmdbId) : tmdbId;
+  if (tmdbKey && numTmdbId != null && Number.isFinite(numTmdbId)) {
+    poster = await tmdbTvPoster(tmdbKey, numTmdbId).catch(() => null);
+  }
   return {
     name: mapping.titles?.en ?? mapping.titles?.["x-jat"] ?? "",
-    poster: null,
+    poster,
     isAnime: true,
     episodes,
   };
@@ -150,7 +166,7 @@ async function cinemetaSeriesUpcoming(
   if (!m?.videos) return null;
   const episodes: ResolvedEpisode[] = [];
   for (const v of m.videos) {
-    const date = (v.released ?? v.firstAired ?? "").slice(0, 10);
+    const { date, time, atMs } = localDateTimeFromIso(v.released ?? v.firstAired);
     if (!date || !inWindow(date)) continue;
     const number = v.episode ?? v.number;
     if (number == null) continue;
@@ -159,6 +175,8 @@ async function cinemetaSeriesUpcoming(
       number,
       name: v.name ?? v.title ?? "",
       airDate: date,
+      releaseTime: time,
+      releaseAtMs: atMs,
       image: v.thumbnail ?? null,
       overview: "",
       voteAverage: 0,
@@ -173,7 +191,7 @@ async function seriesUpcoming(
   inWindow: (date: string) => boolean,
   tmdbKey: string,
 ): Promise<ResolvedSeries | null> {
-  if (isAnimeId(c.id)) return animeUpcoming(c.id, inWindow);
+  if (isAnimeId(c.id)) return animeUpcoming(c.id, inWindow, tmdbKey);
   if (c.id.startsWith("tt")) {
     const cm = await cinemetaSeriesUpcoming(c.id, inWindow);
     if (cm) return cm;
@@ -370,9 +388,11 @@ export async function resolveSavedCalendar(
         imdbId: c.id.startsWith("tt") ? c.id.split(":")[0] : null,
         type: "tv",
         name: ep.name ? `${showName} ${epLabel}: ${ep.name}` : `${showName} ${epLabel}`,
-        poster: ep.image ?? r.poster ?? null,
+        poster: r.isAnime ? (r.poster ?? ep.image ?? null) : (ep.image ?? r.poster ?? null),
         background: null,
         releaseDate: ep.airDate,
+        releaseTime: ep.releaseTime,
+        releaseAtMs: ep.releaseAtMs,
         isAnime: r.isAnime,
         overview: ep.overview,
         voteAverage: ep.voteAverage,

--- a/src/lib/calendar-library.ts
+++ b/src/lib/calendar-library.ts
@@ -81,7 +81,11 @@ function isAnimationGenre(genres: string[] | undefined): boolean {
   });
 }
 
-async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
   const out: R[] = [];
   for (let i = 0; i < items.length; i += limit) {
     out.push(...(await Promise.all(items.slice(i, i + limit).map(fn))));
@@ -301,7 +305,11 @@ function gatherCandidates(
   for (const t of trakt) {
     const id =
       t.ids.imdb ??
-      (t.ids.tmdb ? (t.type === "movie" ? `tmdb:movie:${t.ids.tmdb}` : `tmdb:tv:${t.ids.tmdb}`) : null);
+      (t.ids.tmdb
+        ? t.type === "movie"
+          ? `tmdb:movie:${t.ids.tmdb}`
+          : `tmdb:tv:${t.ids.tmdb}`
+        : null);
     if (!id) continue;
     add({
       id,
@@ -343,7 +351,10 @@ export async function fetchLibraryCalendar(
   return resolveSavedCalendar(candidates, year, month, { tmdbKey: opts.tmdbKey });
 }
 
-async function resolveSeriesCached(c: SavedCandidate, tmdbKey: string): Promise<ResolvedSeries | null> {
+async function resolveSeriesCached(
+  c: SavedCandidate,
+  tmdbKey: string,
+): Promise<ResolvedSeries | null> {
   const hit = seriesCache.get(c.id);
   if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.series;
   const series = await seriesUpcoming(c, wideWindow(), tmdbKey).catch(() => null);
@@ -351,7 +362,10 @@ async function resolveSeriesCached(c: SavedCandidate, tmdbKey: string): Promise<
   return series;
 }
 
-async function resolveMovieCached(c: SavedCandidate, tmdbKey: string): Promise<CalendarItem | null> {
+async function resolveMovieCached(
+  c: SavedCandidate,
+  tmdbKey: string,
+): Promise<CalendarItem | null> {
   const hit = movieCache.get(c.id);
   if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.movie;
   const movie = await movieRelease(c, wideWindow(), tmdbKey).catch(() => null);
@@ -366,8 +380,14 @@ export async function resolveSavedCalendar(
   opts: { tmdbKey: string },
 ): Promise<CalendarItem[]> {
   const inMonth = inMonthFactory(year, month);
-  const series = candidates.filter((c) => c.type === "series").sort(curatedFirst).slice(0, SERIES_LIMIT);
-  const movies = candidates.filter((c) => c.type === "movie").sort(curatedFirst).slice(0, MOVIE_LIMIT);
+  const series = candidates
+    .filter((c) => c.type === "series")
+    .sort(curatedFirst)
+    .slice(0, SERIES_LIMIT);
+  const movies = candidates
+    .filter((c) => c.type === "movie")
+    .sort(curatedFirst)
+    .slice(0, MOVIE_LIMIT);
 
   const out: CalendarItem[] = [];
 
@@ -400,7 +420,9 @@ export async function resolveSavedCalendar(
     }
   }
 
-  const movieResults = await mapLimit(movies, TMDB_CONCURRENCY, (c) => resolveMovieCached(c, opts.tmdbKey));
+  const movieResults = await mapLimit(movies, TMDB_CONCURRENCY, (c) =>
+    resolveMovieCached(c, opts.tmdbKey),
+  );
   for (const mi of movieResults) if (mi && inMonth(mi.releaseDate)) out.push(mi);
 
   const seen = new Set<string>();

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -87,10 +87,7 @@ export async function fetchAniListAiringCalendar(
   return withCalendarCache(cacheKey, () => fetchAniListAiring(year, month).catch(() => []));
 }
 
-export async function fetchAnimeDubCalendar(
-  year: number,
-  month: number,
-): Promise<CalendarItem[]> {
+export async function fetchAnimeDubCalendar(year: number, month: number): Promise<CalendarItem[]> {
   const cacheKey = `anime-dub:${year}-${month}`;
   return withCalendarCache(cacheKey, () => mapDubFeedToCalendar(year, month).catch(() => []));
 }
@@ -194,20 +191,14 @@ function isAnimationGenre(genres: string[] | undefined): boolean {
   return genres.some((g) => wanted.includes(g.toLowerCase()));
 }
 
-export async function fetchTraktCalendar(
-  year: number,
-  month: number,
-): Promise<CalendarItem[]> {
+export async function fetchTraktCalendar(year: number, month: number): Promise<CalendarItem[]> {
   const today = new Date();
   const cur = new Date(year, month, 1);
   const fwdMonths =
     (cur.getFullYear() - today.getFullYear()) * 12 + (cur.getMonth() - today.getMonth());
   if (fwdMonths < 0 || fwdMonths > TRAKT_MAX_FORWARD_MONTHS) return [];
   const days = Math.max(31, (fwdMonths + 1) * 31);
-  const [eps, mvs] = await Promise.all([
-    fetchUpcomingEpisodes(days),
-    fetchUpcomingMovies(days),
-  ]);
+  const [eps, mvs] = await Promise.all([fetchUpcomingEpisodes(days), fetchUpcomingMovies(days)]);
 
   const epsInMonth = eps
     .map((ep) => ({ ep, ...localDateTimeFromIso(ep.airDate) }))
@@ -232,7 +223,7 @@ export async function fetchTraktCalendar(
   const out: CalendarItem[] = [];
   for (const { ep, date, time, atMs } of epsInMonth) {
     const imdb = ep.ids.imdb ?? null;
-    const meta = imdb ? showMeta.get(imdb) ?? null : null;
+    const meta = imdb ? (showMeta.get(imdb) ?? null) : null;
     const baseId = imdb ?? `trakt:${ep.ids.tmdb ?? ep.ids.tvdb ?? ep.title}`;
     const epLabel = `S${pad(ep.season)}E${pad(ep.number)}`;
     const vid = meta?.videos?.find(
@@ -257,7 +248,7 @@ export async function fetchTraktCalendar(
   }
   for (const { m, date, time, atMs } of mvsInMonth) {
     const imdb = m.ids.imdb ?? null;
-    const meta = imdb ? movieMeta.get(imdb) ?? null : null;
+    const meta = imdb ? (movieMeta.get(imdb) ?? null) : null;
     const id = imdb ?? `trakt:${m.ids.tmdb ?? m.title}`;
     out.push({
       id,
@@ -282,10 +273,7 @@ export async function fetchAnticipatedCalendar(
   year: number,
   month: number,
 ): Promise<CalendarItem[]> {
-  const [shows, mvs] = await Promise.all([
-    fetchAnticipatedShows(),
-    fetchAnticipatedMovies(),
-  ]);
+  const [shows, mvs] = await Promise.all([fetchAnticipatedShows(), fetchAnticipatedMovies()]);
   const inMonthShows = shows.filter((s) => inMonth(s.firstAired, year, month));
   const inMonthMovies = mvs.filter((m) => inMonth(m.released, year, month));
   const [showMetas, movieMetas] = await Promise.all([

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -6,6 +6,7 @@ import {
   fetchUpcomingMovies,
 } from "./trakt/calendar";
 import type { CalendarItem } from "./calendar";
+import { localDateTimeFromIso } from "./calendar-time";
 import { resolveSavedCalendar, type SavedCandidate } from "./calendar-library";
 import { fetchWatchlist as fetchSimklWatchlist, fetchWatchingItems } from "./simkl/watchlist";
 import { fetchSimklCdnCalendar } from "./simkl/calendar";
@@ -103,9 +104,8 @@ async function mapDubFeedToCalendar(year: number, month: number): Promise<Calend
     if (!media) continue;
     if (media.isAdult) continue;
     if (media.format === "MOVIE" || e.episodeNumber == null) continue;
-    const dateISO = e.episodeDate ? toLocalISO(e.episodeDate) : "";
+    const { date: dateISO, time, atMs } = localDateTimeFromIso(e.episodeDate);
     if (!inMonth(dateISO, year, month)) continue;
-    const time = e.episodeDate ? toLocalTime(e.episodeDate) : "";
     const title =
       media.title?.english?.trim() ||
       media.title?.romaji?.trim() ||
@@ -124,7 +124,8 @@ async function mapDubFeedToCalendar(year: number, month: number): Promise<Calend
       poster: media.coverImage?.extraLarge ?? media.coverImage?.medium ?? null,
       background: media.bannerImage ?? null,
       releaseDate: dateISO,
-      releaseTime: time || undefined,
+      releaseTime: time,
+      releaseAtMs: atMs,
       isAnime: true,
       overview: "",
       voteAverage: 0,
@@ -132,24 +133,6 @@ async function mapDubFeedToCalendar(year: number, month: number): Promise<Calend
   }
   out.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
   return out;
-}
-
-function toLocalISO(isoDateTime: string): string {
-  const d = new Date(isoDateTime);
-  if (Number.isNaN(d.getTime())) return "";
-  const y = d.getFullYear();
-  const m = pad(d.getMonth() + 1);
-  const day = pad(d.getDate());
-  return `${y}-${m}-${day}`;
-}
-
-function toLocalTime(isoDateTime: string): string {
-  const d = new Date(isoDateTime);
-  if (Number.isNaN(d.getTime())) return "";
-  const hour = d.getHours();
-  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
-  const period = hour >= 12 ? "PM" : "AM";
-  return `${hour12}:${pad(d.getMinutes())} ${period}`;
 }
 
 export async function fetchSimklCalendar(
@@ -226,11 +209,19 @@ export async function fetchTraktCalendar(
     fetchUpcomingMovies(days),
   ]);
 
-  const epsInMonth = eps.filter((ep) => inMonth((ep.airDate ?? "").slice(0, 10), year, month));
-  const mvsInMonth = mvs.filter((m) => inMonth((m.contextDate ?? "").slice(0, 10), year, month));
+  const epsInMonth = eps
+    .map((ep) => ({ ep, ...localDateTimeFromIso(ep.airDate) }))
+    .filter((x) => inMonth(x.date, year, month));
+  const mvsInMonth = mvs
+    .map((m) => ({ m, ...localDateTimeFromIso(m.contextDate) }))
+    .filter((x) => inMonth(x.date, year, month));
 
-  const showIds = [...new Set(epsInMonth.map((e) => e.ids.imdb).filter((x): x is string => !!x))];
-  const movieIds = [...new Set(mvsInMonth.map((m) => m.ids.imdb).filter((x): x is string => !!x))];
+  const showIds = [
+    ...new Set(epsInMonth.map((x) => x.ep.ids.imdb).filter((x): x is string => !!x)),
+  ];
+  const movieIds = [
+    ...new Set(mvsInMonth.map((x) => x.m.ids.imdb).filter((x): x is string => !!x)),
+  ];
   const [showMetas, movieMetas] = await Promise.all([
     Promise.all(showIds.map((id) => cinemetaMeta("series", id).catch(() => null))),
     Promise.all(movieIds.map((id) => cinemetaMeta("movie", id).catch(() => null))),
@@ -239,8 +230,7 @@ export async function fetchTraktCalendar(
   const movieMeta = new Map(movieIds.map((id, i) => [id, movieMetas[i]] as const));
 
   const out: CalendarItem[] = [];
-  for (const ep of epsInMonth) {
-    const date = (ep.airDate ?? "").slice(0, 10);
+  for (const { ep, date, time, atMs } of epsInMonth) {
     const imdb = ep.ids.imdb ?? null;
     const meta = imdb ? showMeta.get(imdb) ?? null : null;
     const baseId = imdb ?? `trakt:${ep.ids.tmdb ?? ep.ids.tvdb ?? ep.title}`;
@@ -258,13 +248,14 @@ export async function fetchTraktCalendar(
       poster: vid?.thumbnail ?? meta?.poster ?? null,
       background: meta?.background ?? null,
       releaseDate: date,
+      releaseTime: time,
+      releaseAtMs: atMs,
       isAnime: isAnimationGenre(meta?.genres),
       overview: meta?.description ?? "",
       voteAverage: parseFloat(meta?.imdbRating ?? "0") || 0,
     });
   }
-  for (const m of mvsInMonth) {
-    const date = (m.contextDate ?? "").slice(0, 10);
+  for (const { m, date, time, atMs } of mvsInMonth) {
     const imdb = m.ids.imdb ?? null;
     const meta = imdb ? movieMeta.get(imdb) ?? null : null;
     const id = imdb ?? `trakt:${m.ids.tmdb ?? m.title}`;
@@ -276,6 +267,8 @@ export async function fetchTraktCalendar(
       poster: meta?.poster ?? null,
       background: meta?.background ?? null,
       releaseDate: date,
+      releaseTime: time,
+      releaseAtMs: atMs,
       isAnime: isAnimationGenre(meta?.genres),
       overview: meta?.description ?? "",
       voteAverage: parseFloat(meta?.imdbRating ?? "0") || 0,

--- a/src/lib/calendar-sources.ts
+++ b/src/lib/calendar-sources.ts
@@ -245,7 +245,7 @@ export async function fetchTraktCalendar(
       name: ep.episodeTitle
         ? `${ep.title} ${epLabel}: ${ep.episodeTitle}`
         : `${ep.title} ${epLabel}`,
-      poster: vid?.thumbnail ?? meta?.poster ?? null,
+      poster: meta?.poster ?? vid?.thumbnail ?? null,
       background: meta?.background ?? null,
       releaseDate: date,
       releaseTime: time,

--- a/src/lib/calendar-time.ts
+++ b/src/lib/calendar-time.ts
@@ -1,0 +1,30 @@
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+export function toLocalDateISO(d: Date): string {
+  if (Number.isNaN(d.getTime())) return "";
+  const y = d.getFullYear();
+  const m = pad(d.getMonth() + 1);
+  const day = pad(d.getDate());
+  return `${y}-${m}-${day}`;
+}
+
+export function toLocalTimeLabel(d: Date): string {
+  if (Number.isNaN(d.getTime())) return "";
+  const hour = d.getHours();
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  const period = hour >= 12 ? "PM" : "AM";
+  return `${hour12}:${pad(d.getMinutes())} ${period}`;
+}
+
+export function localDateTimeFromIso(
+  iso: string | null | undefined,
+): { date: string; time?: string; atMs?: number } {
+  if (!iso) return { date: "" };
+  if (!iso.includes("T")) return { date: iso.slice(0, 10) };
+  const d = new Date(iso);
+  const date = toLocalDateISO(d);
+  if (!date) return { date: iso.slice(0, 10) };
+  return { date, time: toLocalTimeLabel(d) || undefined, atMs: d.getTime() };
+}

--- a/src/lib/calendar-time.ts
+++ b/src/lib/calendar-time.ts
@@ -18,9 +18,11 @@ export function toLocalTimeLabel(d: Date): string {
   return `${hour12}:${pad(d.getMinutes())} ${period}`;
 }
 
-export function localDateTimeFromIso(
-  iso: string | null | undefined,
-): { date: string; time?: string; atMs?: number } {
+export function localDateTimeFromIso(iso: string | null | undefined): {
+  date: string;
+  time?: string;
+  atMs?: number;
+} {
   if (!iso) return { date: "" };
   if (!iso.includes("T")) return { date: iso.slice(0, 10) };
   const d = new Date(iso);

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -55,10 +55,13 @@ type DiscoverTvRow = {
   original_language?: string;
 };
 
-function isAnimeRow(row: { genre_ids?: number[]; original_language?: string; origin_country?: string[] }): boolean {
+function isAnimeRow(row: {
+  genre_ids?: number[];
+  original_language?: string;
+  origin_country?: string[];
+}): boolean {
   const animation = (row.genre_ids ?? []).includes(ANIMATION_GENRE);
-  const japanese =
-    row.original_language === "ja" || (row.origin_country ?? []).includes("JP");
+  const japanese = row.original_language === "ja" || (row.origin_country ?? []).includes("JP");
   return animation && japanese;
 }
 
@@ -111,7 +114,11 @@ async function fetchDiscoverTv(
   }
 }
 
-async function fetchUpcomingMovies(apiKey: string, region: string, page: number): Promise<DiscoverMovieRow[]> {
+async function fetchUpcomingMovies(
+  apiKey: string,
+  region: string,
+  page: number,
+): Promise<DiscoverMovieRow[]> {
   const url = new URL(`${TMDB}/movie/upcoming`);
   url.searchParams.set("api_key", apiKey);
   if (region) url.searchParams.set("region", region);
@@ -141,11 +148,7 @@ export async function fetchCalendarRange(
     fetchDiscoverTv(apiKey, start, end, 1),
     fetchDiscoverTv(apiKey, start, end, 2),
   ]);
-  const movieP1 = [
-    ...m1,
-    ...m2,
-    ...mu1.filter((m) => inRange(m.release_date)),
-  ];
+  const movieP1 = [...m1, ...m2, ...mu1.filter((m) => inRange(m.release_date))];
   const movieP2: DiscoverMovieRow[] = [];
   const tvP1 = [...t1, ...t2];
   const tvP2: DiscoverTvRow[] = [];

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -15,12 +15,14 @@ export type CalendarItem = {
   background: string | null;
   releaseDate: string;
   releaseTime?: string;
+  releaseAtMs?: number;
   isAnime: boolean;
   overview: string;
   voteAverage: number;
 };
 
 export type CalendarFilter = "all" | "movie" | "tv" | "anime";
+export type CalendarPosterSize = "default" | "large";
 
 const POSTER = (path: string | null | undefined) => (path ? `${IMG}/w342${path}` : null);
 const BACKDROP = (path: string | null | undefined) => (path ? `${IMG}/w780${path}` : null);

--- a/src/lib/providers/tmdb/tmdb-calendar.ts
+++ b/src/lib/providers/tmdb/tmdb-calendar.ts
@@ -68,6 +68,11 @@ type SeasonDetail = {
   }>;
 };
 
+export async function tmdbTvPoster(key: string, tvId: number): Promise<string | null> {
+  const tv = await get<TvDetail>(key, `tv/${tvId}`);
+  return tv ? poster(tv.poster_path) : null;
+}
+
 export async function tmdbTvUpcoming(
   key: string,
   tvId: number,

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -474,6 +474,7 @@ export const DEFAULT: Settings = {
   simklScrobbleEnabled: true,
   simklAnimeTitleLanguage: "english",
   weekStartsMonday: false,
+  calendarPosterSize: "default",
   customCalendar: {
     trackedPeople: [],
     includeTraktWatchlist: false,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -283,7 +283,13 @@ export type Settings = {
   subStyle: "shadow" | "outline" | "box";
   subFontFamily: string;
   subBold: boolean;
-  customFonts: Array<{ id: string; name: string; format: string; family?: string; dataUrl?: string }>;
+  customFonts: Array<{
+    id: string;
+    name: string;
+    format: string;
+    family?: string;
+    dataUrl?: string;
+  }>;
   subBoxOpacity: number;
   subBoxColor: string;
   subOpacity: number;

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -1,3 +1,4 @@
+import type { CalendarPosterSize } from "@/lib/calendar";
 import type { ThemeSettings } from "@/lib/theme";
 import type { CustomList } from "@/lib/lists/types";
 import type { SourceRow } from "@/lib/custom-sources";
@@ -541,6 +542,7 @@ export type Settings = {
   simklScrobbleEnabled: boolean;
   simklAnimeTitleLanguage: "english" | "romaji" | "native";
   weekStartsMonday: boolean;
+  calendarPosterSize: CalendarPosterSize;
   customCalendar: {
     trackedPeople: Array<{
       id: number;

--- a/src/lib/use-now.ts
+++ b/src/lib/use-now.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export function useNow(intervalMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+export function formatRemaining(ms: number): string {
+  const totalMinutes = Math.max(0, Math.floor(ms / 60000));
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0 || days > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return parts.join(" ");
+}

--- a/src/views/calendar.tsx
+++ b/src/views/calendar.tsx
@@ -28,6 +28,7 @@ import { SourceSwitcher } from "./calendar/source-switcher";
 import {
   buildLibraryNameSet,
   buildMonthCells,
+  CALENDAR_POSTER_SIZES,
   calendarEpisodeHint,
   calendarToMeta,
   FILTERS,
@@ -296,6 +297,25 @@ export function CalendarView() {
           >
             {t("Start week on Monday")}
           </button>
+          <div className="flex items-center gap-1 rounded-full border border-edge-soft bg-elevated/30 p-1">
+            {CALENDAR_POSTER_SIZES.map(({ value, label }) => {
+              const active = settings.calendarPosterSize === value;
+              return (
+                <button
+                  key={value}
+                  onClick={() => update({ calendarPosterSize: value })}
+                  aria-pressed={active}
+                  className={`rounded-full px-4 py-1.5 text-[12.5px] font-semibold transition-colors ${
+                    active
+                      ? "bg-ink text-canvas"
+                      : "text-ink-muted hover:bg-raised/60 hover:text-ink"
+                  }`}
+                >
+                  {t(label)}
+                </button>
+              );
+            })}
+          </div>
           {source === "custom" && railOverlay && (
             <button
               type="button"

--- a/src/views/calendar.tsx
+++ b/src/views/calendar.tsx
@@ -1,4 +1,10 @@
-import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, SlidersHorizontal, Star } from "lucide-react";
+import {
+  Calendar as CalendarIcon,
+  ChevronLeft,
+  ChevronRight,
+  SlidersHorizontal,
+  Star,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   applyCalendarFilter,
@@ -172,15 +178,16 @@ export function CalendarView() {
   };
 
   const todayISO = todayLocalISO();
-  const dayModalItems = dayModal ? grouped.get(dayModal) ?? [] : [];
+  const dayModalItems = dayModal ? (grouped.get(dayModal) ?? []) : [];
 
   const showAllControls = source === "all";
   const showPremiereFilters = source === "simkl-anticipated";
   const hideTypeTag = source === "anime";
   const filtersActiveCount = buildActiveCount(settings.customCalendar);
-  const filters = settings.hideContent.anime || source === "all"
-    ? FILTERS.filter((f) => f.id !== "anime")
-    : FILTERS;
+  const filters =
+    settings.hideContent.anime || source === "all"
+      ? FILTERS.filter((f) => f.id !== "anime")
+      : FILTERS;
 
   let body: React.ReactNode;
   if (source === "library" && !authKey) {
@@ -347,9 +354,7 @@ export function CalendarView() {
                 {filters.map((f) => {
                   const active = filter === f.id;
                   const count =
-                    f.id === "all"
-                      ? filtered.length
-                      : applyCalendarFilter(items, f.id).length;
+                    f.id === "all" ? filtered.length : applyCalendarFilter(items, f.id).length;
                   return (
                     <button
                       key={f.id}

--- a/src/views/calendar/airing-countdown.tsx
+++ b/src/views/calendar/airing-countdown.tsx
@@ -1,0 +1,10 @@
+import { useT } from "@/lib/i18n";
+import { formatRemaining, useNow } from "@/lib/use-now";
+
+export function AiringCountdown({ atMs }: { atMs: number }) {
+  const t = useT();
+  const now = useNow(30000);
+  const remaining = atMs - now;
+  if (remaining <= 0) return null;
+  return <span className="text-accent"> · {t("in {time}", { time: formatRemaining(remaining) })}</span>;
+}

--- a/src/views/calendar/airing-countdown.tsx
+++ b/src/views/calendar/airing-countdown.tsx
@@ -6,5 +6,7 @@ export function AiringCountdown({ atMs }: { atMs: number }) {
   const now = useNow(30000);
   const remaining = atMs - now;
   if (remaining <= 0) return null;
-  return <span className="text-accent"> · {t("in {time}", { time: formatRemaining(remaining) })}</span>;
+  return (
+    <span className="text-accent"> · {t("in {time}", { time: formatRemaining(remaining) })}</span>
+  );
 }

--- a/src/views/calendar/calendar-chip.tsx
+++ b/src/views/calendar/calendar-chip.tsx
@@ -134,7 +134,9 @@ function ChipTooltip({
       className={`pointer-events-none fixed z-[200] flex flex-col gap-3 rounded-2xl border border-edge bg-elevated/95 p-4 shadow-[0_24px_60px_-18px_rgba(0,0,0,0.7)] backdrop-blur-md transition-opacity duration-100 ${panelWidthClass}`}
     >
       <div className="flex items-start gap-3">
-        <div className={`shrink-0 overflow-hidden rounded-lg bg-canvas/40 ring-1 ring-edge-soft ${posterSizeClass}`}>
+        <div
+          className={`shrink-0 overflow-hidden rounded-lg bg-canvas/40 ring-1 ring-edge-soft ${posterSizeClass}`}
+        >
           <Poster
             src={poster.src}
             onError={poster.onError}

--- a/src/views/calendar/calendar-chip.tsx
+++ b/src/views/calendar/calendar-chip.tsx
@@ -4,7 +4,8 @@ import { Poster, usePosterChain } from "@/components/poster";
 import type { CalendarItem } from "@/lib/calendar";
 import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
-import { formatDateLong } from "./utils";
+import { AiringCountdown } from "./airing-countdown";
+import { formatDateLong, isUpcoming } from "./utils";
 
 export function CalendarChip({
   item,
@@ -17,6 +18,8 @@ export function CalendarChip({
 }) {
   const t = useT();
   const { settings } = useSettings();
+  const tier = settings.calendarPosterSize;
+  const isLarge = tier === "large";
   const poster = usePosterChain(
     settings.rpdbKey,
     item.id,
@@ -31,6 +34,14 @@ export function CalendarChip({
     : item.type === "movie"
       ? "bg-amber-400/20 text-amber-200"
       : "bg-blue-400/20 text-blue-200";
+  const posterSizeClass = isLarge ? "h-10 w-7" : "h-7 w-5";
+  const typeTag = !hideTypeTag && (
+    <span
+      className={`hidden shrink-0 rounded-sm px-1 py-px text-[9px] font-bold uppercase tracking-[0.12em] xl:inline ${tagClass}`}
+    >
+      {tag}
+    </span>
+  );
   return (
     <button
       ref={ref}
@@ -42,25 +53,27 @@ export function CalendarChip({
       onMouseLeave={() => setHovered(false)}
       className="group relative flex min-w-0 items-center gap-2 rounded-md bg-canvas/50 p-1 pe-2 text-start transition-colors hover:bg-canvas/85"
     >
-      <div className="h-7 w-5 shrink-0 overflow-hidden rounded-[3px] bg-elevated/50">
-        {item.poster ? (
-          <Poster
-            src={poster.src}
-            onError={poster.onError}
-            seed={item.id}
-            ratio="portrait"
-            className="h-full w-full"
-          />
-        ) : null}
+      <div className={`shrink-0 overflow-hidden rounded-[3px] bg-elevated/50 ${posterSizeClass}`}>
+        <Poster
+          src={poster.src}
+          onError={poster.onError}
+          seed={item.id}
+          ratio="portrait"
+          className="h-full w-full"
+        />
       </div>
-      <span className="flex-1 truncate text-[11.5px] font-medium text-ink">{item.name}</span>
-      {!hideTypeTag && (
-        <span
-          className={`hidden shrink-0 rounded-sm px-1 py-px text-[9px] font-bold uppercase tracking-[0.12em] xl:inline ${tagClass}`}
-        >
-          {tag}
-        </span>
-      )}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <span className="flex-1 truncate text-[11.5px] font-medium text-ink">{item.name}</span>
+          {typeTag}
+        </div>
+        {item.releaseTime && (
+          <span className="truncate text-[10px] font-medium text-ink-subtle">
+            {item.releaseTime}
+            {isUpcoming(item) && <AiringCountdown atMs={item.releaseAtMs!} />}
+          </span>
+        )}
+      </div>
       {hovered && <ChipTooltip item={item} anchorRef={ref} hideTypeTag={hideTypeTag} />}
     </button>
   );
@@ -77,6 +90,7 @@ function ChipTooltip({
 }) {
   const t = useT();
   const { settings } = useSettings();
+  const tier = settings.calendarPosterSize;
   const poster = usePosterChain(
     settings.rpdbKey,
     item.id,
@@ -108,25 +122,26 @@ function ChipTooltip({
 
   const tag = item.isAnime ? t("Anime") : item.type === "movie" ? t("Movie") : t("TV");
   const dateLabel = formatDateLong(item.releaseDate);
+  const isLarge = tier === "large";
+  const panelWidthClass = isLarge ? "w-[380px]" : "w-[320px]";
+  const posterSizeClass = isLarge ? "h-[180px] w-[120px]" : "h-[120px] w-[80px]";
 
   return createPortal(
     <div
       ref={tipRef}
       onClick={(e) => e.stopPropagation()}
       style={{ left: pos.left, top: pos.top, opacity: pos.ready ? 1 : 0 }}
-      className="pointer-events-none fixed z-[200] flex w-[320px] flex-col gap-3 rounded-2xl border border-edge bg-elevated/95 p-4 shadow-[0_24px_60px_-18px_rgba(0,0,0,0.7)] backdrop-blur-md transition-opacity duration-100"
+      className={`pointer-events-none fixed z-[200] flex flex-col gap-3 rounded-2xl border border-edge bg-elevated/95 p-4 shadow-[0_24px_60px_-18px_rgba(0,0,0,0.7)] backdrop-blur-md transition-opacity duration-100 ${panelWidthClass}`}
     >
       <div className="flex items-start gap-3">
-        <div className="h-[120px] w-[80px] shrink-0 overflow-hidden rounded-lg bg-canvas/40 ring-1 ring-edge-soft">
-          {item.poster ? (
-            <Poster
-              src={poster.src}
-              onError={poster.onError}
-              seed={item.id}
-              ratio="portrait"
-              className="h-full w-full"
-            />
-          ) : null}
+        <div className={`shrink-0 overflow-hidden rounded-lg bg-canvas/40 ring-1 ring-edge-soft ${posterSizeClass}`}>
+          <Poster
+            src={poster.src}
+            onError={poster.onError}
+            seed={item.id}
+            ratio="portrait"
+            className="h-full w-full"
+          />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           {!hideTypeTag && (
@@ -138,6 +153,7 @@ function ChipTooltip({
           <p className="text-[12px] text-ink-muted">
             {dateLabel}
             {item.releaseTime ? ` · ${item.releaseTime}` : ""}
+            {isUpcoming(item) && <AiringCountdown atMs={item.releaseAtMs!} />}
           </p>
           {item.voteAverage > 0 && (
             <p className="text-[11.5px] text-ink-muted">

--- a/src/views/calendar/day-modal.tsx
+++ b/src/views/calendar/day-modal.tsx
@@ -100,7 +100,9 @@ function DayModalRow({
       onClick={() => onOpen(item)}
       className="flex items-start gap-3 rounded-xl border border-edge-soft bg-canvas/40 p-3 text-start transition-colors hover:border-edge hover:bg-canvas/65"
     >
-      <div className={`shrink-0 overflow-hidden rounded-md bg-elevated/50 ring-1 ring-edge-soft ${posterSizeClass}`}>
+      <div
+        className={`shrink-0 overflow-hidden rounded-md bg-elevated/50 ring-1 ring-edge-soft ${posterSizeClass}`}
+      >
         <Poster
           src={poster.src}
           onError={poster.onError}

--- a/src/views/calendar/day-modal.tsx
+++ b/src/views/calendar/day-modal.tsx
@@ -4,7 +4,8 @@ import { Poster, usePosterChain } from "@/components/poster";
 import type { CalendarItem } from "@/lib/calendar";
 import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
-import { formatDateLong } from "./utils";
+import { AiringCountdown } from "./airing-countdown";
+import { formatDateLong, isUpcoming } from "./utils";
 
 export function DayModal({
   dateISO,
@@ -80,6 +81,7 @@ function DayModalRow({
 }) {
   const t = useT();
   const { settings } = useSettings();
+  const tier = settings.calendarPosterSize;
   const poster = usePosterChain(
     settings.rpdbKey,
     item.id,
@@ -92,21 +94,20 @@ function DayModalRow({
     : item.type === "movie"
       ? "bg-amber-400/20 text-amber-200"
       : "bg-blue-400/20 text-blue-200";
+  const posterSizeClass = tier === "large" ? "h-[117px] w-[78px]" : "h-[78px] w-[52px]";
   return (
     <button
       onClick={() => onOpen(item)}
       className="flex items-start gap-3 rounded-xl border border-edge-soft bg-canvas/40 p-3 text-start transition-colors hover:border-edge hover:bg-canvas/65"
     >
-      <div className="h-[78px] w-[52px] shrink-0 overflow-hidden rounded-md bg-elevated/50 ring-1 ring-edge-soft">
-        {item.poster ? (
-          <Poster
-            src={poster.src}
-            onError={poster.onError}
-            seed={item.id}
-            ratio="portrait"
-            className="h-full w-full"
-          />
-        ) : null}
+      <div className={`shrink-0 overflow-hidden rounded-md bg-elevated/50 ring-1 ring-edge-soft ${posterSizeClass}`}>
+        <Poster
+          src={poster.src}
+          onError={poster.onError}
+          seed={item.id}
+          ratio="portrait"
+          className="h-full w-full"
+        />
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex items-center gap-2">
@@ -128,6 +129,7 @@ function DayModalRow({
           <p className="text-[11px] font-medium text-ink-subtle">
             <Clock size={11} className="mr-1 inline text-rose-300" />
             {item.releaseTime}
+            {isUpcoming(item) && <AiringCountdown atMs={item.releaseAtMs!} />}
           </p>
         )}
         {item.overview && (

--- a/src/views/calendar/month-grid.tsx
+++ b/src/views/calendar/month-grid.tsx
@@ -22,6 +22,7 @@ export function MonthGrid({
   hideTypeTag: boolean;
 }) {
   const t = useT();
+  const cap = 2;
   const weekdays = orderedWeekdayNames(weekStartsMonday);
   return (
     <div className="flex flex-col gap-2">
@@ -42,7 +43,7 @@ export function MonthGrid({
           return (
             <div
               key={cell.iso}
-              className={`flex min-h-[112px] flex-col gap-1.5 rounded-xl border p-2 transition-colors ${
+              className={`flex min-h-[136px] flex-col gap-1.5 rounded-xl border p-2 transition-colors ${
                 cell.inMonth
                   ? isToday
                     ? "border-ink/60 bg-elevated/40"
@@ -65,7 +66,7 @@ export function MonthGrid({
                 )}
               </div>
               <div className="flex min-h-0 flex-col gap-1.5">
-                {events.slice(0, 3).map((item) => (
+                {events.slice(0, cap).map((item) => (
                   <CalendarChip
                     key={item.id}
                     item={item}
@@ -73,12 +74,12 @@ export function MonthGrid({
                     hideTypeTag={hideTypeTag}
                   />
                 ))}
-                {events.length > 3 && (
+                {events.length > cap && (
                   <button
                     onClick={() => onOpenDay(cell.iso)}
                     className="self-start rounded px-1 text-start text-[11px] text-ink-subtle transition-colors hover:text-ink"
                   >
-                    {t("+{n} more", { n: events.length - 3 })}
+                    {t("+{n} more", { n: events.length - cap })}
                   </button>
                 )}
               </div>

--- a/src/views/calendar/utils.ts
+++ b/src/views/calendar/utils.ts
@@ -4,8 +4,18 @@ import type { Meta } from "@/lib/cinemeta";
 import type { Cell } from "./types";
 
 export const MONTH_NAMES = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
 ];
 
 export const WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -44,7 +54,9 @@ export function calendarToMeta(item: CalendarItem): Meta {
   };
 }
 
-export function calendarEpisodeHint(item: CalendarItem): { season: number; episode: number } | null {
+export function calendarEpisodeHint(
+  item: CalendarItem,
+): { season: number; episode: number } | null {
   const m = item.id.match(/:(\d+):(\d+)$/);
   if (!m) return null;
   return { season: Number(m[1]), episode: Number(m[2]) };

--- a/src/views/calendar/utils.ts
+++ b/src/views/calendar/utils.ts
@@ -1,4 +1,4 @@
-import type { CalendarFilter, CalendarItem } from "@/lib/calendar";
+import { type CalendarFilter, type CalendarItem, type CalendarPosterSize } from "@/lib/calendar";
 import { type LibraryItem } from "@/lib/stremio";
 import type { Meta } from "@/lib/cinemeta";
 import type { Cell } from "./types";
@@ -21,6 +21,15 @@ export const FILTERS: Array<{ id: CalendarFilter; label: string }> = [
   { id: "tv", label: "TV" },
   { id: "anime", label: "Anime" },
 ];
+
+export const CALENDAR_POSTER_SIZES: Array<{ value: CalendarPosterSize; label: string }> = [
+  { value: "default", label: "Default" },
+  { value: "large", label: "Large" },
+];
+
+export function isUpcoming(item: CalendarItem): boolean {
+  return item.releaseAtMs != null && item.releaseAtMs > Date.now();
+}
 
 export function calendarToMeta(item: CalendarItem): Meta {
   return {

--- a/src/views/detail/anime-airing-banner.tsx
+++ b/src/views/detail/anime-airing-banner.tsx
@@ -1,28 +1,7 @@
 import { CalendarClock } from "lucide-react";
-import { useEffect, useState } from "react";
 import { ReminderInlineLink } from "@/components/reminder-button";
 import { useT } from "@/lib/i18n";
-
-function useNow(intervalMs: number): number {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
-    return () => window.clearInterval(id);
-  }, [intervalMs]);
-  return now;
-}
-
-function formatRemaining(ms: number): string {
-  const totalMinutes = Math.max(0, Math.floor(ms / 60000));
-  const days = Math.floor(totalMinutes / 1440);
-  const hours = Math.floor((totalMinutes % 1440) / 60);
-  const minutes = totalMinutes % 60;
-  const parts: string[] = [];
-  if (days > 0) parts.push(`${days}d`);
-  if (hours > 0 || days > 0) parts.push(`${hours}h`);
-  parts.push(`${minutes}m`);
-  return parts.join(" ");
-}
+import { formatRemaining, useNow } from "@/lib/use-now";
 
 export function AnimeAiringBanner({
   nextAiring,


### PR DESCRIPTION
Fixes three long-standing gaps in the Calendar view:

Local release time & countdown — episode/movie air times are now converted to the user's local timezone and shown alongside the date across every calendar source (Trakt, Cinemeta, TMDB, AniList, anime dub feed, AniZip). A live "in Xd Yh Zm" countdown renders for any item that hasn't aired yet, in the month grid, day modal, and hover tooltip alike.
Larger poster option — added a Default/Large poster-size toggle in the Calendar header; grows the hover tooltip and day-modal artwork.
Blurred/placeholder posters fixed, three separate root causes:
Poster wasn't re-measuring its container on resize, so it sometimes fetched an image sized for the wrong box (ResizeObserver added).
Several calendar sources (fetchTraktCalendar, resolveSavedCalendar for both anime and non-anime library items) were prioritizing a small landscape episode still over the show's actual portrait poster, so it got stretched/cropped and looked blurry. Now the real series/movie poster is always preferred.
Anime posters from the AniZip source (My Library tab) had no series-level poster field at all — now cross-referenced against TMDB via AniZip's themoviedb_id mapping.
Also fixed a native crash on app shutdown: a diagnostic eprintln! in release_stremio_scheme would panic if stderr's pipe was already closed during teardown, taking the whole process down with it.

