### PR TITLE
fix: Arabic subtitle rendering - proper letter shaping (#1225)

### DIFF
--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -696,7 +696,13 @@ pub async fn mpv_start(
         }
     }
     let _ = mpv.set_property("sub-font-provider", "auto");
-    let _ = mpv.set_property("sub-font", "Noto Sans JP");
+    // Use a generic sans-serif font family so the system renders Latin, CJK,
+    // Arabic, and other scripts through the platform's native font fallback.
+    // "Noto Sans JP" was previously the default, but it only covers Japanese
+    // glyphs and caused Arabic/other non-CJK text to show disconnected letters
+    // because libass could not always find a suitable fallback font.
+    let _ = mpv.set_property("sub-font", "sans-serif");
+    let _ = mpv.set_property("sub-ass-shaper", "complex");
     let _ = mpv.set_property("embeddedfonts", "yes");
 
     if let Some(subs) = &args.subtitles {


### PR DESCRIPTION
## Summary
Fix Arabic subtitle rendering where letters appear disconnected and some subtitle files fail to display. RTL text shaping issue.

## Changes
- `src-tauri/src/subtitles.rs`: Updated subtitle font and enabled complex text shaping for Arabic

## Verification
- [x] TypeScript and Rust checks pass

Closes #1225