### PR TITLE
fix: prevent series from auto-adding on page load

### DIFF
--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -1108,7 +1108,7 @@ export function DetailView({
     manualWatchedVersion,
     manualWatchedVersion,
   );
-  const prevSeriesWatchedVerRef = useRef(-1);
+  const prevSeriesWatchedVerRef = useRef(seriesWatchedVer);
   const stremioVideosRef = useRef<{ imdb: string; videos: NonNullable<Meta["videos"]> } | null>(
     null,
   );


### PR DESCRIPTION
## Summary

Stops a series from being auto-added to the watchlist the moment its detail page loads. The change in src/views/detail.tsx initializes prevSeriesWatchedVerRef to the current watched version instead of a stale -1, so the page-load effect no longer fires on the first render and no longer triggers the add.

## Why

Opening any series detail page added the series to the watchlist ("watch later") immediately, even though the user never clicked Add to Watchlist. The -1 sentinel made the first comparison always differ from the current version, so the effect ran on mount. Initializing the ref to the live value skips that spurious first-run add while preserving the correct behavior when the user actually interacts with the watched/watchlist state afterwards

## Verification

- Reproduced on a local build where a series was auto-added to the watchlist the moment its detail page opened.
- After the change, opening the same series detail page no longer adds it to the watchlist.
- Confirmed the add still happens when the user explicitly clicks Add to Watchlist.
- vp check passes for src/views/detail.tsx.
- vp run typecheck passes.

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
