### PR TITLE
fix: poster cards too small on Genre pages with TV card style (#1308)

### DIFF
--- a/src/views/filter/rail-section.tsx
+++ b/src/views/filter/rail-section.tsx
@@ -115,13 +115,9 @@ export function RailSection({ filter, rail }: { filter: MetaFilter; rail: Standa
   return (
     <Row title={title} onEndReached={onEndReached}>
       {visible
-        ? visible.map((m) => (
-            <div key={m.id} className="w-36 shrink-0">
-              <PickCard meta={m} />
-            </div>
-          ))
+        ? visible.map((m) => <PickCard key={m.id} meta={m} />)
         : Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="aspect-[2/3] w-36 shrink-0 animate-pulse rounded-xl bg-elevated/40" />
+            <div key={i} className="aspect-[2/3] w-full animate-pulse rounded-xl bg-elevated/40" />
           ))}
     </Row>
   );

--- a/src/views/filter/spotlight-section.tsx
+++ b/src/views/filter/spotlight-section.tsx
@@ -78,7 +78,12 @@ function jitter(seed: string): number {
 function isCameo(c: PersonCredit): boolean {
   const ch = (c.character ?? "").toLowerCase().trim();
   if (!ch) return false;
-  if (ch.includes("(uncredited)") || ch.includes("archive footage") || ch.includes("archival footage")) return true;
+  if (
+    ch.includes("(uncredited)") ||
+    ch.includes("archive footage") ||
+    ch.includes("archival footage")
+  )
+    return true;
   if (ch === "self" || ch === "himself" || ch === "herself" || ch === "themselves") return true;
   if (ch.startsWith("self ") || ch.startsWith("himself ") || ch.startsWith("herself ")) return true;
   return false;
@@ -158,9 +163,7 @@ export function SpotlightSection({
           reportDone();
           return;
         }
-        setProfileUrl(
-          p.profilePath ? `https://image.tmdb.org/t/p/h632${p.profilePath}` : null,
-        );
+        setProfileUrl(p.profilePath ? `https://image.tmdb.org/t/p/h632${p.profilePath}` : null);
         const credits = spotlightCredits(p, spotlight, genreId);
         const metas = credits.map(creditToMeta);
         claim(metas);
@@ -229,13 +232,9 @@ export function SpotlightSection({
         </div>
       </button>
       {items
-        ? items.map((m) => (
-            <div key={m.id} className="w-36 shrink-0">
-              <PickCard meta={m} />
-            </div>
-          ))
+        ? items.map((m) => <PickCard key={m.id} meta={m} />)
         : Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="aspect-[2/3] w-36 shrink-0 animate-pulse rounded-xl bg-elevated/40" />
+            <div key={i} className="aspect-[2/3] w-full animate-pulse rounded-xl bg-elevated/40" />
           ))}
     </Row>
   );

--- a/src/views/filter/topic-section.tsx
+++ b/src/views/filter/topic-section.tsx
@@ -9,13 +9,7 @@ import { tmdbDiscover, tmdbResolveKeywordIds } from "@/lib/providers/tmdb";
 import { useSettings } from "@/lib/settings";
 import { MAX_PAGES, MIN_INITIAL_FILL, SpotlightGateContext } from "./spotlight-gate";
 
-export function TopicSection({
-  topic,
-  mediaType,
-}: {
-  topic: Topic;
-  mediaType: "movie" | "tv";
-}) {
+export function TopicSection({ topic, mediaType }: { topic: Topic; mediaType: "movie" | "tv" }) {
   const t = useT();
   const { settings } = useSettings();
   const dedup = useDedupOnSeenIds(`topic:${mediaType}:${topic.id}`);
@@ -140,13 +134,9 @@ export function TopicSection({
   return (
     <Row title={title} onEndReached={onEndReached}>
       {items
-        ? items.map((m) => (
-            <div key={m.id} className="w-36 shrink-0">
-              <PickCard meta={m} />
-            </div>
-          ))
+        ? items.map((m) => <PickCard key={m.id} meta={m} />)
         : Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="aspect-[2/3] w-36 shrink-0 animate-pulse rounded-xl bg-elevated/40" />
+            <div key={i} className="aspect-[2/3] w-full animate-pulse rounded-xl bg-elevated/40" />
           ))}
     </Row>
   );


### PR DESCRIPTION
## Summary
Fix poster cards rendering too small on Genre/Language pages when card style is set to TV.

## Changes
- `rail-section.tsx`, `spotlight-section.tsx`, `topic-section.tsx`: Use consistent card sizing for TV style

## Verification
- [x] TypeScript typecheck passes

Closes #1308