### PR TITLE
fix: add Linux desktop categories for Cinnamon start menu (#1219)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -87,7 +87,8 @@
           "openssl-libs",
           "ca-certificates"
         ]
-      }
+      },
+      "categories": ["AudioVideo", "Video", "Player"]
     },
     "macOS": {
       "minimumSystemVersion": "11.0"


### PR DESCRIPTION
## Summary
Fix Harbor not appearing in correct Cinnamon start menu categories. Added Linux desktop categories (AudioVideo, Video, Player) to tauri.conf.json.

## Changes
- `src-tauri/tauri.conf.json`: Add "categories": ["AudioVideo", "Video", "Player"] to linux bundle section

## Verification
- [x] JSON valid

Closes #1219
