### PR TITLE
fix: improve macos fallback to youtube

### DIFF
--- a/src-tauri/src/trailer.rs
+++ b/src-tauri/src/trailer.rs
@@ -17,9 +17,9 @@ const FORMAT_1080: &str =
 const FORMAT_BEST: &str =
     "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/bestvideo+bestaudio/best";
 const FORMAT_LOW_MERGED: &str =
-    "bestvideo[height<=360][ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[height<=360][ext=mp4]+bestaudio[ext=m4a]/best[height<=360][ext=mp4]/bestvideo[height<=360]+bestaudio/best[height<=360]";
+    "bestvideo[height<=360][ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[height<=360][ext=mp4]+bestaudio[ext=m4a]/bestvideo[height<=360]+bestaudio";
 const FORMAT_HIGH_MERGED: &str =
-    "bestvideo[height<=720][ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[height<=720][ext=mp4]/bestvideo[height<=720]+bestaudio/best[height<=720]";
+    "bestvideo[height<=720][ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/bestvideo[height<=720]+bestaudio";
 
 fn cache_dir() -> PathBuf {
     std::env::temp_dir().join("harbor-trailers")
@@ -50,17 +50,33 @@ fn quality_path(id: &str, quality: &str) -> PathBuf {
 }
 
 fn format_for(quality: &str, can_merge: bool) -> &'static str {
-    if !can_merge {
-        return match quality {
-            "360p" => FORMAT_LOW,
-            _ => FORMAT_HIGH,
-        };
+    match (quality, can_merge) {
+        ("1080p", true) => FORMAT_1080,
+        ("best", true) => FORMAT_BEST,
+        ("360p", _) => FORMAT_LOW,
+        _ => FORMAT_HIGH,
+    }
+}
+
+fn should_merge(quality: &str, ffmpeg_available: bool) -> bool {
+    ffmpeg_available && matches!(quality, "1080p" | "best")
+}
+
+fn fallback_format(
+    quality: &str,
+    primary_merged: bool,
+    ffmpeg_available: bool,
+) -> Option<(&'static str, bool)> {
+    if primary_merged {
+        return Some((FORMAT_HIGH, false));
+    }
+    if !ffmpeg_available {
+        return None;
     }
     match quality {
-        "360p" => FORMAT_LOW_MERGED,
-        "1080p" => FORMAT_1080,
-        "best" => FORMAT_BEST,
-        _ => FORMAT_HIGH_MERGED,
+        "360p" => Some((FORMAT_LOW_MERGED, true)),
+        "720p" => Some((FORMAT_HIGH_MERGED, true)),
+        _ => None,
     }
 }
 
@@ -77,13 +93,11 @@ fn cached_info(path: &Path, quality: &str, size: u64, stream_url: Option<String>
 
 struct YtDlpOutput {
     success: bool,
-    #[cfg(target_os = "linux")]
     exit_code: Option<i32>,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
 }
 
-#[cfg(target_os = "linux")]
 fn yt_dlp_failure(source: &str, label: &str, output: &YtDlpOutput) -> String {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -179,9 +193,40 @@ async fn run_yt_dlp(
             .map_err(|error| format!("yt-dlp {label}: {error}"))?;
         Ok(YtDlpOutput {
             success: output.status.success(),
+            exit_code: output.status.code(),
             stdout: output.stdout,
             stderr: output.stderr,
         })
+    }
+}
+
+fn download_args(format: &str, output: &str, url: &str, ffmpeg: Option<&Path>) -> Vec<String> {
+    let mut args = vec![
+        "-f".into(),
+        format.into(),
+        "-o".into(),
+        output.into(),
+        "--no-playlist".into(),
+        "--no-warnings".into(),
+        "--quiet".into(),
+        "--force-overwrites".into(),
+        "--no-mtime".into(),
+    ];
+    if let Some(path) = ffmpeg {
+        args.push("--ffmpeg-location".into());
+        args.push(path.to_string_lossy().to_string());
+        args.push("--merge-output-format".into());
+        args.push("mp4".into());
+    }
+    args.push(url.into());
+    args
+}
+
+fn completed_download(output: Result<YtDlpOutput, String>, label: &str) -> Result<(), String> {
+    match output {
+        Ok(output) if output.success => Ok(()),
+        Ok(output) => Err(yt_dlp_failure("bundled", label, &output)),
+        Err(error) => Err(error),
     }
 }
 
@@ -284,38 +329,60 @@ pub async fn fetch_trailer(
 
     let file_path_str = file_path.to_string_lossy().to_string();
     let ffmpeg = crate::transcode::locate_ffmpeg();
-    let wants_merge = ffmpeg.is_some();
+    let wants_merge = should_merge(quality, ffmpeg.is_some());
     let effective_format = format_for(quality, wants_merge);
-    let mut dl_args: Vec<String> = vec![
-        "-f".into(),
-        effective_format.into(),
-        "-o".into(),
-        file_path_str.clone(),
-        "--no-playlist".into(),
-        "--no-warnings".into(),
-        "--quiet".into(),
-        "--force-overwrites".into(),
-        "--no-mtime".into(),
-    ];
-    if wants_merge {
-        if let Some(ff) = &ffmpeg {
-            dl_args.push("--ffmpeg-location".into());
-            dl_args.push(ff.to_string_lossy().to_string());
-        }
-        dl_args.push("--merge-output-format".into());
-        dl_args.push("mp4".into());
-    }
-    dl_args.push(url.clone());
+    let merge_ffmpeg = if wants_merge { ffmpeg.as_deref() } else { None };
+    let dl_args = download_args(effective_format, &file_path_str, &url, merge_ffmpeg);
     let dl_timeout = if wants_merge {
         Duration::from_secs(240)
     } else {
         DOWNLOAD_TIMEOUT
     };
-    let download_output = run_yt_dlp(&app, dl_args, dl_timeout, "download").await?;
+    let primary = completed_download(
+        run_yt_dlp(&app, dl_args, dl_timeout, "download").await,
+        "download",
+    );
 
-    if !download_output.success {
-        let stderr = String::from_utf8_lossy(&download_output.stderr);
-        return Err(format!("yt-dlp download failed: {}", stderr));
+    if let Err(primary_error) = primary {
+        let Some((fallback_format, fallback_merges)) =
+            fallback_format(quality, wants_merge, ffmpeg.is_some())
+        else {
+            eprintln!("[harbor::trailer] download failed quality={quality}: {primary_error}");
+            return Err(primary_error);
+        };
+        let fallback_label = if fallback_merges {
+            "adaptive fallback"
+        } else {
+            "progressive fallback"
+        };
+        eprintln!(
+            "[harbor::trailer] primary download failed quality={quality}: {primary_error}; retrying {fallback_label}"
+        );
+        let _ = std::fs::remove_file(&file_path);
+        let fallback_ffmpeg = if fallback_merges {
+            ffmpeg.as_deref()
+        } else {
+            None
+        };
+        let fallback_args = download_args(fallback_format, &file_path_str, &url, fallback_ffmpeg);
+        let fallback_timeout = if fallback_merges {
+            Duration::from_secs(240)
+        } else {
+            DOWNLOAD_TIMEOUT
+        };
+        completed_download(
+            run_yt_dlp(&app, fallback_args, fallback_timeout, fallback_label).await,
+            fallback_label,
+        )
+        .map_err(|fallback_error| {
+            eprintln!(
+                "[harbor::trailer] {fallback_label} failed quality={quality}: {fallback_error}"
+            );
+            format!(
+                "primary trailer download failed: {primary_error}; {fallback_label} failed: {fallback_error}"
+            )
+        })?;
+        eprintln!("[harbor::trailer] {fallback_label} completed quality={quality}");
     }
 
     let file_meta = std::fs::metadata(&file_path).map_err(|e| format!("file check: {}", e))?;

--- a/src-tauri/src/transcode.rs
+++ b/src-tauri/src/transcode.rs
@@ -82,6 +82,21 @@ pub fn locate_ffmpeg() -> Option<std::path::PathBuf> {
             }
         }
     } else if cfg!(target_os = "macos") {
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(dir) = exe.parent() {
+                owned.push(dir.join("ffmpeg").to_string_lossy().to_string());
+                owned.push(
+                    dir.join("ffmpeg-aarch64-apple-darwin")
+                        .to_string_lossy()
+                        .to_string(),
+                );
+                owned.push(
+                    dir.join("ffmpeg-x86_64-apple-darwin")
+                        .to_string_lossy()
+                        .to_string(),
+                );
+            }
+        }
         for p in [
             "/opt/homebrew/bin/ffmpeg",
             "/usr/local/bin/ffmpeg",

--- a/src/views/detail/trailer-overlay.tsx
+++ b/src/views/detail/trailer-overlay.tsx
@@ -1,7 +1,7 @@
 import { Cast, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { fetchTrailer, getQualityHint, trailerSrc } from "@/lib/trailer";
+import { fetchTrailer, resolveTrailerQuality, trailerSrc } from "@/lib/trailer";
 import { isMacDesktop } from "@/lib/platform";
 import { openUrl } from "@/lib/window";
 import { useSettings } from "@/lib/settings";
@@ -43,7 +43,7 @@ export function TrailerOverlay({
   useEffect(() => {
     let cancelled = false;
     const pref = settings.trailerQuality;
-    const quality = pref === "auto" ? (getQualityHint() === "360p" ? "360p" : "1080p") : pref;
+    const quality = resolveTrailerQuality(pref);
     fetchTrailer(id, quality).then((info) => {
       if (cancelled) return;
       if (info) setStreamUrl(trailerSrc(info));


### PR DESCRIPTION
## Summary

- Use Harbor’s shared trailer-quality resolver instead of forcing Auto quality to 1080p.
- Prefer progressive MP4 formats for 360p and 720p.
- Retry unavailable progressive formats using adaptive video/audio streams merged with ffmpeg.
- Fall back from failed 1080p/Best merges to a progressive format.
- Detect Harbor’s bundled ffmpeg on Intel and Apple Silicon macOS.

## Why

Some trailers consistently failed depending on the selected quality and immediately fell back to YouTube.

The previous Auto behavior normally selected 1080p, which requires separate video/audio streams and ffmpeg merging. Lower qualities could also unnecessarily require merging.

This change uses simpler progressive files first for 360p/720p and preserves high-quality merging for 1080p/Best. When the requested format is unavailable, Harbor now tries the opposite native strategy before falling back to YouTube.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml`
  - Passed with existing unrelated warnings.
- Manually tested multiple trailers on Linux at 720p.
- Confirmed progressive-format failures retry through bundled yt-dlp and adaptive ffmpeg merging.
- Confirmed successful files are served through Linux’s localhost trailer proxy.

## Platform Impact

- Linux: Manually verified native trailer download, fallback and localhost playback.
- macOS: Adds bundled ffmpeg discovery and the same native fallback strategy; runtime testing is still required.
- Windows: Uses the shared fallback strategy with the existing Windows ffmpeg discovery; runtime testing is still required.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
