### PR TITLE
fix: anime sources missing when accessed through anime section (#1258)

### DIFF
--- a/src/lib/streams/episode-pipeline-input.ts
+++ b/src/lib/streams/episode-pipeline-input.ts
@@ -25,9 +25,9 @@ function embeddedStreams(meta: Meta, episode: PlayEpisode | undefined): Stream[]
       ? vids.find(
           (v) =>
             (v.season ?? null) === episode.season &&
-            ((v.episode ?? v.number) ?? null) === episode.episode,
+            (v.episode ?? v.number ?? null) === episode.episode,
         )
-      : vids.find((v) => v.id === meta.id) ?? (vids.length === 1 ? vids[0] : undefined);
+      : (vids.find((v) => v.id === meta.id) ?? (vids.length === 1 ? vids[0] : undefined));
   const raw = pick?.streams ?? [];
   return raw.map(
     (s) =>
@@ -51,14 +51,24 @@ export function buildEpisodePipelineInput(params: {
   strictMode: boolean;
   filterDisabled: boolean;
 }): PipelineInput {
-  const { meta, episode, imdbId, streamIds, addons, debrids, settings, strictMode, filterDisabled } = params;
+  const {
+    meta,
+    episode,
+    imdbId,
+    streamIds,
+    addons,
+    debrids,
+    settings,
+    strictMode,
+    filterDisabled,
+  } = params;
   const embedded = embeddedStreams(meta, episode);
   const addonNative = isAddonNativeMeta(meta);
   const requestType = addonNative
     ? meta.type
     : episode
       ? "series"
-      : meta.type === "series"
+      : meta.type === "series" || meta.type === "anime"
         ? "series"
         : "movie";
   const animeReq = streamIds.some((id) => id.startsWith("kitsu:") || id.startsWith("mal:"));
@@ -68,7 +78,7 @@ export function buildEpisodePipelineInput(params: {
   const effEpisode = imdbEpAligned ? (episode?.imdbEpisode ?? episode?.episode) : episode?.episode;
   const prevGroup =
     episode && typeof effSeason === "number" && typeof effEpisode === "number" && effEpisode > 1
-      ? readPlayback(meta.id, effSeason, effEpisode - 1)?.releaseGroup ?? undefined
+      ? (readPlayback(meta.id, effSeason, effEpisode - 1)?.releaseGroup ?? undefined)
       : undefined;
   return {
     request: {
@@ -76,7 +86,11 @@ export function buildEpisodePipelineInput(params: {
       ids: streamIds,
     },
     query: {
-      type: episode ? "series" : meta.type === "series" ? "series" : "movie",
+      type: episode
+        ? "series"
+        : meta.type === "series" || meta.type === "anime"
+          ? "series"
+          : "movie",
       imdbId: imdbId ?? "",
       title: meta.name,
       year: parseInt(meta.releaseInfo ?? "", 10) || undefined,
@@ -88,7 +102,11 @@ export function buildEpisodePipelineInput(params: {
     isAnime: animeReq,
     presetStreams: embedded.length > 0 ? embedded : undefined,
     trust: {
-      kind: episode ? "series" : meta.type === "series" ? "series" : "movie",
+      kind: episode
+        ? "series"
+        : meta.type === "series" || meta.type === "anime"
+          ? "series"
+          : "movie",
       expectedTitle: meta.name,
       releaseDate: meta.releaseDate ?? null,
       expectedYear: parseInt(meta.releaseInfo ?? "", 10) || null,
@@ -107,7 +125,7 @@ export function buildEpisodePipelineInput(params: {
       activeDebrids: debrids.map((d) => d.slug),
       preferredLanguages: settings.preferredLanguages,
       releaseDate: meta.releaseDate ?? null,
-      mediaKind: meta.type === "series" || episode ? "series" : "movie",
+      mediaKind: meta.type === "series" || meta.type === "anime" || episode ? "series" : "movie",
       runtimeMinutes: runtimeMinutes(meta.runtime),
       inTheaters: meta.inTheaters === true,
       bandwidthMbps: settings.bandwidthMbps > 0 ? settings.bandwidthMbps : undefined,


### PR DESCRIPTION
## Summary
Fix anime content accessed through the dedicated anime catalog section not returning streams from addons. The anime section was passing `type: "anime"` to stream requests, but most Stremio addons (Torrentio, Comet, etc.) only declare support for `types: ["movie", "series"]`. This caused anime requests to return no results or wrong results.

## Why
When users navigate to anime through the anime catalog section, they get significantly fewer or no addon sources compared to accessing the same anime through search. Search correctly uses `type: "series"` which addons support, while the anime section was using `type: "anime"` which addons ignore.

## Changes
**`src/lib/streams/episode-pipeline-input.ts`**: Changed all four locations where `meta.type` is checked to treat `"anime"` the same as `"series"`:
- Line 57-63: `requestType` now uses `meta.type === "series" || meta.type === "anime"`
- Line 79: `query.type` now uses `meta.type === "series" || meta.type === "anime"`
- Line 91: `trust.kind` now uses `meta.type === "series" || meta.type === "anime"`
- Line 110: `score.mediaKind` now uses `meta.type === "series" || meta.type === "anime"`

## Verification
- [x] `npx tsc -b --pretty false` — passes with no errors
- [x] Only modified the stream pipeline input file
- [x] Did not touch visibility.ts, meta-resource.ts, or other unrelated files

## Platform Impact
All platforms. This affects how stream requests are made for anime content regardless of platform.

## UI Changes
- Anime content accessed from the anime section now shows the same addon sources as accessing via search
- No visual changes to the UI itself

## Checklist
- [x] This pull request is focused and contains no unrelated refactors
- [x] I ran `vp check` for the changed files
- [x] I ran `vp run typecheck` after TypeScript changes
- [x] No Rust changes
- [x] Tested on Windows
- [x] Preserved playback, navigation, and configured hotkey behavior
- [x] No secrets or personal data exposed

Closes #1258