### PR TITLE
fix: whole season download falls back to episode-level streams (#1257)

### DIFF
--- a/src/lib/streams/addons.ts
+++ b/src/lib/streams/addons.ts
@@ -62,7 +62,9 @@ export async function fetchAddonStreams(
     }
   }
   if (skipped.length > 0) console.info(`[addons] skipped: ${skipped.join(", ")}`);
-  console.info(`[addons] querying ${namedTasks.length}: ${namedTasks.map((t) => t.name).join(", ")}`);
+  console.info(
+    `[addons] querying ${namedTasks.length}: ${namedTasks.map((t) => t.name).join(", ")}`,
+  );
 
   const accumulated: Stream[] = [];
   const wrapped = namedTasks.map(({ name, p }) =>
@@ -115,6 +117,10 @@ function pickIds(addon: Addon, type: string, ids: string[]): string[] {
   const animeId = accepted.find((id) => ANIME_SCHEMES.some((s) => id.startsWith(s)));
   const ttId = accepted.find((id) => id.startsWith("tt"));
   if (animeId && ttId) return [animeId, ttId];
+  // For season-level requests (multiple IDs with same prefix), try all accepted
+  // IDs so addons that don't provide season packs can still return individual
+  // episode streams. The pipeline deduplicates by infoHash/URL.
+  if (accepted.length > 1) return accepted;
   return [accepted[0]];
 }
 
@@ -129,9 +135,7 @@ function addonAcceptsId(addon: Addon, type: string, id: string): boolean {
     return streamResources.some((r) => {
       const typeOk = Array.isArray(r.types) && r.types.includes(type);
       const idOk =
-        !r.idPrefixes ||
-        r.idPrefixes.length === 0 ||
-        r.idPrefixes.some((p) => id.startsWith(p));
+        !r.idPrefixes || r.idPrefixes.length === 0 || r.idPrefixes.some((p) => id.startsWith(p));
       return typeOk && idOk;
     });
   }

--- a/src/lib/streams/stream-ids.ts
+++ b/src/lib/streams/stream-ids.ts
@@ -5,6 +5,11 @@ export function buildStreamIds(
   episode: PlayEpisode | undefined,
   imdbId: string | null,
   defaultVideoId?: string | null,
+  videos?: ReadonlyArray<{
+    season?: number | null;
+    episode?: number | null;
+    number?: number | null;
+  }>,
 ): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
@@ -50,6 +55,27 @@ export function buildStreamIds(
   if (imdbId && imdbId.startsWith("tt")) {
     if (!episode) push(imdbId);
     else if (!animeMeta) push(`${imdbId}:${episode.season}:${episode.episode}`);
+  }
+
+  // When doing a season-level request (no episode) and we have video metadata,
+  // also emit individual episode-level IDs so addons that don't provide season
+  // packs can still return streams for individual episodes. The pipeline
+  // deduplicates by infoHash/URL so adding both levels is harmless.
+  // Capped at 50 to avoid excessive requests for very long series.
+  if (!episode && videos) {
+    let added = 0;
+    for (const v of videos) {
+      if (added >= 50) break;
+      const season = v.season;
+      const ep = v.episode ?? v.number;
+      if (season == null || ep == null) continue;
+      // For kitsu meta, episode IDs are kitsu:{id}:{ep} (no season)
+      const epId = metaId.startsWith("kitsu:")
+        ? `kitsu:${metaId.split(":")[1]}:${ep}`
+        : `${metaId}:${season}:${ep}`;
+      push(epId);
+      added++;
+    }
   }
 
   return out;

--- a/src/views/play-picker/use-stream-ids.ts
+++ b/src/views/play-picker/use-stream-ids.ts
@@ -10,7 +10,13 @@ export function useStreamIds(
 ): string[] | null {
   const [streamIds, setStreamIds] = useState<string[] | null>(null);
   useEffect(() => {
-    const out = buildStreamIds(meta.id, episode, imdbId, meta.behaviorHints?.defaultVideoId);
+    const out = buildStreamIds(
+      meta.id,
+      episode,
+      imdbId,
+      meta.behaviorHints?.defaultVideoId,
+      meta.videos,
+    );
     setStreamIds(out.length > 0 ? out : null);
   }, [
     meta.id,


### PR DESCRIPTION
## Summary
Fix whole season download failing when addons don't provide season packages. Now falls back to individual episode streams.

## Changes
- `stream-ids.ts`: Emit episode-level stream IDs for season requests
- `addons.ts`: `pickIds` tries all accepted IDs, not just the first
- `use-stream-ids.ts`: Pass video metadata for episode ID generation

## Verification
- [x] TypeScript typecheck passes
- [x] Backward compatible

Closes #1257
