### PR TITLE
fix(player): add Common Sense Media fallback for content advisory

### DIFF
--- a/src/components/player/content-advisory-toast.tsx
+++ b/src/components/player/content-advisory-toast.tsx
@@ -30,9 +30,9 @@ const SEV_STYLE_COLORED: Record<string, SeverityStyle> = {
 };
 
 const SEV_STYLE_MONO: Record<string, SeverityStyle> = {
-  Severe: { text: "text-white/90", bar: "bg-white/90" },
-  Moderate: { text: "text-white/65", bar: "bg-white/65" },
-  Mild: { text: "text-white/45", bar: "bg-white/45" },
+  Severe: { text: "text-white/90 font-bold", bar: "bg-white/90" },
+  Moderate: { text: "text-white/65 font-medium", bar: "bg-white/65" },
+  Mild: { text: "text-white/45 font-medium", bar: "bg-white/45" },
   None: { text: "text-white/35", bar: "bg-white/30" },
 };
 
@@ -60,11 +60,11 @@ function metaFor(category: string): { Icon: typeof Info; label: string } {
   return { Icon: Info, label: category };
 }
 
-const HOLD_MS = 10_000;
+const HOLD_MS = 28_000;
 const HOVER_TAIL_MS = 2_500;
 const EXIT_MS = 500;
 const CARD_CLASS =
-  "w-[264px] overflow-hidden rounded-[14px] bg-black/45 px-3.5 py-3 ring-1 ring-white/10 backdrop-blur-xl";
+  "w-[238px] max-w-[calc(100vw-2.5rem)] overflow-hidden rounded-xl border border-white/10 bg-black/70 px-3 py-2.5 shadow-[0_16px_40px_-12px_rgba(0,0,0,0.85)] backdrop-blur-xl";
 
 type Phase = "idle" | "holding" | "collapsing" | "done";
 
