### PR TITLE
fix(macos): fit window within visibleFrame and support custom Dock icon

### DIFF
--- a/src-tauri/src/app_icon.rs
+++ b/src-tauri/src/app_icon.rs
@@ -1,0 +1,70 @@
+#[cfg(not(target_os = "macos"))]
+use tauri::Manager;
+
+#[cfg(target_os = "macos")]
+fn set_macos_dock_icon(image_bytes: Option<Vec<u8>>) -> Result<(), String> {
+    let _mtm = objc2_foundation::MainThreadMarker::new()
+        .ok_or_else(|| "set_macos_dock_icon must run on main thread".to_string())?;
+
+    unsafe {
+        use objc2::class;
+        use objc2::msg_send;
+        use objc2::runtime::AnyObject;
+
+        let ns_app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
+        if ns_app.is_null() {
+            return Err("NSApplication sharedApplication returned nil".into());
+        }
+
+        match image_bytes {
+            Some(bytes) if !bytes.is_empty() => {
+                let data: *mut AnyObject = msg_send![
+                    class!(NSData),
+                    dataWithBytes: bytes.as_ptr() as *const std::ffi::c_void,
+                    length: bytes.len()
+                ];
+                if data.is_null() {
+                    return Err("Failed to create NSData from icon bytes".into());
+                }
+                let alloc_img: *mut AnyObject = msg_send![class!(NSImage), alloc];
+                let img: *mut AnyObject = msg_send![alloc_img, initWithData: data];
+                if img.is_null() {
+                    return Err("Failed to create NSImage from icon data".into());
+                }
+                let _: () = msg_send![ns_app, setApplicationIconImage: img];
+                let _: () = msg_send![img, release];
+            }
+            _ => {
+                let nil: *mut AnyObject = std::ptr::null_mut();
+                let _: () = msg_send![ns_app, setApplicationIconImage: nil];
+            }
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn set_app_icon(app: tauri::AppHandle, image_bytes: Option<Vec<u8>>) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        app.run_on_main_thread(move || {
+            if let Err(e) = set_macos_dock_icon(image_bytes) {
+                eprintln!("[harbor::app_icon] failed to set dock icon: {e}");
+            }
+        })
+        .map_err(|e| format!("run_on_main_thread failed: {e}"))?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(window) = app.get_webview_window("main") {
+            if let Some(bytes) = image_bytes {
+                if let Ok(icon) = tauri::image::Image::from_bytes(&bytes) {
+                    let _ = window.set_icon(icon);
+                }
+            } else if let Some(default_icon) = app.default_window_icon().cloned() {
+                let _ = window.set_icon(default_icon);
+            }
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/display_fit.rs
+++ b/src-tauri/src/display_fit.rs
@@ -6,6 +6,37 @@ const FLOOR_W: f64 = 480.0;
 const FLOOR_H: f64 = 400.0;
 const MARGIN: f64 = 0.94;
 
+#[cfg(target_os = "macos")]
+fn macos_screen_insets(window: &WebviewWindow) -> Option<(f64, f64, f64, f64)> {
+    let _mtm = objc2_foundation::MainThreadMarker::new()?;
+    let ns_window_ptr = window.ns_window().ok()? as i64;
+    if ns_window_ptr == 0 {
+        return None;
+    }
+    unsafe {
+        use objc2_app_kit::NSWindow;
+        let raw: *mut objc2::runtime::AnyObject = ns_window_ptr as *mut objc2::runtime::AnyObject;
+        let ns_win: &NSWindow = &*(raw as *const NSWindow);
+        let screen = ns_win.screen()?;
+        let screen_frame = screen.frame();
+        let visible_frame = screen.visibleFrame();
+
+        let top_inset = (screen_frame.origin.y + screen_frame.size.height)
+            - (visible_frame.origin.y + visible_frame.size.height);
+        let bottom_inset = visible_frame.origin.y - screen_frame.origin.y;
+        let left_inset = visible_frame.origin.x - screen_frame.origin.x;
+        let right_inset = (screen_frame.origin.x + screen_frame.size.width)
+            - (visible_frame.origin.x + visible_frame.size.width);
+
+        Some((
+            top_inset.max(0.0),
+            bottom_inset.max(0.0),
+            left_inset.max(0.0),
+            right_inset.max(0.0),
+        ))
+    }
+}
+
 fn logical_monitor(window: &WebviewWindow) -> Option<(f64, f64, PhysicalPosition<i32>, f64)> {
     let monitor = window.current_monitor().ok().flatten()?;
     let scale = monitor.scale_factor();
@@ -29,8 +60,17 @@ pub fn fit_to_monitor(window: &WebviewWindow) {
         return;
     };
 
-    let usable_w = (mon_w * MARGIN).max(FLOOR_W);
-    let usable_h = (mon_h * MARGIN).max(FLOOR_H);
+    #[cfg(target_os = "macos")]
+    let (top_inset, bottom_inset, left_inset, right_inset) =
+        macos_screen_insets(window).unwrap_or((0.0, 0.0, 0.0, 0.0));
+    #[cfg(not(target_os = "macos"))]
+    let (top_inset, bottom_inset, left_inset, right_inset) = (0.0, 0.0, 0.0, 0.0);
+
+    let vis_w = (mon_w - left_inset - right_inset).max(FLOOR_W);
+    let vis_h = (mon_h - top_inset - bottom_inset).max(FLOOR_H);
+
+    let usable_w = (vis_w * MARGIN).max(FLOOR_W);
+    let usable_h = (vis_h * MARGIN).max(FLOOR_H);
     let min_w = CONFIG_MIN_W.min(usable_w).max(FLOOR_W);
     let min_h = CONFIG_MIN_H.min(usable_h).max(FLOOR_H);
 
@@ -50,8 +90,8 @@ pub fn fit_to_monitor(window: &WebviewWindow) {
     }
     let _ = window.set_size(LogicalSize::new(want_w, want_h));
 
-    let left = mon_pos.x as f64 + ((mon_w - want_w) / 2.0) * scale;
-    let top = mon_pos.y as f64 + ((mon_h - want_h) / 2.0) * scale;
+    let left = mon_pos.x as f64 + (left_inset + ((vis_w - want_w).max(0.0) / 2.0)) * scale;
+    let top = mon_pos.y as f64 + (top_inset + ((vis_h - want_h).max(0.0) / 2.0)) * scale;
     let _ = window.set_position(PhysicalPosition::new(left.round() as i32, top.round() as i32));
 }
 
@@ -59,7 +99,17 @@ pub fn install(app: &tauri::AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
         return;
     };
-    fit_to_monitor(&window);
+    #[cfg(target_os = "macos")]
+    {
+        let win = window.clone();
+        let _ = app.run_on_main_thread(move || {
+            fit_to_monitor(&win);
+        });
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        fit_to_monitor(&window);
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod anime4k;
+mod app_icon;
 mod asr_model;
 mod binary_lookup;
 mod browser;
@@ -846,6 +847,7 @@ pub fn run() {
             discord_auth::discord_auth_start,
             song_id::recognize_now_playing,
             song_id::recognize_now_playing_ai,
+            app_icon::set_app_icon,
             deeplink_set_stremio,
             deeplink_is_stremio_registered,
             harbor_take_pending_file,

--- a/src/lib/app-icon.ts
+++ b/src/lib/app-icon.ts
@@ -17,16 +17,15 @@ export type ApplyIconResult = { ok: true } | { ok: false; reason: string };
 
 export async function applyAppIcon(dataUrl: string): Promise<ApplyIconResult> {
   if (!isTauri()) return { ok: false, reason: "not running in the desktop app" };
-  if (!dataUrl) return { ok: false, reason: "no icon selected" };
-  const bytes = dataUrlToBytes(dataUrl);
-  if (!bytes) return { ok: false, reason: "could not read the icon image" };
+  const bytes = dataUrl ? dataUrlToBytes(dataUrl) : null;
+  if (dataUrl && !bytes) return { ok: false, reason: "could not read the icon image" };
   try {
-    const { getCurrentWindow } = await import("@tauri-apps/api/window");
-    await getCurrentWindow().setIcon(bytes);
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("set_app_icon", { imageBytes: bytes ? Array.from(bytes) : null });
     return { ok: true };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    console.error("[harbor] app icon setIcon failed:", reason);
+    console.error("[harbor] app icon set_app_icon failed:", reason);
     return { ok: false, reason };
   }
 }


### PR DESCRIPTION
## Summary

This PR addresses two macOS-specific issues:

1. **Bug 1: Oversized Window / Traffic-Light Controls Obscured**
   - **Root Cause:** Initial window fitting queried `NSScreen.frame` without subtracting macOS menu bar, camera notch, and dock insets.
   - **Fix:** On macOS, query Cocoa's `NSScreen.visibleFrame` on the main thread to compute top/bottom/left/right insets and constrain initial window sizing and placement within the safe usable work area.

2. **Bug 3: Custom Theme App Icon Not Applied to macOS Dock**
   - **Root Cause:** Tauri's default `window.setIcon()` only affects window-level icons, which macOS does not display for application icons in the Dock.
   - **Fix:** Added a `set_app_icon` Tauri command that dispatches to the main thread and calls Cocoa's `[NSApplication.sharedApplication setApplicationIconImage:]` (and resets via `nil`).


## Changed Files
- `src-tauri/src/display_fit.rs`
- `src-tauri/src/app_icon.rs`
- `src-tauri/src/lib.rs`
- `src/lib/app-icon.ts`

## Verification
- `cargo check --manifest-path src-tauri/Cargo.toml` passed with 0 errors.
- `cargo test --manifest-path src-tauri/Cargo.toml --lib display_fit` passed (3/3 tests).
- `pnpm run typecheck` passed cleanly.
- `pnpm test` passed (555/555 tests).