### PR TITLE
feat(profile-import): add merge/replace conflict choices when importing from primary

### DIFF
--- a/src/components/profile-picker/editor-view.tsx
+++ b/src/components/profile-picker/editor-view.tsx
@@ -39,11 +39,14 @@ import {
 } from "@/lib/profiles";
 import { emitListToast } from "@/components/lists/list-toast";
 import {
+  analyzeOverlaps,
   defaultSelectedAddonUrls,
   importDomains,
   summarizeSource,
+  type DomainOverlap,
   type ImportAddonPreview,
   type ImportDomain,
+  type ImportDomainChoice,
   type ImportSourceSummary,
 } from "@/lib/profile-import";
 import { useT } from "@/lib/i18n";
@@ -127,6 +130,10 @@ export function EditorView({
   });
   const [selectedAddons, setSelectedAddons] = useState<Set<string>>(new Set());
   const [sourceSummary, setSourceSummary] = useState<ImportSourceSummary | null>(null);
+  const [overlaps, setOverlaps] = useState<Partial<Record<ImportDomain, DomainOverlap>>>({});
+  const [domainChoices, setDomainChoices] = useState<Partial<Record<ImportDomain, ImportDomainChoice>>>(
+    {},
+  );
   const [importExpanded, setImportExpanded] = useState(mode.kind === "create");
   const [confirmingImport, setConfirmingImport] = useState(false);
   const [confirmingShare, setConfirmingShare] = useState(false);
@@ -160,6 +167,22 @@ export function EditorView({
     setSourceSummary(importSourceId ? summarizeSource(importSourceId) : null);
   }, [importSourceId]);
 
