### PR TITLE
fix(addons): keep addon position and avoid duplicates on update

### DIFF
--- a/src/lib/addon-store.ts
+++ b/src/lib/addon-store.ts
@@ -1,7 +1,11 @@
 import { safeFetch as fetch } from "@/lib/safe-fetch";
 import { readActiveStremioAuthKey } from "./auth";
 import { setUserAddons, userAddons, type Addon } from "./addons";
-import { applyOrderToItems } from "./addons-store/reorder";
+import {
+  applyOrderToItems,
+  loadDisplayOrder,
+  saveDisplayOrder,
+} from "./addons-store/reorder";
 
 const PROFILES_KEY = "harbor.profiles.v1";
 
@@ -107,13 +111,42 @@ function readAuthKey(): string | null {
   return readActiveStremioAuthKey();
 }
 
-async function pushToStremio(addon: Addon, mode: "install" | "uninstall"): Promise<boolean> {
+async function pushToStremio(
+  addon: Addon,
+  mode: "install" | "uninstall",
+  replacedUrls: string[] = [],
+): Promise<boolean> {
   const authKey = readAuthKey();
   if (!authKey) return true;
   try {
     const current = await userAddons(authKey);
-    const filtered = current.filter((a) => a.transportUrl !== addon.transportUrl);
-    const next = mode === "install" ? [...filtered, addon] : filtered;
+    const id = addon.manifest.id;
+    const replaced = new Set(replacedUrls.filter((u) => u !== addon.transportUrl));
+    // Only remove entries that are actually being replaced (same id, same transport
+    // URL, or an explicitly replaced transport URL), so an update keeps the addon's
+    // place in the collection rather than pushing a fresh copy to the end.
+    const insertIndex = current.findIndex(
+      (a) =>
+        a.manifest.id === id ||
+        a.transportUrl === addon.transportUrl ||
+        replaced.has(a.transportUrl),
+    );
+    const filtered = current.filter(
+      (a) =>
+        a.manifest.id !== id &&
+        a.transportUrl !== addon.transportUrl &&
+        !replaced.has(a.transportUrl),
+    );
+    let next: Addon[];
+    if (mode === "uninstall") {
+      next = filtered;
+    } else if (insertIndex === -1) {
+      next = [...filtered, addon];
+    } else {
+      next = filtered.slice(0, insertIndex);
+      next.push(addon);
+      next.push(...filtered.slice(insertIndex));
+    }
     return await setUserAddons(authKey, next);
   } catch {
     return false;
@@ -214,6 +247,27 @@ export function reorderInstalled(urlSequence: string[]): void {
   const items = loadInstalled();
   if (items.length < 2) return;
   saveInstalled(applyOrderToItems(items, urlSequence));
+}
+
+function preserveOrderOnReplace(oldUrls: string[], newUrl: string): void {
+  let order = loadDisplayOrder();
+  if (order.length === 0) {
+    order = loadInstalled().map((a) => a.transportUrl);
+  }
+  if (order.length === 0) return;
+  const replaced = order.map((u) => (oldUrls.includes(u) ? newUrl : u));
+  const deduped: string[] = [];
+  for (const u of replaced) {
+    if (u === newUrl) {
+      if (!deduped.includes(newUrl)) deduped.push(newUrl);
+    } else {
+      deduped.push(u);
+    }
+  }
+  for (const u of oldUrls) {
+    if (!deduped.includes(u)) deduped.push(u);
+  }
+  saveDisplayOrder(deduped);
 }
 
 export function loadDisabledAddons(): Set<string> {
@@ -342,11 +396,22 @@ export type InstallResult = {
 export async function installAddon(id: string, transportUrl: string): Promise<Addon> {
   const manifest = await fetchManifestAt(transportUrl);
   const canonicalId = manifest.id || id;
-  const next = loadInstalled().filter((a) => a.transportUrl !== transportUrl);
+  const before = loadInstalled();
+  // Deduplicate by ID (handles URL changes during updates) and by URL (re-installs)
+  const next = before.filter(
+    (a) => a.id !== canonicalId && a.transportUrl !== transportUrl,
+  );
+  const replaced = before.filter(
+    (a) => a.id === canonicalId || a.transportUrl === transportUrl,
+  );
+  const replacedUrls = replaced.map((a) => a.transportUrl);
+  if (replaced.length > 0) {
+    preserveOrderOnReplace(replacedUrls, transportUrl);
+  }
   next.push({ id: canonicalId, transportUrl, installedAt: Date.now(), manifest });
   saveInstalled(next);
   const addon: Addon = { manifest, transportUrl };
-  await pushToStremio(addon, "install");
+  await pushToStremio(addon, "install", replacedUrls);
   return addon;
 }
 
@@ -362,27 +427,25 @@ export async function installFromUrl(
   const replaceId = options.replaceId && options.replaceId !== id ? options.replaceId : null;
   const replacedById = before.some((a) => a.id === id);
   const replacedByOld = replaceId != null && before.some((a) => a.id === replaceId);
+  // Deduplicate by ID (updates), URL (re-installs), or explicit replaceId
   const next = before.filter(
-    (a) => a.transportUrl !== parsed.url && (!replaceId || a.id !== replaceId),
+    (a) =>
+      a.id !== id &&
+      a.transportUrl !== parsed.url &&
+      (!replaceId || a.id !== replaceId),
   );
+  const replaced = before.filter(
+    (a) =>
+      a.id === id || a.transportUrl === parsed.url || (replaceId != null && a.id === replaceId),
+  );
+  const replacedUrls = replaced.map((a) => a.transportUrl);
+  if (replaced.length > 0) {
+    preserveOrderOnReplace(replacedUrls, parsed.url);
+  }
   next.push({ id, transportUrl: parsed.url, installedAt: Date.now(), manifest });
   saveInstalled(next);
   const addon: Addon = { manifest, transportUrl: parsed.url };
-  const syncedToStremio = await pushToStremio(addon, "install");
-  if (replaceId && replaceId !== id) {
-    const authKey = readAuthKey();
-    if (authKey) {
-      try {
-        const current = await userAddons(authKey);
-        const trimmed = current.filter((a) => a.manifest.id !== replaceId);
-        if (trimmed.length !== current.length) {
-          await setUserAddons(authKey, trimmed);
-        }
-      } catch {
-        /* noop */
-      }
-    }
-  }
+  const syncedToStremio = await pushToStremio(addon, "install", replacedUrls);
   return { addon, syncedToStremio, replaced: replacedById || replacedByOld };
 }
 


### PR DESCRIPTION
## Summary

When an addon was updated, Harbor pushed a duplicate copy to the end of the collection instead of replacing the original, which also dropped the addon to the bottom of the ordering — both in the local Installed tab and in the Stremio account collection.

The update flow now resolves the addon being replaced by its manifest id, transport URL, or explicit replaceId, removes only those entries, and re-inserts the new addon at the original's position — matching Stremio's own update behavior. Local display order is preserved through harbor.addonOrder via a new preserveOrderOnReplace helper.

## Why

- Duplicates: installAddon/installFromUrl only deduplicated by transport URL, so an update with a changed URL (or a matched replaceId handled after the fact) produced a second entry.
- Position reset: pushToStremio blindly appended the updated addon to the end of the cloud collection. For addons synced from a Stremio account — which are read from the cloud and never present in loadInstalled() — the replacement slot was always empty, so the addon fell to the bottom even though Stremio itself preserves position on direct updates. Keeping the position on reinstall is the expected, predictable behavior for the app.

The dedup/splice logic lives in pushToStremio (against the cloud collection) and a shared preserveOrderOnReplace helper (against the local order), keeping the ordering concern in the addon-store layer rather than scattered across views.

## Verification

- pnpm run typecheck (tsc -b --pretty false) — exit 0, clean.
- Reviewed the splice logic for index alignment when the replacement removes multiple entries before the insert index.
- Confirmed the position is now resolved from the Stremio collection by manifest.id, so cloud-synced addons (not present in loadInstalled()) keep their position.
- Manual scenario to confirm: sign in to Stremio in Harbor, update an addon, and verify no duplicate appears and the addon stays in the same place in the Installed tab and the Organize/reorder page.

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
