### PR TITLE
fix: allow decimal subtitle outline thickness values

### DIFF
--- a/src/components/player/sub-style-bar/advanced-menu.tsx
+++ b/src/components/player/sub-style-bar/advanced-menu.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, Minus, Plus, Settings2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSettings, type Settings } from "@/lib/settings";
+import { stepSubBorderSize } from "@/lib/settings/border-size";
 import { useT } from "@/lib/i18n";
 
 function clamp(n: number, lo: number, hi: number): number {
@@ -92,17 +93,27 @@ export function AdvancedMenu() {
                 <Row label={t("Thickness")}>
                   <Stepper
                     value={settings.subBorderSize}
-                    onDec={() => update({ subBorderSize: clamp(settings.subBorderSize - 1, 1, 6) })}
-                    onInc={() => update({ subBorderSize: clamp(Math.max(1, settings.subBorderSize) + 1, 1, 6) })}
+                    onDec={() =>
+                      update({ subBorderSize: stepSubBorderSize(settings.subBorderSize, -1) })
+                    }
+                    onInc={() =>
+                      update({ subBorderSize: stepSubBorderSize(settings.subBorderSize, 1) })
+                    }
                   />
                 </Row>
               )}
               <Row label={t("Position")}>
                 <div className="flex items-center gap-1">
-                  <IconBtn label={t("Raise subtitles")} onClick={() => update({ subMarginY: clamp(settings.subMarginY + 2, 0, 100) })}>
+                  <IconBtn
+                    label={t("Raise subtitles")}
+                    onClick={() => update({ subMarginY: clamp(settings.subMarginY + 2, 0, 100) })}
+                  >
                     <ChevronDown size={15} className="rotate-180" />
                   </IconBtn>
-                  <IconBtn label={t("Lower subtitles")} onClick={() => update({ subMarginY: clamp(settings.subMarginY - 2, 0, 100) })}>
+                  <IconBtn
+                    label={t("Lower subtitles")}
+                    onClick={() => update({ subMarginY: clamp(settings.subMarginY - 2, 0, 100) })}
+                  >
                     <ChevronDown size={15} />
                   </IconBtn>
                 </div>