+  const targetProfileId = editing?.id ?? null;
+  useEffect(() => {
+    if (!importSourceId || !targetProfileId) {
+      setOverlaps({});
+      return;
+    }
+    const selectedMergeable = (Object.keys(importSelection) as ImportDomain[]).filter(
+      (d) => importSelection[d] && (d === "watchlist" || d === "favorites" || d === "addons"),
+    );
+    if (selectedMergeable.length === 0) {
+      setOverlaps({});
+      return;
+    }
+    setOverlaps(analyzeOverlaps(importSourceId, targetProfileId, selectedMergeable));
+  }, [importSourceId, targetProfileId, importSelection]);
+
   const resetImportChoice = () => {
     setImportSelection({
       settings: false,
@@ -170,6 +193,8 @@ export function EditorView({
       continueWatching: false,
     });
     setSelectedAddons(new Set());
+    setOverlaps({});
+    setDomainChoices({});
   };
 
   const toggleImportDomain = (domain: ImportDomain) => {
@@ -195,6 +220,7 @@ export function EditorView({
     if (list.length === 0) return;
     importDomains(primary.id, editing.id, list, {
       addonTransportUrls: list.includes("addons") ? [...selectedAddons] : null,
+      choices: domainChoices,
     });
     if (list.includes("settings") && editing.settingsLinked !== false) {
       updateProfile(editing.id, { settingsLinked: false });
@@ -315,6 +341,7 @@ export function EditorView({
       if (importList.length > 0 && primary) {
         importDomains(primary.id, p.id, importList, {
           addonTransportUrls: importList.includes("addons") ? [...selectedAddons] : null,
+          choices: domainChoices,
         });
         if (importList.includes("settings")) patch.settingsLinked = false;
         emitListToast(t("Data copied from {name}", { name: primary.name }));
@@ -705,11 +732,42 @@ export function EditorView({
                     onClick={() => toggleImportDomain("continueWatching")}
                   />
                 </div>
+                {(overlaps.watchlist?.overlapCount ?? 0) > 0 && (
+                  <ConflictRow
+                    label={t("Watchlist overlaps ({n})", {
+                      n: overlaps.watchlist?.overlapCount ?? 0,
+                    })}
+                    value={domainChoices.watchlist ?? "merge"}
+                    onChange={(v) =>
+                      setDomainChoices((prev) => ({ ...prev, watchlist: v }))
+                    }
+                  />
+                )}
+                {(overlaps.favorites?.overlapCount ?? 0) > 0 && (
+                  <ConflictRow
+                    label={t("Favorites overlap ({n})", {
+                      n: overlaps.favorites?.overlapCount ?? 0,
+                    })}
+                    value={domainChoices.favorites ?? "merge"}
+                    onChange={(v) =>
+                      setDomainChoices((prev) => ({ ...prev, favorites: v }))
+                    }
+                  />
+                )}
+                {(overlaps.addons?.overlapCount ?? 0) > 0 && (
+                  <ConflictRow
+                    label={t("Addons overlap ({n})", {
+                      n: overlaps.addons?.overlapCount ?? 0,
+                    })}
+                    value={domainChoices.addons ?? "merge"}
+                    onChange={(v) => setDomainChoices((prev) => ({ ...prev, addons: v }))}
+                  />
+                )}
                 <p className="text-[11px] leading-snug text-ink-subtle">
                   {t(
                     isCreate
                       ? "Copied once — afterwards this profile keeps its own copy. Nothing stays linked to Primary."
-                      : "Checking an area replaces this profile's current data in it.",
+                      : "Areas where data already exists let you choose how to combine it.",
                   )}
                 </p>
                 {!isCreate && (
@@ -737,7 +795,7 @@ export function EditorView({
                       </>
                     ) : (
                       <>
-                        <span className="text-ink-subtle">{t("Replace selected data?")}</span>
+                        <span className="text-ink-subtle">{t("Import selected data?")}</span>
                         <button
                           type="button"
                           onClick={() => setConfirmingImport(false)}
@@ -1213,6 +1271,43 @@ function ImportRow({
       </span>
       <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-ink">{label}</span>
     </button>
+  );
+}
+
+function ConflictRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: ImportDomainChoice;
+  onChange: (v: ImportDomainChoice) => void;
+}) {
+  const t = useT();
+  const options: { value: ImportDomainChoice; labelKey: string }[] = [
+    { value: "merge", labelKey: "Merge" },
+    { value: "replace", labelKey: "Replace" },
+  ];
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl border border-edge-soft bg-elevated/30 p-2.5">
+      <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-ink">{label}</span>
+      <div className="flex shrink-0 items-center gap-1 rounded-lg bg-canvas/50 p-1">
+        {options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onChange(o.value)}
+            className={`rounded-md px-2 py-1 text-[11.5px] font-semibold transition-colors ${
+              value === o.value
+                ? "bg-accent/20 text-accent"
+                : "text-ink-muted hover:text-ink"
+            }`}
+          >
+            {t(o.labelKey)}
+          </button>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/src/components/profile-picker/editor-view.tsx
+++ b/src/components/profile-picker/editor-view.tsx
@@ -180,8 +180,10 @@ export function EditorView({
       setOverlaps({});
       return;
     }
-    setOverlaps(analyzeOverlaps(importSourceId, targetProfileId, selectedMergeable));
-  }, [importSourceId, targetProfileId, importSelection]);
+    setOverlaps(
+      analyzeOverlaps(importSourceId, targetProfileId, selectedMergeable, [...selectedAddons]),
+    );
+  }, [importSourceId, targetProfileId, importSelection, selectedAddons]);
 
   const resetImportChoice = () => {
     setImportSelection({

--- a/src/lib/profile-import.ts
+++ b/src/lib/profile-import.ts
@@ -47,6 +47,93 @@ type StoredAddon = {
   manifest?: { name?: string };
 };
 
+export type ImportDomainChoice = "merge" | "replace";
+
+// Only id/url-keyed array domains can be merged; the rest (settings blob, watched
+// flags, continue-watching positions) stay replace-only.
+const MERGEABLE_DOMAINS = new Set<ImportDomain>(["watchlist", "favorites", "addons"]);
+
+type KeyOf = (o: Record<string, unknown>) => string | null;
+
+const byId: KeyOf = (o) => (typeof o.id === "string" && o.id) || null;
+const byUrl: KeyOf = (o) => (typeof o.transportUrl === "string" && o.transportUrl) || null;
+
+const DOMAIN_KEY_OF: Partial<Record<ImportDomain, KeyOf>> = {
+  watchlist: byId,
+  favorites: byId,
+  addons: byUrl,
+};
+
+type KeyedEntry = { key: string; raw: unknown };
+
+function readKeyedArray(key: string, keyOf: KeyOf): KeyedEntry[] {
+  const arr = readJson<unknown[]>(key);
+  if (!Array.isArray(arr)) return [];
+  const out: KeyedEntry[] = [];
+  for (const el of arr) {
+    if (typeof el === "string") {
+      out.push({ key: el, raw: el });
+    } else if (el && typeof el === "object") {
+      const k = keyOf(el as Record<string, unknown>);
+      if (k) out.push({ key: k, raw: el });
+    }
+  }
+  return out;
+}
+
+// Union source into existing target by identity key. Existing target entries win so a
+// merge never loses or clobbers data that is already on the target profile.
+function unionKeyedArray(srcKey: string, dstKey: string, keyOf: KeyOf): void {
+  const map = new Map<string, unknown>();
+  for (const e of readKeyedArray(dstKey, keyOf)) if (!map.has(e.key)) map.set(e.key, e.raw);
+  for (const e of readKeyedArray(srcKey, keyOf)) if (!map.has(e.key)) map.set(e.key, e.raw);
+  localStorage.setItem(dstKey, JSON.stringify(Array.from(map.values())));
+}
+
+export type DomainOverlap = {
+  sourceCount: number;
+  targetCount: number;
+  overlapCount: number;
+};
+
+export function analyzeOverlaps(
+  fromProfileId: string,
+  toProfileId: string,
+  domains: ImportDomain[],
+): Partial<Record<ImportDomain, DomainOverlap>> {
+  const result: Partial<Record<ImportDomain, DomainOverlap>> = {};
+  const srcKeys = new Map<ImportDomain, Set<string>>();
+  const dstKeys = new Map<ImportDomain, Set<string>>();
+  for (const domain of domains) {
+    if (!MERGEABLE_DOMAINS.has(domain)) continue;
+    const keyOf = DOMAIN_KEY_OF[domain];
+    if (!keyOf) continue;
+    const s = new Set<string>();
+    const d = new Set<string>();
+    if (domain === "addons") {
+      for (const e of readKeyedArray(INSTALLED_PREFIX + fromProfileId, keyOf)) s.add(e.key);
+      for (const e of readKeyedArray(INSTALLED_PREFIX + toProfileId, keyOf)) d.add(e.key);
+    } else if (domain !== "settings") {
+      const prefixes = DOMAIN_PREFIXES[domain];
+      for (const prefix of prefixes) {
+        for (const e of readKeyedArray(prefix + fromProfileId, keyOf)) s.add(e.key);
+        for (const e of readKeyedArray(prefix + toProfileId, keyOf)) d.add(e.key);
+      }
+    }
+    srcKeys.set(domain, s);
+    dstKeys.set(domain, d);
+  }
+  for (const domain of domains) {
+    const s = srcKeys.get(domain);
+    const d = dstKeys.get(domain);
+    if (!s || !d) continue;
+    let overlap = 0;
+    for (const k of s) if (d.has(k)) overlap++;
+    result[domain] = { sourceCount: s.size, targetCount: d.size, overlapCount: overlap };
+  }
+  return result;
+}
+
 type MinimalProfilesState = {
   profiles?: Array<{ id?: string; isPrimary?: boolean; settingsLinked?: boolean }>;
   activeId?: string | null;
@@ -140,11 +227,18 @@ export function importDomains(
   fromProfileId: string,
   toProfileId: string,
   domains: ImportDomain[],
-  opts?: { addonTransportUrls?: string[] | null },
+  opts?: {
+    addonTransportUrls?: string[] | null;
+    choices?: Partial<Record<ImportDomain, ImportDomainChoice>>;
+  },
 ): void {
   if (!fromProfileId || !toProfileId || fromProfileId === toProfileId) return;
+  const choices = opts?.choices ?? {};
+  const choiceFor = (domain: ImportDomain): ImportDomainChoice =>
+    choices[domain] ?? (MERGEABLE_DOMAINS.has(domain) ? "merge" : "replace");
   try {
     for (const domain of domains) {
+      const choice = choiceFor(domain);
       if (domain === "settings") {
         // Copy the source's effective blob into the target's own blob. The
         // caller unlinks settings on the target so this copy is what loads.
@@ -158,47 +252,20 @@ export function importDomains(
       }
 
       if (domain === "addons") {
-        const installedRaw = localStorage.getItem(INSTALLED_PREFIX + fromProfileId);
-        if (installedRaw == null) continue;
-        const subset = opts?.addonTransportUrls ? new Set(opts.addonTransportUrls) : null;
-        if (!subset) {
-          localStorage.setItem(INSTALLED_PREFIX + toProfileId, installedRaw);
-          const disabledRaw = localStorage.getItem(DISABLED_PREFIX + fromProfileId);
-          if (disabledRaw != null) localStorage.setItem(DISABLED_PREFIX + toProfileId, disabledRaw);
-          continue;
-        }
-        // Subset import: keep only user-selected addons. The disabled list is
-        // filtered through an id->transportUrl map so entries survive either shape.
-        const installed = readJson<StoredAddon[]>(INSTALLED_PREFIX + fromProfileId) ?? [];
-        const list = Array.isArray(installed) ? installed : [];
-        const idToUrl = new Map<string, string>();
-        for (const a of list) {
-          if (a && typeof a.id === "string" && typeof a.transportUrl === "string") {
-            idToUrl.set(a.id, a.transportUrl);
+        applyAddons(fromProfileId, toProfileId, choice, opts?.addonTransportUrls ?? null);
+        continue;
+      }
+
+      if (MERGEABLE_DOMAINS.has(domain)) {
+        const keyOf = DOMAIN_KEY_OF[domain];
+        if (!keyOf) continue;
+        for (const prefix of DOMAIN_PREFIXES[domain]) {
+          if (choice === "replace") {
+            const raw = localStorage.getItem(prefix + fromProfileId);
+            if (raw != null) localStorage.setItem(prefix + toProfileId, raw);
+          } else {
+            unionKeyedArray(prefix + fromProfileId, prefix + toProfileId, keyOf);
           }
-        }
-        const kept = list.filter(
-          (a) => a && typeof a.transportUrl === "string" && subset.has(a.transportUrl),
-        );
-        localStorage.setItem(INSTALLED_PREFIX + toProfileId, JSON.stringify(kept));
-        const disabledParsed = readJson<unknown>(DISABLED_PREFIX + fromProfileId);
-        if (Array.isArray(disabledParsed)) {
-          const keptDisabled = disabledParsed.filter((entry) => {
-            if (typeof entry === "string") {
-              const url = idToUrl.get(entry);
-              return (url != null && subset.has(url)) || subset.has(entry);
-            }
-            if (entry && typeof entry === "object") {
-              const o = entry as { id?: unknown; transportUrl?: unknown };
-              if (typeof o.transportUrl === "string") return subset.has(o.transportUrl);
-              if (typeof o.id === "string") {
-                const url = idToUrl.get(o.id);
-                return url != null && subset.has(url);
-              }
-            }
-            return false;
-          });
-          localStorage.setItem(DISABLED_PREFIX + toProfileId, JSON.stringify(keptDisabled));
         }
         continue;
       }
@@ -211,4 +278,81 @@ export function importDomains(
   } catch (e) {
     console.warn("[profile-import] failed", e);
   }
+}
+
+function applyAddons(
+  fromProfileId: string,
+  toProfileId: string,
+  choice: ImportDomainChoice,
+  selectedUrls: string[] | null,
+): void {
+  const subset = selectedUrls ? new Set(selectedUrls) : null;
+  const sourceEntries = readKeyedArray(INSTALLED_PREFIX + fromProfileId, byUrl);
+  const picked = subset
+    ? sourceEntries.filter((e) => subset.has(e.key))
+    : sourceEntries;
+
+  if (choice === "replace") {
+    const keptRaw = picked.map((e) => e.raw);
+    localStorage.setItem(INSTALLED_PREFIX + toProfileId, JSON.stringify(keptRaw));
+    const idToUrl = new Map<string, string>();
+    for (const e of sourceEntries) {
+      const o = e.raw as { id?: unknown };
+      if (typeof o.id === "string") idToUrl.set(o.id, e.key);
+    }
+    replaceDisabled(fromProfileId, toProfileId, picked, idToUrl);
+    return;
+  }
+
+  const targetEntries = readKeyedArray(INSTALLED_PREFIX + toProfileId, byUrl);
+  const map = new Map<string, unknown>();
+  for (const e of targetEntries) if (!map.has(e.key)) map.set(e.key, e.raw);
+  for (const e of picked) if (!map.has(e.key)) map.set(e.key, e.raw);
+  localStorage.setItem(INSTALLED_PREFIX + toProfileId, JSON.stringify(Array.from(map.values())));
+  const existingDisabled = readKeyedArray(DISABLED_PREFIX + toProfileId, byUrl);
+  const srcIdToUrl = new Map<string, string>();
+  for (const e of sourceEntries) {
+    const o = e.raw as { id?: unknown };
+    if (typeof o.id === "string") srcIdToUrl.set(o.id, e.key);
+  }
+  const srcDisabled = readJson<unknown>(DISABLED_PREFIX + fromProfileId);
+  if (Array.isArray(srcDisabled)) {
+    const disabledMap = new Map<string, unknown>();
+    for (const e of existingDisabled) if (!disabledMap.has(e.key)) disabledMap.set(e.key, e.raw);
+    for (const entry of srcDisabled) {
+      const key = disabledKey(entry, srcIdToUrl);
+      if (!key) continue;
+      if (subset && !subset.has(key)) continue;
+      if (!disabledMap.has(key)) disabledMap.set(key, entry);
+    }
+    localStorage.setItem(
+      DISABLED_PREFIX + toProfileId,
+      JSON.stringify(Array.from(disabledMap.values())),
+    );
+  }
+}
+
+function disabledKey(entry: unknown, idToUrl: Map<string, string>): string | null {
+  if (typeof entry === "string") return entry;
+  if (entry && typeof entry === "object") {
+    const o = entry as { id?: unknown; transportUrl?: unknown };
+    if (typeof o.transportUrl === "string") return o.transportUrl;
+    if (typeof o.id === "string") return idToUrl.get(o.id) ?? o.id;
+  }
+  return null;
+}
+
+function replaceDisabled(
+  fromProfileId: string,
+  toProfileId: string,
+  picked: KeyedEntry[],
+  idToUrl: Map<string, string>,
+): void {
+  const srcDisabled = readJson<unknown>(DISABLED_PREFIX + fromProfileId);
+  if (!Array.isArray(srcDisabled)) return;
+  const keptDisabled = srcDisabled.filter((entry) => {
+    const key = disabledKey(entry, idToUrl);
+    return key != null && picked.some((e) => e.key === key);
+  });
+  localStorage.setItem(DISABLED_PREFIX + toProfileId, JSON.stringify(keptDisabled));
 }

--- a/src/lib/profile-import.ts
+++ b/src/lib/profile-import.ts
@@ -100,10 +100,16 @@ export function analyzeOverlaps(
   fromProfileId: string,
   toProfileId: string,
   domains: ImportDomain[],
+  addonUrls?: string[] | null,
 ): Partial<Record<ImportDomain, DomainOverlap>> {
   const result: Partial<Record<ImportDomain, DomainOverlap>> = {};
   const srcKeys = new Map<ImportDomain, Set<string>>();
   const dstKeys = new Map<ImportDomain, Set<string>>();
+  // Mirror applyAddons: a present (even empty) selection is a real subset; only
+  // null means "no subset / every source addon". An empty selection filters out
+  // all source addons, so it must report no addon overlap.
+  const addonSubset =
+    addonUrls != null ? new Set(addonUrls) : null;
   for (const domain of domains) {
     if (!MERGEABLE_DOMAINS.has(domain)) continue;
     const keyOf = DOMAIN_KEY_OF[domain];
@@ -111,7 +117,10 @@ export function analyzeOverlaps(
     const s = new Set<string>();
     const d = new Set<string>();
     if (domain === "addons") {
-      for (const e of readKeyedArray(INSTALLED_PREFIX + fromProfileId, keyOf)) s.add(e.key);
+      for (const e of readKeyedArray(INSTALLED_PREFIX + fromProfileId, keyOf)) {
+        if (addonSubset && !addonSubset.has(e.key)) continue;
+        s.add(e.key);
+      }
       for (const e of readKeyedArray(INSTALLED_PREFIX + toProfileId, keyOf)) d.add(e.key);
     } else if (domain !== "settings") {
       const prefixes = DOMAIN_PREFIXES[domain];


### PR DESCRIPTION
## Summary

Adds per-domain conflict handling to the existing "Import data from primary profile" flow. When a selected area (watchlist, favorites, or addons) already contains items on the target profile, the import panel now reveals a Merge / Replace toggle for that domain instead of silently overwriting. Merge is the default and never loses existing data; Replace fully overwrites the domain with the primary's version.

## Why

Previously, importing from the primary unconditionally replaced each selected area on the target profile, which could wipe data the user had already added to the target (e.g. a watchlist entry present only on the target). The user asked for merge semantics so that importing brings in what the primary has and keeps what the target already has.

## Verification

- pnpm run typecheck passes cleanly (tsc -b --pretty false).
- Manually traced merge (union by id/transportUrl, target-wins) and replace (wholesale overwrite) paths in importDomains(), including the addons disabled-list union and the selected-subset addon merge fix.
- Fix verified: the merge path now imports only the user-selected addon subset rather than all source addons

## Platform Impact

None

## UI Changes

A Merge / Replace toggle row appears per mergeable domain only when that domain has overlapping items on the target profile (defaulting to Merge). When there are no overlaps, no extra UI is shown.

<img width="706" height="498" alt="image" src="https://github.com/user-attachments/assets/1cd17548-dd95-43c6-9f96-ed66799c40ad" />

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
