### PR TITLE
feat: Added descriptions to custom and featured lists

### DIFF
--- a/src/components/lists/create-list-modal.tsx
+++ b/src/components/lists/create-list-modal.tsx
@@ -14,6 +14,7 @@ export function CreateListModal({
   const t = useT();
   const lists = useCustomLists();
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const atMax = lists.length >= MAX_LISTS;
 
   useEffect(() => {
@@ -26,7 +27,7 @@ export function CreateListModal({
     e.preventDefault();
     const trimmed = name.trim();
     if (!trimmed || atMax) return;
-    const id = createList(trimmed);
+    const id = createList(trimmed, description);
     if (!id) return;
     emitListToast(t('Created "{name}"', { name: trimmed }));
     onCreated?.(id);
@@ -65,6 +66,21 @@ export function CreateListModal({
             placeholder={t("Weekend watchlist")}
             spellCheck={false}
             className="h-11 w-full rounded-xl border border-edge bg-canvas px-3.5 text-[14px] text-ink outline-none transition-colors placeholder:text-ink-subtle focus:border-ink disabled:opacity-50"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-ink-subtle">
+            {t("Description")}
+          </span>
+          <textarea
+            value={description}
+            maxLength={240}
+            disabled={atMax}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder={t("A short note about this list")}
+            rows={3}
+            className="w-full resize-none rounded-xl border border-edge bg-canvas px-3.5 py-2.5 text-[14px] text-ink outline-none transition-colors placeholder:text-ink-subtle focus:border-ink disabled:opacity-50"
           />
         </label>
 

--- a/src/components/lists/list-card.tsx
+++ b/src/components/lists/list-card.tsx
@@ -4,13 +4,7 @@ import { relativeTime } from "@/lib/dates";
 import { useT } from "@/lib/i18n";
 import { Poster, posterPlate } from "@/components/poster";
 
-export function ListCard({
-  list,
-  onOpen,
-}: {
-  list: CustomList;
-  onOpen?: (id: string) => void;
-}) {
+export function ListCard({ list, onOpen }: { list: CustomList; onOpen?: (id: string) => void }) {
   const t = useT();
   const covers = list.items.slice(0, 3);
   const count = list.items.length;
@@ -48,7 +42,11 @@ export function ListCard({
         <h3 className="line-clamp-1 font-display text-[16px] font-medium leading-tight text-ink">
           {list.name}
         </h3>
-        {list.description && <p className="line-clamp-2 text-[12.5px] leading-snug text-ink-muted">{list.description}</p>}
+        {list.description && (
+          <p className="line-clamp-2 text-[12.5px] leading-snug text-ink-muted">
+            {list.description}
+          </p>
+        )}
         <p className="text-[12px] text-ink-subtle">
           {count === 1 ? t("1 item") : t("{n} items", { n: count })}
           {list.updatedAt > 0 &&

--- a/src/components/lists/list-card.tsx
+++ b/src/components/lists/list-card.tsx
@@ -48,6 +48,7 @@ export function ListCard({
         <h3 className="line-clamp-1 font-display text-[16px] font-medium leading-tight text-ink">
           {list.name}
         </h3>
+        {list.description && <p className="line-clamp-2 text-[12.5px] leading-snug text-ink-muted">{list.description}</p>}
         <p className="text-[12px] text-ink-subtle">
           {count === 1 ? t("1 item") : t("{n} items", { n: count })}
           {list.updatedAt > 0 &&

--- a/src/components/row.tsx
+++ b/src/components/row.tsx
@@ -193,6 +193,7 @@ function Skeleton({ shape }: { shape: RowShape }) {
 export function Row({
   title,
   titleExtra,
+  headerDescription,
   className = "",
   min = 144,
   shape = "portrait",
@@ -210,6 +211,7 @@ export function Row({
 }: {
   title?: React.ReactNode;
   titleExtra?: React.ReactNode;
+  headerDescription?: React.ReactNode;
   className?: string;
   min?: number;
   shape?: RowShape;
@@ -677,14 +679,17 @@ export function Row({
       {(title || onViewAll || headerRight) && (
         <div className="flex items-baseline justify-between gap-4 pe-1">
           {title && (
-            <div className="flex min-w-0 items-center gap-2">
-              <h3
-                className={`truncate font-medium tracking-tight ${titleClassName}`}
-                style={{ fontSize: `${Math.round(17 * settings.rowTitleScale * titleScale)}px` }}
-              >
-                {title}
-              </h3>
-              {titleExtra}
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <h3
+                  className={`truncate font-medium tracking-tight ${titleClassName}`}
+                  style={{ fontSize: `${Math.round(17 * settings.rowTitleScale * titleScale)}px` }}
+                >
+                  {title}
+                </h3>
+                {titleExtra}
+              </div>
+              {headerDescription}
             </div>
           )}
           {(onViewAll || headerRight) && (

--- a/src/lib/custom-lists.ts
+++ b/src/lib/custom-lists.ts
@@ -56,6 +56,7 @@ export type ListBgMode = "auto" | "custom";
 export type CustomList = {
   id: string;
   name: string;
+  description?: string;
   createdAt: number;
   updatedAt: number;
   order?: number;
@@ -127,6 +128,7 @@ function read(): CustomList[] {
       out.push({
         id: e.id,
         name: e.name,
+        description: typeof e.description === "string" ? e.description : undefined,
         createdAt: typeof e.createdAt === "number" ? e.createdAt : 0,
         updatedAt: typeof e.updatedAt === "number" ? e.updatedAt : 0,
         order: typeof e.order === "number" ? e.order : undefined,
@@ -205,14 +207,22 @@ export function subscribeLists(fn: () => void): () => void {
   };
 }
 
-export function createList(name: string): string | null {
+export function createList(name: string, description = ""): string | null {
   const trimmed = name.trim();
   if (!trimmed) return null;
+  const trimmedDescription = description.trim();
   const lists = read();
   if (lists.length >= MAX_LISTS) return null;
   const id = randomUuid();
   const now = Date.now();
-  lists.push({ id, name: trimmed, createdAt: now, updatedAt: now, items: [] });
+  lists.push({
+    id,
+    name: trimmed,
+    description: trimmedDescription || undefined,
+    createdAt: now,
+    updatedAt: now,
+    items: [],
+  });
   write(lists);
   return id;
 }
@@ -224,6 +234,16 @@ export function renameList(id: string, name: string): void {
   const list = lists.find((l) => l.id === id);
   if (!list) return;
   list.name = trimmed;
+  list.updatedAt = Date.now();
+  write(lists);
+}
+
+export function updateListDescription(id: string, description: string): void {
+  const lists = read();
+  const list = lists.find((l) => l.id === id);
+  if (!list) return;
+  const trimmed = description.trim();
+  list.description = trimmed || undefined;
   list.updatedAt = Date.now();
   write(lists);
 }

--- a/src/lib/social/featured-lists.ts
+++ b/src/lib/social/featured-lists.ts
@@ -22,6 +22,7 @@ export type FeaturedItem = {
 export type FeaturedList = {
   id: string;
   name: string;
+  description?: string;
   items: FeaturedItem[];
   coverImage?: string;
   bgImage?: string;
@@ -33,6 +34,7 @@ export type FeaturedList = {
 export type PickableList = {
   id: string;
   name: string;
+  description?: string;
   items: FeaturedItem[];
   coverImage?: string;
   bgImage?: string;
@@ -43,6 +45,7 @@ export function toPickableList(list: CustomList): PickableList {
   return {
     id: list.id,
     name: list.name,
+    description: list.description,
     coverImage: list.coverImage,
     bgImage: list.bgImage,
     bgMode: list.bgMode,
@@ -63,6 +66,7 @@ export function toFeaturedList(list: PickableList): FeaturedList {
   return {
     id: "",
     name: list.name,
+    description: list.description,
     items: list.items,
     coverImage: list.coverImage,
     bgImage: list.bgImage,
@@ -86,6 +90,7 @@ export function buildFeaturedPayload(
   return selected.map((l) => ({
     id: idByName.get(normalizeListName(l.name)) ?? "",
     name: l.name,
+    description: l.description,
     coverImage: l.coverImage,
     bgImage: l.bgImage,
     bgMode: l.bgMode,

--- a/src/lib/social/save-list.ts
+++ b/src/lib/social/save-list.ts
@@ -10,7 +10,7 @@ export async function saveList(handle: string, listId: string): Promise<SaveList
   const existing = readLists();
   if (nameLc && existing.some((l) => l.name.trim().toLowerCase() === nameLc)) return { ok: true, already: true };
   if (existing.length >= MAX_LISTS) return { ok: false, full: true };
-  const newId = createList(list.name || "Saved list");
+  const newId = createList(list.name || "Saved list", list.description);
   if (!newId) return { ok: false, full: true };
   for (const it of list.items) addToList(newId, { id: it.id, type: it.type, name: it.name, poster: it.poster });
   return { ok: true };

--- a/src/lib/social/save-list.ts
+++ b/src/lib/social/save-list.ts
@@ -8,10 +8,12 @@ export async function saveList(handle: string, listId: string): Promise<SaveList
   if (!list || !list.items || list.items.length === 0) throw new Error("save list: not found");
   const nameLc = list.name.trim().toLowerCase();
   const existing = readLists();
-  if (nameLc && existing.some((l) => l.name.trim().toLowerCase() === nameLc)) return { ok: true, already: true };
+  if (nameLc && existing.some((l) => l.name.trim().toLowerCase() === nameLc))
+    return { ok: true, already: true };
   if (existing.length >= MAX_LISTS) return { ok: false, full: true };
   const newId = createList(list.name || "Saved list", list.description);
   if (!newId) return { ok: false, full: true };
-  for (const it of list.items) addToList(newId, { id: it.id, type: it.type, name: it.name, poster: it.poster });
+  for (const it of list.items)
+    addToList(newId, { id: it.id, type: it.type, name: it.name, poster: it.poster });
   return { ok: true };
 }

--- a/src/lib/social/use-featured-sync.ts
+++ b/src/lib/social/use-featured-sync.ts
@@ -89,7 +89,8 @@ export function useFeaturedListsSync(): void {
       let changed = false;
       const next = current.map((f) => {
         const local = localByName.get(normalizeListName(f.name));
-        if (!local || (sig(f.items) === sig(local.items) && f.description === local.description)) return f;
+        if (!local || (sig(f.items) === sig(local.items) && f.description === local.description))
+          return f;
         changed = true;
         return { ...f, description: local.description, items: local.items };
       });

--- a/src/lib/social/use-featured-sync.ts
+++ b/src/lib/social/use-featured-sync.ts
@@ -89,9 +89,9 @@ export function useFeaturedListsSync(): void {
       let changed = false;
       const next = current.map((f) => {
         const local = localByName.get(normalizeListName(f.name));
-        if (!local || sig(f.items) === sig(local.items)) return f;
+        if (!local || (sig(f.items) === sig(local.items) && f.description === local.description)) return f;
         changed = true;
-        return { ...f, items: local.items };
+        return { ...f, description: local.description, items: local.items };
       });
       if (!changed || !next.length) return;
       const saved = await saveFeaturedLists(next, true);

--- a/src/views/library/list-detail.tsx
+++ b/src/views/library/list-detail.tsx
@@ -100,6 +100,7 @@ export function ListDetail({ listId, onBack }: { listId: string; onBack: () => v
           <h1 className="font-display text-[34px] font-medium leading-[1.05] text-ink">
             {list.name}
           </h1>
+          {list.description && <p className="max-w-2xl text-[14px] leading-relaxed text-ink-muted">{list.description}</p>}
           <p className="text-[12.5px] text-ink-muted">
             {t("{n} / {max} items", { n: list.items.length, max: MAX_ITEMS })}
             {list.updatedAt > 0 &&

--- a/src/views/library/list-detail.tsx
+++ b/src/views/library/list-detail.tsx
@@ -100,7 +100,11 @@ export function ListDetail({ listId, onBack }: { listId: string; onBack: () => v
           <h1 className="font-display text-[34px] font-medium leading-[1.05] text-ink">
             {list.name}
           </h1>
-          {list.description && <p className="max-w-2xl text-[14px] leading-relaxed text-ink-muted">{list.description}</p>}
+          {list.description && (
+            <p className="max-w-2xl text-[14px] leading-relaxed text-ink-muted">
+              {list.description}
+            </p>
+          )}
           <p className="text-[12.5px] text-ink-muted">
             {t("{n} / {max} items", { n: list.items.length, max: MAX_ITEMS })}
             {list.updatedAt > 0 &&

--- a/src/views/library/list-detail/list-settings-menu.tsx
+++ b/src/views/library/list-detail/list-settings-menu.tsx
@@ -7,13 +7,7 @@ import { unfeatureListByName } from "@/lib/social/featured-lists";
 import { AnchoredMenu } from "@/components/anchored-menu";
 import { emitListToast } from "@/components/lists/list-toast";
 
-export function ListSettingsMenu({
-  list,
-  onDeleted,
-}: {
-  list: CustomList;
-  onDeleted: () => void;
-}) {
+export function ListSettingsMenu({ list, onDeleted }: { list: CustomList; onDeleted: () => void }) {
   const t = useT();
   const anchorRef = useRef<HTMLButtonElement>(null);
   const [open, setOpen] = useState(false);

--- a/src/views/library/list-detail/list-settings-menu.tsx
+++ b/src/views/library/list-detail/list-settings-menu.tsx
@@ -1,7 +1,7 @@
 import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { deleteList, renameList, type CustomList } from "@/lib/custom-lists";
+import { deleteList, renameList, updateListDescription, type CustomList } from "@/lib/custom-lists";
 import { useT } from "@/lib/i18n";
 import { unfeatureListByName } from "@/lib/social/featured-lists";
 import { AnchoredMenu } from "@/components/anchored-menu";
@@ -57,9 +57,11 @@ export function ListSettingsMenu({
       {renaming && (
         <RenameModal
           initial={list.name}
+          initialDescription={list.description ?? ""}
           onClose={() => setRenaming(false)}
-          onSubmit={(name) => {
+          onSubmit={(name, description) => {
             renameList(list.id, name);
+            updateListDescription(list.id, description);
             emitListToast(t("List renamed"));
             setRenaming(false);
           }}
@@ -109,15 +111,18 @@ function MenuItem({
 
 function RenameModal({
   initial,
+  initialDescription,
   onClose,
   onSubmit,
 }: {
   initial: string;
+  initialDescription: string;
   onClose: () => void;
-  onSubmit: (name: string) => void;
+  onSubmit: (name: string, description: string) => void;
 }) {
   const t = useT();
   const [name, setName] = useState(initial);
+  const [description, setDescription] = useState(initialDescription);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
@@ -129,7 +134,7 @@ function RenameModal({
     e.preventDefault();
     const trimmed = name.trim();
     if (!trimmed) return;
-    onSubmit(trimmed);
+    onSubmit(trimmed, description);
   };
 
   return createPortal(
@@ -152,6 +157,14 @@ function RenameModal({
           onChange={(e) => setName(e.target.value)}
           spellCheck={false}
           className="h-11 w-full rounded-xl border border-edge bg-canvas px-3.5 text-[14px] text-ink outline-none transition-colors placeholder:text-ink-subtle focus:border-ink"
+        />
+        <textarea
+          value={description}
+          maxLength={240}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={t("A short note about this list")}
+          rows={3}
+          className="w-full resize-none rounded-xl border border-edge bg-canvas px-3.5 py-2.5 text-[14px] text-ink outline-none transition-colors placeholder:text-ink-subtle focus:border-ink"
         />
         <div className="flex items-center justify-end gap-2 pt-1">
           <button

--- a/src/views/profile/my-lists-picker.tsx
+++ b/src/views/profile/my-lists-picker.tsx
@@ -66,7 +66,11 @@ function ListRow({
       </span>
       <div className="min-w-0 flex-1">
         <div className="truncate text-[14px] font-medium text-ink">{list.name}</div>
-        {list.description && <div className="line-clamp-2 text-[12px] leading-snug text-ink-muted">{list.description}</div>}
+        {list.description && (
+          <div className="line-clamp-2 text-[12px] leading-snug text-ink-muted">
+            {list.description}
+          </div>
+        )}
         <div className="text-[12px] text-ink-subtle">
           {list.items.length} {list.items.length === 1 ? t("title") : t("titles")}
           {ghost && <span> · {t("not in your library")}</span>}
@@ -75,7 +79,12 @@ function ListRow({
       <div className="flex shrink-0 gap-1">
         {list.items.slice(0, 4).map((item) => (
           <div key={item.id} className="w-8">
-            <Poster src={item.poster || undefined} seed={item.name || item.id} ratio="portrait" className="rounded-sm" />
+            <Poster
+              src={item.poster || undefined}
+              seed={item.name || item.id}
+              ratio="portrait"
+              className="rounded-sm"
+            />
           </div>
         ))}
       </div>
@@ -121,10 +130,16 @@ function SelectedRow({
           <ChevronDown size={16} strokeWidth={2.5} />
         </button>
       </div>
-      <span className="w-4 shrink-0 text-center text-[13px] font-semibold tabular-nums text-ink-subtle">{index + 1}</span>
+      <span className="w-4 shrink-0 text-center text-[13px] font-semibold tabular-nums text-ink-subtle">
+        {index + 1}
+      </span>
       <div className="min-w-0 flex-1">
         <div className="truncate text-[14px] font-medium text-ink">{list.name}</div>
-        {list.description && <div className="line-clamp-2 text-[12px] leading-snug text-ink-muted">{list.description}</div>}
+        {list.description && (
+          <div className="line-clamp-2 text-[12px] leading-snug text-ink-muted">
+            {list.description}
+          </div>
+        )}
         <div className="text-[12px] text-ink-subtle">
           {list.items.length} {list.items.length === 1 ? t("title") : t("titles")}
           {ghost && <span> · {t("not in your library")}</span>}
@@ -133,7 +148,12 @@ function SelectedRow({
       <div className="flex shrink-0 gap-1">
         {list.items.slice(0, 3).map((item) => (
           <div key={item.id} className="w-8">
-            <Poster src={item.poster || undefined} seed={item.name || item.id} ratio="portrait" className="rounded-sm" />
+            <Poster
+              src={item.poster || undefined}
+              seed={item.name || item.id}
+              ratio="portrait"
+              className="rounded-sm"
+            />
           </div>
         ))}
       </div>
@@ -162,15 +182,24 @@ export function MyListsPicker({ onClose }: { onClose?: () => void }) {
     const localNames = new Set(lists.map((l) => normName(l.name)));
     return served
       .filter((s) => !localNames.has(normName(s.name)))
-      .map((s) => ({ id: "srv:" + s.id, name: s.name, description: s.description, items: s.items }));
+      .map((s) => ({
+        id: "srv:" + s.id,
+        name: s.name,
+        description: s.description,
+        items: s.items,
+      }));
   }, [lists, served]);
   const entries = useMemo(() => [...lists, ...ghosts], [lists, ghosts]);
   const ghostIds = useMemo(() => new Set(ghosts.map((g) => g.id)), [ghosts]);
   const selectedEntries = useMemo(
-    () => selected.map((id) => entries.find((e) => e.id === id)).filter((l): l is PickableList => !!l),
+    () =>
+      selected.map((id) => entries.find((e) => e.id === id)).filter((l): l is PickableList => !!l),
     [selected, entries],
   );
-  const unselectedEntries = useMemo(() => entries.filter((e) => !selected.includes(e.id)), [entries, selected]);
+  const unselectedEntries = useMemo(
+    () => entries.filter((e) => !selected.includes(e.id)),
+    [entries, selected],
+  );
 
   useEffect(() => {
     const handle = currentAuthor()?.handle;
@@ -182,7 +211,9 @@ export function MyListsPicker({ onClose }: { onClose?: () => void }) {
         const localPick = readLocalLists();
         const localNames = new Set(localPick.map((l) => normName(l.name)));
         const matched = matchSelection(featured, localPick);
-        const gIds = featured.filter((f) => !localNames.has(normName(f.name))).map((f) => "srv:" + f.id);
+        const gIds = featured
+          .filter((f) => !localNames.has(normName(f.name)))
+          .map((f) => "srv:" + f.id);
         setSelected([...matched, ...gIds]);
         setLoaded(true);
       })
@@ -223,9 +254,7 @@ export function MyListsPicker({ onClose }: { onClose?: () => void }) {
     setError(null);
     try {
       const byId = new Map(entries.map((l) => [l.id, l] as const));
-      const picked = selected
-        .map((id) => byId.get(id))
-        .filter((l): l is PickableList => !!l);
+      const picked = selected.map((id) => byId.get(id)).filter((l): l is PickableList => !!l);
       await saveFeaturedLists(buildFeaturedPayload(picked, served), true);
       onClose?.();
     } catch {
@@ -236,7 +265,11 @@ export function MyListsPicker({ onClose }: { onClose?: () => void }) {
   };
 
   return createPortal(
-    <div className="fixed inset-0 z-[185] flex items-center justify-center p-4" role="dialog" aria-modal>
+    <div
+      className="fixed inset-0 z-[185] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal
+    >
       <button aria-label={t("Close")} className="absolute inset-0 bg-black/55" onClick={onClose} />
       <div className="relative flex max-h-[88vh] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-surface ring-1 ring-edge">
         <div className="flex items-center justify-between border-b border-edge-soft px-6 py-4">
@@ -252,19 +285,25 @@ export function MyListsPicker({ onClose }: { onClose?: () => void }) {
 
         <div className="flex-1 space-y-2 overflow-y-auto px-6 py-5">
           <p className="pb-1 text-[13px] text-ink-muted">
-            {t("Pick up to {max} lists to show on your public profile.", { max: MAX_FEATURED_LISTS })}
+            {t("Pick up to {max} lists to show on your public profile.", {
+              max: MAX_FEATURED_LISTS,
+            })}
           </p>
           {entries.length === 0 ? (
             <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-edge py-12 text-center">
               <ListVideo size={24} className="text-ink-subtle" />
               <p className="mt-2 text-[14px] text-ink-muted">{t("You have no lists yet")}</p>
-              <p className="mt-1 text-[12px] text-ink-subtle">{t("Create lists in your library to feature them here")}</p>
+              <p className="mt-1 text-[12px] text-ink-subtle">
+                {t("Create lists in your library to feature them here")}
+              </p>
             </div>
           ) : (
             <>
               {selectedEntries.length > 0 && (
                 <div className="space-y-2">
-                  <div className="text-[11px] font-semibold uppercase tracking-wide text-ink-subtle">{t("Featured order")}</div>
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-ink-subtle">
+                    {t("Featured order")}
+                  </div>
                   {selectedEntries.map((list, i) => (
                     <SelectedRow
                       key={list.id}
@@ -282,7 +321,9 @@ export function MyListsPicker({ onClose }: { onClose?: () => void }) {
               {unselectedEntries.length > 0 && (
                 <div className="space-y-2 pt-1">
                   {selectedEntries.length > 0 && (
-                    <div className="text-[11px] font-semibold uppercase tracking-wide text-ink-subtle">{t("Add a list")}</div>
+                    <div className="text-[11px] font-semibold uppercase tracking-wide text-ink-subtle">
+                      {t("Add a list")}
+                    </div>
                   )}
                   {unselectedEntries.map((list) => (
                     <ListRow

--- a/src/views/profile/my-lists-picker.tsx
+++ b/src/views/profile/my-lists-picker.tsx
@@ -66,6 +66,7 @@ function ListRow({
       </span>
       <div className="min-w-0 flex-1">
         <div className="truncate text-[14px] font-medium text-ink">{list.name}</div>
+        {list.description && <div className="line-clamp-2 text-[12px] leading-snug text-ink-muted">{list.description}</div>}
         <div className="text-[12px] text-ink-subtle">
           {list.items.length} {list.items.length === 1 ? t("title") : t("titles")}
           {ghost && <span> · {t("not in your library")}</span>}
@@ -123,6 +124,7 @@ function SelectedRow({
       <span className="w-4 shrink-0 text-center text-[13px] font-semibold tabular-nums text-ink-subtle">{index + 1}</span>
       <div className="min-w-0 flex-1">
         <div className="truncate text-[14px] font-medium text-ink">{list.name}</div>
+        {list.description && <div className="line-clamp-2 text-[12px] leading-snug text-ink-muted">{list.description}</div>}
         <div className="text-[12px] text-ink-subtle">
           {list.items.length} {list.items.length === 1 ? t("title") : t("titles")}
           {ghost && <span> · {t("not in your library")}</span>}
@@ -160,7 +162,7 @@ export function MyListsPicker({ onClose }: { onClose?: () => void }) {
     const localNames = new Set(lists.map((l) => normName(l.name)));
     return served
       .filter((s) => !localNames.has(normName(s.name)))
-      .map((s) => ({ id: "srv:" + s.id, name: s.name, items: s.items }));
+      .map((s) => ({ id: "srv:" + s.id, name: s.name, description: s.description, items: s.items }));
   }, [lists, served]);
   const entries = useMemo(() => [...lists, ...ghosts], [lists, ghosts]);
   const ghostIds = useMemo(() => new Set(ghosts.map((g) => g.id)), [ghosts]);

--- a/src/views/profile/my-lists-showcase.tsx
+++ b/src/views/profile/my-lists-showcase.tsx
@@ -70,6 +70,7 @@ export function MyListsShowcase({
               key={list.id || `${list.name}:${i}`}
               title={list.name || t("Untitled list")}
               titleExtra={<span className="text-[12px] tabular-nums text-ink-subtle">{list.items.length}</span>}
+              headerDescription={list.description && <p className="max-w-2xl text-[13px] leading-relaxed text-ink-muted">{list.description}</p>}
               headerRight={
                 <div className="flex items-center gap-2.5">
                   <ListHeart

--- a/src/views/profile/my-lists-showcase.tsx
+++ b/src/views/profile/my-lists-showcase.tsx
@@ -8,7 +8,13 @@ import { ListShareButton } from "./list-share-button";
 import { SaveListButton } from "./save-list-button";
 import type { FeaturedItem, FeaturedList } from "@/lib/social/featured-lists";
 
-function ListPoster({ item, onOpenMeta }: { item: FeaturedItem; onOpenMeta?: (id: string, kind?: string, hint?: { name?: string; poster?: string }) => void }) {
+function ListPoster({
+  item,
+  onOpenMeta,
+}: {
+  item: FeaturedItem;
+  onOpenMeta?: (id: string, kind?: string, hint?: { name?: string; poster?: string }) => void;
+}) {
   return (
     <button
       onClick={() => onOpenMeta?.(item.id, item.type, { name: item.name, poster: item.poster })}
@@ -48,7 +54,10 @@ export function MyListsShowcase({
   const shown = lists.filter((l) => l.items.length > 0);
   if (shown.length === 0 && !isOwner) {
     return (
-      <section aria-label={t("My lists")} className="rounded-lg bg-surface p-5 ring-1 ring-edge-soft">
+      <section
+        aria-label={t("My lists")}
+        className="rounded-lg bg-surface p-5 ring-1 ring-edge-soft"
+      >
         <SectionHeader icon={<ListVideo size={20} />} label={t("My lists")} />
         <p className="py-6 text-center text-[13px] text-ink-subtle">
           {t("This user hasn't featured any lists")}
@@ -69,8 +78,18 @@ export function MyListsShowcase({
             <Row
               key={list.id || `${list.name}:${i}`}
               title={list.name || t("Untitled list")}
-              titleExtra={<span className="text-[12px] tabular-nums text-ink-subtle">{list.items.length}</span>}
-              headerDescription={list.description && <p className="max-w-2xl text-[13px] leading-relaxed text-ink-muted">{list.description}</p>}
+              titleExtra={
+                <span className="text-[12px] tabular-nums text-ink-subtle">
+                  {list.items.length}
+                </span>
+              }
+              headerDescription={
+                list.description && (
+                  <p className="max-w-2xl text-[13px] leading-relaxed text-ink-muted">
+                    {list.description}
+                  </p>
+                )
+              }
               headerRight={
                 <div className="flex items-center gap-2.5">
                   <ListHeart
@@ -81,7 +100,9 @@ export function MyListsShowcase({
                     interactive={!!signedIn && !isOwner}
                   />
                   <ListShareButton handle={handle ?? ""} listId={list.id} name={list.name} />
-                  {signedIn && !isOwner && <SaveListButton handle={handle ?? ""} listId={list.id} />}
+                  {signedIn && !isOwner && (
+                    <SaveListButton handle={handle ?? ""} listId={list.id} />
+                  )}
                 </div>
               }
               min={96}
@@ -105,7 +126,9 @@ export function MyListsShowcase({
       ) : (
         <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-edge py-10 text-center">
           <p className="text-[14px] text-ink-muted">{t("No lists featured yet")}</p>
-          <p className="mt-1 text-[12px] text-ink-subtle">{t("Pick lists from your library to show them here")}</p>
+          <p className="mt-1 text-[12px] text-ink-subtle">
+            {t("Pick lists from your library to show them here")}
+          </p>
           {onManage && (
             <button
               onClick={onManage}

--- a/src/views/profile/profile-view-all.tsx
+++ b/src/views/profile/profile-view-all.tsx
@@ -134,6 +134,7 @@ function ListsSection({
               <ListShareButton handle={handle ?? ""} listId={list.id} name={list.name} />
             </div>
           </div>
+          {list.description && <p className="mb-3 max-w-2xl text-[13px] leading-relaxed text-ink-muted">{list.description}</p>}
           <div className="grid grid-cols-[repeat(auto-fill,minmax(104px,1fr))] gap-x-4 gap-y-5">
             {list.items.map((item) => (
               <button

--- a/src/views/profile/profile-view-all.tsx
+++ b/src/views/profile/profile-view-all.tsx
@@ -88,7 +88,9 @@ export function ProfileViewAll({
             />
           )}
           {section === "badges" && <BadgesSection badges={badges} />}
-          {section === "activity" && <ActivitySection activity={activity} onOpenMeta={onOpenMeta} />}
+          {section === "activity" && (
+            <ActivitySection activity={activity} onOpenMeta={onOpenMeta} />
+          )}
         </div>
       </div>
     </div>,
@@ -97,7 +99,11 @@ export function ProfileViewAll({
 }
 
 function Empty({ label }: { label: string }) {
-  return <div className="flex h-40 items-center justify-center text-[13.5px] text-ink-muted">{label}</div>;
+  return (
+    <div className="flex h-40 items-center justify-center text-[13.5px] text-ink-muted">
+      {label}
+    </div>
+  );
 }
 
 function ListsSection({
@@ -134,12 +140,18 @@ function ListsSection({
               <ListShareButton handle={handle ?? ""} listId={list.id} name={list.name} />
             </div>
           </div>
-          {list.description && <p className="mb-3 max-w-2xl text-[13px] leading-relaxed text-ink-muted">{list.description}</p>}
+          {list.description && (
+            <p className="mb-3 max-w-2xl text-[13px] leading-relaxed text-ink-muted">
+              {list.description}
+            </p>
+          )}
           <div className="grid grid-cols-[repeat(auto-fill,minmax(104px,1fr))] gap-x-4 gap-y-5">
             {list.items.map((item) => (
               <button
                 key={item.id}
-                onClick={() => onOpenMeta?.(item.id, item.type, { name: item.name, poster: item.poster })}
+                onClick={() =>
+                  onOpenMeta?.(item.id, item.type, { name: item.name, poster: item.poster })
+                }
                 disabled={!onOpenMeta}
                 className="group text-start disabled:cursor-default"
               >
@@ -150,7 +162,9 @@ function ListsSection({
                   className="rounded-md ring-1 ring-edge-soft transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0.24,1)] motion-safe:group-hover:will-change-transform motion-safe:group-hover:-translate-y-1"
                   lazy
                 />
-                {item.name && <div className="mt-1.5 line-clamp-2 text-[12px] text-ink-muted">{item.name}</div>}
+                {item.name && (
+                  <div className="mt-1.5 line-clamp-2 text-[12px] text-ink-muted">{item.name}</div>
+                )}
               </button>
             ))}
           </div>
@@ -196,7 +210,13 @@ function BadgesSection({ badges }: { badges: Badge[] }) {
   );
 }
 
-function ActivitySection({ activity, onOpenMeta }: { activity: ActivityItem[]; onOpenMeta?: (id: string) => void }) {
+function ActivitySection({
+  activity,
+  onOpenMeta,
+}: {
+  activity: ActivityItem[];
+  onOpenMeta?: (id: string) => void;
+}) {
   const t = useT();
   if (activity.length === 0) return <Empty label={t("No recent activity")} />;
   return (
@@ -221,7 +241,9 @@ function ActivitySection({ activity, onOpenMeta }: { activity: ActivityItem[]; o
             <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-[0.08em] text-ink-subtle">
               <ActivityGlyph kind={a.kind} size={15} />
               {ACTIVITY_VERB[a.kind]}
-              {a.kind === "rated" && a.rating !== undefined && <span className="text-accent">{a.rating}/10</span>}
+              {a.kind === "rated" && a.rating !== undefined && (
+                <span className="text-accent">{a.rating}/10</span>
+              )}
             </div>
             <div className="mt-0.5 truncate text-[14px] font-medium text-ink">{a.title}</div>
             {a.subtitle && <div className="truncate text-[12px] text-ink-muted">{a.subtitle}</div>}

--- a/src/views/profile/profile.tsx
+++ b/src/views/profile/profile.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/social/stats-sync";
 import { useProfiles } from "@/lib/profiles";
 import { useSettings } from "@/lib/settings";
+import { useCustomLists } from "@/lib/custom-lists";
 import { currentAuthor } from "@/lib/theme-auth";
 import { useScrollMemory, useView } from "@/lib/view";
 import { pushBackHandler } from "@/lib/back-intercept";
@@ -79,6 +80,7 @@ export function ProfileView({
   const mangaProgress = useMangaProgressList();
   const watchedCount = useWatchedCount();
   const { state, summary, friends, badges, activity, reload, patchSummary } = useProfile(handle);
+  const localLists = useCustomLists();
   const isOwner = summary?.isOwner ?? false;
   const viewerSignedIn = !!currentAuthor();
   const libWatched = useLibraryWatchedCount(authKey, isOwner);
@@ -174,6 +176,11 @@ export function ProfileView({
   }
 
   const c = resolveCustomization(summary);
+  const featuredLists = summary.featuredLists?.map((featured) => {
+    if (!summary.isOwner || featured.description) return featured;
+    const local = localLists.find((list) => list.name.trim().toLowerCase() === featured.name.trim().toLowerCase());
+    return local?.description ? { ...featured, description: local.description } : featured;
+  });
 
   const layout = sanitizeLayout(summary.cardLayout);
   const hiddenSet = new Set(layout.hidden ?? []);
@@ -220,7 +227,7 @@ export function ProfileView({
     ),
     lists: (
       <MyListsShowcase
-        lists={summary.featuredLists ?? []}
+        lists={featuredLists ?? []}
         isOwner={summary.isOwner}
         signedIn={viewerSignedIn}
         onOpenMeta={onOpenMeta}
@@ -390,7 +397,7 @@ export function ProfileView({
         {expanded && (
           <ProfileViewAll
             section={expanded}
-            lists={summary.featuredLists ?? []}
+            lists={featuredLists ?? []}
             badges={badges}
             activity={activity}
             signedIn={viewerSignedIn}

--- a/src/views/profile/profile.tsx
+++ b/src/views/profile/profile.tsx
@@ -178,7 +178,9 @@ export function ProfileView({
   const c = resolveCustomization(summary);
   const featuredLists = summary.featuredLists?.map((featured) => {
     if (!summary.isOwner || featured.description) return featured;
-    const local = localLists.find((list) => list.name.trim().toLowerCase() === featured.name.trim().toLowerCase());
+    const local = localLists.find(
+      (list) => list.name.trim().toLowerCase() === featured.name.trim().toLowerCase(),
+    );
     return local?.description ? { ...featured, description: local.description } : featured;
   });
 

--- a/src/views/shared-list/shared-list-hero.tsx
+++ b/src/views/shared-list/shared-list-hero.tsx
@@ -38,6 +38,7 @@ export function SharedListHero({
         <h1 className="font-display text-[36px] leading-[1.04] text-ink sm:text-[46px]">
           {list.name || "Untitled list"}
         </h1>
+        {list.description && <p className="max-w-2xl text-[14px] leading-relaxed text-ink-muted">{list.description}</p>}
         <span className="text-[13px] tabular-nums text-ink-subtle">
           {count} {count === 1 ? "title" : "titles"}
         </span>

--- a/src/views/shared-list/shared-list-hero.tsx
+++ b/src/views/shared-list/shared-list-hero.tsx
@@ -29,7 +29,9 @@ export function SharedListHero({
       >
         <Avatar src={summary.avatarUrl} size={88} alias={summary.alias} />
         <span className="inline-flex items-center gap-1.5 text-[13.5px]">
-          <span className="font-medium text-ink-muted transition-colors group-hover:text-ink">{summary.alias}</span>
+          <span className="font-medium text-ink-muted transition-colors group-hover:text-ink">
+            {summary.alias}
+          </span>
           <span className="text-ink-subtle">@{summary.handle}</span>
         </span>
       </button>
@@ -38,7 +40,9 @@ export function SharedListHero({
         <h1 className="font-display text-[36px] leading-[1.04] text-ink sm:text-[46px]">
           {list.name || "Untitled list"}
         </h1>
-        {list.description && <p className="max-w-2xl text-[14px] leading-relaxed text-ink-muted">{list.description}</p>}
+        {list.description && (
+          <p className="max-w-2xl text-[14px] leading-relaxed text-ink-muted">{list.description}</p>
+        )}
         <span className="text-[13px] tabular-nums text-ink-subtle">
           {count} {count === 1 ? "title" : "titles"}
         </span>
@@ -53,7 +57,9 @@ export function SharedListHero({
           interactive={signedIn && !summary.isOwner}
         />
         <ListShareButton handle={summary.handle} listId={list.id} name={list.name} />
-        {signedIn && !summary.isOwner && <SaveListButton handle={summary.handle} listId={list.id} />}
+        {signedIn && !summary.isOwner && (
+          <SaveListButton handle={summary.handle} listId={list.id} />
+        )}
         {openMaker && (
           <button
             type="button"


### PR DESCRIPTION
## Summary

- Added optional descriptions to custom lists.
- Display descriptions in library, profile, picker, and shared-list views.
- Preserved descriptions when saving and syncing featured lists.

## Why

Featured lists had no way to show context beyond their title. This keeps descriptions with the existing list data without changing list behavior or limits.

## Verification

- Focused editor diagnostics passed.
- `git diff --check` passed.
- Manually verified list creation, editing, featuring, and profile display.
- `pnpm run typecheck` was attempted but exited with code 130 without diagnostics.

## Platform Impact

None.

## UI Changes

Added list descriptions to library cards, list details, featured profile lists, expanded profile lists, and shared-list pages.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.