### PR TITLE
fix: clock overlay hidden in windowed mode (#1278)

### DIFF
--- a/src/components/player/transport.tsx
+++ b/src/components/player/transport.tsx
@@ -361,6 +361,7 @@ export function Transport({
     timeFormat: chromeConfig.options.timeFormat,
     onCycleTimeFormat,
     volumeStyle: chromeConfig.options.volumeStyle,
+    alwaysShowClock: settings.playerAlwaysShowClock,
     seekBackStepSec: settings.seekBackStepSec,
     seekForwardStepSec: settings.seekForwardStepSec,
     title,

--- a/src/components/player/transport/control-renderer.tsx
+++ b/src/components/player/transport/control-renderer.tsx
@@ -98,6 +98,7 @@ export type ControlContext = {
   timeFormat?: TimeFormat;
   onCycleTimeFormat?: () => void;
   volumeStyle?: VolumeStyle;
+  alwaysShowClock?: boolean;
   seekBackStepSec: number;
   seekForwardStepSec: number;
   title?: string;
@@ -267,6 +268,7 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
           durationSec={ctx.snap.durationSec}
           isLiveChannel={ctx.isLiveChannel}
           tight={ctx.tight}
+          alwaysShowClock={ctx.alwaysShowClock}
           active={ctx.active}
         />
       );
@@ -278,11 +280,13 @@ export function renderControl(id: PlayerControlId, ctx: ControlContext): ReactNo
           timeFormat={ctx.timeFormat}
           isLiveChannel={ctx.isLiveChannel}
           tight={ctx.tight}
+          alwaysShowClock={ctx.alwaysShowClock}
           active={ctx.active}
           onCycle={ctx.editing ? undefined : ctx.onCycleTimeFormat}
         />
       );
     }
+
     case "volume": {
       if (ctx.tight) return null;
       return (

--- a/src/components/player/transport/time-display.tsx
+++ b/src/components/player/transport/time-display.tsx
@@ -23,6 +23,7 @@ export function TimeStart({
   timeFormat,
   isLiveChannel,
   tight,
+  alwaysShowClock,
   active,
   stremio,
   onCycle,
@@ -31,6 +32,7 @@ export function TimeStart({
   timeFormat?: TimeFormat;
   isLiveChannel: boolean;
   tight?: boolean;
+  alwaysShowClock?: boolean;
   active: boolean;
   stremio?: boolean;
   onCycle?: () => void;
@@ -40,7 +42,8 @@ export function TimeStart({
   if (stremio) {
     const fmt: TimeFormat = timeFormat ?? "start-end";
     const positionText = fmtTime(positionSec);
-    const cls = "pointer-events-auto ms-2 shrink-0 font-medium tabular-nums text-[14px] text-white/90";
+    const cls =
+      "pointer-events-auto ms-2 shrink-0 font-medium tabular-nums text-[14px] text-white/90";
     const inner =
       fmt === "elapsed-only" ? (
         <>
@@ -71,9 +74,14 @@ export function TimeStart({
     }
     return <span className={cls}>{inner}</span>;
   }
-  if (tight) return null;
+  // In tight/compact windows, show a compact version instead of hiding
+  const isCompact = tight && !alwaysShowClock;
   return (
-    <span className="shrink-0 font-mono text-[13px] tabular-nums text-white/85 drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)]">
+    <span
+      className={`shrink-0 font-mono tabular-nums text-white/85 drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)] ${
+        isCompact ? "text-[11px]" : "text-[13px]"
+      }`}
+    >
       {fmtTime(positionSec)}
     </span>
   );
@@ -84,6 +92,7 @@ export function TimeEnd({
   timeFormat,
   isLiveChannel,
   tight,
+  alwaysShowClock,
   active,
   onCycle,
 }: {
@@ -91,18 +100,22 @@ export function TimeEnd({
   timeFormat?: TimeFormat;
   isLiveChannel: boolean;
   tight?: boolean;
+  alwaysShowClock?: boolean;
   active: boolean;
   onCycle?: () => void;
 }): ReactNode {
   const positionSec = usePlaybackPositionGated(active);
-  if (isLiveChannel || tight) return null;
+  if (isLiveChannel) return null;
   const fmt: TimeFormat = timeFormat ?? "start-end";
   if (fmt === "elapsed-only") return null;
   const duration = durationSec ?? 0;
   const text =
     fmt === "remaining" ? `-${fmtTime(Math.max(0, duration - positionSec))}` : fmtTime(duration);
-  const cls =
-    "inline-flex shrink-0 items-center font-mono text-[13px] tabular-nums text-white/65 drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)]";
+  // In tight/compact windows, show a compact version instead of hiding
+  const isCompact = tight && !alwaysShowClock;
+  const cls = isCompact
+    ? "inline-flex shrink-0 items-center font-mono text-[11px] tabular-nums text-white/55 drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)]"
+    : "inline-flex shrink-0 items-center font-mono text-[13px] tabular-nums text-white/65 drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)]";
   if (onCycle) {
     return (
       <button

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -171,6 +171,7 @@ export const DEFAULT: Settings = {
   playerAnime4kIndicator: true,
   playerMpvEmbed: true,
   playerP2pChip: true,
+  playerAlwaysShowClock: false,
   showQualityInfo: false,
   stremioServerTranscode: false,
   directTorrentStream: true,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -209,6 +209,7 @@ export type Settings = {
   playerAnime4kIndicator: boolean;
   playerMpvEmbed: boolean;
   playerP2pChip: boolean;
+  playerAlwaysShowClock: boolean;
   showQualityInfo: boolean;
   stremioServerTranscode: boolean;
   directTorrentStream: boolean;

--- a/src/views/settings/player-layout-panel/index.tsx
+++ b/src/views/settings/player-layout-panel/index.tsx
@@ -31,11 +31,7 @@ import {
 } from "@/lib/player-chrome-profiles";
 import { useSettings } from "@/lib/settings";
 import { resolveChromeTheme } from "@/lib/theme";
-import {
-  moveControlOrder,
-  moveControlSlot,
-  sameConfig,
-} from "./config-helpers";
+import { moveControlOrder, moveControlSlot, sameConfig } from "./config-helpers";
 import { EditorOverlay } from "./editor-overlay";
 import { OptionsSection } from "./options-section";
 import { EditLayoutCard, FooterBar, ThemeTabs } from "./panel-bars";
@@ -68,7 +64,10 @@ export function PlayerLayoutPanel() {
   const bumpProfiles = useCallback(() => setProfileVersion((v) => v + 1), []);
 
   const profiles = useMemo(() => listProfiles(theme), [theme, profileVersion]);
-  const activeProfileId = useMemo(() => getActiveProfile(theme)?.id ?? null, [theme, profileVersion]);
+  const activeProfileId = useMemo(
+    () => getActiveProfile(theme)?.id ?? null,
+    [theme, profileVersion],
+  );
 
   useEffect(() => {
     const next = readPlayerChromeConfig(theme);
@@ -126,9 +125,7 @@ export function PlayerLayoutPanel() {
     if (!selectedId) return;
     setDraft((cur) => ({
       ...cur,
-      controls: cur.controls.map((c) =>
-        c.id === selectedId ? { ...c, hidden: !c.hidden } : c,
-      ),
+      controls: cur.controls.map((c) => (c.id === selectedId ? { ...c, hidden: !c.hidden } : c)),
     }));
   }, [selectedId]);
 
@@ -172,21 +169,18 @@ export function PlayerLayoutPanel() {
     [],
   );
 
-  const setVariant = useCallback(
-    (id: PlayerControlId, variant: ControlVariant | null) => {
-      setDraft((cur) => ({
-        ...cur,
-        controls: cur.controls.map((c) => {
-          if (c.id !== id) return c;
-          const next: PlayerControlConfig = { ...c };
-          if (variant == null) delete next.variant;
-          else next.variant = variant;
-          return next;
-        }),
-      }));
-    },
-    [],
-  );
+  const setVariant = useCallback((id: PlayerControlId, variant: ControlVariant | null) => {
+    setDraft((cur) => ({
+      ...cur,
+      controls: cur.controls.map((c) => {
+        if (c.id !== id) return c;
+        const next: PlayerControlConfig = { ...c };
+        if (variant == null) delete next.variant;
+        else next.variant = variant;
+        return next;
+      }),
+    }));
+  }, []);
 
   const setPanelCorner = useCallback((id: PanelId, corner: PanelCorner) => {
     setDraft((cur) => {
@@ -226,7 +220,7 @@ export function PlayerLayoutPanel() {
     async (id: string) => {
       if (!sameConfig(draft, saved)) {
         const ok = await confirmDialog(
-          t("You have unsaved changes that will be lost when switching profiles. Continue?")
+          t("You have unsaved changes that will be lost when switching profiles. Continue?"),
         );
         if (!ok) return;
       }
@@ -380,14 +374,25 @@ export function PlayerLayoutPanel() {
 
       <ToggleRow
         label={t("Show P2P status chip")}
-        sub={t("Peers, speed and progress while a torrent streams. Sits clear of the exit button, top left.")}
+        sub={t(
+          "Peers, speed and progress while a torrent streams. Sits clear of the exit button, top left.",
+        )}
         value={settings.playerP2pChip}
         onChange={(v) => update({ playerP2pChip: v })}
       />
 
       <ToggleRow
+        label={t("Always show clock overlay")}
+        sub={t("Keep the time display visible in compact player windows instead of shrinking it.")}
+        value={settings.playerAlwaysShowClock}
+        onChange={(v) => update({ playerAlwaysShowClock: v })}
+      />
+
+      <ToggleRow
         label={t("Content advisory on start")}
-        sub={t("When a movie or episode starts, briefly show its IMDb parental guide (violence, profanity, substances, frightening scenes and more) with severity. Fades on its own.")}
+        sub={t(
+          "When a movie or episode starts, briefly show its IMDb parental guide (violence, profanity, substances, frightening scenes and more) with severity. Fades on its own.",
+        )}
         value={settings.contentAdvisoryToast}
         onChange={(v) => update({ contentAdvisoryToast: v })}
       />
@@ -414,7 +419,7 @@ export function PlayerLayoutPanel() {
           onClose={async () => {
             if (!sameConfig(draft, saved)) {
               const ok = await confirmDialog(
-                t("You have unsaved changes. Close the editor and discard them?")
+                t("You have unsaved changes. Close the editor and discard them?"),
               );
               if (!ok) return;
               setDraft(saved);
@@ -447,5 +452,3 @@ export function PlayerLayoutPanel() {
     </div>
   );
 }
-
-


### PR DESCRIPTION
## Summary
Fix the clock overlay and "Ends at" time display disappearing in windowed mode. When the player controls bar is narrower than 600px (normal windowed mode), the time display was completely hidden. Now it renders a compact version with smaller font instead.

## Why
Players in windowed mode had no way to see the current time or estimated end time, which is essential for tracking playback progress. The time display should always be visible regardless of window size.

## Changes
- **`time-display.tsx`**: Changed `TimeStart` and `TimeEnd` to render compact versions (font size `text-[11px]` instead of `text-[13px]`) when controls bar is narrow, instead of returning `null`
- **`transport.tsx`**: Threaded `alwaysShowClock` through to control context
- **`control-renderer.tsx`**: Added `alwaysShowClock` to control context type
- **`settings/types.ts`**: Added `playerAlwaysShowClock: boolean` setting
- **`settings/defaults.ts`**: Default value `false`
- **`player-layout-panel/index.tsx`**: Added "Always show clock overlay" toggle in player settings

## Verification
- [x] `npx tsc -b --pretty false` — passes with no errors
- [x] Manual: clock now shows in both windowed and fullscreen modes
- [x] Setting "Always show clock overlay" keeps full-size clock even in narrow windows

## Platform Impact
All platforms (Windows, macOS, Linux). This is a frontend-only CSS/layout change.

## UI Changes
- **Before**: Clock time hidden when controls bar < 600px wide
- **After**: Compact clock always visible; optional "Always show clock overlay" setting keeps full-size clock

## Checklist
- [x] This pull request is focused and contains no unrelated refactors
- [x] I ran `vp check` for the changed files
- [x] I ran `vp run typecheck` after TypeScript changes
- [x] No Rust changes
- [x] Tested on Windows
- [x] Preserved playback and navigation behavior
- [x] No secrets or personal data exposed

Closes #1278