### PR TITLE
fix(simkl): CDN v2, Retry-After+jitter, watchlist extended, poster wsrv

### DIFF
--- a/src/lib/simkl/calendar.ts
+++ b/src/lib/simkl/calendar.ts
@@ -28,7 +28,7 @@ export type SimklCdnItem = {
 const UA = `${SIMKL_APP_NAME}/${SIMKL_APP_VERSION}`;
 
 function cdnUrl(path: string): string {
-  return `https://data.simkl.in/calendar/${path}?client_id=${SIMKL_CLIENT_ID}&app-name=${SIMKL_APP_NAME}&app-version=${SIMKL_APP_VERSION}`;
+  return `https://data.simkl.in/calendar/v2/${path}?client_id=${SIMKL_CLIENT_ID}&app-name=${SIMKL_APP_NAME}&app-version=${SIMKL_APP_VERSION}`;
 }
 
 function pad(n: number): string {
@@ -50,7 +50,7 @@ function mapCdnItem(item: SimklCdnItem, type: "tv" | "movie", isAnime: boolean):
     name = `${item.title} S${pad(item.episode.season)}E${pad(item.episode.episode)}`;
   }
 
-  const poster = item.poster ? `https://simkl.in/posters/${item.poster}_m.jpg` : null;
+  const poster = item.poster ? `https://wsrv.nl/?url=https://simkl.in/posters/${item.poster}_m.webp&q=90` : null;
 
   return {
     id,

--- a/src/lib/simkl/client.ts
+++ b/src/lib/simkl/client.ts
@@ -63,7 +63,19 @@ async function sendRequest<T>(path: string, opts: SimklRequestOptions): Promise<
   let res = await doFetch(path, opts);
 
   for (let attempt = 0; RETRY_STATUSES.has(res.status) && attempt < 5; attempt += 1) {
-    await new Promise((r) => setTimeout(r, Math.min(16, 2 ** attempt) * 1000));
+    const retryAfter = res.headers.get("Retry-After");
+    let delayMs = Math.min(16, 2 ** attempt) * 1000;
+    if (retryAfter) {
+      const secs = Number(retryAfter);
+      if (Number.isFinite(secs)) delayMs = Math.max(delayMs, secs * 1000);
+      else {
+        const date = Date.parse(retryAfter);
+        if (Number.isFinite(date)) delayMs = Math.max(delayMs, date - Date.now());
+      }
+    }
+    // jitter 0-1000ms to avoid thundering herd
+    delayMs += Math.floor(Math.random() * 1000);
+    await new Promise((r) => setTimeout(r, delayMs));
     res = await doFetch(path, opts);
   }
 

--- a/src/lib/simkl/home-rails/cdn.ts
+++ b/src/lib/simkl/home-rails/cdn.ts
@@ -119,7 +119,7 @@ export async function fetchCdnCalendarCombined(): Promise<SimklCdnItem[]> {
   }
 
   const fetchCatalog = async (catalog: "tv" | "anime"): Promise<SimklCdnItem[]> => {
-    const url = `https://data.simkl.in/calendar/${catalog}.json?${APP_QS}`;
+    const url = `https://data.simkl.in/calendar/v2/${catalog}.json?${APP_QS}`;
     try {
       const res = await safeFetch(url, { headers: { "User-Agent": UA } });
       if (!res.ok) return [];

--- a/src/lib/simkl/watchlist.ts
+++ b/src/lib/simkl/watchlist.ts
@@ -55,7 +55,7 @@ async function fetchByStatus(status: string): Promise<SimklItem[]> {
 }
 
 async function fetchByStatusRaw(status: string): Promise<SimklItem[]> {
-  const data = await simklRequest<RawAllItems>(`/sync/all-items/all/${status}`).catch(
+  const data = await simklRequest<RawAllItems>(`/sync/all-items/all/${status}?extended=full`).catch(
     () => ({}) as RawAllItems,
   );
   const out: SimklItem[] = [];


### PR DESCRIPTION
**P0**
- `calendar.ts` + `home-rails/cdn.ts`: migrate `data.simkl.in/calendar/{file}.json` → `/calendar/v2/{file}.json` (legacy deprecated 2027-02-01, will go stale — verified both 200 HIT via curl).
- `client.ts`: respect `Retry-After` (seconds or HTTP-date) on 429/500/502/503, add 0-1000ms jitter to exp backoff (spec `rate-limits` requires it).

**P1**
- `watchlist.ts`: `fetchByStatusRaw` `.../all/{status}` → `.../all/{status}?extended=full` for richer payloads (poster/year/ids).
- `calendar.ts`: poster `simkl.in/posters/{id}_m.jpg` → `wsrv.nl/?url=https://simkl.in/posters/{id}_m.webp&q=90` per `conventions/images.md` (free resize/cache, correct .webp).

**notes**
- `simkl-api-key` header is alternative to `?client_id=` (spec `headers.md`), Harbor sends both — valid.
- No `tsc` baseline change (node_modules missing, brace-count + 200 curl verified).