### PR TITLE
fix: fix chevron direction in RTL

### DIFF
--- a/src/views/settings/nav.tsx
+++ b/src/views/settings/nav.tsx
@@ -12,11 +12,15 @@ import { settingsAnchor, type SectionId } from "./shared";
 import { TOP_GROUPS } from "./groups";
 import { markSectionSeen, useSettingsNew } from "./settings-new";
 
-type IconProps = { size?: number; strokeWidth?: number };
-
+type IconProps = {
+  size?: number;
+  strokeWidth?: number;
+  className?: string;
+};
 const IconBase = ({
   size = 20,
   strokeWidth = 1.7,
+  className,
   children,
 }: IconProps & { children: React.ReactNode }) => (
   <svg
@@ -29,6 +33,7 @@ const IconBase = ({
     strokeLinecap="round"
     strokeLinejoin="round"
     aria-hidden
+    className={className}
   >
     {children}
   </svg>
@@ -36,7 +41,7 @@ const IconBase = ({
 
 function IconChevronRight(p: IconProps) {
   return (
-    <IconBase {...p}>
+    <IconBase {...p} className="rtl:transform-[scaleX(-1)]">
       <path d="M9 5l7 7-7 7" />
     </IconBase>
   );
@@ -9549,7 +9554,7 @@ export function SettingsNav({
                   {anyNew && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />}
                   <span
                     className={`shrink-0 text-ink-subtle transition-transform ${
-                      isActive ? "rotate-90" : ""
+                      isActive ? "rotate-90 rtl:rotate-270" : ""
                     }`}
                   >
                     <IconChevronRight size={14} strokeWidth={2} />


### PR DESCRIPTION
## Summary
Fix chevron direction for RTL layout.

- Chevron points left in RTL when inactive.
- Chevron points down when active.

## Why
- The chevron was rotating in the wrong direction in RTL mode.
- This change keeps the chevron pointing down when the section is active.
<!-- Explain the problem being solved and why this approach fits Harbor. -->

## Verification
- Tested the chevron in LTR and RTL layouts.
- Verified inactive and active states.
- Verified the RTL chevron points left when inactive and down when active.

## Platform Impact
- None
<!-- Note behavior verified on Windows, macOS, Linux, and TV-style input. Write "None" when not applicable. -->

## UI Changes
- Fixed chevron direction in RTL layout.

<!-- Include before/after screenshots for visual changes and a short recording for motion or interaction changes. Remove this section when not applicable. -->

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
