### PR TITLE
feat: clickable theme-creator name → profile, with hover preview

### DIFF
--- a/src/views/settings/theme-panel/custom-themes-section/community-browser.tsx
+++ b/src/views/settings/theme-panel/custom-themes-section/community-browser.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { AlertCircle, Check, Download, Loader2, Star, Upload } from "lucide-react";
 import { Search } from "@/components/icons/search-icon";
 import { browseThemes, downloadTheme, rateTheme, type StoreTheme } from "@/lib/theme-store";
+import { UserHoverCard } from "@/views/profile/user-hover-card";
 import { CommunityDetail } from "./community-detail";
 import { ThemeUploadFlow } from "./theme-upload-flow";
 
@@ -193,7 +194,16 @@ function CommunityCard({ theme, onOpen }: { theme: StoreTheme; onOpen: () => voi
       <div className="flex min-w-0 flex-col px-4 py-3">
         <span className="truncate text-[14.5px] font-semibold text-ink">{t.name}</span>
         <span className="truncate text-[11.5px] text-ink-subtle">
-          {t.author} · {t.downloads} downloads
+          {t.authorHandle ? (
+            <UserHoverCard handle={t.authorHandle}>
+              <span className="transition-colors hover:text-ink" onClick={(e) => e.stopPropagation()}>
+                {t.author}
+              </span>
+            </UserHoverCard>
+          ) : (
+            t.author
+          )}{" "}
+          · {t.downloads} downloads
         </span>
       </div>
     </div>

--- a/src/views/settings/theme-panel/custom-themes-section/community-detail.tsx
+++ b/src/views/settings/theme-panel/custom-themes-section/community-detail.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useEscape, useModalExit } from "@/components/modal-shell";
 import { createPortal } from "react-dom";
 import { Check, Download, Loader2, Share2, Star, X } from "lucide-react";
 import { downloadTheme, rateTheme, type StoreTheme } from "@/lib/theme-store";
+import { UserHoverCard } from "@/views/profile/user-hover-card";
+import { subscribeOpenProfile } from "@/lib/social/open-profile";
 
 export function CommunityDetail({
   theme,
@@ -13,6 +15,7 @@ export function CommunityDetail({
 }) {
   const { closing, close } = useModalExit(onClose);
   useEscape(close);
+  useEffect(() => subscribeOpenProfile(close), [close]);
   const [t, setT] = useState(theme);
   const [downloading, setDownloading] = useState(false);
   const [done, setDone] = useState(false);
@@ -72,7 +75,15 @@ export function CommunityDetail({
               </div>
               <h2 className="mt-2 font-display text-[26px] font-medium leading-tight text-ink">{t.name}</h2>
               <p className="text-[13px] text-ink-subtle">
-                by {t.author} · {t.downloads} downloads · {t.ratingAvg || "-"}/5 ({t.ratingCount})
+                by{" "}
+                {t.authorHandle ? (
+                  <UserHoverCard handle={t.authorHandle}>
+                    <span className="cursor-pointer transition-colors hover:text-ink">{t.author}</span>
+                  </UserHoverCard>
+                ) : (
+                  t.author
+                )}{" "}
+                · {t.downloads} downloads · {t.ratingAvg || "-"}/5 ({t.ratingCount})
               </p>
             </div>
             {t.blurb && <p className="text-[13.5px] leading-relaxed text-ink-muted">{t.blurb}</p>}

--- a/src/views/settings/theme-panel/custom-themes-section/community-store/market/market-hero.tsx
+++ b/src/views/settings/theme-panel/custom-themes-section/community-store/market/market-hero.tsx
@@ -3,6 +3,7 @@ import { ArrowDownToLine, Star } from "lucide-react";
 import type { StoreTheme } from "@/lib/theme-store";
 import type { StoreBundle } from "@/lib/bundle-store";
 import { FeaturedBadge } from "@/views/profile/profile-bits";
+import { UserHoverCard } from "@/views/profile/user-hover-card";
 import { fmtCount } from "../format";
 import { Fit } from "./fit";
 import { PaletteSeam } from "./palette-seam";
@@ -72,7 +73,15 @@ export function MarketHero({
             <ArrowDownToLine size={14} strokeWidth={2.2} />
             {fmtCount(item.downloads)} downloads
           </span>
-          <span>by {item.author || "Anonymous"}</span>
+          {"swatch" in item && item.authorHandle ? (
+            <UserHoverCard handle={item.authorHandle}>
+              <span className="cursor-pointer transition-colors hover:text-ink">
+                by {item.author || "Anonymous"}
+              </span>
+            </UserHoverCard>
+          ) : (
+            <span>by {item.author || "Anonymous"}</span>
+          )}
         </div>
         <div className="max-w-[34rem]">{payload}</div>
         <div className="mt-1 flex flex-wrap items-center gap-3">

--- a/src/views/settings/theme-panel/custom-themes-section/community-store/store-top-charts.tsx
+++ b/src/views/settings/theme-panel/custom-themes-section/community-store/store-top-charts.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownToLine, Flame, Sparkles, Star, TrendingUp, type LucideIcon } from "lucide-react";
 import { SectionHeader } from "@/views/profile/section-header";
+import { UserHoverCard } from "@/views/profile/user-hover-card";
 import type { StoreTheme } from "@/lib/theme-store";
 import { fmtCount } from "./format";
 
@@ -117,7 +118,17 @@ function ChartRow({
       <RowThumb theme={theme} />
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-[13px] font-semibold leading-tight text-ink">{theme.name}</span>
-        <span className="truncate text-[11.5px] text-ink-subtle">{theme.author || "Anonymous"}</span>
+        <span className="truncate text-[11.5px] text-ink-subtle">
+          {theme.authorHandle ? (
+            <UserHoverCard handle={theme.authorHandle}>
+              <span className="transition-colors hover:text-ink" onClick={(e) => e.stopPropagation()}>
+                {theme.author || "Anonymous"}
+              </span>
+            </UserHoverCard>
+          ) : (
+            theme.author || "Anonymous"
+          )}
+        </span>
       </span>
       <span className="shrink-0 ps-1">
         {kind === "rating" && theme.ratingCount > 0 ? (

--- a/src/views/settings/theme-panel/custom-themes-section/community-store/theme-detail.tsx
+++ b/src/views/settings/theme-panel/custom-themes-section/community-store/theme-detail.tsx
@@ -4,6 +4,8 @@ import { createPortal } from "react-dom";
 import { ArrowDownToLine, Check, RefreshCw, Share2, Star, X } from "lucide-react";
 import { downloadTheme, rateTheme, type StoreTheme } from "@/lib/theme-store";
 import { FeaturedBadge } from "@/views/profile/profile-bits";
+import { UserHoverCard } from "@/views/profile/user-hover-card";
+import { subscribeOpenProfile } from "@/lib/social/open-profile";
 import { fmtCount } from "./format";
 import { CommentsSection } from "./comments/comments-section";
 import { Fit } from "./market/fit";
@@ -33,6 +35,8 @@ export function ThemeDetail({ theme, onClose }: { theme: StoreTheme; onClose: ()
     document.addEventListener("keydown", onKey, true);
     return () => document.removeEventListener("keydown", onKey, true);
   }, [close]);
+
+  useEffect(() => subscribeOpenProfile(close), [close]);
 
   const rate = async (v: number) => {
     setMyRating(v);
@@ -91,7 +95,15 @@ export function ThemeDetail({ theme, onClose }: { theme: StoreTheme; onClose: ()
                     <ArrowDownToLine size={12} strokeWidth={2.2} />
                     {fmtCount(t.downloads)}
                   </span>
-                  <span>by {t.author || "Anonymous"}</span>
+                  {t.authorHandle ? (
+                    <UserHoverCard handle={t.authorHandle}>
+                      <span className="cursor-pointer transition-colors hover:text-ink">
+                        by {t.author || "Anonymous"}
+                      </span>
+                    </UserHoverCard>
+                  ) : (
+                    <span>by {t.author || "Anonymous"}</span>
+                  )}
                 </div>
               </div>
 


### PR DESCRIPTION
## Theme Creator Profile Linking

This PR completes the missing half of the `theme-creator-handle-sync` fix.

Previously, updating a theme creator's `@handle` could leave the creator information displayed on themes outdated or disconnected from their current profile. With the backend now providing a live `authorHandle`, this change makes the creator's name clickable and hoverable across all theme surfaces, allowing users to open the creator's profile.

The implementation reuses the existing `UserHoverCard` pattern from `market-card.tsx` rather than introducing a new implementation.

### Changed Files

* `theme-detail.tsx` — Full theme details modal, which is the screen referenced in the original bug report.
* `community-detail.tsx` — Legacy theme details modal.
* `community-browser.tsx` — Theme grid cards.
* `community-store/market/market-hero.tsx` — Featured theme hero card.
* `community-store/store-top-charts.tsx` — Trending, Popular, and New theme rows.

### Implementation

Where `authorHandle` is available, the creator name is wrapped with:

`<UserHoverCard handle={authorHandle}>`

This makes the creator name interactive and allows users to open their profile.

If `authorHandle` is not available, the UI falls back to plain text. This covers cases such as anonymous or unclaimed uploads and follows the same conditional pattern already used in `market-card.tsx`.

In `market-hero.tsx`, the existing `"swatch" in item` type guard is used because `authorHandle` exists on `StoreTheme` but not on `StoreBundle`.

### Additional Regressions Fixed

During live testing, two additional interaction issues were identified and fixed:

1. **Card click propagation**

   Clicking the profile interaction inside a theme card also triggered the card's `onClick`, causing the theme details page to open behind the profile.

   Fixed by adding `e.stopPropagation()` in:

   * `community-browser.tsx`
   * `store-top-charts.tsx`

2. **Theme modal remaining open**

   Opening a creator profile from inside `ThemeDetail` or `CommunityDetail` left the theme details modal open over the profile page.

   Both modals now subscribe to `subscribeOpenProfile` and call `close()` when a profile is opened, following the same pattern already used in `add-friends-modal.tsx`.

### Backend Dependency

This change depends on the `harbor-hosted` commit:

`6814fcb` — `feat(harbor-themes): enhance theme ownership details in public view`

The backend now returns a live `authorHandle` and `author` resolved from the creator's current account instead of relying on the frozen string stored when the theme was originally uploaded.

Without this backend change, `authorHandle` will always be `null`, causing all theme surfaces to fall back to plain, non-clickable creator text.
<img width="774" height="928" alt="befor" src="https://github.com/user-attachments/assets/f8a97a22-dd61-4010-87fa-43a87ed91be2" />
<img width="992" height="668" alt="لقطة شاشة 2026-08-31 142018" src="https://github.com/user-attachments/assets/0509a744-6f49-49ed-ad82-9a08d1754716" />
