### PR TITLE
fix: custom metadata preference inconsistently ignored (#1285)

### DIFF
--- a/src/lib/meta-resource.ts
+++ b/src/lib/meta-resource.ts
@@ -46,7 +46,9 @@ export async function resolveMeta(
   if (preferCustomMeta()) {
     for (const { a, p } of addonRaces) {
       const result = await p;
-      if (result && result.poster) return withOrigin(result, a);
+      if (result && (result.poster || (result.name && (result.description || result.videos)))) {
+        return withOrigin(result, a);
+      }
     }
     return (await cinemetaPromise) ?? null;
   }

--- a/src/lib/visibility.ts
+++ b/src/lib/visibility.ts
@@ -2,7 +2,7 @@ import { useEffect, useState, type RefObject } from "react";
 
 type Callback = (visible: boolean) => void;
 
-const subs = new WeakMap<Element, Callback>();
+const subs = new WeakMap<Element, Set<Callback>>();
 let observer: IntersectionObserver | null = null;
 
 function ensureObserver(): IntersectionObserver {
@@ -10,8 +10,8 @@ function ensureObserver(): IntersectionObserver {
   observer = new IntersectionObserver(
     (entries) => {
       for (const e of entries) {
-        const cb = subs.get(e.target);
-        if (cb) cb(e.isIntersecting);
+        const set = subs.get(e.target);
+        if (set) for (const cb of set) cb(e.isIntersecting);
       }
     },
     { rootMargin: "100px" },
@@ -21,18 +21,25 @@ function ensureObserver(): IntersectionObserver {
 
 export function observe(el: Element, cb: Callback): () => void {
   const o = ensureObserver();
-  subs.set(el, cb);
-  o.observe(el);
+  let set = subs.get(el);
+  if (!set) {
+    set = new Set();
+    subs.set(el, set);
+    o.observe(el);
+  }
+  set.add(cb);
   return () => {
-    o.unobserve(el);
-    subs.delete(el);
+    const s = subs.get(el);
+    if (!s) return;
+    s.delete(cb);
+    if (s.size === 0) {
+      o.unobserve(el);
+      subs.delete(el);
+    }
   };
 }
 
-export function useInViewport(
-  ref: RefObject<Element | null>,
-  initial = false,
-): boolean {
+export function useInViewport(ref: RefObject<Element | null>, initial = false): boolean {
   const [inView, setInView] = useState(initial);
   useEffect(() => {
     const el = ref.current;
@@ -43,9 +50,7 @@ export function useInViewport(
 }
 
 export function usePageVisible(): boolean {
-  const [visible, setVisible] = useState(
-    typeof document === "undefined" ? true : !document.hidden,
-  );
+  const [visible, setVisible] = useState(typeof document === "undefined" ? true : !document.hidden);
   useEffect(() => {
     const onChange = () => setVisible(!document.hidden);
     document.addEventListener("visibilitychange", onChange);

--- a/src/views/detail/series-episodes.tsx
+++ b/src/views/detail/series-episodes.tsx
@@ -162,6 +162,7 @@ export function SeriesEpisodes({
     imdbId,
     tvdbKey: settings.tvdbKey,
     omdbKey: settings.omdbKey,
+    cinemetaVideos,
   });
   const tvdbStills = useSeriesTvdbStills(imdbId, enrichedBase.length, settings.tvdbSeasonType);
   const enrichedEpisodes = useMemo(() => {

--- a/src/views/detail/series-episodes/use-episode-enrich.ts
+++ b/src/views/detail/series-episodes/use-episode-enrich.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import type { Meta } from "@/lib/cinemeta";
 import { harborImdbEpisodes } from "@/lib/providers/harbor-imdb";
 import { omdbSeasonRatings } from "@/lib/providers/omdb";
 import type { Episode } from "@/lib/providers/tmdb";
@@ -10,14 +11,18 @@ export function useEpisodeEnrich({
   imdbId,
   tvdbKey,
   omdbKey,
+  cinemetaVideos,
 }: {
   episodes: Episode[];
   active: number;
   imdbId: string | null;
   tvdbKey: string;
   omdbKey: string;
+  cinemetaVideos?: NonNullable<Meta["videos"]>;
 }): Episode[] {
-  const [tvdbBySeason, setTvdbBySeason] = useState<Map<number, Map<number, TvdbEpisode>>>(new Map());
+  const [tvdbBySeason, setTvdbBySeason] = useState<Map<number, Map<number, TvdbEpisode>>>(
+    new Map(),
+  );
   const [omdbBySeason, setOmdbBySeason] = useState<Map<number, Map<number, number>>>(new Map());
   const [harborImdb, setHarborImdb] = useState<Map<string, number>>(new Map());
 
@@ -67,7 +72,8 @@ export function useEpisodeEnrich({
   const tvdbForSeason = tvdbBySeason.get(active);
   const omdbForSeason = omdbBySeason.get(active);
   return useMemo<Episode[]>(() => {
-    if (!tvdbForSeason && !omdbForSeason && harborImdb.size === 0) return episodes;
+    if (!tvdbForSeason && !omdbForSeason && harborImdb.size === 0 && !cinemetaVideos)
+      return episodes;
     return episodes.map((ep): Episode => {
       let next: Episode = ep;
       const tv = tvdbForSeason?.get(ep.episodeNumber);
@@ -89,7 +95,24 @@ export function useEpisodeEnrich({
       if (imdbRating != null && imdbRating > 0) {
         next = { ...next, imdbRating };
       }
+      // Overlay preferred addon video fields onto fallback metadata
+      if (cinemetaVideos && cinemetaVideos.length > 0) {
+        const v = cinemetaVideos.find(
+          (cv) =>
+            cv.season === active &&
+            (cv.episode === ep.episodeNumber || cv.number === ep.episodeNumber),
+        );
+        if (v) {
+          next = {
+            ...next,
+            name: v.name || v.title || next.name,
+            overview: v.overview || v.description || next.overview,
+            stillUrl: v.thumbnail || next.stillUrl,
+            airDate: v.released || v.firstAired || next.airDate,
+          };
+        }
+      }
       return next;
     });
-  }, [episodes, tvdbForSeason, omdbForSeason, harborImdb, active]);
+  }, [episodes, tvdbForSeason, omdbForSeason, harborImdb, active, cinemetaVideos]);
 }


### PR DESCRIPTION
## Summary
Fix "Prefer custom metadata addon" not consistently applying localized metadata across catalog cards, detail pages, and episode views. Three root causes: visibility observer overwrites, poster-less addon responses rejected, and episode metadata bypassed.

## Changes
- `visibility.ts`: Support multiple subscribers per DOM element
- `meta-resource.ts`: Accept addon responses without poster
- `use-episode-enrich.ts` + `series-episodes.tsx`: Overlay preferred addon episode fields

## Verification
- [x] TypeScript typecheck passes
- [x] All existing tests pass

Closes #1285