### PR TITLE
fix: Harbor respects remote streaming server config (#1298)

### DIFF
--- a/src-tauri/src/settings_store.rs
+++ b/src-tauri/src/settings_store.rs
@@ -42,7 +42,7 @@ pub fn read_torrents_disabled(app: &tauri::AppHandle) -> bool {
 
 fn parse_torrents_disabled(json: &str) -> bool {
     // Cheap field scan. We only need to know whether
-    // `"torrentsDisabled":true` appears in the file. False is the safe
+    // `\"torrentsDisabled\":true` appears in the file. False is the safe
     // default if we cannot confirm it.
     let needle = "\"torrentsDisabled\"";
     let Some(idx) = json.find(needle) else {
@@ -59,4 +59,49 @@ fn parse_torrents_disabled(json: &str) -> bool {
         }
     }
     matches!(chars.next(), Some('t') | Some('T'))
+}
+
+/// Read the `remoteStreamServerUrl` field from the settings file. Returns the
+/// URL string if set to a non-empty value, or an empty string otherwise.
+pub fn read_remote_stream_server_url(app: &tauri::AppHandle) -> String {
+    let path = match settings_path(app) {
+        Ok(p) => p,
+        Err(_) => return String::new(),
+    };
+    let s = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return String::new(),
+    };
+    parse_remote_stream_server_url(&s)
+}
+
+fn parse_remote_stream_server_url(json: &str) -> String {
+    // Cheap field scan for `\"remoteStreamServerUrl\":\"...\"`
+    let needle = "\"remoteStreamServerUrl\"";
+    let Some(idx) = json.find(needle) else {
+        return String::new();
+    };
+    let rest = &json[idx + needle.len()..];
+    let mut chars = rest.chars().peekable();
+    // Skip whitespace and ':'
+    while let Some(c) = chars.peek() {
+        if c.is_whitespace() || *c == ':' {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    // Expect opening quote
+    if !matches!(chars.next(), Some('"')) {
+        return String::new();
+    }
+    // Read until closing quote
+    let mut url = String::new();
+    loop {
+        match chars.next() {
+            None | Some('"') => break,
+            Some(c) => url.push(c),
+        }
+    }
+    url
 }

--- a/src-tauri/src/torrent_engine.rs
+++ b/src-tauri/src/torrent_engine.rs
@@ -321,6 +321,12 @@ pub fn ensure_started_on_setup(app: &AppHandle) {
         st.last_error = Some("torrents disabled in settings".to_string());
         return;
     }
+    if !crate::settings_store::read_remote_stream_server_url(app).is_empty() {
+        eprintln!("[torrent-engine] remote streaming server configured — skipping local engine init");
+        let mut st = engine().lock().unwrap();
+        st.last_error = Some("remote streaming server in use".to_string());
+        return;
+    }
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         if let Err(e) = init(app).await {

--- a/src/lib/streams/resolve.ts
+++ b/src/lib/streams/resolve.ts
@@ -5,6 +5,8 @@ import { magnetFromHash, type DebridResult, type DebridStore, type DirectLink } 
 import { lastEngineAddError, torrentEngineAdd, torrentEngineSelect } from "@/lib/torrent/local-engine";
 import { fullDownloadEnabled, startFullDownload } from "@/lib/torrent/full-download";
 import {
+  buildTorrentStreamUrl,
+  createAndListFiles,
   directTorrentEnabled,
   engineP2pEligible,
   isVideoFile,
@@ -12,6 +14,7 @@ import {
   trackersFromSources,
   type TorrentFile,
 } from "@/lib/torrent/stremio-stream";
+import { remoteStreamServerUrl } from "@/lib/stremio-server";
 import type { ParsedStream, ScoredStream } from "./types";
 import { matchEpisodeFileIndex, type EpisodeHint } from "./episode-file";
 
@@ -275,7 +278,57 @@ async function tryTorrentEngine(
   stream: ParsedStream | ScoredStream,
   hint?: EpisodeHint,
 ): Promise<DirectLink | null> {
+  if (remoteStreamServerUrl()) {
+    return tryRemoteStream(stream, hint);
+  }
   return tryLocalEngine(stream, hint);
+}
+
+async function tryRemoteStream(
+  stream: ParsedStream | ScoredStream,
+  hint?: EpisodeHint,
+): Promise<DirectLink | null> {
+  if (!stream.infoHash) return null;
+  const trackers = trackersFromSources(stream.sources);
+  const season = hint?.season ?? stream.season;
+  const episode = hint?.episode ?? stream.episode;
+  const seriesInfo =
+    season != null && episode != null ? { season, episode } : null;
+  const created = await createAndListFiles(
+    stream.infoHash,
+    trackers,
+    seriesInfo,
+    15000,
+  );
+  if (!created || created.files.length === 0) return null;
+  let chosenIdx = stream.fileIdx;
+  if (chosenIdx == null || chosenIdx < 0) {
+    if (created.guessedFileIdx != null && created.guessedFileIdx >= 0) {
+      chosenIdx = created.guessedFileIdx;
+    } else {
+      chosenIdx = selectEngineFileIdx(created.files, season, episode);
+    }
+  }
+  const filename =
+    stream.behaviorHints?.filename ?? stream.behaviorHints?.fileName ?? null;
+  const url = buildTorrentStreamUrl({
+    infoHash: stream.infoHash,
+    fileIdx: chosenIdx,
+    sources: stream.sources,
+    trackers,
+    filename,
+  });
+  return {
+    url,
+    fileIdx: chosenIdx,
+    filename: filename ?? undefined,
+    notWebReady: stream.behaviorHints?.notWebReady,
+    subtitles: stream.subtitles?.map((s) => ({
+      url: s.url,
+      lang: s.lang,
+      id: s.id,
+    })),
+  };
 }
 
 function engineFailureCode(): string {


### PR DESCRIPTION
## Summary
Fix Harbor ignoring configured remote streaming server and always using local engine.

## Changes
- `resolve.ts`: Check remote server configuration in stream resolution
- `settings_store.rs`: Expose remote server settings to engine
- `torrent_engine.rs`: Respect remote server config when initializing

## Verification
- [x] TypeScript and Rust checks pass
- [x] Backward compatible — local engine works when no remote configured

Closes #1298