@@ -117,8 +128,12 @@ export function AdvancedMenu() {
               <Row label={t("Line spacing")}>
                 <Stepper
                   value={settings.subLineSpacing ?? 0}
-                  onDec={() => update({ subLineSpacing: clamp((settings.subLineSpacing ?? 0) - 1, 0, 12) })}
-                  onInc={() => update({ subLineSpacing: clamp((settings.subLineSpacing ?? 0) + 1, 0, 12) })}
+                  onDec={() =>
+                    update({ subLineSpacing: clamp((settings.subLineSpacing ?? 0) - 1, 0, 12) })
+                  }
+                  onInc={() =>
+                    update({ subLineSpacing: clamp((settings.subLineSpacing ?? 0) + 1, 0, 12) })
+                  }
                 />
               </Row>
               <div className="my-1.5 h-px bg-edge-soft" />
@@ -127,7 +142,9 @@ export function AdvancedMenu() {
                 className="flex w-full items-start gap-3 rounded-[10px] p-2 text-start transition-colors hover:bg-raised"
               >
                 <span className="min-w-0 flex-1">
-                  <span className="block text-[13.5px] font-semibold text-ink">{t("Override embedded styles")}</span>
+                  <span className="block text-[13.5px] font-semibold text-ink">
+                    {t("Override embedded styles")}
+                  </span>
                   <span className="mt-0.5 block text-[11.5px] leading-snug text-ink-subtle">
                     {t("Force your look onto subtitles that carry their own styling.")}
                   </span>
@@ -138,7 +155,9 @@ export function AdvancedMenu() {
                     overrideOn ? "bg-accent" : "bg-edge"
                   }`}
                 >
-                  <span className={`h-4 w-4 rounded-full bg-white transition-transform ${overrideOn ? "translate-x-4" : ""}`} />
+                  <span
+                    className={`h-4 w-4 rounded-full bg-white transition-transform ${overrideOn ? "translate-x-4" : ""}`}
+                  />
                 </span>
               </button>
             </div>
@@ -190,7 +209,9 @@ function Stepper({ value, onDec, onInc }: { value: number; onDec: () => void; on
       <IconBtn label="−" onClick={onDec}>
         <Minus size={14} />
       </IconBtn>
-      <span className="min-w-[28px] text-center font-mono text-[13px] tabular-nums text-ink">{value}</span>
+      <span className="min-w-[28px] text-center font-mono text-[13px] tabular-nums text-ink">
+        {value}
+      </span>
       <IconBtn label="+" onClick={onInc}>
         <Plus size={14} />
       </IconBtn>
@@ -198,7 +219,15 @@ function Stepper({ value, onDec, onInc }: { value: number; onDec: () => void; on
   );
 }
 
-function IconBtn({ label, onClick, children }: { label: string; onClick: () => void; children: React.ReactNode }) {
+function IconBtn({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
   return (
     <button
       aria-label={label}

--- a/src/components/player/subtitle-overlay.tsx
+++ b/src/components/player/subtitle-overlay.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useActiveKid } from "@/lib/profiles";
 import { useSettings } from "@/lib/settings";
+import { buildSubtitleOutline } from "@/lib/player/subtitle-outline";
 
 type Props = {
   text: string;
@@ -46,14 +47,14 @@ export const SubtitleOverlay = memo(function SubtitleOverlay({ text, startSec, s
     align === "left" ? "justify-start" : align === "right" ? "justify-end" : "justify-center";
 
   const borderSize = useMemo(
-    () => Math.max(1, Math.round((clamp(settings.subBorderSize, 1, 6) || 2) * responsive)),
+    () => Math.max(1, (clamp(settings.subBorderSize, 1, 6) || 2) * responsive),
     [settings.subBorderSize, responsive],
   );
   const borderColor = settings.subBorderColor || "#000000";
 
   const textShadow = useMemo(() => {
     if (style === "outline") {
-      return buildOutline(borderColor, borderSize);
+      return buildSubtitleOutline(borderColor, borderSize);
     } else if (style === "shadow") {
       return "0 1px 2px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55)";
     }
@@ -136,18 +137,6 @@ function fontFamilyFor(family: string | undefined): string {
     default:
       return '"Inter", -apple-system, system-ui, sans-serif';
   }
-}
-
-function buildOutline(color: string, size: number): string {
-  const offsets: [number, number][] = [];
-  for (let dx = -size; dx <= size; dx++) {
-    for (let dy = -size; dy <= size; dy++) {
-      const r = Math.sqrt(dx * dx + dy * dy);
-      if (r > size + 0.1 || r < 0.1) continue;
-      offsets.push([dx, dy]);
-    }
-  }
-  return offsets.map(([dx, dy]) => `${dx}px ${dy}px 0 ${color}`).join(", ");
 }
 
 function clamp(n: number, lo: number, hi: number): number {

--- a/src/lib/player/subtitle-outline.ts
+++ b/src/lib/player/subtitle-outline.ts
@@ -1,0 +1,13 @@
+export function buildSubtitleOutline(color: string, size: number): string {
+  const radius = Number.isFinite(size) ? Math.max(0, size) : 0;
+  const limit = Math.ceil(radius);
+  const offsets: Array<[number, number]> = [];
+  for (let dx = -limit; dx <= limit; dx++) {
+    for (let dy = -limit; dy <= limit; dy++) {
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      if (distance > radius + 0.1 || distance < 0.1) continue;
+      offsets.push([dx, dy]);
+    }
+  }
+  return offsets.map(([dx, dy]) => `${dx}px ${dy}px 0 ${color}`).join(", ");
+}

--- a/src/lib/settings/border-size.ts
+++ b/src/lib/settings/border-size.ts
@@ -1,0 +1,27 @@
+export const SUB_BORDER_SIZE_MIN = 1;
+export const SUB_BORDER_SIZE_MAX = 6;
+const STEP = 0.5;
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+/**
+ * Clamp the outline thickness to [1, 6] and snap to the 0.5 UI step so
+ * floating point drift can never accumulate in the stored setting.
+ */
+export function normalizeSubBorderSize(value: number): number {
+  if (!Number.isFinite(value)) return SUB_BORDER_SIZE_MIN;
+  return clamp(Math.round(value / STEP) * STEP, SUB_BORDER_SIZE_MIN, SUB_BORDER_SIZE_MAX);
+}
+
+/** One +/- click on the player quick menu, snapped to the 0.5 step. */
+export function stepSubBorderSize(value: number, direction: -1 | 1): number {
+  const base = Number.isFinite(value) ? value : SUB_BORDER_SIZE_MIN;
+  return normalizeSubBorderSize(base + direction * STEP);
+}
+
+/** Display form for the thickness value, trimming floating point noise. */
+export function formatSubBorderSize(value: number): string {
+  return `${Number(value.toFixed(2))}px`;
+}

--- a/src/views/settings/player-panel/subtitle-section.tsx
+++ b/src/views/settings/player-panel/subtitle-section.tsx
@@ -2,6 +2,7 @@ import { Plus, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import godfatherStill from "@/assets/godfather-offer.svg";
 import { useSettings } from "@/lib/settings";
+import { formatSubBorderSize, normalizeSubBorderSize } from "@/lib/settings/border-size";
 import { useT } from "@/lib/i18n";
 import { ColorPopoverTrigger } from "../color-picker";
 import { ToggleRow } from "../shared";
@@ -12,9 +13,21 @@ export function SubtitleStylePanel() {
   const t = useT();
 
   const styles: Array<{ id: "shadow" | "outline" | "box"; label: string; sub: string }> = [
-    { id: "shadow", label: t("Drop shadow"), sub: t("Soft halo around the text. Cleanest on most content.") },
-    { id: "outline", label: t("Outline"), sub: t("Hard stroke around each letter. High contrast.") },
-    { id: "box", label: t("Black bar"), sub: t("Rounded background panel behind the text. Most readable.") },
+    {
+      id: "shadow",
+      label: t("Drop shadow"),
+      sub: t("Soft halo around the text. Cleanest on most content."),
+    },
+    {
+      id: "outline",
+      label: t("Outline"),
+      sub: t("Hard stroke around each letter. High contrast."),
+    },
+    {
+      id: "box",
+      label: t("Black bar"),
+      sub: t("Rounded background panel behind the text. Most readable."),
+    },
   ];
 
   const aligns: Array<{ id: "left" | "center" | "right"; label: string }> = [
@@ -24,9 +37,23 @@ export function SubtitleStylePanel() {
   ];
 
   const assModes: Array<{ id: "no" | "scale" | "force"; label: string; sub: string }> = [
-    { id: "no", label: t("Keep original"), sub: t("Styled (ASS) subs keep their own fonts, colors, and effects. Truest to the release.") },
-    { id: "scale", label: t("Resize only"), sub: t("Keep the original look but apply your size and position.") },
-    { id: "force", label: t("Use my style"), sub: t("Force your font, size, and color onto styled subs. Use this for Arabic or any subs showing boxes. Can affect karaoke and signs.") },
+    {
+      id: "no",
+      label: t("Keep original"),
+      sub: t("Styled (ASS) subs keep their own fonts, colors, and effects. Truest to the release."),
+    },
+    {
+      id: "scale",
+      label: t("Resize only"),
+      sub: t("Keep the original look but apply your size and position."),
+    },
+    {
+      id: "force",
+      label: t("Use my style"),
+      sub: t(
+        "Force your font, size, and color onto styled subs. Use this for Arabic or any subs showing boxes. Can affect karaoke and signs.",
+      ),
+    },
   ];
 
   const isDefault =
@@ -107,12 +134,17 @@ export function SubtitleStylePanel() {
           })}
         </div>
         <p className="text-[11.5px] leading-snug text-ink-muted">
-          {t("Seeing empty boxes instead of letters? Choose Arabic under Font and switch to Use my style.")}
+          {t(
+            "Seeing empty boxes instead of letters? Choose Arabic under Font and switch to Use my style.",
+          )}
         </p>
       </div>
 
       {settings.subStyle === "box" && (
-        <SubField label={t("Background opacity")} value={`${Math.round(settings.subBoxOpacity * 100)}%`}>
+        <SubField
+          label={t("Background opacity")}
+          value={`${Math.round(settings.subBoxOpacity * 100)}%`}
+        >
           <input
             type="range"
             min={0.2}
@@ -126,14 +158,19 @@ export function SubtitleStylePanel() {
       )}
 
       {settings.subStyle === "outline" && (
-        <SubField label={t("Outline thickness")} value={`${settings.subBorderSize}px`}>
+        <SubField
+          label={t("Outline thickness")}
+          value={formatSubBorderSize(settings.subBorderSize)}
+        >
           <input
             type="range"
             min={1}
             max={6}
-            step={1}
+            step={0.5}
             value={Math.max(1, settings.subBorderSize)}
-            onChange={(e) => update({ subBorderSize: parseInt(e.target.value, 10) })}
+            onChange={(e) =>
+              update({ subBorderSize: normalizeSubBorderSize(parseFloat(e.target.value)) })
+            }
             className="h-1 w-full appearance-none rounded-full bg-edge-soft accent-ink"
           />
         </SubField>
@@ -205,7 +242,9 @@ export function SubtitleStylePanel() {
                 type="button"
                 onClick={() => update({ subAlignX: a.id })}
                 className={`flex h-10 items-center justify-center rounded-xl border text-[12.5px] font-semibold transition-colors ${
-                  sel ? "border-ink bg-elevated text-ink" : "border-edge-soft bg-canvas/40 text-ink-muted hover:border-edge hover:text-ink"
+                  sel
+                    ? "border-ink bg-elevated text-ink"
+                    : "border-edge-soft bg-canvas/40 text-ink-muted hover:border-edge hover:text-ink"
                 }`}
               >
                 {a.label}
@@ -319,7 +358,8 @@ function SubtitlePreview() {
     }
     textShadow = offsets.map(([dx, dy]) => `${dx * 0.55}px ${dy * 0.55}px 0 ${c}`).join(", ");
   } else if (settings.subStyle === "shadow") {
-    textShadow = "0 1px 2px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55)";
+    textShadow =
+      "0 1px 2px rgba(0,0,0,0.95), 0 2px 6px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.55)";
   }
 
   const boxRgb = (() => {
@@ -341,7 +381,8 @@ function SubtitlePreview() {
       : undefined;
 
   const align = settings.subAlignX || "center";
-  const justify = align === "left" ? "justify-start" : align === "right" ? "justify-end" : "justify-center";
+  const justify =
+    align === "left" ? "justify-start" : align === "right" ? "justify-end" : "justify-center";
 
   return (
     <div
@@ -349,7 +390,10 @@ function SubtitlePreview() {
       style={{ backgroundImage: `url(${godfatherStill})` }}
     >
       <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-transparent to-transparent" />
-      <div className={`absolute inset-x-0 flex ${justify} px-[6%]`} style={{ bottom: `${settings.subMarginY}%`, opacity: settings.subOpacity }}>
+      <div
+        className={`absolute inset-x-0 flex ${justify} px-[6%]`}
+        style={{ bottom: `${settings.subMarginY}%`, opacity: settings.subOpacity }}
+      >
         <div style={boxStyle}>
           <div
             style={{
@@ -363,7 +407,7 @@ function SubtitlePreview() {
               textAlign: align as "left" | "center" | "right",
             }}
           >
-                  I&apos;m gonna make him an offer he can&apos;t refuse.
+            I&apos;m gonna make him an offer he can&apos;t refuse.
           </div>
         </div>
       </div>
@@ -371,7 +415,10 @@ function SubtitlePreview() {
   );
 }
 
-const PRESET_FONTS: Array<{ id: "inter" | "system" | "rounded" | "serif" | "arabic"; label: string }> = [
+const PRESET_FONTS: Array<{
+  id: "inter" | "system" | "rounded" | "serif" | "arabic";
+  label: string;
+}> = [
   { id: "inter", label: "Inter" },
   { id: "system", label: "System" },
   { id: "rounded", label: "Rounded" },
@@ -379,7 +426,8 @@ const PRESET_FONTS: Array<{ id: "inter" | "system" | "rounded" | "serif" | "arab
   { id: "arabic", label: "Arabic" },
 ];
 
-const FONT_ACCEPT = ".ttf,.otf,.woff,.woff2,font/ttf,font/otf,font/woff,font/woff2,application/x-font-ttf,application/x-font-otf,application/font-woff,application/font-woff2";
+const FONT_ACCEPT =
+  ".ttf,.otf,.woff,.woff2,font/ttf,font/otf,font/woff,font/woff2,application/x-font-ttf,application/x-font-otf,application/font-woff,application/font-woff2";
 const MAX_FONT_BYTES = 4 * 1024 * 1024;
 
 function FontPicker() {
@@ -416,7 +464,8 @@ function FontPicker() {
     try {
       const dataUrl = await new Promise<string>((resolve, reject) => {
         const r = new FileReader();
-        r.onload = () => (typeof r.result === "string" ? resolve(r.result) : reject(new Error("read failed")));
+        r.onload = () =>
+          typeof r.result === "string" ? resolve(r.result) : reject(new Error("read failed"));
         r.onerror = () => reject(r.error);
         r.readAsDataURL(file);
       });
@@ -424,7 +473,12 @@ function FontPicker() {
       const baseName = file.name.replace(/\.(ttf|otf|woff2?|ttc)$/i, "");
       const next = [
         ...customFonts,
-        { id, name: baseName || `Custom ${customFonts.length + 1}`, dataUrl, format: formatMap[ext] },
+        {
+          id,
+          name: baseName || `Custom ${customFonts.length + 1}`,
+          dataUrl,
+          format: formatMap[ext],
+        },
       ];
       update({ customFonts: next, subFontFamily: `custom:${id}` });
     } catch (e) {

--- a/tests/subtitle-border-size.test.ts
+++ b/tests/subtitle-border-size.test.ts
@@ -1,0 +1,50 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+import {
+  formatSubBorderSize,
+  normalizeSubBorderSize,
+  stepSubBorderSize,
+} from "../src/lib/settings/border-size.ts";
+
+test("normalize keeps decimal half steps", () => {
+  assert.equal(normalizeSubBorderSize(3.5), 3.5);
+  assert.equal(normalizeSubBorderSize(2), 2);
+  assert.equal(normalizeSubBorderSize(1.5), 1.5);
+});
+
+test("normalize clamps to [1, 6]", () => {
+  assert.equal(normalizeSubBorderSize(0), 1);
+  assert.equal(normalizeSubBorderSize(-4), 1);
+  assert.equal(normalizeSubBorderSize(6), 6);
+  assert.equal(normalizeSubBorderSize(9), 6);
+});
+
+test("normalize snaps to the 0.5 step and guards float drift", () => {
+  assert.equal(normalizeSubBorderSize(3.25), 3.5);
+  assert.equal(normalizeSubBorderSize(3.3), 3.5);
+  assert.equal(normalizeSubBorderSize(3.1500000000000004), 3); // float noise, nearest step is 3
+  assert.equal(normalizeSubBorderSize(Number.NaN), 1);
+  assert.equal(normalizeSubBorderSize(Number.POSITIVE_INFINITY), 1);
+});
+
+test("stepper moves by 0.5 without drift and respects bounds", () => {
+  assert.equal(stepSubBorderSize(3.5, 1), 4);
+  assert.equal(stepSubBorderSize(3.5, -1), 3);
+  assert.equal(stepSubBorderSize(0, 1), 1);
+  assert.equal(stepSubBorderSize(0, -1), 1);
+  assert.equal(stepSubBorderSize(6, 1), 6);
+  assert.equal(stepSubBorderSize(1, -1), 1);
+  // repeated increments from a default-sentinel 0 land on valid values
+  let v = 0;
+  for (let i = 0; i < 12; i++) v = stepSubBorderSize(v, 1);
+  assert.equal(v, 6);
+});
+
+test("format trims floating point noise", () => {
+  assert.equal(formatSubBorderSize(0), "0px");
+  assert.equal(formatSubBorderSize(3.5), "3.5px");
+  assert.equal(formatSubBorderSize(2), "2px");
+  assert.equal(formatSubBorderSize(0.1 + 0.2), "0.3px");
+});

--- a/tests/subtitle-border-size.test.ts
+++ b/tests/subtitle-border-size.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeSubBorderSize,
   stepSubBorderSize,
 } from "../src/lib/settings/border-size.ts";
+import { buildSubtitleOutline } from "../src/lib/player/subtitle-outline.ts";
 
 test("normalize keeps decimal half steps", () => {
   assert.equal(normalizeSubBorderSize(3.5), 3.5);
@@ -47,4 +48,12 @@ test("format trims floating point noise", () => {
   assert.equal(formatSubBorderSize(3.5), "3.5px");
   assert.equal(formatSubBorderSize(2), "2px");
   assert.equal(formatSubBorderSize(0.1 + 0.2), "0.3px");
+});
+
+test("HTML5 subtitle outlines preserve fractional radii", () => {
+  const integer = buildSubtitleOutline("#000000", 3);
+  const fractional = buildSubtitleOutline("#000000", 3.5);
+  assert.notEqual(fractional, integer);
+  assert.ok(fractional.split(", ").length > integer.split(", ").length);
+  assert.equal(buildSubtitleOutline("#000000", 3.5), fractional);
 });


### PR DESCRIPTION
Fixes #1130

## Problem
The subtitle outline thickness control only accepted whole numbers. The settings slider used `step={1}` with `parseInt`, and the in-player thickness stepper changed by whole integers, so values such as 3.5 could not be selected.

## Fix
- Allow 0.5 increments in the settings slider and preserve decimal values with `parseFloat`.
- Apply the same half-step behavior to the in-player subtitle controls.
- Normalize values to the supported 1–6 range and avoid floating-point drift.
- Preserve the existing `subBorderSize = 0` default sentinel.
- Preserve fractional thickness in the HTML5 subtitle fallback instead of rounding it away.
- Add regression coverage for both stored values and rendered outline behavior.

## Verification
- `node --test tests/subtitle-border-size.test.ts` — 6/6 passed
- `pnpm typecheck` — passed
- Focused `vp check` on the follow-up files — passed
- The original four-file focused check also passed
- Full frontend suite — 106/107 passed; the single failing startup-loader test reproduces on untouched `main` and is unrelated to this change
- No secrets or unrelated logic changes included