### PR TITLE
Fix/the copy link button fails in production (tauri build)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -41,6 +41,7 @@
       ]
     },
     "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
     "dialog:default",
     "dialog:allow-open",
     "dialog:allow-save",

--- a/src/components/player/copy-link-button.tsx
+++ b/src/components/player/copy-link-button.tsx
@@ -1,10 +1,20 @@
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, Magnet } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { serializeMagnet } from "@/lib/torrent/magnet";
 
-export function resolveStreamLink(stream: { url?: string; externalUrl?: string }): string | null {
-  return stream.url ?? stream.externalUrl ?? null;
+export function resolveStreamLink(stream: { url?: string; externalUrl?: string, infoHash?: string, fileIdx?: number, sources?: string[], behaviorHints?: { filename?: string } }): string | null {
+  if (stream.url || stream.externalUrl) return stream.url || stream.externalUrl || null;
+  if (stream.infoHash) {
+    return serializeMagnet({
+      infoHash: stream.infoHash,
+      name: stream.behaviorHints?.filename ?? null,
+      trackers: stream.sources ?? [],
+    });
+  }
+  return null;
+
 }
 
 export async function copyText(text: string): Promise<boolean> {
@@ -24,7 +34,6 @@ export async function copyText(text: string): Promise<boolean> {
     console.error("failed to copy: ", error);
   }
   return false;
-
 }
 
 export function CopyLinkButton({
@@ -39,9 +48,11 @@ export function CopyLinkButton({
   label?: string;
 }) {
   const t = useT();
-  const resolvedLabel = label ?? t("Copy link");
+  const isMagnetLink = url.startsWith("magnet:");
+  const resolvedLabel = label ?? t(isMagnetLink ? "Copy magnet link" : "Copy link");
   const [copied, setCopied] = useState(false);
   const timer = useRef<number | null>(null);
+  const Icon = isMagnetLink ? Magnet : Copy;
 
   useEffect(
     () => () => {
@@ -57,6 +68,7 @@ export function CopyLinkButton({
     if (timer.current !== null) window.clearTimeout(timer.current);
     timer.current = window.setTimeout(() => setCopied(false), 1400);
   };
+
 
   return (
     <span
@@ -79,7 +91,8 @@ export function CopyLinkButton({
         copied ? "bg-success/12 text-success" : "text-ink-subtle hover:bg-canvas/60 hover:text-ink"
       } ${className}`}
     >
-      <Copy
+
+      <Icon
         size={size}
         strokeWidth={2}
         className={`absolute transition-all duration-200 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${

--- a/src/components/player/copy-link-button.tsx
+++ b/src/components/player/copy-link-button.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 
 export function resolveStreamLink(stream: { url?: string; externalUrl?: string }): string | null {
   return stream.url ?? stream.externalUrl ?? null;
@@ -8,26 +9,22 @@ export function resolveStreamLink(stream: { url?: string; externalUrl?: string }
 
 export async function copyText(text: string): Promise<boolean> {
   try {
+    await writeText(text);
+    return true;
+  } catch {
+    /* fallback: Use standard web API */
+  }
+  try {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);
       return true;
     }
-  } catch {
-    /* fall through to legacy path */
   }
-  try {
-    const ta = document.createElement("textarea");
-    ta.value = text;
-    ta.style.position = "fixed";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
-    ta.select();
-    const ok = document.execCommand("copy");
-    document.body.removeChild(ta);
-    return ok;
-  } catch {
-    return false;
+  catch (error) {
+    console.error("failed to copy: ", error);
   }
+  return false;
+
 }
 
 export function CopyLinkButton({

--- a/src/lib/torrent/magnet.ts
+++ b/src/lib/torrent/magnet.ts
@@ -80,6 +80,22 @@ export function parseMagnet(value: string): ParsedMagnet | null {
   };
 }
 
+export function serializeMagnet(magnet: ParsedMagnet): string {
+  const params = new URLSearchParams();
+
+  params.append('xt', `urn:btih:${magnet.infoHash}`);
+
+  if (magnet.name) {
+    params.append('dn', magnet.name);
+  }
+
+  for (const tracker of magnet.trackers) {
+    params.append('tr', tracker);
+  }
+
+  return `magnet:?${params.toString()}`;
+}
+
 export function infoHashFromUrl(url: string): { infoHash: string; fileIdx?: number } | null {
   const m = url.match(/(?:^|[/=])([a-fA-F0-9]{40})(?:\/(\d+))?(?=[/?#]|$)/);
   if (!m) return null;


### PR DESCRIPTION
## Summary

<!-- Describe the change clearly and keep its scope focused. -->

Webview engines block the standard navigator.clipboard API on custom local production protocols. This PR updates the copyText utility to prioritize Tauri's native clipboard API while keeping the browser API as a fallback.
and adds support for copying torrent magnet links.

## Verification

<!-- List the commands and manual scenarios used to verify the change. -->
Successfully built and worked.


## UI Changes
<!-- Include before/after screenshots for visual changes and a short recording for motion or interaction changes. Remove this section when not applicable. -->
Just added Magnet Icon for p2p streams

<img width="1043" height="213" alt="image" src="https://github.com/user-attachments/assets/24060668-a9d5-43fd-bf8e-57112cab2c18" />