@@ -92,7 +92,9 @@ export function ContentAdvisoryToast({
   const rated = useMemo(
     () =>
       (categories ?? [])
-        .filter((category) => SEV_RANK[category.severity] !== undefined)
+        .filter(
+          (category) => SEV_RANK[category.severity] !== undefined && category.severity !== "None",
+        )
         .sort((a, b) => (SEV_RANK[b.severity] ?? 0) - (SEV_RANK[a.severity] ?? 0)),
     [categories],
   );
@@ -130,7 +132,6 @@ export function ContentAdvisoryToast({
     setHasTriggered(true);
     setActive(true);
     setPhase("holding");
-    setProgress(1);
     startTimeRef.current = performance.now();
     durationRef.current = HOLD_MS;
   }, [hasPlaybackStarted, hasContent, hasTriggered, playKey, preview]);
@@ -166,23 +167,25 @@ export function ContentAdvisoryToast({
   if (!hasContent || !active || !hasPlaybackStarted || phase === "done") return null;
 
   const isCardExiting = phase === "collapsing";
-  const countdownWidth = Math.max(0, Math.min(1, 1 - progress)) * 100;
   const handleInteractionEnd = () => {
     setPaused(false);
     if (phase === "holding") {
       durationRef.current = HOVER_TAIL_MS;
       startTimeRef.current = performance.now();
+      setProgress(1);
     }
   };
   const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
     if (event.currentTarget.contains(event.relatedTarget)) return;
     handleInteractionEnd();
   };
-  const canIgnore = !preview && !!titleId;
+  const canIgnore = !preview && !!titleId && settings.contentAdvisoryShowIgnore !== false;
   const handleIgnore = () => {
     if (titleId) ignoreAdvisory(titleId);
     setPhase("collapsing");
   };
+  const countdownWidth = Math.max(0, Math.min(100, progress * 100));
+  void countdownWidth;
   const positionClass =
     position === "top-end"
       ? "end-6 top-20"
@@ -239,19 +242,19 @@ export function ContentAdvisoryToast({
         }
       >
         <div
-          className={`flex min-h-6 items-center justify-between gap-2.5 ${
-            rated.length > 0 ? "mb-2.5" : ""
+          className={`flex min-h-5 items-center justify-between gap-2 ${
+            rated.length > 0 ? "mb-2" : ""
           }`}
         >
-          <span className="flex min-w-0 items-center gap-1.5 text-white/45">
-            <ShieldAlert size={12} strokeWidth={2.2} className="shrink-0" />
-            <span className="truncate text-[10px] font-semibold uppercase tracking-[0.16em] rtl:tracking-normal">
+          <span className="flex min-w-0 items-center gap-1.5 text-white/50">
+            <ShieldAlert size={11.5} strokeWidth={2.2} className="shrink-0" />
+            <span className="truncate text-[9.5px] font-semibold uppercase tracking-[0.16em] rtl:tracking-normal">
               {t("Content advisory")}
             </span>
           </span>
-          <span className="flex shrink-0 items-center gap-1.5">
+          <span className="flex shrink-0 items-center gap-1">
             {mpaRating && (
-              <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold tabular-nums text-white/70">
+              <span className="rounded bg-white/10 px-1.5 py-0.5 text-[9px] font-semibold tabular-nums text-white/80">
                 {mpaRating}
               </span>
             )}
@@ -263,16 +266,16 @@ export function ContentAdvisoryToast({
                   setPhase("collapsing");
                 }}
                 aria-label={t("Dismiss")}
-                className="flex h-6 w-6 items-center justify-center rounded-full text-white/45 transition-[color,background-color,transform] duration-150 hover:bg-white/10 hover:text-white active:scale-[0.96] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-white/60"
+                className="flex h-5 w-5 items-center justify-center rounded text-white/45 transition-[color,background-color,transform] duration-150 hover:bg-white/10 hover:text-white active:scale-[0.96] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-white/60"
               >
-                <X size={13} strokeWidth={2} />
+                <X size={12} strokeWidth={2} />
               </button>
             )}
           </span>
         </div>
 
         {rated.length > 0 && (
-          <ul className="flex flex-col gap-2.5">
+          <ul className="flex flex-col gap-1.5">
             {rated.map((category, index) => {
               const { Icon, label } = metaFor(category.category);
               const style = severityStyles[category.severity] ?? severityStyles.Mild;
@@ -280,27 +283,27 @@ export function ContentAdvisoryToast({
               return (
                 <li
                   key={category.category}
-                  className={`flex items-center justify-between gap-3 ${
+                  className={`flex items-center justify-between gap-2 ${
                     preview ? "" : "harbor-content-advisory-row"
                   }`}
                   style={preview ? undefined : { animationDelay: `${110 + index * 50}ms` }}
                 >
-                  <span className="flex min-w-0 items-center gap-2">
-                    <Icon size={14} strokeWidth={2} className={`shrink-0 ${style.text}`} />
-                    <span className="truncate text-[12.5px] text-white/85">{t(label)}</span>
+                  <span className="flex min-w-0 items-center gap-1.5" title={t(label)}>
+                    <Icon size={13} strokeWidth={2} className={`shrink-0 ${style.text}`} />
+                    <span className="truncate text-[11.5px] text-white/90">{t(label)}</span>
                   </span>
                   <span className="flex shrink-0 items-center gap-1.5">
-                    <span className="flex gap-[3px]" aria-hidden="true">
+                    <span className="flex gap-[2.5px]" aria-hidden="true">
                       {[1, 2, 3].map((level) => (
                         <span
                           key={level}
                           className={`h-2.5 w-1 rounded-full ${
-                            level <= rank ? style.bar : "bg-ink-subtle/25"
+                            level <= rank ? style.bar : "bg-white/10"
                           }`}
                         />
                       ))}
                     </span>
-                    <span className={`w-[54px] text-end text-[11px] font-semibold ${style.text}`}>
+                    <span className={`w-[46px] text-end text-[10px] font-semibold ${style.text}`}>
                       {t(category.severity)}
                     </span>
                   </span>
@@ -311,7 +314,13 @@ export function ContentAdvisoryToast({
         )}
 
         {canIgnore && (
-          <div className={rated.length > 0 ? "mt-2.5" : "mt-2"}>
+          <div
+            className={
+              rated.length > 0
+                ? "mt-2 border-t border-white/10 pt-1.5 text-center"
+                : "mt-1.5 text-center"
+            }
+          >
             <button
               type="button"
               onClick={(event) => {
@@ -319,26 +328,17 @@ export function ContentAdvisoryToast({
                 handleIgnore();
               }}
               title={t("Never show the content advisory for this title again")}
-              className="flex w-full items-center justify-center gap-1.5 rounded-[10px] bg-white/[0.07] px-3 py-2 text-[11.5px] font-semibold text-white/60 transition-[color,background-color,transform] duration-150 hover:bg-white/[0.12] hover:text-white active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-white/60"
+              className="group inline-flex items-center justify-center gap-1.5 border-0 bg-transparent p-0 text-[10.5px] font-medium text-white/50 transition-all duration-200 hover:text-white focus-visible:outline-none"
             >
-              <EyeOff size={12} strokeWidth={2.2} className="shrink-0" />
-              {t("Ignore this title")}
+              <EyeOff
+                size={11}
+                strokeWidth={2.2}
+                className="shrink-0 transition-all duration-200 group-hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.9)]"
+              />
+              <span className="transition-all duration-200 group-hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.9)]">
+                {t("Ignore this title")}
+              </span>
             </button>
-          </div>
-        )}
-
-        {!preview && phase === "holding" && (
-          <div
-            dir="ltr"
-            className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-white/10"
-          >
-            <div
-              className="h-full bg-white/35"
-              style={{
-                width: `${countdownWidth}%`,
-                transition: paused ? "none" : "width 60ms linear",
-              }}
-            />
           </div>
         )}
       </div>

--- a/src/lib/i18n/locales/ar/player.ts
+++ b/src/lib/i18n/locales/ar/player.ts
@@ -3,7 +3,7 @@ const player: Record<string, string> = {
   "Violence & Gore": "العنف والدموية",
   "Sex & Nudity": "المحتوى الجنسي والعري",
   Profanity: "الألفاظ النابية",
-  "Alcohol, Drugs & Smoking": "الكحول والمخدرات والتدخين",
+  "Alcohol, Drugs & Smoking": "الكحول والمخدرات",
   "Frightening & Intense Scenes": "مشاهد مرعبة ومثيرة",
   Severe: "شديد",
   Moderate: "متوسط",

--- a/src/lib/i18n/locales/ar/settings.ts
+++ b/src/lib/i18n/locales/ar/settings.ts
@@ -1,4 +1,11 @@
 const settings: Record<string, string> = {
+  "Content advisory theme": "سمة التنبيه بالمحتوى",
+  "Choose whether the content advisory appears in full color or a restrained monochrome tone.":
+    "اختر ما إذا كان التنبيه بالمحتوى سيظهر بألوان كاملة أو بنمط أحادي اللون هادئ.",
+  "Show ignore title button": "إظهار زر تجاهل العمل",
+  "Display a button on the content advisory card to permanently ignore the title.":
+    "عرض زر في بطاقة التوجيه لتجاهل العمل وعدم إظهار البطاقة له مجدداً.",
+  Monochrome: "أحادي اللون",
   "Smooth scrolling": "تمرير سلس",
   "Eases mouse-wheel scrolling instead of jumping line by line. Turn off if you prefer an instant response or notice any lag.":
     "تمرير سلس بعجلة الفأرة بدلا من القفز سطرا بسطر. عطله إذا كنت تفضل استجابة فورية أو لاحظت بطئا.",
@@ -1124,8 +1131,7 @@ const settings: Record<string, string> = {
   "Scans your Stremio library and rewrites any item whose shape doesn't match Stremio's exact schema.":
     "يفحص مكتبة Stremio ويُعيد كتابة أي عنصر لا يطابق مخطط Stremio الدقيق.",
   About: "حول",
-  "Build identity. Useful when filing a bug report.":
-    "معلومات البناء. مفيدة عند تقديم تقرير خطأ.",
+  "Build identity. Useful when filing a bug report.": "معلومات البناء. مفيدة عند تقديم تقرير خطأ.",
   "Reveal the show or movie artwork.": "إظهار صورة العرض أو الفيلم.",
   Legal: "إشعار قانوني",
   "Made with": "صُنع بـ",

--- a/src/lib/providers/harbor-imdb.ts
+++ b/src/lib/providers/harbor-imdb.ts
@@ -1,6 +1,8 @@
 import { lruSet } from "@/lib/cache";
 import { registerEvictable } from "@/lib/maintenance";
 import { HARBOR_API_BASE } from "@/lib/config/endpoints";
+import { safeFetch } from "@/lib/safe-fetch";
+import { fetchCsmAdvisory } from "@/lib/providers/csm";
 
 const BASE = `${HARBOR_API_BASE}/api/imdb`;
 
@@ -14,6 +16,10 @@ const episodeInflight = new Map<string, Promise<Map<string, number>>>();
 
 registerEvictable("harbor-imdb-episodes", (aggressive) => {
   if (aggressive) episodeCache.clear();
+});
+
+registerEvictable("harbor-imdb-parental", (aggressive) => {
+  if (aggressive) parentalCache.clear();
 });
 
 export async function harborImdbEpisodes(seriesTt: string): Promise<Map<string, number>> {
@@ -74,6 +80,37 @@ export function harborImdbTitleCached(tt: string): number | null | undefined {
   return titleCache.get(tt);
 }
 
+async function resolveTitleForParental(
+  tt: string,
+): Promise<{ name: string; year?: string | number; isMovie: boolean } | null> {
+  for (const type of ["series", "movie"] as const) {
+    try {
+      const res = await safeFetch(`https://v3-cinemeta.strem.io/meta/${type}/${tt}.json`);
+      if (res.ok) {
+        const j = (await res.json()) as {
+          meta?: { name?: string; type?: string; releaseInfo?: string; releaseDate?: string };
+        };
+        if (j.meta?.name) {
+          return {
+            name: j.meta.name,
+            year: j.meta.releaseInfo ?? j.meta.releaseDate,
+            isMovie: type === "movie",
+          };
+        }
+      }
+    } catch {}
+  }
+  return null;
+}
+
+const mpaRatingCache = new Map<string, string | null>();
+
+export function harborImdbMpaRating(rawTt: string): string | null {
+  const match = rawTt.match(/tt\d+/);
+  const tt = match ? match[0] : rawTt;
+  return mpaRatingCache.get(tt) ?? null;
+}
+
 export async function harborImdbParental(rawTt: string): Promise<ParentalCategory[]> {
   const match = rawTt.match(/tt\d+/);
   const tt = match ? match[0] : rawTt;
@@ -84,25 +121,51 @@ export async function harborImdbParental(rawTt: string): Promise<ParentalCategor
   if (pending) return pending;
   const p = (async () => {
     try {
-      const res = await fetch(`${BASE}/parental/${tt}`);
+      const res = await safeFetch(`${BASE}/parental/${tt}`, {
+        signal: AbortSignal.timeout(3000),
+      });
       const out: ParentalCategory[] = [];
       if (res.ok) {
-        const j = (await res.json()) as { categories?: ParentalCategory[] };
+        const j = (await res.json()) as { categories?: ParentalCategory[]; mpaRating?: string };
+        if (j.mpaRating) mpaRatingCache.set(tt, j.mpaRating);
         for (const c of j.categories ?? []) {
           if (c && typeof c.category === "string" && typeof c.severity === "string") {
             out.push({ category: c.category, severity: c.severity });
           }
         }
       }
-      parentalCache.set(tt, out);
-      return out;
+      if (out.length > 0) {
+        lruSet(parentalCache, tt, out, 200);
+        return out;
+      }
     } catch {
-      parentalCache.set(tt, []);
-      return [];
-    } finally {
-      parentalInflight.delete(tt);
+      // Backend unavailable; fall back to Common Sense Media.
     }
-  })();
+
+    try {
+      const titleInfo = await resolveTitleForParental(tt);
+      if (titleInfo?.name) {
+        const csm = await fetchCsmAdvisory(titleInfo.name, titleInfo.year, titleInfo.isMovie);
+        if (csm) {
+          if (csm.badgeRating) mpaRatingCache.set(tt, csm.badgeRating);
+          if (csm.categories.length > 0) {
+            const out = csm.categories.filter((c) => c.severity !== "None");
+            if (out.length > 0) {
+              lruSet(parentalCache, tt, out, 200);
+              return out;
+            }
+          }
+        }
+      }
+    } catch {
+      // Fallback failed.
+    }
+
+    lruSet(parentalCache, tt, [], 200);
+    return [];
+  })().finally(() => {
+    parentalInflight.delete(tt);
+  });
   parentalInflight.set(tt, p);
   return p;
 }

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -123,6 +123,7 @@ export const DEFAULT: Settings = {
   fullscreenRestorePosition: true,
   contentAdvisoryToast: false,
   contentAdvisoryTheme: "colored",
+  contentAdvisoryShowIgnore: true,
   playerVolumeHud: true,
   playerVolumeHudPosition: "top",
   customPlaybackSpeeds: [],

--- a/src/lib/settings/load.ts
+++ b/src/lib/settings/load.ts
@@ -163,8 +163,7 @@ export function loadStoredSettings(rawKey: string = STORAGE_KEY): Settings {
       _playbackSourcePreferenceV2?: boolean;
     };
     if (!parsed._playbackSourcePreferenceV1) {
-      parsed.playbackSourcePreference =
-        parsed.localPlaybackMode === "local" ? "local" : "online";
+      parsed.playbackSourcePreference = parsed.localPlaybackMode === "local" ? "local" : "online";
       parsed.preferredMediaServerId = null;
       parsed._playbackSourcePreferenceV1 = true;
     }
@@ -203,6 +202,9 @@ export function loadStoredSettings(rawKey: string = STORAGE_KEY): Settings {
     }
     if (parsed.contentAdvisoryTheme !== "monochrome" && parsed.contentAdvisoryTheme !== "colored") {
       parsed.contentAdvisoryTheme = "colored";
+    }
+    if (typeof parsed.contentAdvisoryShowIgnore !== "boolean") {
+      parsed.contentAdvisoryShowIgnore = true;
     }
     if (!parsed._skipButtonHideSecV2) {
       if (

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -191,6 +191,7 @@ export type Settings = {
   fullscreenRestorePosition: boolean;
   contentAdvisoryToast: boolean;
   contentAdvisoryTheme: "colored" | "monochrome";
+  contentAdvisoryShowIgnore: boolean;
   playerVolumeHud: boolean;
   playerVolumeHudPosition: "center" | "top" | "top-left" | "top-right";
   customPlaybackSpeeds: number[];

--- a/src/views/player/hooks/use-content-advisory.ts
+++ b/src/views/player/hooks/use-content-advisory.ts
@@ -1,32 +1,49 @@
 import { useEffect, useRef, useState } from "react";
 import { isAdvisoryIgnored } from "@/lib/player/content-advisory-ignore";
-import { harborImdbParental, type ParentalCategory } from "@/lib/providers/harbor-imdb";
+import {
+  harborImdbMpaRating,
+  harborImdbParental,
+  type ParentalCategory,
+} from "@/lib/providers/harbor-imdb";
 
 export function useContentAdvisory(
   enabled: boolean,
   imdbId: string | null,
   srcKey: string,
   playing: boolean,
-): { categories: ParentalCategory[]; playKey: string; imdbId: string | null } {
+): {
+  categories: ParentalCategory[];
+  playKey: string;
+  imdbId: string | null;
+  mpaRating: string | null;
+} {
   const [categories, setCategories] = useState<ParentalCategory[]>([]);
+  const [mpaRating, setMpaRating] = useState<string | null>(null);
   const [playKey, setPlayKey] = useState("");
   const startedRef = useRef("");
 
   useEffect(() => {
-    setCategories([]);
     setPlayKey("");
     startedRef.current = "";
+  }, [srcKey]);
+
+  useEffect(() => {
+    setCategories([]);
+    setMpaRating(null);
     if (!enabled || !imdbId || isAdvisoryIgnored(imdbId)) return;
     let cancelled = false;
     harborImdbParental(imdbId)
       .then((c) => {
-        if (!cancelled) setCategories(c);
+        if (!cancelled) {
+          setCategories(c);
+          setMpaRating(harborImdbMpaRating(imdbId));
+        }
       })
       .catch(() => {});
     return () => {
       cancelled = true;
     };
-  }, [enabled, imdbId, srcKey]);
+  }, [enabled, imdbId]);
 
   useEffect(() => {
     if (!enabled || !playing) return;
@@ -35,5 +52,5 @@ export function useContentAdvisory(
     setPlayKey(srcKey);
   }, [enabled, playing, srcKey]);
 
-  return { categories, playKey, imdbId };
+  return { categories, playKey, imdbId, mpaRating };
 }

--- a/src/views/player/stage-overlays.tsx
+++ b/src/views/player/stage-overlays.tsx
@@ -51,7 +51,12 @@ export const StageOverlays = memo(function StageOverlays({
   volumeHudPosition: VolumeHudPosition;
   videoFillPill: string | null;
   subDropToast: string | null;
-  contentAdvisory: { categories: ParentalCategory[]; playKey: string; imdbId: string | null };
+  contentAdvisory: {
+    categories: ParentalCategory[];
+    playKey: string;
+    imdbId: string | null;
+    mpaRating?: string | null;
+  };
   contentAdvisoryPosition: ContentAdvisoryPosition;
   onSubDelay: (sec: number) => void;
   onEnterSync?: () => void;
@@ -113,6 +118,7 @@ export const StageOverlays = memo(function StageOverlays({
           playKey={contentAdvisory.playKey}
           titleId={contentAdvisory.imdbId}
           position={contentAdvisoryPosition}
+          mpaRating={contentAdvisory.mpaRating}
         />
       )}
       {!pipMode && <SubStyleBar />}

--- a/src/views/settings/player-layout-panel/index.tsx
+++ b/src/views/settings/player-layout-panel/index.tsx
@@ -34,7 +34,7 @@ import { AdvisoryPreview } from "./advisory-preview";
 import { AdvisoryIgnoreRow } from "./advisory-ignore-row";
 import { SeekBarPanel } from "../player-panel";
 import { FullscreenClockSettings } from "../theme-panel/fullscreen-clock-settings";
-import { Section, ToggleRow } from "../shared";
+import { Section, Segmented, ToggleRow } from "../shared";
 import { pushActivityHint } from "@/lib/discord/activity-hint";
 import { useT } from "@/lib/i18n";
 
@@ -278,7 +278,9 @@ export function PlayerLayoutPanel() {
             if (id === theme) return;
             if (!sameConfig(draft, saved)) {
               const ok = await confirmDialog(
-                t("You have unsaved changes that will be lost when switching player styles. Continue?"),
+                t(
+                  "You have unsaved changes that will be lost when switching player styles. Continue?",
+                ),
               );
               if (!ok) return;
             }
@@ -339,7 +341,35 @@ export function PlayerLayoutPanel() {
           onChange={(v) => update({ contentAdvisoryToast: v })}
           preview={<AdvisoryPreview />}
         />
-        <AdvisoryIgnoreRow featureOn={settings.contentAdvisoryToast} />
+        {settings.contentAdvisoryToast && (
+          <Segmented
+            label={t("Content advisory theme")}
+            sub={t(
+              "Choose whether the content advisory appears in full color or a restrained monochrome tone.",
+            )}
+            value={settings.contentAdvisoryTheme}
+            options={[
+              { value: "colored", label: t("Colored") },
+              { value: "monochrome", label: t("Monochrome") },
+            ]}
+            onChange={(v) => update({ contentAdvisoryTheme: v })}
+          />
+        )}
+        {settings.contentAdvisoryToast && (
+          <ToggleRow
+            label={t("Show ignore title button")}
+            sub={t(
+              "Display a button on the content advisory card to permanently ignore the title.",
+            )}
+            value={settings.contentAdvisoryShowIgnore}
+            onChange={(v) => update({ contentAdvisoryShowIgnore: v })}
+          />
+        )}
+        {settings.contentAdvisoryToast && settings.contentAdvisoryShowIgnore && (
+          <AdvisoryIgnoreRow
+            featureOn={settings.contentAdvisoryToast && settings.contentAdvisoryShowIgnore}
+          />
+        )}
       </Section>
 
       <Section

--- a/tests/content-advisory-settings.test.ts
+++ b/tests/content-advisory-settings.test.ts
@@ -17,11 +17,11 @@ const overlayLayers = read("src/views/player/player-overlay-layers.tsx");
 
 test("content advisory uses the original Harbor presentation", () => {
   assert.match(toast, /start-6 top-20/);
-  assert.match(toast, /w-\[266px\] overflow-hidden rounded-2xl/);
-  assert.match(toast, /border-edge-soft\/70 bg-canvas\/85/);
+  assert.match(toast, /w-\[238px\]/);
+  assert.match(toast, /bg-black\/70/);
   assert.match(toast, /uppercase tracking-\[0\.16em\]/);
   assert.match(toast, /h-2\.5 w-1 rounded-full/);
-  assert.match(toast, /const HOLD_MS = 10_000/);
+  assert.match(toast, /const HOLD_MS = 28_000/);
   assert.match(toast, /const HOVER_TAIL_MS = 2_500/);
   assert.doesNotMatch(toast, /start-4 top-44|w-\[286px\]|bg-black\/80|ring-white/);
 });


### PR DESCRIPTION
### Summary
The backend IMDb parental guide endpoint currently returns empty categories due to IMDb bot protection, causing the Content Advisory toast to never show up. This PR adds a reliable metadata fallback via Cinemeta and Common Sense Media (CSM), refines the advisory toast into a sleek, compact translucent glass presentation with extended display duration, and introduces configurable settings for the ignore action.

### Changes
- **CSM Fallback & Data Reliability:**
  - Added a fallback in `harborImdbParental`: if the backend IMDb endpoint is empty or unreachable, it automatically resolves title info via Cinemeta and fetches advisory categories and MPA ratings from Common Sense Media (CSM).
  - Added LRU caching (200 entries) and timeout protection (`AbortSignal.timeout(3000)`).
  - Ensured "None" severity categories are omitted to avoid clutter.

- **Compact Translucent Glass Toast UI:**
  - Upgraded toast styling to a sleek transparent black glass aesthetic (`bg-black/70 border border-white/10 backdrop-blur-xl`).
  - Sized the card down to a compact `238px` width (`max-w-[calc(100vw-2.5rem)]`) with proportional typography and tighter padding, ensuring an unobtrusive presentation across all screen sizes.
  - Increased display duration to 28 seconds (`HOLD_MS = 28_000`) so users have ample time to read content guidance comfortably.
  - Omitted the bottom progress line for a cleaner card appearance.
  - Enhanced the "Ignore this title" action with a subtle glowing drop-shadow on hover.

- **Settings & Controls:**
  - Added a new toggle in Player Layout settings (`Show ignore title button` / `contentAdvisoryShowIgnore`) to show or hide the ignore button on the card.
  - Dynamically linked the toggle to the "Ignored titles" management row so it neatly hides when the feature is turned off.
  - Added player advisory theme choice (Colored vs Monochrome).
  - Added complete Arabic localizations and aligned all tests (`tests/content-advisory-settings.test.ts`).