### PR TITLE
fix(cw): honor metadata addon for CW artwork and keep rewatched movies when signed out out stremio

### DIFF
--- a/src/components/continue-card.tsx
+++ b/src/components/continue-card.tsx
@@ -2,7 +2,8 @@ import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Check, X } from "lucide-react";
 import { Play } from "@/components/icons/play-filled";
 import simklLogo from "@/assets/simkl.png";
-import { meta as fetchMeta, narrowMediaType, type Meta } from "@/lib/cinemeta";
+import { narrowMediaType, type Meta } from "@/lib/cinemeta";
+import { resolveMeta } from "@/lib/meta-resource";
 import { animeKitsuMeta, type AnimeKitsuVideo } from "@/lib/providers/anime-kitsu-addon";
 import { tmdbLiteMeta } from "@/lib/providers/tmdb/tmdb-lite";
 import { tmdbIdFromImdb } from "@/lib/providers/tmdb";
@@ -18,6 +19,7 @@ import {
 import { useHasNewEpisode } from "@/lib/new-episodes";
 import { Tooltip } from "@/views/detail/tooltip";
 import { useProfiles, sharesStremioStorage } from "@/lib/profiles";
+import { useAuth } from "@/lib/auth";
 import { useSettings } from "@/lib/settings";
 import { useView, type PlayEpisode } from "@/lib/view";
 import { getWatchedBy } from "@/lib/watched-by";
@@ -53,6 +55,7 @@ export const ContinueCard = memo(function ContinueCard({
   const { openMeta, openPicker, openPlayer } = useView();
   const t = useT();
   const { settings, update } = useSettings();
+  const { authKey } = useAuth();
   const { profiles, activeProfile } = useProfiles();
   const watcherId = getWatchedBy(item._id);
   const watcher = watcherId ? profiles.find((p) => p.id === watcherId) : null;
@@ -207,7 +210,9 @@ export const ContinueCard = memo(function ContinueCard({
         return;
       }
       const looksEpisodic = item.type === "movie" && episodeFromVideoId(item.state?.video_id);
-      fetchMeta(looksEpisodic ? "series" : narrowMediaType(item.type), item._id)
+      // resolveMeta honours a custom metadata addon before Cinemeta, so disabling the Cinemeta
+      // toggle (to use another addon) no longer leaves this card with a blank/stretched thumbnail.
+      resolveMeta(authKey, looksEpisodic ? "series" : narrowMediaType(item.type), item._id)
         .then((full) => {
           if (cancelled || !full) return;
           setHydratedMeta(full);

--- a/src/views/player/hooks/use-resume-autosave.ts
+++ b/src/views/player/hooks/use-resume-autosave.ts
@@ -10,7 +10,7 @@ import { isLocalUrl } from "@/lib/player/local-url";
 import { isManuallyWatched, recordManualWatchedMeta, setManualWatched } from "@/lib/manual-watched";
 import { savePlayback } from "@/lib/playback-history";
 import { clearResume, saveResumeMs } from "@/lib/resume";
-import { setMovieWatchedLocal } from "@/lib/movie-watched";
+import { isMovieWatchedLocal, setMovieWatchedLocal } from "@/lib/movie-watched";
 import { setViewedSeason } from "@/lib/season-view-pref";
 import type { PlayerSnapshot } from "@/lib/player/bridge";
 import { getPlaybackPosition, subscribePlaybackClock } from "@/lib/player/playback-clock";
@@ -24,6 +24,7 @@ const TICK_MS = 4000;
 const MIN_POSITION_SEC = 5;
 const TASTE_MIN_SEC = 90;
 const WATCHED_RATIO = 0.85;
+const REWATCH_RESUME_SEC = 45;
 const STUB_MAX_SEC = 150;
 
 const isAnimeId = (id: string) =>
@@ -125,9 +126,20 @@ export function useResumeAutosave(params: {
       id.startsWith("tt") &&
       !!s.episode?.kitsuStreamId &&
       (s.episode.imdbSeason == null || s.episode.imdbEpisode == null);
+    // Rewatching an already-finished movie (resumed past 45s, still below the finish ratio)
+    // must put it back in Continue Watching even when the Stremio cloud write is skipped (e.g.
+    // signed out). Clearing the local watched marker and tracking it locally yields an in-progress
+    // item with flaggedWatched=0 that isCwMember accepts, independent of authKey.
+    const rewatchMovie =
+      s.meta.type === "movie" &&
+      sn.durationSec > 0 &&
+      pos >= REWATCH_RESUME_SEC &&
+      pos / sn.durationSec < WATCHED_RATIO &&
+      isMovieWatchedLocal(id);
+    if (rewatchMovie) setMovieWatchedLocal(id, false);
     if (
       (s.meta.type === "series" || s.meta.type === "movie" || animeLocal) &&
-      (!CLOUD_OK.test(id) || isLocalUrl(s.url) || animeLocal || ttAnimeUnmapped)
+      (!CLOUD_OK.test(id) || isLocalUrl(s.url) || animeLocal || ttAnimeUnmapped || rewatchMovie)
     ) {
       saveLocalCw({
         id,


### PR DESCRIPTION
## Summary

1. CW artwork now respects your metadata addon. ContinueCard previously resolved its image through the raw Cinemeta call, which short-circuits to null whenever "Use Cinemeta for title metadata" is toggled off. It now routes through resolveMeta (src/lib/meta-resource.ts), which prefers an installed custom metadata addon, respects "Prefer my installed metadata addon," and falls back to (forced) Cinemeta — so the card no longer degrades to a stretched poster/backdrop.

2. Rewatching a finished movie returns it to Continue Watching without Stremio sign-in. The watched-flag reset lived only in the Stremio cloud write (gated on authKey). When not signed in, flaggedWatched never cleared, so a rewatched movie stayed hidden. The reset is now done locally on a meaningful rewatch (≥45s, below the finish ratio) via setMovieWatchedLocal + a local CW entry.

## Why

continue-card.tsx called meta(type, id) without force, so cinemetaEnabled=false made it return null immediately (src/lib/cinemeta.ts:132). That left metaBg/logo/hydratedMeta unset and the card fell back to item.background (backdrop) or a 2:3 poster crammed into a 16:9 box. Routing through resolveMeta honors the addon preference (the intended reason a user toggles Cinemeta off) and still falls back to Cinemeta when no addon has data.

use-resume-autosave.ts previously wrote CW progress only for non-cloud ids. When Harbor isn't signed into Stremio, the cloud write that normally resets flaggedWatched on a rewatch never runs, so a rewatched finished movie was filtered out by isCwMember. Treating the rewatch locally (pure localStorage) fixes it independent of authKey, gated on isMovieWatchedLocal so it doesn't broaden into "all cloud movies appear when signed out."

## Verification

- pnpm run typecheck (tsc -b --pretty false) — exit 0, no errors
- Manual scenario (recommended, not executable in this headless env): with Harbor signed out of Stremio, rewatch a previously-finished movie past ~45s but below 85% → it should reappear in Continue Watching; mark/unmark watched → item leaves/returns with progress intact.

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
