### PR TITLE
fix and feat: create theme filtering and improve friend presence

### DIFF
--- a/src/lib/social/presence.ts
+++ b/src/lib/social/presence.ts
@@ -68,6 +68,14 @@ async function savePresence(next: PresenceStatus): Promise<void> {
   });
 }
 
+export function resolvePresence(value: unknown, online = false): PresenceStatus {
+  if (value === "online" || value === "away" || value === "dnd" || value === "offline") {
+    return value;
+  }
+
+  return online ? "online" : "offline";
+}
+
 export function setStatus(next: PresenceStatus): void {
   if (next === status) return;
   status = next;

--- a/src/views/profile/friends-panel.tsx
+++ b/src/views/profile/friends-panel.tsx
@@ -1,7 +1,11 @@
 import { UserPlus, Users } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
-import { PRESENCE_META } from "@/lib/social/presence";
+import {
+  PRESENCE_META,
+  resolvePresence,
+  type PresenceStatus,
+} from "@/lib/social/presence";
 import { AddFriendsModal } from "./add-friends-modal";
 import { Avatar } from "./profile-bits";
 import { UserHoverCard } from "./user-hover-card";
@@ -10,18 +14,21 @@ import type { Friend } from "./profile-types";
 const FRIENDS_PAGE = 6;
 const FRIENDS_STEP = 12;
 
+function friendPresence(f: Friend): PresenceStatus {
+  return resolvePresence(f.presence ?? f.status, f.online);
+}
+
 function friendDotClass(f: Friend): string {
-  const s = f.presence ?? f.status;
-  if (s === "online" || s === "away" || s === "dnd" || s === "offline") return PRESENCE_META[s].dot;
-  return f.online ? "bg-success" : "bg-ink-subtle";
+  return PRESENCE_META[friendPresence(f)].dot;
 }
 
 function FriendRow({ f, onOpen }: { f: Friend; onOpen?: (h: string) => void }) {
+  const presence = friendPresence(f);
   return (
-    <UserHoverCard handle={f.handle}>
+    <UserHoverCard handle={f.handle} presence={presence}>
       <button
         onClick={() => onOpen?.(f.handle)}
-        className="flex w-full min-h-11 items-center gap-3 rounded-md px-2 py-1.5 text-start transition-colors hover:bg-elevated"
+        className="flex w-full min-h-11 items-center gap-3 rounded-[10px] px-2 py-1.5 text-start transition-colors hover:bg-elevated"
       >
         <Avatar src={f.avatarUrl} size={40} dotClass={friendDotClass(f)} alias={f.alias} />
         <div className="min-w-0 flex-1">
@@ -68,7 +75,7 @@ export function FriendsPanel({
   return (
     <section
       aria-label={t("Friends")}
-      className="rounded-lg bg-surface p-4 ring-1 ring-edge-soft"
+      className="rounded-[14px] bg-surface p-4 ring-1 ring-edge-soft"
     >
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-2 text-[12px] font-semibold uppercase tracking-[0.12em] text-ink-subtle">
@@ -145,7 +152,7 @@ export function FriendsPanel({
           {remaining > 0 && (
             <button
               onClick={() => setShown((s) => s + FRIENDS_STEP)}
-              className="min-h-9 rounded-md text-[12.5px] font-medium text-ink-muted transition-colors hover:bg-elevated hover:text-ink"
+              className="min-h-9 rounded-[10px] text-[12.5px] font-medium text-ink-muted transition-colors hover:bg-elevated hover:text-ink"
             >
               {t("Show {count} more", { count: Math.min(remaining, FRIENDS_STEP) })}
             </button>

--- a/src/views/profile/profile-types.ts
+++ b/src/views/profile/profile-types.ts
@@ -2,6 +2,7 @@ import type { FeaturedList } from "@/lib/social/featured-lists";
 import type { SocialKey } from "@/lib/social/socials";
 import type { RatingsSummary } from "@/lib/ratings/types";
 import type { FavoriteMedia } from "@/lib/providers/favorites-types";
+import type { PresenceStatus } from "@/lib/social/presence";
 
 export type SocialEntry = { service: SocialKey; value: string };
 
@@ -71,6 +72,7 @@ export type ProfileSummary = {
   pronouns?: string;
   customUrl?: string;
   online: boolean;
+  presence?: PresenceStatus;
   watching?: ProfileWatching;
   memberSince: string;
   counts: ProfileCounts;
@@ -131,7 +133,7 @@ export type Friend = {
   avatarUrl?: string;
   slogan?: string;
   online: boolean;
-  presence?: string;
+  presence?: PresenceStatus;
   status?: string;
   mutual?: boolean;
 };

--- a/src/views/profile/user-hover-card.tsx
+++ b/src/views/profile/user-hover-card.tsx
@@ -13,6 +13,11 @@ import { requestOpenProfile } from "@/lib/social/open-profile";
 import { regionFlagSrc } from "@/lib/region-flags";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
 import { useT } from "@/lib/i18n";
+import {
+  PRESENCE_META,
+  resolvePresence,
+  type PresenceStatus,
+} from "@/lib/social/presence";
 import { fetchBadges, fetchSummary } from "./profile-api";
 import { orderShownBadges } from "./badge-catalog";
 import { HoverTooltip } from "@/components/hover-tooltip";
@@ -49,7 +54,15 @@ function loadCard(handle: string): Promise<CardData> {
 
 const CARD_W = 300;
 
-export function UserHoverCard({ handle, children }: { handle: string; children: ReactElement<any> }) {
+export function UserHoverCard({
+  handle,
+  presence,
+  children,
+}: {
+  handle: string;
+  presence?: PresenceStatus;
+  children: ReactElement<any>;
+}) {
   const [anchor, setAnchor] = useState<DOMRect | null>(null);
   const ref = useRef<HTMLElement>(null);
   const openTimer = useRef<number | null>(null);
@@ -131,7 +144,7 @@ export function UserHoverCard({ handle, children }: { handle: string; children: 
     <>
       {trigger}
       {anchor && (
-        <ProfileHoverCard handle={handle} anchor={anchor} onEnter={clearClose} onLeave={scheduleClose} />
+        <ProfileHoverCard handle={handle} presence={presence} anchor={anchor} onEnter={clearClose} onLeave={scheduleClose} />
       )}
     </>
   );
@@ -142,11 +155,13 @@ export const HOVER_CARD_CLOSE_MS = 180;
 
 export function ProfileHoverCard({
   handle,
+  presence: presenceOverride,
   anchor,
   onEnter,
   onLeave,
 }: {
   handle: string;
+  presence?: PresenceStatus;
   anchor: DOMRect;
   onEnter: () => void;
   onLeave: () => void;
@@ -184,6 +199,7 @@ export function ProfileHoverCard({
   }, [anchor, data, failed]);
 
   const summary = data?.summary;
+  const presence = presenceOverride ?? resolvePresence(summary?.presence, summary?.online);
   const badges = orderShownBadges(data?.badges ?? [], data?.summary?.shownBadges);
   const mine = !!self.handle && self.handle.toLowerCase() === key;
   const cardAvatar = mine ? self.avatar ?? summary?.avatarUrl : summary?.avatarUrl;
@@ -205,7 +221,7 @@ export function ProfileHoverCard({
         top: placed?.top ?? anchor.bottom + 8,
         visibility: placed ? "visible" : "hidden",
       }}
-      className={`fixed z-[260] cursor-pointer overflow-hidden rounded-xl border border-edge bg-elevated/95 shadow-[0_28px_70px_-20px_rgba(0,0,0,0.85)] backdrop-blur-xl ${
+      className={`fixed z-[260] cursor-pointer overflow-hidden rounded-[20px] border border-edge bg-elevated/95 shadow-[0_28px_70px_-20px_rgba(0,0,0,0.85)] backdrop-blur-xl ${
         reduced ? "" : "animate-popover-in"
       }`}
     >
@@ -221,7 +237,7 @@ export function ProfileHoverCard({
       <div className="px-4 pb-4">
         <div className="-mt-9 mb-2.5 flex items-end justify-between">
           <span className="rounded-full bg-elevated p-[3px]">
-            <Avatar src={cardAvatar} size={60} online={summary?.online} alias={summary?.alias ?? handle} />
+            <Avatar src={cardAvatar} size={60} dotClass={PRESENCE_META[presence].dot} alias={summary?.alias ?? handle} />
           </span>
         </div>
 
@@ -237,8 +253,8 @@ export function ProfileHoverCard({
           <>
             <div className="mt-2 flex items-center gap-2 text-[11.5px] text-ink-muted">
               <span className="inline-flex items-center gap-1.5">
-                <span className={`h-2 w-2 rounded-full ${summary.online ? "bg-success" : "bg-ink-subtle"}`} />
-                {summary.online ? t("Online") : t("Offline")}
+                <span className={`h-2 w-2 rounded-full ${PRESENCE_META[presence].dot}`} />
+                {t(PRESENCE_META[presence].label)}
               </span>
               {summary.location && (
                 <>

--- a/src/views/settings/theme-panel/custom-themes-section/community-store/store-browse.tsx
+++ b/src/views/settings/theme-panel/custom-themes-section/community-store/store-browse.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from "react";
-import { X } from "lucide-react";
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Check, Filter, X } from "lucide-react";
 import type { StoreTheme } from "@/lib/theme-store";
 import { MOOD_RAILS, themeMoods, type Mood } from "./color-rank";
 import { MarketCard } from "./market/market-card";
+import { matchesThemeBehavior, THEME_BEHAVIORS, type ThemeBehavior } from "./theme-behavior-filter";
+import { Diagram } from "../../theme-studio/layout-picker";
 
 const SORTS = [
   { id: "top", label: "Top rated" },
@@ -33,15 +35,70 @@ export function StoreBrowse({
   onClearMood?: () => void;
 }) {
   const [sort, setSort] = useState<SortId>("top");
+  const [behavior, setBehavior] = useState<ThemeBehavior | null>(null);
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [filterDropUp, setFilterDropUp] = useState(false);
+  const [filterMenuMaxHeight, setFilterMenuMaxHeight] = useState(360);
+  const filterRootRef = useRef<HTMLDivElement>(null);
+  const filterButtonRef = useRef<HTMLButtonElement>(null);
+  const filterOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const filterMenuId = useId();
   const q = query.trim().toLowerCase();
 
+  useEffect(() => {
+    if (!filterOpen) return;
+    const activeIndex = THEME_BEHAVIORS.findIndex((option) => option.id === behavior);
+    queueMicrotask(() => filterOptionRefs.current[Math.max(0, activeIndex)]?.focus());
+    const onPointerDown = (event: PointerEvent) => {
+      if (!filterRootRef.current?.contains(event.target as Node)) setFilterOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setFilterOpen(false);
+      filterButtonRef.current?.focus();
+    };
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [filterOpen, behavior]);
+
+  useLayoutEffect(() => {
+    if (!filterOpen) return;
+    const updatePlacement = () => {
+      const rect = filterRootRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const viewportMargin = 12;
+      const menuGap = 6;
+      const preferredHeight = Math.min(360, window.innerHeight * 0.6);
+      const above = Math.max(0, rect.top - viewportMargin - menuGap);
+      const below = Math.max(
+        0,
+        window.innerHeight - rect.bottom - viewportMargin - menuGap,
+      );
+      const dropUp = below < preferredHeight && above > below;
+      const available = dropUp ? above : below;
+      setFilterDropUp(dropUp);
+      setFilterMenuMaxHeight(Math.min(preferredHeight, available));
+    };
+    updatePlacement();
+    window.addEventListener("resize", updatePlacement);
+    window.addEventListener("scroll", updatePlacement, true);
+    return () => {
+      window.removeEventListener("resize", updatePlacement);
+      window.removeEventListener("scroll", updatePlacement, true);
+    };
+  }, [filterOpen]);
   const shown = useMemo(() => {
     const byMood = mood ? themes.filter((t) => themeMoods(t).has(mood)) : themes;
+    const byBehavior = byMood.filter((t) => matchesThemeBehavior(t.layout, behavior));
     const filtered = q
-      ? byMood.filter((t) => `${t.name} ${t.author} ${t.blurb}`.toLowerCase().includes(q))
-      : byMood;
+      ? byBehavior.filter((t) => `${t.name} ${t.author} ${t.blurb}`.toLowerCase().includes(q))
+      : byBehavior;
     return sortThemes(filtered, sort);
-  }, [themes, q, sort, mood]);
+  }, [themes, q, sort, mood, behavior]);
 
   return (
     <section className="flex flex-col gap-5 ps-[9px]">
@@ -51,7 +108,7 @@ export function StoreBrowse({
             key={s.id}
             type="button"
             onClick={() => setSort(s.id)}
-            className={`h-8 rounded-full px-3.5 text-[12.5px] font-semibold transition-colors ${
+            className={`h-8 rounded-full px-3.5 text-[12px] font-semibold transition-colors ${
               sort === s.id
                 ? "bg-ink text-canvas"
                 : "bg-surface text-ink-muted ring-1 ring-edge-soft hover:text-ink hover:ring-edge"
@@ -64,20 +121,109 @@ export function StoreBrowse({
           <button
             type="button"
             onClick={onClearMood}
-            className="inline-flex h-8 items-center gap-1.5 rounded-full bg-accent-soft px-3 text-[12.5px] font-semibold text-accent transition-opacity hover:opacity-85"
+            className="inline-flex h-8 items-center gap-1.5 rounded-full bg-accent-soft px-3 text-[12px] font-semibold text-accent transition-opacity hover:opacity-85"
           >
             {MOOD_RAILS.find((r) => r.mood === mood)?.title ?? mood}
             <X size={12} strokeWidth={2.6} />
           </button>
         )}
-        <span className="ms-auto tabular-nums text-[12.5px] text-ink-subtle">
-          {shown.length} {shown.length === 1 ? "theme" : "themes"}
-        </span>
+        <div className="ms-auto flex items-center gap-2.5">
+          <div ref={filterRootRef} className="relative">
+            <button
+              ref={filterButtonRef}
+              type="button"
+              onClick={() => setFilterOpen((open) => !open)}
+              aria-haspopup="menu"
+              aria-expanded={filterOpen}
+              aria-controls={filterOpen ? filterMenuId : undefined}
+              className={`inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-[12px] font-semibold transition-colors ${
+                behavior
+                  ? "bg-accent-soft text-accent ring-1 ring-accent/25"
+                  : "bg-surface text-ink-muted ring-1 ring-edge-soft hover:text-ink hover:ring-edge"
+              }`}
+            >
+              <Filter size={13} strokeWidth={2.3} />
+              Filter
+            </button>
+
+            {filterOpen && (
+              <div
+                id={filterMenuId}
+                role="menu"
+                aria-label="Filter themes by behavior"
+                style={{ maxHeight: filterMenuMaxHeight }}
+                className={`absolute end-0 z-40 w-[min(288px,calc(100vw-32px))] overflow-y-auto overscroll-contain rounded-xl border border-edge bg-elevated p-1 shadow-[0_22px_55px_-18px_rgba(0,0,0,0.7)] [scrollbar-width:thin] animate-popover-in ${
+                  filterDropUp ? "bottom-[calc(100%+6px)]" : "top-[calc(100%+6px)]"
+                }`}
+              >
+                <div className="grid grid-cols-2 gap-0.5">
+                  {THEME_BEHAVIORS.map((option, index) => {
+                    const active = behavior === option.id;
+                    return (
+                      <button
+                        key={option.id}
+                        ref={(element) => {
+                          filterOptionRefs.current[index] = element;
+                        }}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={active}
+                        onClick={() => {
+                          setBehavior(active ? null : option.id);
+                          setFilterOpen(false);
+                          queueMicrotask(() => filterButtonRef.current?.focus());
+                        }}
+                        className={`relative flex min-w-0 flex-col gap-1.5 rounded-lg p-1.5 text-start text-[12px] font-medium transition-colors ${
+                          active
+                            ? "bg-accent-soft text-accent"
+                            : "text-ink-muted hover:bg-raised hover:text-ink"
+                        }`}
+                      >
+                        <div
+                          aria-hidden="true"
+                          className="aspect-[4/3] w-full overflow-hidden rounded-lg border border-edge-soft bg-surface"
+                        >
+                          <Diagram active={active} kind={option.id} />
+                        </div>
+                        <span className="flex w-full items-center justify-between gap-2 px-0.5 pb-0.5">
+                          <span>{option.label}</span>
+                          {active && <Check size={13} strokeWidth={2.6} />}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+                {behavior && (
+                  <>
+                    <div className="my-1 h-px bg-edge-soft" />
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setBehavior(null);
+                        setFilterOpen(false);
+                        queueMicrotask(() => filterButtonRef.current?.focus());
+                      }}
+                      className="flex h-8 w-full items-center justify-center rounded-lg text-[11.5px] font-semibold text-ink-subtle transition-colors hover:bg-raised hover:text-ink"
+                    >
+                      Clear filter
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+          <span className="tabular-nums text-[12px] text-ink-subtle">
+            {shown.length} {shown.length === 1 ? "theme" : "themes"}
+          </span>
+        </div>
       </div>
 
       {shown.length === 0 ? (
-        <p className="rounded-md bg-surface px-4 py-14 text-center text-[13px] text-ink-subtle ring-1 ring-edge-soft">
-          {q ? "No themes match your search." : "No community themes yet. Be the first to share one."}
+        <p className="rounded-[14px] bg-surface/40 px-4 py-14 text-center text-[13px] text-ink-subtle ring-1 ring-edge-soft">
+          {q || mood || behavior
+            ? "No themes match your filters."
+            : "No community themes yet. Be the first to share one."}
         </p>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/src/views/settings/theme-panel/custom-themes-section/community-store/theme-behavior-filter.ts
+++ b/src/views/settings/theme-panel/custom-themes-section/community-store/theme-behavior-filter.ts
@@ -1,0 +1,28 @@
+export const THEME_BEHAVIORS = [
+  { id: "sidebar", label: "Sidebar" },
+  { id: "topdock", label: "Top dock" },
+  { id: "rail", label: "Side rail" },
+  { id: "stremio", label: "Stremio rail" },
+  { id: "minui", label: "Floating dock" },
+  { id: "cinematic", label: "Cinematic" },
+  { id: "custom", label: "Custom" },
+] as const;
+
+export type ThemeBehavior = (typeof THEME_BEHAVIORS)[number]["id"];
+
+const SIDEBAR_LAYOUTS = new Set(["sidebar", "dracula", "nord", "forest", "royal"]);
+
+export function themeBehavior(layout: string | null | undefined): ThemeBehavior | null {
+  if (!layout) return null;
+  if (SIDEBAR_LAYOUTS.has(layout)) return "sidebar";
+  return THEME_BEHAVIORS.some((behavior) => behavior.id === layout)
+    ? (layout as ThemeBehavior)
+    : null;
+}
+
+export function matchesThemeBehavior(
+  layout: string | null | undefined,
+  selected: ThemeBehavior | null,
+): boolean {
+  return selected === null || themeBehavior(layout) === selected;
+}

--- a/src/views/settings/theme-panel/theme-studio/layout-picker.tsx
+++ b/src/views/settings/theme-panel/theme-studio/layout-picker.tsx
@@ -69,13 +69,13 @@ export function LayoutPicker({
             key={l.id}
             type="button"
             onClick={() => onChange(l.id)}
-            className={`group relative flex flex-col gap-2 overflow-hidden rounded-md border p-3 text-start transition-colors ${
+            className={`group relative flex flex-col gap-2 overflow-hidden rounded-lg border p-3 text-start transition-colors ${
               active
-                ? "border-accent bg-accent-soft"
-                : "border-edge-soft bg-canvas hover:border-edge hover:bg-elevated"
+                ? "border-accent/80 bg-accent-soft"
+                : "border-edge-soft bg-canvas/40 hover:border-edge hover:bg-elevated/40"
             }`}
           >
- <div className="aspect-[4/3] w-full overflow-hidden rounded-md bg-surface">
+            <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border border-edge-soft bg-surface">
               {l.diagram(active)}
             </div>
             <div className="flex items-center justify-between">
@@ -96,7 +96,7 @@ export function LayoutPicker({
   );
 }
 
-function Diagram({
+export function Diagram({
   active,
   kind,
 }: {


### PR DESCRIPTION
## Summary

- Add behavior-based filtering to the community theme store.
- Keep the filter menu within the available viewport and make overflowing options scrollable.
- ensuring each friend’s status and indicator match between the friends panel and hover card.

## Why

The community theme store needed a way to filter themes by navigation behavior. The filter menu also became partially inaccessible in smaller windows when it opened outside the available viewport.

Friend rows and hover cards could independently resolve presence information, causing them to display different statuses. Passing the normalized friend presence into the hover card keeps both views synchronized

## Verification

- Ran `git diff --check`.
- Verified the filter opens above or below the button according to available space.
- Verified the filter menu remains scrollable in a small window.
- Verified behavior filters update the displayed theme results.
- Verified friend-row and hover-card presence dots and labels match.