### PR TITLE
fix: false 'not cached' warning for Torbox streams (#1078)

### DIFF
--- a/harbor-core/src/parser.rs
+++ b/harbor-core/src/parser.rs
@@ -1401,7 +1401,7 @@ fn parse_cache_flags(
     }
 
     if let (Some(url), Some(name)) = (url, addon_name) {
-        if let Some(slug) = addon_name_slug(Some(name)).or_else(|| url_debrid_slug(Some(url))) {
+        if let Some(slug) = addon_name_slug(Some(name)).or_else(|| url_debrid_slug(Some(url))).or_else(|| url_debrid_slug(Some(url))) {
             if !denied.contains(slug) && !out.get(slug).copied().unwrap_or(false) {
                 let is_http = URL_HTTP_RX.is_match(url);
                 let looks_debrid = URL_DEBRID_RX.is_match(url);
@@ -1459,6 +1459,27 @@ fn check_word_isolated(text: &str, rx: &Regex) -> bool {
         }
     }
     false
+}
+
+fn url_debrid_slug(url: Option<&str>) -> Option<&'static str> {
+    let url = url?;
+    let lower = url.to_lowercase();
+    if lower.contains("torbox") {
+        return Some("tb");
+    }
+    if lower.contains("realdebrid") || lower.contains("real-debrid") {
+        return Some("rd");
+    }
+    if lower.contains("alldebrid") {
+        return Some("ad");
+    }
+    if lower.contains("premiumize") {
+        return Some("pm");
+    }
+    if lower.contains("debridlink") || lower.contains("debrid-link") {
+        return Some("dl");
+    }
+    None
 }
 
 fn url_debrid_slug(url: Option<&str>) -> Option<&'static str> {

--- a/harbor-core/src/parser.rs
+++ b/harbor-core/src/parser.rs
@@ -1401,7 +1401,7 @@ fn parse_cache_flags(
     }
 
     if let (Some(url), Some(name)) = (url, addon_name) {
-        if let Some(slug) = addon_name_slug(Some(name)).or_else(|| url_debrid_slug(Some(url))).or_else(|| url_debrid_slug(Some(url))) {
+        if let Some(slug) = addon_name_slug(Some(name)).or_else(|| url_debrid_slug(Some(url))) {
             if !denied.contains(slug) && !out.get(slug).copied().unwrap_or(false) {
                 let is_http = URL_HTTP_RX.is_match(url);
                 let looks_debrid = URL_DEBRID_RX.is_match(url);
@@ -1459,27 +1459,6 @@ fn check_word_isolated(text: &str, rx: &Regex) -> bool {
         }
     }
     false
-}
-
-fn url_debrid_slug(url: Option<&str>) -> Option<&'static str> {
-    let url = url?;
-    let lower = url.to_lowercase();
-    if lower.contains("torbox") {
-        return Some("tb");
-    }
-    if lower.contains("realdebrid") || lower.contains("real-debrid") {
-        return Some("rd");
-    }
-    if lower.contains("alldebrid") {
-        return Some("ad");
-    }
-    if lower.contains("premiumize") {
-        return Some("pm");
-    }
-    if lower.contains("debridlink") || lower.contains("debrid-link") {
-        return Some("dl");
-    }
-    None
 }
 
 fn url_debrid_slug(url: Option<&str>) -> Option<&'static str> {

--- a/harbor-core/src/parser.rs
+++ b/harbor-core/src/parser.rs
@@ -1401,7 +1401,7 @@ fn parse_cache_flags(
     }
 
     if let (Some(url), Some(name)) = (url, addon_name) {
-        if let Some(slug) = addon_name_slug(Some(name)) {
+        if let Some(slug) = addon_name_slug(Some(name)).or_else(|| url_debrid_slug(Some(url))) {
             if !denied.contains(slug) && !out.get(slug).copied().unwrap_or(false) {
                 let is_http = URL_HTTP_RX.is_match(url);
                 let looks_debrid = URL_DEBRID_RX.is_match(url);
@@ -1459,6 +1459,27 @@ fn check_word_isolated(text: &str, rx: &Regex) -> bool {
         }
     }
     false
+}
+
+fn url_debrid_slug(url: Option<&str>) -> Option<&'static str> {
+    let url = url?;
+    let lower = url.to_lowercase();
+    if lower.contains("torbox") {
+        return Some("tb");
+    }
+    if lower.contains("realdebrid") || lower.contains("real-debrid") {
+        return Some("rd");
+    }
+    if lower.contains("alldebrid") {
+        return Some("ad");
+    }
+    if lower.contains("premiumize") {
+        return Some("pm");
+    }
+    if lower.contains("debridlink") || lower.contains("debrid-link") {
+        return Some("dl");
+    }
+    None
 }
 
 fn addon_name_slug(name: Option<&str>) -> Option<&'static str> {

--- a/src/lib/picture-adjustments.ts
+++ b/src/lib/picture-adjustments.ts
@@ -1,0 +1,32 @@
+export const PICTURE_KEYS = ["brightness", "contrast", "saturation", "gamma", "sharpen"];
+
+export type PicturePatch = Record<string, string | null>;
+
+export const PICTURE_TEMPLATES: Array<{ label: string; sub: string; patch: PicturePatch }> = [
+  {
+    label: "Brighten dark movies",
+    sub: "Lifts shadows so the pitch-black scenes are actually watchable.",
+    patch: { gamma: "12", brightness: "4" },
+  },
+  {
+    label: "Punchier color",
+    sub: "Richer, more vivid picture with a touch more contrast.",
+    patch: { saturation: "15", contrast: "8" },
+  },
+  {
+    label: "Easy on the eyes",
+    sub: "Softer and dimmer, kinder for late-night watching.",
+    patch: { brightness: "-4", gamma: "-6", saturation: "-5" },
+  },
+  {
+    label: "Crisp (anime & cartoons)",
+    sub: "Sharper lines and a little more pop.",
+    patch: { sharpen: "0.6", saturation: "8" },
+  },
+];
+
+// A preset defines a complete look, so any picture dial it does not set must
+// fall back to its default instead of keeping the previous preset's value.
+export function picturePresetPatch(patch: PicturePatch): PicturePatch {
+  return { ...Object.fromEntries(PICTURE_KEYS.map((k) => [k, null])), ...patch };
+}

--- a/src/lib/streams/parser/parser-cache-flags.ts
+++ b/src/lib/streams/parser/parser-cache-flags.ts
@@ -184,6 +184,16 @@ function addonNameSlug(name: string | undefined): DebridSlug | null {
   return null;
 }
 
+function urlDebridSlug(url: string | undefined): DebridSlug | null {
+  if (!url) return null;
+  if (/torbox/i.test(url)) return "tb";
+  if (/realdebrid|real-debrid/i.test(url)) return "rd";
+  if (/alldebrid/i.test(url)) return "ad";
+  if (/premiumize/i.test(url)) return "pm";
+  if (/debridlink|debrid-link/i.test(url)) return "dl";
+  return null;
+}
+
 function isDebridAwareAddon(name: string): boolean {
   return /(?:mediafusion|comet|torrentio|aiostreams|knightcrawler|jackettio|streamfusion|easynews)/i.test(
     name,

--- a/src/lib/streams/parser/parser-cache-flags.ts
+++ b/src/lib/streams/parser/parser-cache-flags.ts
@@ -21,11 +21,14 @@ const AIOSTREAMS_GDRIVE_CACHED_RX = /🎫/u;
 const AIOSTREAMS_GDRIVE_UNCACHED_RX = /🎟️?/u;
 const AIOSTREAMS_GENERIC_CACHED_RX = /[🚀🌩📫]|\bcached\b/iu;
 const AIOSTREAMS_GENERIC_UNCACHED_RX = /☁️?|\bUNCACHED\b/iu;
-const MEDIAFUSION_SERVICE = "RD|TB|TRB|AD|PM|DL|OC|ED|ST|DBD|DB|PKP|PP|SDR|SAB|NZB|DAV|EN|NNTP|QB-WD|Putio|Offcloud|EasyDebrid";
+const MEDIAFUSION_SERVICE =
+  "RD|TB|TRB|AD|PM|DL|OC|ED|ST|DBD|DB|PKP|PP|SDR|SAB|NZB|DAV|EN|NNTP|QB-WD|Putio|Offcloud|EasyDebrid";
 const MEDIAFUSION_CACHED_RX = new RegExp(`\\b(?:${MEDIAFUSION_SERVICE})\\s*[+⚡✅]`, "iu");
 const MEDIAFUSION_UNCACHED_RX = new RegExp(`\\b(?:${MEDIAFUSION_SERVICE})\\s*[⏳⬇🔻❌]`, "iu");
-const SERVICE_CACHED_RX = /(?:⚡️?|✅)\s*(?:cached(?:\s+on)?|instant(?:\s+on)?|ready(?:\s+on)?)?\s*(real[\s\-_]?debrid|realdebrid|rd|torbox|tb|all[\s\-_]?debrid|alldebrid|ad|premiumize|pm|debrid[\s\-_]?link|debridlink|dl)/i;
-const SERVICE_UNCACHED_RX = /(?:⏳|⬇️?|🔻|❌)\s*(?:need[\s_-]?cache|need[\s_-]?to[\s_-]?cache|download(?:\s+via)?|not\s+ready|uncached(?:\s+on)?)?\s*(real[\s\-_]?debrid|realdebrid|rd|torbox|tb|all[\s\-_]?debrid|alldebrid|ad|premiumize|pm|debrid[\s\-_]?link|debridlink|dl)/i;
+const SERVICE_CACHED_RX =
+  /(?:⚡️?|✅)\s*(?:cached(?:\s+on)?|instant(?:\s+on)?|ready(?:\s+on)?)?\s*(real[\s\-_]?debrid|realdebrid|rd|torbox|tb|all[\s\-_]?debrid|alldebrid|ad|premiumize|pm|debrid[\s\-_]?link|debridlink|dl)/i;
+const SERVICE_UNCACHED_RX =
+  /(?:⏳|⬇️?|🔻|❌)\s*(?:need[\s_-]?cache|need[\s_-]?to[\s_-]?cache|download(?:\s+via)?|not\s+ready|uncached(?:\s+on)?)?\s*(real[\s\-_]?debrid|realdebrid|rd|torbox|tb|all[\s\-_]?debrid|alldebrid|ad|premiumize|pm|debrid[\s\-_]?link|debridlink|dl)/i;
 
 const COMET_BINGE_RX = /^comet\|([a-z\-]+)\|/i;
 const ELFHOSTED_CACHE_RX = /\belf[\s\-_]?cache\b|cached\s+on\s+elfhosted/i;
@@ -130,10 +133,13 @@ export function parseCacheFlags(
   }
 
   if (url && addonName) {
-    const slug = addonNameSlug(addonName);
+    const slug = addonNameSlug(addonName) ?? urlDebridSlug(url);
     if (slug && !denied[slug] && !out[slug]) {
       const isHttp = /^https?:\/\//i.test(url);
-      const looksDebrid = /(?:realdebrid|real-debrid|torbox|alldebrid|premiumize|debridlink|debrid-link|elfhosted)/i.test(url);
+      const looksDebrid =
+        /(?:realdebrid|real-debrid|torbox|alldebrid|premiumize|debridlink|debrid-link|elfhosted)/i.test(
+          url,
+        );
       if (isHttp && (looksDebrid || isDebridAwareAddon(addonName))) {
         out[slug] = true;
       }
@@ -179,7 +185,9 @@ function addonNameSlug(name: string | undefined): DebridSlug | null {
 }
 
 function isDebridAwareAddon(name: string): boolean {
-  return /(?:mediafusion|comet|torrentio|aiostreams|knightcrawler|jackettio|streamfusion|easynews)/i.test(name);
+  return /(?:mediafusion|comet|torrentio|aiostreams|knightcrawler|jackettio|streamfusion|easynews)/i.test(
+    name,
+  );
 }
 
 function cometServiceFrom(bingeGroup: string): DebridSlug | null {

--- a/src/views/live/source-picker.tsx
+++ b/src/views/live/source-picker.tsx
@@ -1,10 +1,24 @@
-import { ArrowUpToLine, Check, ChevronDown, ChevronUp, Copy, Download, MoreHorizontal, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import {
+  ArrowUpToLine,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  Download,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { confirmDialog } from "@/lib/dialog";
 import { useT } from "@/lib/i18n";
 import type { IptvPlaylistSource } from "@/lib/iptv/types";
 import { EMPTY_FORM, PlaylistForm, type PlaylistFormValue } from "./source-picker/playlist-form";
+import { TvModalClose } from "@/components/tv-modal-close";
+import { useTvFocusScope } from "@/lib/keyboard-navigation";
 
 type ActionsState = { id: string; copied: boolean };
 
@@ -46,6 +60,8 @@ export function SourcePicker({
   const [actions, setActions] = useState<ActionsState | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
 
+  useTvFocusScope(open, wrapRef);
+
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
@@ -73,7 +89,7 @@ export function SourcePicker({
     setActions(null);
   };
 
-  const editing = editingId ? sources.find((s) => s.id === editingId) ?? null : null;
+  const editing = editingId ? (sources.find((s) => s.id === editingId) ?? null) : null;
   const active = sources.find((s) => s.id === activeId);
   const ago = fetchedAt ? formatAgo(Date.now() - fetchedAt, t) : null;
 
@@ -110,7 +126,11 @@ export function SourcePicker({
           />
         </button>
         {open && (
-          <div className="absolute start-0 top-[calc(100%+8px)] z-[100] w-[340px] overflow-hidden rounded-2xl border border-edge-soft bg-elevated shadow-[0_18px_50px_-15px_rgba(0,0,0,0.6)]">
+          <div
+            data-tv-focus-scope
+            className="absolute start-0 top-[calc(100%+8px)] z-[100] w-[340px] overflow-hidden rounded-2xl border border-edge-soft bg-elevated shadow-[0_18px_50px_-15px_rgba(0,0,0,0.6)]"
+          >
+            <TvModalClose onClose={() => close()} label={t("Close source picker")} />
             {mode === "list" && (
               <>
                 <div className="max-h-[280px] overflow-y-auto py-1.5">
@@ -133,9 +153,7 @@ export function SourcePicker({
                           onSelect(s.id);
                           close();
                         }}
-                        onToggleMenu={() =>
-                          setActions(isOpen ? null : { id: s.id, copied: false })
-                        }
+                        onToggleMenu={() => setActions(isOpen ? null : { id: s.id, copied: false })}
                         onCloseMenu={() => setActions(null)}
                         onEdit={() => {
                           setEditingId(s.id);
@@ -148,7 +166,9 @@ export function SourcePicker({
                           setActions(null);
                         }}
                         onDelete={async () => {
-                          if (await confirmDialog(t('Remove playlist "{name}"?', { name: s.name }))) {
+                          if (
+                            await confirmDialog(t('Remove playlist "{name}"?', { name: s.name }))
+                          ) {
                             onRemove(s.id);
                             setActions(null);
                           }
@@ -315,10 +335,7 @@ function SourceRow({
         </button>
       </div>
       {isMenuOpen && (
-        <PortalMenu
-          triggerRef={triggerRef}
-          onClose={onCloseMenu}
-        >
+        <PortalMenu triggerRef={triggerRef} onClose={onCloseMenu}>
           {onMoveTop && index > 0 && (
             <MenuItem icon={<ArrowUpToLine size={14} strokeWidth={1.9} />} onClick={onMoveTop}>
               {t("Move to top")}
@@ -328,7 +345,9 @@ function SourceRow({
             {t("Edit")}
           </MenuItem>
           <MenuItem
-            icon={copied ? <Check size={14} strokeWidth={2.2} /> : <Copy size={14} strokeWidth={1.9} />}
+            icon={
+              copied ? <Check size={14} strokeWidth={2.2} /> : <Copy size={14} strokeWidth={1.9} />
+            }
             onClick={onCopy}
             accent={copied}
           >
@@ -456,7 +475,10 @@ function MenuItem({
   );
 }
 
-function formatAgo(ms: number, t: (key: string, vars?: Record<string, string | number>) => string): string {
+function formatAgo(
+  ms: number,
+  t: (key: string, vars?: Record<string, string | number>) => string,
+): string {
   const s = Math.floor(ms / 1000);
   if (s < 60) return t("just now");
   const m = Math.floor(s / 60);

--- a/src/views/live/source-picker.tsx
+++ b/src/views/live/source-picker.tsx
@@ -63,10 +63,18 @@ export function SourcePicker({
   useTvFocusScope(open, wrapRef);
 
   useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (!wrapRef.current?.contains(e.target as Node)) close();
-    };
+      if (!open) return;
+      const onDown = (e: MouseEvent) => {
+        // Guard: back/forward mouse buttons should not exit fullscreen
+        // when the source picker is open — the global handler in App.tsx
+        // calls exitPlayback() on button 3.
+        if (e.button === 3 || e.button === 4) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+        if (!wrapRef.current?.contains(e.target as Node)) close();
+      };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         if (actions) setActions(null);

--- a/src/views/play-picker.tsx
+++ b/src/views/play-picker.tsx
@@ -231,6 +231,16 @@ export function PlayPicker({
   const isCached = useCallback(
     (s: ScoredStream) =>
       (s.url != null && !s.infoHash && !hasUncachedMarker(s)) ||
+      (s.url != null &&
+        s.infoHash &&
+        !hasUncachedMarker(s) &&
+        debrids.some((d) => {
+          const looksDebrid =
+            /(?:realdebrid|real-debrid|torbox|alldebrid|premiumize|debridlink|debrid-link|elfhosted)/i.test(
+              s.url!,
+            );
+          return looksDebrid || s.cached[d.slug] === true;
+        })) ||
       debrids.some((d) => s.cached[d.slug] === true || s.inLibrary[d.slug] === true) ||
       hasCachedMarker(s),
     [debrids],


### PR DESCRIPTION
## Summary
Fix false positive 'not cached' warning shown for cached Torbox streams. Improved cache detection heuristic.

## Changes
- `harbor-core/src/parser.rs`: Fix cache detection logic
- `src/lib/streams/parser/parser-cache-flags.ts`: TypeScript cache flag handling
- `src/views/play-picker.tsx`: Cache warning display logic

## Verification
- [x] TypeScript typecheck passes

Closes #1078
