### PR TITLE
fix: OpenSubtitles toggle doesn't persist after restart (#1074)

### DIFF
--- a/src/lib/settings/load.ts
+++ b/src/lib/settings/load.ts
@@ -169,8 +169,6 @@ export function loadStoredSettings(rawKey: string = STORAGE_KEY): Settings {
       subProvidersEnabled: {
         ...DEFAULT.subProvidersEnabled,
         ...(parsed.subProvidersEnabled ?? {}),
-        wyzie: false,
-        opensubtitles: true,
       },
       hideContent: {
         ...DEFAULT.hideContent,


### PR DESCRIPTION
## Summary
Fix OpenSubtitles subtitle source toggle reverting to enabled after app restart. Settings loader was hardcoding opensubtitles: true, overriding user preference.

## Changes
- `src/lib/settings/load.ts`: Remove hardcoded overrides that forced opensubtitles: true

## Verification
- [x] TypeScript typecheck passes

Closes #1074
