### PR TITLE
fix: seed initial player volume from saved prefs to avoid stale baseline

### DIFF
--- a/src/lib/player/bridge.ts
+++ b/src/lib/player/bridge.ts
@@ -1,3 +1,4 @@
+import { readPlayerVolume } from "@/lib/player-volume";
 import type { SubCue } from "@/lib/subtitles/parser";
 import type { SubtitleLoadMetadata } from "@/lib/subtitles/types";
 import type { SubtitleMatchConfidence } from "@/lib/subtitles/release-match";
@@ -160,3 +161,9 @@ export const emptySnapshot: PlayerSnapshot = {
   errorMessage: null,
   errorCode: null,
 };
+
+/** Snapshot seeded with the persisted volume/mute preference instead of the 1.0/100% default. */
+export function initialPlayerSnapshot(): PlayerSnapshot {
+  const saved = readPlayerVolume();
+  return { ...emptySnapshot, volume: saved.volume, muted: saved.muted };
+}

--- a/src/lib/player/html5/bridge.ts
+++ b/src/lib/player/html5/bridge.ts
@@ -1,7 +1,7 @@
 import Hls from "hls.js";
 import mpegts from "mpegts.js";
 import {
-  emptySnapshot,
+  initialPlayerSnapshot,
   type PlayerBridge,
   type PlayerCapabilities,
   type PlayerSnapshot,
@@ -22,7 +22,7 @@ let DOCUMENT_PIP_KNOWN_BROKEN = false;
 export function createHtml5Bridge(): PlayerBridge {
   let video: HTMLVideoElement | null = null;
   let host: HTMLElement | null = null;
-  let snap: PlayerSnapshot = { ...emptySnapshot };
+  let snap: PlayerSnapshot = initialPlayerSnapshot();
   const listeners = new Set<(s: PlayerSnapshot) => void>();
   let pendingStart: number | null = null;
   let pipWindow: Window | null = null;

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -14,7 +14,7 @@ import {
 import { SUBTITLE_FPS_TRANSITION_FAILED_EVENT } from "./subtitle-fps";
 import { finishPlaybackTrace, markPlaybackTrace } from "@/lib/perf/playback-trace";
 import {
-  emptySnapshot,
+  initialPlayerSnapshot,
   type PlayerBridge,
   type PlayerCapabilities,
   type PlayerSeekPrecision,
@@ -210,7 +210,7 @@ function normalizeMediaPath(path: string): string {
 
 export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
   let host: HTMLElement | null = null;
-  let snap: PlayerSnapshot = { ...emptySnapshot };
+  let snap: PlayerSnapshot = initialPlayerSnapshot();
   let profileAf = "";
   let hdrToSdr = mpvOptions?.hdrToSdr ?? true;
   const applyAudioFilters = () => {

--- a/src/views/player/hooks/use-player-bridge.ts
+++ b/src/views/player/hooks/use-player-bridge.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
-import { emptySnapshot, type PlayerBridge, type PlayerSnapshot } from "@/lib/player/bridge";
+import {
+  emptySnapshot,
+  initialPlayerSnapshot,
+  type PlayerBridge,
+  type PlayerSnapshot,
+} from "@/lib/player/bridge";
 import { probeMpv } from "@/lib/player/mpv";
 import { mergeMpvOptions } from "@/lib/player/mpv-tuning";
 import { metaIsAnime } from "@/lib/player/anime-src";
@@ -50,7 +55,7 @@ export function usePlayerBridge(params: {
 }) {
   const { bridgeRef, videoMountRef, src, settings } = params;
 
-  const [snap, setSnap] = useState<PlayerSnapshot>(emptySnapshot);
+  const [snap, setSnap] = useState<PlayerSnapshot>(initialPlayerSnapshot);
   const prevSnapRef = useRef<PlayerSnapshot>(emptySnapshot);
   const [engine, setEngine] = useState<"html5" | "mpv">("html5");
   const [autoFallbackTried, setAutoFallbackTried] = useState(false);


### PR DESCRIPTION
## Summary

Every fresh player bridge initialized its volume state to a hard-coded 100% (volume: 1) via emptySnapshot, and only corrected it once mpv emitted a volume property-change event. When mpv was already at the persisted volume, the restore write was a silent no-op (libmpv emits no property-change for same-value sets), so the event never arrived and the frontend baseline stayed at 100% — making the first scroll-wheel or keyboard volume step jump to ~95% instead of stepping down from the saved value.

This change seeds the initial snapshot on every fresh player session from the persisted prefs (readPlayerVolume()), so a no-op restore can no longer leave a stale 100% baseline. Volume persistence itself is unchanged

## Why

- Bug (log-confirmed): with a retained mpv instance already at the saved volume, the restore effect's setVolume(savedVolume) was a same-value no-op; libmpv sent no property-change event, so snap.volume stayed at the emptySnapshot default of 1.0. The first wheel/keyboard step then computed 1.0 − 0.05 = 95%, matching the reported "at 50%, going down goes to 90%" symptom. Verified in the mpv log: restore volume="60" followed by first wheel volume="95".
- Why this approach fits Harbor: it treats the restore value as the truthful initial state (the restore always pins mpv to the saved value), keeps mpv as the source of truth for changes, and requires no new events or protocol changes. It aligns with the existing optimistic-update pattern already used by the wheel

## Verification

- pnpm run typecheck (tsc -b) — clean on all changed files.
- Manually confirmed fix behavior across scenarios: new user (nothing saved → defaults to 100%, unchanged); saved 0.5 → bridge starts at 0.5; boosted volume (2.0) preserved; corrupt saved JSON → graceful fallback to 100%; bridge reuse across episodes unchanged.
- Reproduced the no-op-restore path in code review: retained-mpv-already-at-saved-value now leaves the frontend at the correct baseline instead of 100%

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
