### PR TITLE
fix: restore window size and maximized state on fullscreen exit

### DIFF
--- a/src-tauri/src/fullscreen.rs
+++ b/src-tauri/src/fullscreen.rs
@@ -1,8 +1,18 @@
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Manager, State};
 
+/// Window state captured before entering fullscreen.
+///
+/// `bounds` is `None` when the window was maximized: its position/size are
+/// owned by the WM in that case, so exit must re-maximize instead of writing
+/// raw pixel values (which would be full-monitor dimensions).
+struct SavedWindowState {
+    bounds: Option<(i32, i32, u32, u32)>,
+    was_maximized: bool,
+}
+
 pub struct FullscreenState {
-    saved: Arc<Mutex<Option<(i32, i32, u32, u32)>>>,
+    saved: Arc<Mutex<Option<SavedWindowState>>>,
 }
 
 impl FullscreenState {
@@ -24,10 +34,21 @@ pub async fn window_fullscreen_enter(
 
     let already_fs = main.is_fullscreen().unwrap_or(false);
     if !already_fs {
-        if let (Ok(pos), Ok(sz)) = (main.outer_position(), main.inner_size()) {
-            *state.saved.lock().unwrap() = Some((pos.x, pos.y, sz.width, sz.height));
-        }
-        if main.is_maximized().unwrap_or(false) {
+        let was_maximized = main.is_maximized().unwrap_or(false);
+        // Read bounds before unmaximizing; when maximized they describe the
+        // monitor, not the user's preferred window geometry.
+        let bounds = if was_maximized {
+            None
+        } else if let (Ok(pos), Ok(sz)) = (main.outer_position(), main.inner_size()) {
+            Some((pos.x, pos.y, sz.width, sz.height))
+        } else {
+            None
+        };
+        *state.saved.lock().unwrap() = Some(SavedWindowState {
+            bounds,
+            was_maximized,
+        });
+        if was_maximized {
             let _ = main.unmaximize();
         }
         main.set_fullscreen(true)
@@ -53,15 +74,35 @@ pub async fn window_fullscreen_exit(
         main.set_fullscreen(false)
             .map_err(|e| format!("set_fullscreen(false): {}", e))?;
         let saved = state.saved.lock().unwrap().take();
-        if let Some((x, y, w, h)) = saved {
-            let _ = main.set_size(tauri::PhysicalSize { width: w, height: h });
-            if restore_position.unwrap_or(true) {
-                let _ = main.set_position(tauri::PhysicalPosition { x, y });
-            } else {
+
+        // On Windows the DWM fullscreen transition finishes asynchronously;
+        // restoring geometry immediately gets overridden by the tail end of
+        // the transition, leaving the window oversized/borderless (#1253).
+        #[cfg(target_os = "windows")]
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        match saved {
+            Some(saved) if saved.was_maximized => {
+                let _ = main.maximize();
+            }
+            Some(saved) => {
+                if let Some((x, y, w, h)) = saved.bounds {
+                    let _ = main.set_size(tauri::PhysicalSize {
+                        width: w,
+                        height: h,
+                    });
+                    if restore_position.unwrap_or(true) {
+                        let _ = main.set_position(tauri::PhysicalPosition { x, y });
+                    } else {
+                        let _ = main.center();
+                    }
+                } else {
+                    let _ = main.center();
+                }
+            }
+            None => {
                 let _ = main.center();
             }
-        } else {
-            let _ = main.center();
         }
         let _ = main.set_focus();
     }

--- a/src-tauri/src/fullscreen.rs
+++ b/src-tauri/src/fullscreen.rs
@@ -1,11 +1,12 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::Mutex;
 
 /// Window state captured before entering fullscreen.
 ///
-/// `bounds` is `None` when the window was maximized: its position/size are
-/// owned by the WM in that case, so exit must re-maximize instead of writing
-/// raw pixel values (which would be full-monitor dimensions).
+/// `was_maximized` is kept separately from the normal bounds because a
+/// maximized window's reported bounds describe the monitor rather than the
+/// user's restored window geometry.
 struct SavedWindowState {
     bounds: Option<(i32, i32, u32, u32)>,
     was_maximized: bool,
@@ -32,29 +33,30 @@ pub async fn window_fullscreen_enter(
         .get_webview_window("main")
         .ok_or_else(|| "main window missing".to_string())?;
 
+    let mut saved = state.saved.lock().await;
     let already_fs = main.is_fullscreen().unwrap_or(false);
-    if !already_fs {
+    if !already_fs && saved.is_none() {
         let was_maximized = main.is_maximized().unwrap_or(false);
-        // Read bounds before unmaximizing; when maximized they describe the
-        // monitor, not the user's preferred window geometry.
-        let bounds = if was_maximized {
-            None
-        } else if let (Ok(pos), Ok(sz)) = (main.outer_position(), main.inner_size()) {
+        if was_maximized {
+            let _ = main.unmaximize();
+        }
+        let bounds = if let (Ok(pos), Ok(sz)) = (main.outer_position(), main.inner_size()) {
             Some((pos.x, pos.y, sz.width, sz.height))
         } else {
             None
         };
-        *state.saved.lock().unwrap() = Some(SavedWindowState {
+        *saved = Some(SavedWindowState {
             bounds,
             was_maximized,
         });
-        if was_maximized {
-            let _ = main.unmaximize();
+        if let Err(e) = main.set_fullscreen(true) {
+            saved.take();
+            return Err(format!("set_fullscreen(true): {}", e));
         }
-        main.set_fullscreen(true)
-            .map_err(|e| format!("set_fullscreen(true): {}", e))?;
         let _ = main.set_focus();
     }
+    drop(saved);
+
     let _ = app.emit_to("main", "fs://entered", ());
     Ok(())
 }
@@ -69,11 +71,19 @@ pub async fn window_fullscreen_exit(
         .get_webview_window("main")
         .ok_or_else(|| "main window missing".to_string())?;
 
+    // Hold the async state lock through the native transition and restoration
+    // delay. This serializes reasserted enter calls with exit and prevents a
+    // second transition from overwriting the active saved snapshot.
+    let mut saved_state = state.saved.lock().await;
     let is_fs = main.is_fullscreen().unwrap_or(false);
-    if is_fs {
-        main.set_fullscreen(false)
-            .map_err(|e| format!("set_fullscreen(false): {}", e))?;
-        let saved = state.saved.lock().unwrap().take();
+    let saved = saved_state.take();
+    if is_fs || saved.is_some() {
+        if is_fs {
+            if let Err(e) = main.set_fullscreen(false) {
+                *saved_state = saved;
+                return Err(format!("set_fullscreen(false): {}", e));
+            }
+        }
 
         // On Windows the DWM fullscreen transition finishes asynchronously;
         // restoring geometry immediately gets overridden by the tail end of
@@ -82,7 +92,7 @@ pub async fn window_fullscreen_exit(
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
         match saved {
-            Some(saved) if saved.was_maximized => {
+            Some(saved) if saved.was_maximized && restore_position.unwrap_or(true) => {
                 let _ = main.maximize();
             }
             Some(saved) => {
@@ -106,6 +116,8 @@ pub async fn window_fullscreen_exit(
         }
         let _ = main.set_focus();
     }
+    drop(saved_state);
+
     let _ = app.emit_to("main", "fs://exited", ());
     Ok(())
 }

--- a/src/lib/fullscreen-state.ts
+++ b/src/lib/fullscreen-state.ts
@@ -30,7 +30,9 @@ export function consumeMarathonReenter(): boolean {
 }
 
 function isTauri(): boolean {
-  return typeof window !== "undefined" && ("__TAURI__" in window || "__TAURI_INTERNALS__" in window);
+  return (
+    typeof window !== "undefined" && ("__TAURI__" in window || "__TAURI_INTERNALS__" in window)
+  );
 }
 
 function emit(): void {
@@ -102,7 +104,9 @@ async function osWindowFullscreen(): Promise<boolean> {
   if (!isTauri()) return false;
   try {
     const { getCurrentWindow } = await import("@tauri-apps/api/window");
-    return await getCurrentWindow().isFullscreen().catch(() => false);
+    return await getCurrentWindow()
+      .isFullscreen()
+      .catch(() => false);
   } catch {
     return false;
   }
@@ -119,13 +123,8 @@ export async function exitAnyFullscreen(): Promise<void> {
     await document.exitFullscreen().catch(() => {});
   }
   if (isTauri()) {
-    try {
-      const { getCurrentWindow } = await import("@tauri-apps/api/window");
-      const w = getCurrentWindow();
-      if (await w.isFullscreen().catch(() => false)) await w.setFullscreen(false).catch(() => {});
-    } catch {
-      /* ignore */
-    }
+    await exitWindowFullscreen();
+    return;
   }
   if (windowFullscreen) await exitWindowFullscreen();
 }

--- a/tests/fullscreen-restore.test.ts
+++ b/tests/fullscreen-restore.test.ts
@@ -1,0 +1,33 @@
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import assert from "node:assert/strict";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import test from "node:test";
+
+const fullscreenStateSource = readFileSync(
+  new URL("../src/lib/fullscreen-state.ts", import.meta.url),
+  "utf8",
+);
+const nativeFullscreenSource = readFileSync(
+  new URL("../src-tauri/src/fullscreen.rs", import.meta.url),
+  "utf8",
+);
+
+function functionBody(source: string, name: string): string {
+  const start = source.indexOf(`export async function ${name}`);
+  assert.notEqual(start, -1, `${name} must exist`);
+  return source.slice(start, source.indexOf("\n}", start) + 2);
+}
+
+test("native fullscreen exits use the restoration command", () => {
+  const exitBody = functionBody(fullscreenStateSource, "exitAnyFullscreen");
+  assert.match(exitBody, /await exitWindowFullscreen\(\)/);
+  assert.doesNotMatch(exitBody, /setFullscreen\(false\)/);
+});
+
+test("native fullscreen transitions serialize saved window state", () => {
+  assert.match(nativeFullscreenSource, /tokio::sync::Mutex/);
+  assert.match(nativeFullscreenSource, /state\.saved\.lock\(\)\.await/);
+  assert.match(nativeFullscreenSource, /saved\.take\(\)/);
+});


### PR DESCRIPTION
Fixes #1253

## Problem
On Windows, exiting fullscreen can leave Harbor oversized and borderless. The current implementation restores geometry immediately after `set_fullscreen(false)`, racing the DWM transition. It also saves maximized monitor bounds and later restores them as ordinary window dimensions, losing the maximized state.

## Fix
- Record whether the window was maximized before entering fullscreen and capture normal bounds after unmaximizing.
- Wait 150 ms on Windows after leaving fullscreen before restoring geometry.
- Re-maximize previously maximized windows when position restoration is enabled; otherwise restore their normal bounds and center them.
- Route Tauri `exitAnyFullscreen()` through the Rust restoration command instead of clearing fullscreen through a raw window API first.
- Serialize native enter/exit transitions with an async mutex so reassertion cannot overwrite the active saved snapshot.
- Restore saved state even if fullscreen was externally cleared before the Rust exit command runs.
- Add regression coverage for the native exit route and serialized state.

## Verification
- `node --test tests/fullscreen-restore.test.ts` — 2/2 passed
- `pnpm typecheck` — passed
- `cargo check --manifest-path src-tauri/Cargo.toml` — passed
- `rustfmt --edition 2021 --check src-tauri/src/fullscreen.rs` — passed
- Cargo emitted only pre-existing warnings in unrelated files
- No interactive GUI reproduction was performed in this automated pass