### PR TITLE
feat(linux): implement MPRIS v2 media controls and metadata integration

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -948,6 +948,7 @@ pub fn run() {
             discord_rp::discord_set_presence,
             discord_rp::discord_clear,
             media_controls::media_controls_update,
+            media_controls::media_controls_seeked,
             media_controls::media_controls_clear,
             gamepad::gamepad_list,
             gamepad::gamepad_set_enabled,

--- a/src-tauri/src/media_controls.rs
+++ b/src-tauri/src/media_controls.rs
@@ -104,23 +104,429 @@ mod win {
     }
 }
 
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::collections::HashMap;
+    use std::sync::{Arc, OnceLock};
+    use tauri::{AppHandle, Emitter, Manager};
+    use tokio::sync::Mutex;
+    use zbus::zvariant::{ObjectPath, Value};
+    use zbus::{interface, connection::Connection};
+
+    #[derive(Default, Clone)]
+    pub struct PlaybackState {
+        pub playing: bool,
+        pub title: String,
+        pub subtitle: String,
+        pub art_url: Option<String>,
+        pub duration_us: i64,
+        pub position_us: i64,
+    }
+
+    pub struct MprisHandle {
+        connection: Connection,
+        state: Arc<Mutex<PlaybackState>>,
+    }
+
+    static MPRIS: OnceLock<Option<MprisHandle>> = OnceLock::new();
+
+    struct MprisRoot {
+        app: AppHandle,
+    }
+
+    #[interface(name = "org.mpris.MediaPlayer2")]
+    impl MprisRoot {
+        async fn raise(&self) {
+            if let Some(window) = self.app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }
+
+        async fn quit(&self) {
+            self.app.exit(0);
+        }
+
+        #[zbus(property)]
+        fn can_quit(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        fn can_raise(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        fn has_track_list(&self) -> bool {
+            false
+        }
+
+        #[zbus(property)]
+        fn identity(&self) -> &str {
+            "Harbor"
+        }
+
+        #[zbus(property)]
+        fn desktop_entry(&self) -> &str {
+            "site.harbor.Harbor"
+        }
+
+        #[zbus(property)]
+        fn supported_uri_schemes(&self) -> Vec<&str> {
+            vec!["http", "https", "file"]
+        }
+
+        #[zbus(property)]
+        fn supported_mime_types(&self) -> Vec<&str> {
+            vec!["video/*", "audio/*"]
+        }
+    }
+
+    struct MprisPlayer {
+        app: AppHandle,
+        state: Arc<Mutex<PlaybackState>>,
+    }
+
+    #[interface(name = "org.mpris.MediaPlayer2.Player")]
+    impl MprisPlayer {
+        async fn next(&self) {
+            let _ = self.app.emit("harbor://media-key", "next");
+        }
+
+        async fn previous(&self) {
+            let _ = self.app.emit("harbor://media-key", "previous");
+        }
+
+        async fn pause(&self) {
+            let _ = self.app.emit("harbor://media-key", "pause");
+        }
+
+        async fn play_pause(&self) {
+            let _ = self.app.emit("harbor://media-key", "playpause");
+        }
+
+        async fn stop(&self) {
+            let _ = self.app.emit("harbor://media-key", "stop");
+        }
+
+        async fn play(&self) {
+            let _ = self.app.emit("harbor://media-key", "play");
+        }
+
+        async fn seek(&self, offset_us: i64) {
+            let offset_sec = offset_us as f64 / 1_000_000.0;
+            let _ = self.app.emit("harbor://media-seek-relative", offset_sec);
+        }
+
+        async fn set_position(&self, _track_id: ObjectPath<'_>, position_us: i64) {
+            let pos_sec = position_us as f64 / 1_000_000.0;
+            let _ = self.app.emit("harbor://media-seek-absolute", pos_sec);
+        }
+
+        #[zbus(signal)]
+        async fn seeked(emitter: &zbus::object_server::SignalEmitter<'_>, position_us: i64) -> zbus::Result<()>;
+
+        #[zbus(property)]
+        async fn playback_status(&self) -> String {
+            let s = self.state.lock().await;
+            if s.title.is_empty() {
+                "Stopped".to_string()
+            } else if s.playing {
+                "Playing".to_string()
+            } else {
+                "Paused".to_string()
+            }
+        }
+
+        #[zbus(property)]
+        fn loop_status(&self) -> &str {
+            "None"
+        }
+
+        #[zbus(property)]
+        fn set_loop_status(&self, _status: &str) -> zbus::Result<()> {
+            Ok(())
+        }
+
+        #[zbus(property)]
+        fn rate(&self) -> f64 {
+            1.0
+        }
+
+        #[zbus(property)]
+        fn set_rate(&self, _rate: f64) -> zbus::Result<()> {
+            Ok(())
+        }
+
+        #[zbus(property)]
+        fn shuffle(&self) -> bool {
+            false
+        }
+
+        #[zbus(property)]
+        fn set_shuffle(&self, _shuffle: bool) -> zbus::Result<()> {
+            Ok(())
+        }
+
+        #[zbus(property)]
+        fn volume(&self) -> f64 {
+            1.0
+        }
+
+        #[zbus(property)]
+        fn set_volume(&self, _vol: f64) -> zbus::Result<()> {
+            Ok(())
+        }
+
+        #[zbus(property)]
+        async fn position(&self) -> i64 {
+            self.state.lock().await.position_us
+        }
+
+        #[zbus(property)]
+        fn minimum_rate(&self) -> f64 {
+            1.0
+        }
+
+        #[zbus(property)]
+        fn maximum_rate(&self) -> f64 {
+            1.0
+        }
+
+        #[zbus(property)]
+        fn can_control(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        fn can_play(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        fn can_pause(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        fn can_seek(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        fn can_go_next(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        fn can_go_previous(&self) -> bool {
+            true
+        }
+
+        #[zbus(property)]
+        async fn metadata(&self) -> HashMap<String, Value<'static>> {
+            let s = self.state.lock().await;
+            let mut meta = HashMap::new();
+            let track_id = ObjectPath::try_from("/org/mpris/MediaPlayer2/track/0")
+                .unwrap_or_else(|_| ObjectPath::from_static_str_unchecked("/org/mpris/MediaPlayer2/TrackList/NoTrack"));
+            meta.insert("mpris:trackid".to_string(), Value::from(track_id));
+
+            if !s.title.is_empty() {
+                meta.insert("xesam:title".to_string(), Value::from(s.title.clone()));
+            }
+            if !s.subtitle.is_empty() {
+                meta.insert("xesam:album".to_string(), Value::from(s.subtitle.clone()));
+            }
+            if let Some(art) = &s.art_url {
+                if !art.is_empty() {
+                    meta.insert("mpris:artUrl".to_string(), Value::from(art.clone()));
+                }
+            }
+            if s.duration_us > 0 {
+                meta.insert("mpris:length".to_string(), Value::from(s.duration_us));
+            }
+            meta
+        }
+    }
+
+    pub fn init(app: &AppHandle) {
+        let app_handle = app.clone();
+        tauri::async_runtime::spawn(async move {
+            let state = Arc::new(Mutex::new(PlaybackState::default()));
+            let root = MprisRoot {
+                app: app_handle.clone(),
+            };
+            let player = MprisPlayer {
+                app: app_handle.clone(),
+                state: state.clone(),
+            };
+
+            let primary_name = "org.mpris.MediaPlayer2.harbor";
+            let fallback_name = format!("org.mpris.MediaPlayer2.harbor.instance{}", std::process::id());
+
+            let build_result = match zbus::connection::Builder::session() {
+                Ok(builder) => builder
+                    .name(primary_name)
+                    .and_then(|b| b.serve_at("/org/mpris/MediaPlayer2", root))
+                    .and_then(|b| b.serve_at("/org/mpris/MediaPlayer2", player)),
+                Err(e) => {
+                    eprintln!("[harbor::mpris] Session bus unavailable: {e:?}");
+                    return;
+                }
+            };
+
+            let conn = match build_result {
+                Ok(builder) => match builder.build().await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("[harbor::mpris] Primary bus name '{primary_name}' failed ({e:?}), retrying with '{fallback_name}'");
+                        // If primary name failed, retry with fallback instance name
+                        let root = MprisRoot {
+                            app: app_handle.clone(),
+                        };
+                        let player = MprisPlayer {
+                            app: app_handle.clone(),
+                            state: state.clone(),
+                        };
+                        match zbus::connection::Builder::session()
+                            .and_then(|b| b.name(fallback_name.as_str()))
+                            .and_then(|b| b.serve_at("/org/mpris/MediaPlayer2", root))
+                            .and_then(|b| b.serve_at("/org/mpris/MediaPlayer2", player))
+                        {
+                            Ok(builder) => match builder.build().await {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    eprintln!("[harbor::mpris] Fallback bus name also failed: {e:?}");
+                                    return;
+                                }
+                            },
+                            Err(e) => {
+                                eprintln!("[harbor::mpris] Fallback builder error: {e:?}");
+                                return;
+                            }
+                        }
+                    }
+                },
+                Err(e) => {
+                    eprintln!("[harbor::mpris] Failed to configure MPRIS server: {e:?}");
+                    return;
+                }
+            };
+
+            let _ = MPRIS.set(Some(MprisHandle {
+                connection: conn,
+                state,
+            }));
+            eprintln!("[harbor::mpris] Registered D-Bus interface org.mpris.MediaPlayer2");
+        });
+    }
+
+    pub fn update(
+        playing: bool,
+        title: &str,
+        subtitle: &str,
+        art_url: Option<&str>,
+        duration_sec: Option<f64>,
+        position_sec: Option<f64>,
+    ) {
+        let Some(Some(handle)) = MPRIS.get() else { return };
+        let state = handle.state.clone();
+        let conn = handle.connection.clone();
+        let title = title.to_string();
+        let subtitle = subtitle.to_string();
+        let art_url = art_url.map(|s| s.to_string());
+        let duration_us = duration_sec
+            .filter(|d| d.is_finite() && *d > 0.0)
+            .map(|d| (d * 1_000_000.0) as i64)
+            .unwrap_or(0);
+        let position_us = position_sec
+            .filter(|p| p.is_finite() && *p >= 0.0)
+            .map(|p| (p * 1_000_000.0) as i64)
+            .unwrap_or(0);
+
+        tauri::async_runtime::spawn(async move {
+            {
+                let mut s = state.lock().await;
+                s.playing = playing;
+                s.title = title;
+                s.subtitle = subtitle;
+                s.art_url = art_url;
+                s.duration_us = duration_us;
+                s.position_us = position_us;
+            }
+
+            if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
+                let player = iface.get().await;
+                let _ = MprisPlayer::playback_status_changed(&*player, iface.signal_emitter()).await;
+                let _ = MprisPlayer::metadata_changed(&*player, iface.signal_emitter()).await;
+            }
+        });
+    }
+
+    pub fn clear() {
+        let Some(Some(handle)) = MPRIS.get() else { return };
+        let state = handle.state.clone();
+        let conn = handle.connection.clone();
+
+        tauri::async_runtime::spawn(async move {
+            {
+                let mut s = state.lock().await;
+                s.playing = false;
+                s.title.clear();
+                s.subtitle.clear();
+                s.art_url = None;
+                s.duration_us = 0;
+                s.position_us = 0;
+            }
+
+            if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
+                let player = iface.get().await;
+                let _ = MprisPlayer::playback_status_changed(&*player, iface.signal_emitter()).await;
+                let _ = MprisPlayer::metadata_changed(&*player, iface.signal_emitter()).await;
+            }
+        });
+    }
+}
+
 pub fn ensure_started_on_setup(app: &tauri::AppHandle) {
     #[cfg(windows)]
     win::init(app);
-    #[cfg(not(windows))]
+    #[cfg(target_os = "linux")]
+    linux::init(app);
+    #[cfg(not(any(windows, target_os = "linux")))]
     let _ = app;
 }
 
 #[tauri::command]
-pub fn media_controls_update(playing: bool, title: String, subtitle: String) {
+pub fn media_controls_update(
+    playing: bool,
+    title: String,
+    subtitle: String,
+    art_url: Option<String>,
+    duration_sec: Option<f64>,
+    position_sec: Option<f64>,
+) {
     #[cfg(windows)]
     win::update(playing, &title, &subtitle);
-    #[cfg(not(windows))]
-    let _ = (playing, title, subtitle);
+    #[cfg(target_os = "linux")]
+    linux::update(
+        playing,
+        &title,
+        &subtitle,
+        art_url.as_deref(),
+        duration_sec,
+        position_sec,
+    );
+    #[cfg(not(any(windows, target_os = "linux")))]
+    let _ = (playing, title, subtitle, art_url, duration_sec, position_sec);
 }
 
 #[tauri::command]
 pub fn media_controls_clear() {
     #[cfg(windows)]
     win::clear();
+    #[cfg(target_os = "linux")]
+    linux::clear();
 }

--- a/src-tauri/src/media_controls.rs
+++ b/src-tauri/src/media_controls.rs
@@ -121,6 +121,7 @@ mod linux {
         pub art_url: Option<String>,
         pub duration_us: i64,
         pub position_us: i64,
+        pub volume: f64,
         pub updated_at: std::time::Instant,
     }
 
@@ -133,6 +134,7 @@ mod linux {
                 art_url: None,
                 duration_us: 0,
                 position_us: 0,
+                volume: 1.0,
                 updated_at: std::time::Instant::now(),
             }
         }
@@ -144,6 +146,10 @@ mod linux {
     }
 
     static MPRIS: OnceLock<Option<MprisHandle>> = OnceLock::new();
+
+    fn get_connection() -> Option<Connection> {
+        MPRIS.get().and_then(|h| h.as_ref()).map(|h| h.connection.clone())
+    }
 
     struct MprisRoot {
         app: AppHandle,
@@ -184,8 +190,44 @@ mod linux {
         }
 
         #[zbus(property)]
-        fn desktop_entry(&self) -> &str {
-            "site.harbor.Harbor"
+        fn desktop_entry(&self) -> String {
+            if let Ok(flatpak_id) = std::env::var("FLATPAK_ID") {
+                if !flatpak_id.trim().is_empty() {
+                    return flatpak_id;
+                }
+            }
+
+            let candidates = [
+                "Harbor Beta.desktop",
+                "app.harbor.desktop",
+                "harbor.desktop",
+                "site.harbor.Harbor.desktop",
+            ];
+
+            let mut search_dirs: Vec<std::path::PathBuf> = Vec::new();
+            if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
+                search_dirs.push(std::path::PathBuf::from(data_home).join("applications"));
+            } else if let Some(home) = std::env::var_os("HOME") {
+                search_dirs.push(std::path::PathBuf::from(home).join(".local/share/applications"));
+            }
+
+            let xdg_dirs = std::env::var("XDG_DATA_DIRS")
+                .unwrap_or_else(|_| "/usr/local/share:/usr/share".to_string());
+            for d in xdg_dirs.split(':') {
+                if !d.is_empty() {
+                    search_dirs.push(std::path::Path::new(d).join("applications"));
+                }
+            }
+
+            for dir in &search_dirs {
+                for candidate in candidates {
+                    if dir.join(candidate).exists() {
+                        return candidate.trim_end_matches(".desktop").to_string();
+                    }
+                }
+            }
+
+            "app.harbor".to_string()
         }
 
         #[zbus(property)]
@@ -233,24 +275,42 @@ mod linux {
         async fn seek(&self, offset_us: i64) {
             let offset_sec = offset_us as f64 / 1_000_000.0;
             let _ = self.app.emit("harbor://media-seek-relative", offset_sec);
-            let mut s = self.state.lock().await;
-            let current = if s.playing {
-                s.position_us + s.updated_at.elapsed().as_micros() as i64
-            } else {
-                s.position_us
+            let new_pos = {
+                let mut s = self.state.lock().await;
+                let current = if s.playing {
+                    s.position_us + s.updated_at.elapsed().as_micros() as i64
+                } else {
+                    s.position_us
+                };
+                let new_pos = (current + offset_us).max(0);
+                let new_pos = if s.duration_us > 0 { new_pos.min(s.duration_us) } else { new_pos };
+                s.position_us = new_pos;
+                s.updated_at = std::time::Instant::now();
+                new_pos
             };
-            let new_pos = (current + offset_us).max(0);
-            let new_pos = if s.duration_us > 0 { new_pos.min(s.duration_us) } else { new_pos };
-            s.position_us = new_pos;
-            s.updated_at = std::time::Instant::now();
+            if let Some(conn) = get_connection() {
+                if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
+                    let _ = MprisPlayer::seeked(iface.signal_emitter(), new_pos).await;
+                }
+            }
         }
 
         async fn set_position(&self, _track_id: ObjectPath<'_>, position_us: i64) {
             let pos_sec = position_us as f64 / 1_000_000.0;
             let _ = self.app.emit("harbor://media-seek-absolute", pos_sec);
-            let mut s = self.state.lock().await;
-            s.position_us = position_us.max(0);
-            s.updated_at = std::time::Instant::now();
+            let new_pos = {
+                let mut s = self.state.lock().await;
+                let p = position_us.max(0);
+                let p = if s.duration_us > 0 { p.min(s.duration_us) } else { p };
+                s.position_us = p;
+                s.updated_at = std::time::Instant::now();
+                p
+            };
+            if let Some(conn) = get_connection() {
+                if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
+                    let _ = MprisPlayer::seeked(iface.signal_emitter(), new_pos).await;
+                }
+            }
         }
 
         #[zbus(signal)]
@@ -299,12 +359,24 @@ mod linux {
         }
 
         #[zbus(property)]
-        fn volume(&self) -> f64 {
-            1.0
+        async fn volume(&self) -> f64 {
+            self.state.lock().await.volume
         }
 
         #[zbus(property)]
-        fn set_volume(&self, _vol: f64) -> zbus::Result<()> {
+        async fn set_volume(&self, vol: f64) -> zbus::Result<()> {
+            let clamped = vol.clamp(0.0, 1.0);
+            {
+                let mut s = self.state.lock().await;
+                s.volume = clamped;
+            }
+            let _ = self.app.emit("harbor://media-set-volume", clamped);
+            if let Some(conn) = get_connection() {
+                if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
+                    let player = iface.get().await;
+                    let _ = MprisPlayer::volume_changed(&*player, iface.signal_emitter()).await;
+                }
+            }
             Ok(())
         }
 
@@ -469,6 +541,7 @@ mod linux {
         art_url: Option<&str>,
         duration_sec: Option<f64>,
         position_sec: Option<f64>,
+        volume: Option<f64>,
     ) {
         let Some(Some(handle)) = MPRIS.get() else { return };
         let state = handle.state.clone();
@@ -486,21 +559,78 @@ mod linux {
             .unwrap_or(0);
 
         tauri::async_runtime::spawn(async move {
+            let mut vol_changed = false;
+            let mut status_changed = false;
+            let mut meta_changed = false;
+            let mut pos_jumped = false;
+
             {
                 let mut s = state.lock().await;
-                s.playing = playing;
-                s.title = title;
-                s.subtitle = subtitle;
-                s.art_url = art_url;
-                s.duration_us = duration_us;
-                s.position_us = position_us;
-                s.updated_at = std::time::Instant::now();
+                if s.playing != playing {
+                    s.playing = playing;
+                    s.updated_at = std::time::Instant::now();
+                    status_changed = true;
+                }
+                if s.title != title || s.subtitle != subtitle || s.art_url != art_url || s.duration_us != duration_us {
+                    s.title = title;
+                    s.subtitle = subtitle;
+                    s.art_url = art_url;
+                    s.duration_us = duration_us;
+                    meta_changed = true;
+                }
+                let current = if s.playing {
+                    s.position_us + s.updated_at.elapsed().as_micros() as i64
+                } else {
+                    s.position_us
+                };
+                let drift = (current - position_us).abs();
+                if drift > 1_200_000 || status_changed {
+                    s.position_us = position_us;
+                    s.updated_at = std::time::Instant::now();
+                    if drift > 1_200_000 {
+                        pos_jumped = true;
+                    }
+                }
+                if let Some(vol) = volume {
+                    let clamped = vol.clamp(0.0, 1.0);
+                    if (s.volume - clamped).abs() > 0.005 {
+                        s.volume = clamped;
+                        vol_changed = true;
+                    }
+                }
             }
 
             if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
                 let player = iface.get().await;
-                let _ = MprisPlayer::playback_status_changed(&*player, iface.signal_emitter()).await;
-                let _ = MprisPlayer::metadata_changed(&*player, iface.signal_emitter()).await;
+                if status_changed {
+                    let _ = MprisPlayer::playback_status_changed(&*player, iface.signal_emitter()).await;
+                }
+                if meta_changed {
+                    let _ = MprisPlayer::metadata_changed(&*player, iface.signal_emitter()).await;
+                }
+                if vol_changed {
+                    let _ = MprisPlayer::volume_changed(&*player, iface.signal_emitter()).await;
+                }
+                if pos_jumped {
+                    let _ = MprisPlayer::seeked(iface.signal_emitter(), position_us).await;
+                }
+            }
+        });
+    }
+
+    pub fn seeked(position_sec: f64) {
+        let Some(Some(handle)) = MPRIS.get() else { return };
+        let state = handle.state.clone();
+        let conn = handle.connection.clone();
+        let position_us = (position_sec.max(0.0) * 1_000_000.0) as i64;
+        tauri::async_runtime::spawn(async move {
+            {
+                let mut s = state.lock().await;
+                s.position_us = position_us;
+                s.updated_at = std::time::Instant::now();
+            }
+            if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
+                let _ = MprisPlayer::seeked(iface.signal_emitter(), position_us).await;
             }
         });
     }
@@ -548,6 +678,7 @@ pub fn media_controls_update(
     art_url: Option<String>,
     duration_sec: Option<f64>,
     position_sec: Option<f64>,
+    volume: Option<f64>,
 ) {
     #[cfg(windows)]
     win::update(playing, &title, &subtitle);
@@ -559,9 +690,26 @@ pub fn media_controls_update(
         art_url.as_deref(),
         duration_sec,
         position_sec,
+        volume,
     );
     #[cfg(not(any(windows, target_os = "linux")))]
-    let _ = (playing, title, subtitle, art_url, duration_sec, position_sec);
+    let _ = (
+        playing,
+        title,
+        subtitle,
+        art_url,
+        duration_sec,
+        position_sec,
+        volume,
+    );
+}
+
+#[tauri::command]
+pub fn media_controls_seeked(position_sec: f64) {
+    #[cfg(target_os = "linux")]
+    linux::seeked(position_sec);
+    #[cfg(not(target_os = "linux"))]
+    let _ = position_sec;
 }
 
 #[tauri::command]

--- a/src-tauri/src/media_controls.rs
+++ b/src-tauri/src/media_controls.rs
@@ -113,7 +113,7 @@ mod linux {
     use zbus::zvariant::{ObjectPath, Value};
     use zbus::{interface, connection::Connection};
 
-    #[derive(Default, Clone)]
+    #[derive(Clone)]
     pub struct PlaybackState {
         pub playing: bool,
         pub title: String,
@@ -121,6 +121,21 @@ mod linux {
         pub art_url: Option<String>,
         pub duration_us: i64,
         pub position_us: i64,
+        pub updated_at: std::time::Instant,
+    }
+
+    impl Default for PlaybackState {
+        fn default() -> Self {
+            Self {
+                playing: false,
+                title: String::new(),
+                subtitle: String::new(),
+                art_url: None,
+                duration_us: 0,
+                position_us: 0,
+                updated_at: std::time::Instant::now(),
+            }
+        }
     }
 
     pub struct MprisHandle {
@@ -218,11 +233,24 @@ mod linux {
         async fn seek(&self, offset_us: i64) {
             let offset_sec = offset_us as f64 / 1_000_000.0;
             let _ = self.app.emit("harbor://media-seek-relative", offset_sec);
+            let mut s = self.state.lock().await;
+            let current = if s.playing {
+                s.position_us + s.updated_at.elapsed().as_micros() as i64
+            } else {
+                s.position_us
+            };
+            let new_pos = (current + offset_us).max(0);
+            let new_pos = if s.duration_us > 0 { new_pos.min(s.duration_us) } else { new_pos };
+            s.position_us = new_pos;
+            s.updated_at = std::time::Instant::now();
         }
 
         async fn set_position(&self, _track_id: ObjectPath<'_>, position_us: i64) {
             let pos_sec = position_us as f64 / 1_000_000.0;
             let _ = self.app.emit("harbor://media-seek-absolute", pos_sec);
+            let mut s = self.state.lock().await;
+            s.position_us = position_us.max(0);
+            s.updated_at = std::time::Instant::now();
         }
 
         #[zbus(signal)]
@@ -282,7 +310,18 @@ mod linux {
 
         #[zbus(property)]
         async fn position(&self) -> i64 {
-            self.state.lock().await.position_us
+            let s = self.state.lock().await;
+            if s.playing {
+                let elapsed = s.updated_at.elapsed().as_micros() as i64;
+                let cur = s.position_us + elapsed;
+                if s.duration_us > 0 {
+                    cur.min(s.duration_us)
+                } else {
+                    cur
+                }
+            } else {
+                s.position_us
+            }
         }
 
         #[zbus(property)]
@@ -455,6 +494,7 @@ mod linux {
                 s.art_url = art_url;
                 s.duration_us = duration_us;
                 s.position_us = position_us;
+                s.updated_at = std::time::Instant::now();
             }
 
             if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {
@@ -479,6 +519,7 @@ mod linux {
                 s.art_url = None;
                 s.duration_us = 0;
                 s.position_us = 0;
+                s.updated_at = std::time::Instant::now();
             }
 
             if let Ok(iface) = conn.object_server().interface::<_, MprisPlayer>("/org/mpris/MediaPlayer2").await {

--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -14,12 +14,28 @@ export function mediaKeyGate(): boolean {
   return true;
 }
 
-export function updateMediaControls(playing: boolean, title: string, subtitle: string): void {
+export function updateMediaControls(
+  playing: boolean,
+  title: string,
+  subtitle: string,
+  artUrl?: string | null,
+  durationSec?: number | null,
+  positionSec?: number | null,
+): void {
   if (!isTauri()) return;
-  const state = `${playing ? 1 : 0}|${title}|${subtitle}`;
+  const art = artUrl ?? null;
+  const dur = typeof durationSec === "number" && Number.isFinite(durationSec) && durationSec > 0 ? Math.round(durationSec) : null;
+  const state = `${playing ? 1 : 0}|${title}|${subtitle}|${art ?? ""}|${dur ?? 0}`;
   if (state === lastState) return;
   lastState = state;
-  invoke("media_controls_update", { playing, title, subtitle }).catch(() => {});
+  invoke("media_controls_update", {
+    playing,
+    title,
+    subtitle,
+    artUrl: art,
+    durationSec: durationSec != null && Number.isFinite(durationSec) ? durationSec : null,
+    positionSec: positionSec != null && Number.isFinite(positionSec) ? positionSec : null,
+  }).catch(() => {});
 }
 
 export function clearMediaControls(): void {

--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -5,6 +5,9 @@ const isTauri = () => typeof window !== "undefined" && "__TAURI_INTERNALS__" in 
 
 let lastState = "";
 let lastActionAt = 0;
+let lastPositionSec: number | null = null;
+let lastPositionAt = 0;
+let lastPlaying = false;
 
 export function mediaKeyGate(): boolean {
   if (isPlayerInteractionLocked()) return false;
@@ -21,25 +24,68 @@ export function updateMediaControls(
   artUrl?: string | null,
   durationSec?: number | null,
   positionSec?: number | null,
+  volume?: number | null,
 ): void {
   if (!isTauri()) return;
   const art = artUrl ?? null;
   const dur = typeof durationSec === "number" && Number.isFinite(durationSec) && durationSec > 0 ? Math.round(durationSec) : null;
-  const state = `${playing ? 1 : 0}|${title}|${subtitle}|${art ?? ""}|${dur ?? 0}`;
-  if (state === lastState) return;
+  const vol = typeof volume === "number" && Number.isFinite(volume) ? Math.max(0, Math.min(1, volume)) : null;
+  const volKey = vol != null ? Math.round(vol * 100) : "";
+  const pos = typeof positionSec === "number" && Number.isFinite(positionSec) && positionSec >= 0 ? positionSec : null;
+
+  const now = Date.now();
+  const state = `${playing ? 1 : 0}|${title}|${subtitle}|${art ?? ""}|${dur ?? 0}|${volKey}`;
+  const metadataChanged = state !== lastState;
+
+  let positionDrift = false;
+  if (pos != null) {
+    if (lastPositionSec == null || playing !== lastPlaying) {
+      positionDrift = true;
+    } else if (playing) {
+      const elapsed = (now - lastPositionAt) / 1000;
+      const expected = lastPositionSec + elapsed;
+      if (Math.abs(pos - expected) > 1.2) {
+        positionDrift = true;
+      }
+    } else {
+      if (Math.abs(pos - lastPositionSec) > 0.5) {
+        positionDrift = true;
+      }
+    }
+  }
+
+  if (!metadataChanged && !positionDrift) return;
+
   lastState = state;
+  lastPlaying = playing;
+  if (pos != null) {
+    lastPositionSec = pos;
+    lastPositionAt = now;
+  }
+
   invoke("media_controls_update", {
     playing,
     title,
     subtitle,
     artUrl: art,
-    durationSec: durationSec != null && Number.isFinite(durationSec) ? durationSec : null,
-    positionSec: positionSec != null && Number.isFinite(positionSec) ? positionSec : null,
+    durationSec: dur,
+    positionSec: pos,
+    volume: vol,
   }).catch(() => {});
+}
+
+export function notifyMediaSeeked(positionSec: number): void {
+  if (!isTauri() || !Number.isFinite(positionSec)) return;
+  lastPositionSec = Math.max(0, positionSec);
+  lastPositionAt = Date.now();
+  invoke("media_controls_seeked", { positionSec }).catch(() => {});
 }
 
 export function clearMediaControls(): void {
   if (!isTauri()) return;
   lastState = "";
+  lastPositionSec = null;
+  lastPositionAt = 0;
+  lastPlaying = false;
   invoke("media_controls_clear").catch(() => {});
 }

--- a/src/lib/player/mpv.ts
+++ b/src/lib/player/mpv.ts
@@ -743,9 +743,14 @@ export function createMpvBridge(mpvOptions?: MpvOptions): PlayerBridge {
       invoke("mpv_command", { cmd: [dir > 0 ? "frame-step" : "frame-back-step"] }).catch(() => {});
     },
     setVolume(v) {
+      snap.volume = v;
+      if (v > 0) snap.muted = false;
+      emit();
       invoke("mpv_set_property", { name: "volume", value: Math.round(v * 100) }).catch(() => {});
     },
     setMuted(m) {
+      snap.muted = m;
+      emit();
       invoke("mpv_set_property", { name: "mute", value: m }).catch(() => {});
     },
     setRate(r) {

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -32,6 +32,7 @@ import { useEngineStats } from "./player/hooks/use-engine-stats";
 import { useContentAdvisory } from "./player/hooks/use-content-advisory";
 import {
   getPlaybackPosition,
+  subscribePlaybackClock,
   resolvePlaybackDownloadedFraction,
   setPlaybackDownloaded,
 } from "@/lib/player/playback-clock";
@@ -792,10 +793,30 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   useEffect(() => {
     const ep = src.episode;
     const subtitle = ep ? `S${ep.season} E${ep.episode}${ep.name ? ` · ${ep.name}` : ""}` : "";
-    // const artUrl = src.meta.poster || src.meta.background || null;
-    const artUrl = src.meta.background || src.meta.poster || null;
-    updateMediaControls(playing, src.meta.name, subtitle, artUrl, snap.durationSec, snap.positionSec);
-  }, [playing, src.meta.name, src.episode, src.meta.poster, src.meta.background, snap.durationSec]);
+    const artUrl = src.episode?.still || src.meta.background || src.meta.poster || null;
+    const vol = snap.muted ? 0 : snap.volume;
+    const isPlaying = snap.status === "playing" && (snap.firstFrameReady || snap.positionSec > 0.3);
+    const pos = getPlaybackPosition();
+    updateMediaControls(isPlaying, src.meta.name, subtitle, artUrl, snap.durationSec, pos, vol);
+
+    const unsub = subscribePlaybackClock(() => {
+      const livePos = getPlaybackPosition();
+      const currentSnap = snapRef.current;
+      const playingNow = currentSnap.status === "playing" && (currentSnap.firstFrameReady || livePos > 0.3);
+      updateMediaControls(playingNow, src.meta.name, subtitle, artUrl, currentSnap.durationSec, livePos, vol);
+    });
+    return () => unsub();
+  }, [
+    snap.status,
+    snap.firstFrameReady,
+    src.meta.name,
+    src.episode,
+    src.meta.poster,
+    src.meta.background,
+    snap.durationSec,
+    snap.volume,
+    snap.muted,
+  ]);
   useEffect(() => () => clearMediaControls(), []);
 
   const onPrevEpisode = useCallback(() => playPrevRef.current(), [playPrevRef]);

--- a/src/views/player.tsx
+++ b/src/views/player.tsx
@@ -792,8 +792,10 @@ export function PlayerView({ src }: { src: PlayerSrc }) {
   useEffect(() => {
     const ep = src.episode;
     const subtitle = ep ? `S${ep.season} E${ep.episode}${ep.name ? ` · ${ep.name}` : ""}` : "";
-    updateMediaControls(playing, src.meta.name, subtitle);
-  }, [playing, src.meta.name, src.episode]);
+    // const artUrl = src.meta.poster || src.meta.background || null;
+    const artUrl = src.meta.background || src.meta.poster || null;
+    updateMediaControls(playing, src.meta.name, subtitle, artUrl, snap.durationSec, snap.positionSec);
+  }, [playing, src.meta.name, src.episode, src.meta.poster, src.meta.background, snap.durationSec]);
   useEffect(() => () => clearMediaControls(), []);
 
   const onPrevEpisode = useCallback(() => playPrevRef.current(), [playPrevRef]);

--- a/src/views/player/hooks/use-keyboard-shortcuts.ts
+++ b/src/views/player/hooks/use-keyboard-shortcuts.ts
@@ -598,15 +598,25 @@ export function useKeyboardShortcuts(params: {
           mediaRef.current.seekTo(e.payload);
         }
       });
+      const u4 = await listen<number>("harbor://media-set-volume", (e) => {
+        if (typeof e.payload === "number" && Number.isFinite(e.payload)) {
+          const vol = Math.max(0, Math.min(1, e.payload));
+          bridgeRef.current?.setVolume(vol);
+          writePlayerVolume({ volume: vol, muted: false });
+          onVolumeFeedback?.(vol, false);
+        }
+      });
       if (dead) {
         u1();
         u2();
         u3();
+        u4();
       } else {
         cleanup = () => {
           u1();
           u2();
           u3();
+          u4();
         };
       }
     });

--- a/src/views/player/hooks/use-keyboard-shortcuts.ts
+++ b/src/views/player/hooks/use-keyboard-shortcuts.ts
@@ -602,6 +602,7 @@ export function useKeyboardShortcuts(params: {
         if (typeof e.payload === "number" && Number.isFinite(e.payload)) {
           const vol = Math.max(0, Math.min(1, e.payload));
           bridgeRef.current?.setVolume(vol);
+          bridgeRef.current?.setMuted(false);
           writePlayerVolume({ volume: vol, muted: false });
           onVolumeFeedback?.(vol, false);
         }

--- a/src/views/player/hooks/use-keyboard-shortcuts.ts
+++ b/src/views/player/hooks/use-keyboard-shortcuts.ts
@@ -126,6 +126,8 @@ export function useKeyboardShortcuts(params: {
   const mediaRef = useRef({
     status: snap.status,
     playPauseToggle,
+    seekStep,
+    seekTo,
     onNextEp,
     onPrevEp,
     hasNextEp,
@@ -134,6 +136,8 @@ export function useKeyboardShortcuts(params: {
   mediaRef.current = {
     status: snap.status,
     playPauseToggle,
+    seekStep,
+    seekTo,
     onNextEp,
     onPrevEp,
     hasNextEp,
@@ -560,9 +564,9 @@ export function useKeyboardShortcuts(params: {
   useEffect(() => {
     if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) return;
     let dead = false;
-    let unlisten: (() => void) | undefined;
-    void import("@tauri-apps/api/event").then(({ listen }) =>
-      listen<string>("harbor://media-key", (e) => {
+    let cleanup: (() => void) | undefined;
+    void import("@tauri-apps/api/event").then(async ({ listen }) => {
+      const u1 = await listen<string>("harbor://media-key", (e) => {
         const m = mediaRef.current;
         const playing = m.status === "playing";
         switch (e.payload) {
@@ -583,14 +587,32 @@ export function useKeyboardShortcuts(params: {
             if (m.hasPrevEp && m.onPrevEp && mediaKeyGate()) m.onPrevEp();
             break;
         }
-      }).then((u) => {
-        if (dead) u();
-        else unlisten = u;
-      }),
-    );
+      });
+      const u2 = await listen<number>("harbor://media-seek-relative", (e) => {
+        if (typeof e.payload === "number" && Number.isFinite(e.payload)) {
+          mediaRef.current.seekStep(e.payload);
+        }
+      });
+      const u3 = await listen<number>("harbor://media-seek-absolute", (e) => {
+        if (typeof e.payload === "number" && Number.isFinite(e.payload)) {
+          mediaRef.current.seekTo(e.payload);
+        }
+      });
+      if (dead) {
+        u1();
+        u2();
+        u3();
+      } else {
+        cleanup = () => {
+          u1();
+          u2();
+          u3();
+        };
+      }
+    });
     return () => {
       dead = true;
-      unlisten?.();
+      cleanup?.();
     };
   }, []);
 

--- a/src/views/player/hooks/use-pending-seek-apply.ts
+++ b/src/views/player/hooks/use-pending-seek-apply.ts
@@ -1,5 +1,6 @@
 import { useEffect, type RefObject } from "react";
 import type { PlayerBridge } from "@/lib/player/bridge";
+import { notifyMediaSeeked } from "@/lib/media-session";
 
 export function usePendingSeekApply(params: {
   pendingSeekSec: number | null;
@@ -18,6 +19,7 @@ export function usePendingSeekApply(params: {
     clearPendingSeek();
     const t = target <= 5 || target >= durationSec - 20 ? 0 : Math.min(target, durationSec - 1);
     b.seek(t);
+    notifyMediaSeeked(t);
     if (!inRoomRef.current) b.play().catch(() => {});
   }, [pendingSeekSec, durationSec, clearPendingSeek]);
 }

--- a/src/views/player/hooks/use-playback-controls.ts
+++ b/src/views/player/hooks/use-playback-controls.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/subtitles/subtitle-memory";
 import { hasImportedSubTitle } from "@/lib/player/imported-subs";
 import type { RoomCommand } from "@/lib/together/protocol";
+import { notifyMediaSeeked } from "@/lib/media-session";
 
 const SEEK_ACCUM_WINDOW_MS = 700;
 
@@ -127,6 +128,7 @@ export function usePlaybackControls(params: {
       return;
     }
     bridgeRef.current?.seek(target, "keyframes");
+    notifyMediaSeeked(target);
   };
 
   const seekTo = useCallback(
@@ -144,6 +146,7 @@ export function usePlaybackControls(params: {
         return;
       }
       bridgeRef.current?.seek(target, "keyframes");
+      notifyMediaSeeked(target);
     },
     [castDevice, canControl, inRoom, isHost, sendCommand, seekCast, bridgeRef],
   );


### PR DESCRIPTION
## Summary

- Implements MPRIS v2 over D-Bus via `zbus` 5 under `org.mpris.MediaPlayer2.harbor`.
- Exposes playback controls (`Play`, `Pause`, `Next`, `Previous`, `Seek`, `SetPosition`), metadata (`title`, `album`, `artUrl`, `length`), and window controls (`Raise`, `Quit`).
- Sets `DesktopEntry` to `site.harbor.Harbor` for app icon integration in desktop environments.

## Why

Linux desktop environments (GNOME, KDE Plasma, XFCE, Cinnamon, COSMIC) and hardware media keys communicate with media players exclusively through the MPRIS D-Bus interface.

## Verification

- Passed `cargo check --manifest-path src-tauri/Cargo.toml` and `pnpm run typecheck`.
- Verified live playback controls, track metadata, and status toggling via `playerctl` and `busctl`.

## Platform Impact

Linux only. Windows (SMTC) and macOS remain isolated and unaffected.

## UI Changes

None.

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [x] I ran the relevant Cargo checks after Rust changes.
- [x] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.