### PR TITLE
Fix downloaded streams not showing as cached

### DIFF
--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -154,6 +154,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     (isBundledEngineUrl(src.url) || isLocalEngineUrl(src.url)) &&
     !src.url.includes("/hlsv2/") &&
     !!src.streamRef?.infoHash;
+  const isLocalSrc = isLocalUrl(src.url);
   const { stats: engineStats, genuineFailure } = useEngineStats({
     url: src.url,
     infoHash: src.streamRef?.infoHash ?? null,
@@ -171,6 +172,8 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
           streamLen: engineStats?.streamLen ?? 0,
         }),
       );
+    } else if (isLocalSrc) {
+      setPlaybackDownloaded(1);
     } else if (!isLive && !isHls) {
       const dur = snap.durationSec || 0;
       setPlaybackDownloaded(dur > 0 ? Math.min(1, (snap.positionSec + snap.bufferedSec) / dur) : 0);
@@ -182,6 +185,7 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     engineStats?.streamLen,
     src.url,
     isP2pEngine,
+    isLocalSrc,
     src.isLive,
     src.meta.id,
     snap.positionSec,
@@ -868,7 +872,6 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
     exitPlayer,
   });
 
-  const isLocalSrc = isLocalUrl(src.url);
   const cancelToPicker = useCallback(() => {
     if (isLocalSrc || src.meta.id?.startsWith("iptv:")) {
       void closePlayer();

--- a/tests/player-buffer-policy.test.ts
+++ b/tests/player-buffer-policy.test.ts
@@ -1,6 +1,8 @@
 // @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
 import assert from "node:assert/strict";
 // @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
+import { readFileSync } from "node:fs";
+// @ts-expect-error Node test types are intentionally outside the browser-only tsconfig.
 import test from "node:test";
 import type { Settings } from "../src/lib/settings/types.ts";
 import { compileMpvOptions, svpMpvLines } from "../src/lib/player/mpv-tuning.ts";
@@ -31,6 +33,32 @@ test("only the P2P engine reports whole-file download progress", () => {
       streamLen: 0,
     }),
     0,
+  );
+});
+
+test("a fully downloaded local file is reported as cached immediately, not buffering", () => {
+  const source = readFileSync(new URL("../src/views/player.tsx", import.meta.url), "utf8");
+
+  const p2pBranchAt = source.indexOf("if (isP2pEngine) {");
+  const localBranchAt = source.indexOf("} else if (isLocalSrc) {");
+  const genericBufferBranchAt = source.indexOf(
+    "setPlaybackDownloaded(dur > 0 ? Math.min(1, (snap.positionSec + snap.bufferedSec) / dur) : 0);",
+  );
+
+  assert.ok(p2pBranchAt !== -1, "playback-downloaded effect's P2P branch is missing");
+  assert.ok(localBranchAt !== -1, "local-source branch is missing from the playback-downloaded effect");
+  assert.ok(genericBufferBranchAt !== -1, "generic position+buffered heuristic branch is missing");
+  assert.ok(
+    p2pBranchAt < localBranchAt && localBranchAt < genericBufferBranchAt,
+    "local-source branch must be checked before the generic position+buffered heuristic, " +
+      "so an already-on-disk downloaded file isn't treated as still buffering",
+  );
+
+  const localBranch = source.slice(localBranchAt, genericBufferBranchAt);
+  assert.match(
+    localBranch,
+    /setPlaybackDownloaded\(1\);/,
+    "a local (already-on-disk) file must be reported as 100% downloaded, not derived from position + buffered",
   );
 });
 


### PR DESCRIPTION
Summary
Fixes the Downloads-tab player so a fully downloaded local file is immediately shown as Cached (green dot, no buffer-progress bar) instead of behaving like it's still streaming/buffering.

Why
The playback-downloaded effect in src/views/player.tsx only special-cased the P2P torrent engine. Every other non-live, non-HLS source — including an already-downloaded local file played from the Downloads tab — fell into a generic branch that derived "downloaded" from (position + buffered) / duration. That heuristic only crosses the 99.9% "fully cached" threshold near the very end of playback, so a file that already exists in full on disk kept showing a growing seekbar buffer and never got the green Cached dot, even though nothing was actually being downloaded.

Fix: added an isLocalSrc check (via the existing isLocalUrl helper) ahead of the generic branch — when the source is a local file, downloaded is set to 1 immediately.

Verification
pnpm run typecheck — clean
pnpm run test (tests/player-buffer-policy.test.ts) — 5/5 passing, including a new regression test asserting the local-source branch exists, runs before the generic buffer heuristic, and sets downloaded = 1
Not manually verified in a running app session (no browser/app UI pass performed)
Platform Impact
None — change is in shared TypeScript player logic (src/views/player.tsx), no native/platform-specific code touched.

UI Changes
Seekbar/time-display "Cached" green dot now appears immediately for local downloaded files, and the buffer-progress fill stays hidden. No screenshots captured.

Checklist
 Focused change, no unrelated refactors
 pnpm run typecheck (vp check/vp run typecheck scripts aren't present in this checkout)
 Cargo checks — N/A, no Rust changes
 Tested on Windows/macOS/Linux/TV input — not performed