### PR TITLE
fix(stream-ids): emit bare tmdb:{id} so stream addons match

### DIFF
--- a/src/lib/streams/stream-ids.ts
+++ b/src/lib/streams/stream-ids.ts
@@ -58,9 +58,18 @@ export function buildStreamIds(
   } else if (metaId.startsWith("tt") && !episode) {
     push(metaId);
   } else if (metaId.startsWith("tmdb:")) {
+    // Some stream addons (and AIOMetadata) use the bare `tmdb:{id}` scheme
+    // without the movie/tv segment. Emit it first so addons that match the bare
+    // prefix (they also match the scoped form) are queried with it; they index
+    // by the bare id and return nothing for the scoped form.
+    const bareBase = metaId.replace(/^tmdb:(movie|tv):/, "tmdb:");
     if (episode) {
-      if (!animeMeta) push(`${metaId}:${episode.season}:${episode.episode}`);
+      if (!animeMeta) {
+        if (bareBase !== metaId) push(`${bareBase}:${episode.season}:${episode.episode}`);
+        push(`${metaId}:${episode.season}:${episode.episode}`);
+      }
     } else {
+      if (bareBase !== metaId) push(bareBase);
       push(metaId);
     }
   } else {


### PR DESCRIPTION
## Summary

buildStreamIds now also emits the bare tmdb:{id} form (without the movie:/tv: segment) for tmdb:movie:{id} / tmdb:tv:{id} meta ids, and emits it first.

## Why

Harbor's own TMDB search produced a type-scoped id (tmdb:movie:1488254), but stream addons — and catalog addons like AIOMetadata — index content by the bare id (tmdb:1488254). So searching for a title in Harbor yielded "no source found", while the same title resolved fine when opened via AIOMetadata. No sources were missing; Harbor was querying the wrong id scheme. Emitting the bare form first ensures bare-indexing addons receive the id they use, while addons that only accept the scoped form still get it. This keeps the fix minimal and contained to id construction.

## Verification

- pnpm run typecheck (tsc -b --pretty false) → passes.
- Relevant tests: tests/anime-stream-identity.test.ts, tests/cw-anime-sync-ids.test.ts, tests/tmdb-language-separation.test.ts, tests/local-library-grouping.test.ts → all pass.
- Manually confirmed: with the fix, searching a title in Harbor yields a real source from addons that index by the bare id, instead of "source not found".

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
