### PR TITLE
feat(updater): prepare beta 0.9.124 experimental bootstrap

### DIFF
--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harbor-setup",
-  "version": "0.9.123",
+  "version": "0.9.124",
   "private": true,
   "type": "module",
   "scripts": {

--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -1226,7 +1226,7 @@ version = "0.1.0"
 
 [[package]]
 name = "harbor-setup"
-version = "0.9.123"
+version = "0.9.124"
 dependencies = [
  "crc32fast",
  "harbor-install-recovery",

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor-setup"
-version = "0.9.123"
+version = "0.9.124"
 edition = "2021"
 rust-version = "1.77"
 default-run = "harbor-setup"

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Harbor Setup",
-  "version": "0.9.123",
+  "version": "0.9.124",
   "identifier": "app.harbor.setup",
   "build": {
     "frontendDist": "../ui"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harbor",
-  "version": "0.9.123",
+  "version": "0.9.124",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "0.9.123"
+version = "0.9.124"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor"
-version = "0.9.123"
+version = "0.9.124"
 description = "A Stremio client built for adventure"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Harbor",
-  "version": "0.9.123",
+  "version": "0.9.124",
   "identifier": "app.harbor",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/update/update-card.tsx
+++ b/src/components/update/update-card.tsx
@@ -75,12 +75,14 @@ export function UpdateCard() {
             </span>
             {u.version && (
               <span className="text-[12.5px] text-ink-subtle">
-                {t("update.harborVersion", { version: u.version })}
+                {u.channel === "experimental" && u.experimentalVersion
+                  ? `${t("Experimental")} ${u.experimentalVersion}`
+                  : t("update.harborVersion", { version: u.version })}
               </span>
             )}
             {u.channel === "experimental" && (
               <span className="break-words text-[12px] text-accent">
-                {t("Experimental")}
+                {u.version ? t("update.harborVersion", { version: u.version }) : t("Experimental")}
                 {u.buildId ? ` · ${u.buildId}` : ""}
               </span>
             )}

--- a/src/components/update/update-card.tsx
+++ b/src/components/update/update-card.tsx
@@ -76,14 +76,11 @@ export function UpdateCard() {
             {u.version && (
               <span className="text-[12.5px] text-ink-subtle">
                 {u.channel === "experimental" && u.experimentalVersion
-                  ? `${t("Experimental")} ${u.experimentalVersion}`
+                  ? t("Experimental {version} · Build {buildId}", {
+                      version: u.experimentalVersion,
+                      buildId: u.buildId ?? "—",
+                    })
                   : t("update.harborVersion", { version: u.version })}
-              </span>
-            )}
-            {u.channel === "experimental" && (
-              <span className="break-words text-[12px] text-accent">
-                {u.version ? t("update.harborVersion", { version: u.version }) : t("Experimental")}
-                {u.buildId ? ` · ${u.buildId}` : ""}
               </span>
             )}
           </div>

--- a/src/lib/i18n/locales/ar/experimental-updates.ts
+++ b/src/lib/i18n/locales/ar/experimental-updates.ts
@@ -54,8 +54,8 @@ export default {
   "Enable experimental updates on this device? This replaces your normal update feed until you leave. It does not install a build now.":
     "هل تريد تفعيل التحديثات التجريبية المبكرة على هذا الجهاز؟ سيحل ذلك محل قناة التحديث المعتادة حتى توقفه. لن يتم تثبيت أي إصدار الآن.",
   "Enable and check": "تفعيل والتحقق",
-  "Leaving returns you to {channel} updates when a newer version is available. It does not downgrade Harbor.":
-    "عند الإيقاف ستعود إلى تحديثات {channel} عند توفر إصدار أحدث. لن يعود Harbor إلى إصدار أقدم.",
+  "Leaving only turns off experimental checks. Use Return to beta below to replace the experimental app.":
+    "يؤدي الإيقاف إلى تعطيل التحقق من الإصدارات التجريبية فقط. استخدم العودة إلى بيتا أدناه لاستبدال التطبيق التجريبي.",
   "Couldn't save the update channel. Free some storage and try again.":
     "تعذّر حفظ قناة التحديث. أفرغ بعض مساحة التخزين وحاول مجددًا.",
   "Finish the current download or installation before changing channels.":

--- a/src/lib/i18n/locales/pt/experimental-updates.ts
+++ b/src/lib/i18n/locales/pt/experimental-updates.ts
@@ -55,8 +55,8 @@ export default {
   "Enable experimental updates on this device? This replaces your normal update feed until you leave. It does not install a build now.":
     "Ativar atualizações experimentais neste dispositivo? Isso substitui seu canal normal de atualizações até você sair. Nenhuma versão será instalada agora.",
   "Enable and check": "Ativar e verificar",
-  "Leaving returns you to {channel} updates when a newer version is available. It does not downgrade Harbor.":
-    "Ao sair, você volta às atualizações do canal {channel} quando uma versão mais recente estiver disponível. Isso não reverte o Harbor para uma versão anterior.",
+  "Leaving only turns off experimental checks. Use Return to beta below to replace the experimental app.":
+    "Sair apenas desativa a busca por versões experimentais. Use Voltar para beta abaixo para substituir o aplicativo experimental.",
   "Couldn't save the update channel. Free some storage and try again.":
     "Não foi possível salvar o canal de atualização. Libere espaço de armazenamento e tente novamente.",
   "Finish the current download or installation before changing channels.":

--- a/src/lib/i18n/locales/ru/experimental-updates.ts
+++ b/src/lib/i18n/locales/ru/experimental-updates.ts
@@ -55,8 +55,8 @@ export default {
   "Enable experimental updates on this device? This replaces your normal update feed until you leave. It does not install a build now.":
     "Включить экспериментальные обновления на этом устройстве? Они заменят обычный канал обновлений до вашего отказа. Сейчас никакая сборка не будет установлена.",
   "Enable and check": "Включить и проверить",
-  "Leaving returns you to {channel} updates when a newer version is available. It does not downgrade Harbor.":
-    "После отказа обновления канала «{channel}» возобновятся, когда появится более новая версия. Версия Harbor не будет понижена.",
+  "Leaving only turns off experimental checks. Use Return to beta below to replace the experimental app.":
+    "Выход отключает только проверку экспериментальных сборок. Чтобы заменить экспериментальное приложение, используйте возврат к бета-версии ниже.",
   "Couldn't save the update channel. Free some storage and try again.":
     "Не удалось сохранить канал обновлений. Освободите место в хранилище и повторите попытку.",
   "Finish the current download or installation before changing channels.":

--- a/src/lib/updater/beta-return.ts
+++ b/src/lib/updater/beta-return.ts
@@ -1,4 +1,4 @@
-import { experimentalPayloadVersion } from "./experimental";
+import { experimentalChannelVersion, experimentalPayloadVersion } from "./experimental";
 import type { HandoffPlan, HandoffProbe } from "./handoff";
 import { UPDATE_CHANNEL_KEY } from "./channel";
 
@@ -6,6 +6,7 @@ export const BETA_RETURN_KEY = "harbor.update.beta-return.v1";
 export type BetaReturnTarget = HandoffPlan & { recoveryProtocol: 1 };
 export type BetaReturnContext = {
   version: string;
+  experimentalVersion: string;
   buildId: string;
   platformKey: string;
   targets: BetaReturnTarget[];
@@ -80,6 +81,8 @@ export function readBetaReturnContext(installed?: string): BetaReturnContext | n
     if (
       !value ||
       typeof value.version !== "string" ||
+      typeof value.experimentalVersion !== "string" ||
+      experimentalChannelVersion(value.experimentalVersion) === null ||
       typeof value.buildId !== "string" ||
       !/^[A-Za-z0-9][\w.-]{0,79}$/.test(value.buildId) ||
       value.buildId.includes("..") ||
@@ -95,6 +98,7 @@ export function readBetaReturnContext(installed?: string): BetaReturnContext | n
 
 export function saveBetaReturnContext(
   version: string,
+  experimentalVersion: string,
   buildId: string,
   platformKey: string,
   returnToBeta: unknown,
@@ -102,7 +106,7 @@ export function saveBetaReturnContext(
   if (!parseBetaReturnTargets(returnToBeta, version, platformKey).length) {
     throw new Error("No tested return to beta is available for this build.");
   }
-  const raw = JSON.stringify({ version, buildId, platformKey, returnToBeta });
+  const raw = JSON.stringify({ version, experimentalVersion, buildId, platformKey, returnToBeta });
   localStorage.setItem(`${BETA_RETURN_KEY}.${version}`, raw);
   localStorage.setItem(BETA_RETURN_KEY, raw);
 }

--- a/src/lib/updater/experimental.ts
+++ b/src/lib/updater/experimental.ts
@@ -4,6 +4,7 @@ type Artifact = { url: string; signature: string };
 type InstallerArtifact = Artifact & { payloadVersion: number; size: number; recoveryProtocol?: 1 };
 export type ExperimentalRelease = {
   version: string;
+  experimentalVersion: string;
   buildId: string;
   notes: string | null;
   artifact: Artifact;
@@ -39,6 +40,11 @@ export function experimentalPayloadVersion(version: string): number | null {
   return Number.isSafeInteger(value) ? value : null;
 }
 
+export function experimentalChannelVersion(version: string): number | null {
+  const value = experimentalPayloadVersion(version);
+  return value !== null && value > 0 && value < 1_000_000 ? value : null;
+}
+
 export function parseExperimentalRelease(
   raw: unknown,
   platformKey: string,
@@ -52,6 +58,11 @@ export function parseExperimentalRelease(
   if ("url" in manifest || "signature" in manifest) return null;
   const payloadVersion = experimentalPayloadVersion(manifest.version);
   if (payloadVersion === null) return null;
+  if (
+    typeof manifest.experimentalVersion !== "string" ||
+    experimentalChannelVersion(manifest.experimentalVersion) === null
+  )
+    return null;
   if (typeof manifest.buildId !== "string" || !/^[\w.-]{1,80}$/.test(manifest.buildId)) return null;
   const platform = artifact(object(manifest.platforms)?.[platformKey]);
   if (!platform) return null;
@@ -78,6 +89,7 @@ export function parseExperimentalRelease(
   }
   return {
     version: manifest.version,
+    experimentalVersion: manifest.experimentalVersion,
     buildId: manifest.buildId,
     notes: typeof manifest.notes === "string" ? manifest.notes : null,
     artifact: platform,
@@ -89,6 +101,7 @@ export function parseExperimentalRelease(
 export function sameExperimentalRelease(a: ExperimentalRelease, b: ExperimentalRelease): boolean {
   return (
     a.version === b.version &&
+    a.experimentalVersion === b.experimentalVersion &&
     a.buildId === b.buildId &&
     a.artifact.url === b.artifact.url &&
     a.artifact.signature === b.artifact.signature

--- a/src/lib/updater/use-update.ts
+++ b/src/lib/updater/use-update.ts
@@ -57,6 +57,7 @@ export type UpdateState = {
   intent: "update" | "return-beta";
   channel: UpdateChannel;
   buildId: string | null;
+  experimentalVersion: string | null;
   status: UpdateStatus;
   version: string | null;
   notes: string | null;
@@ -84,6 +85,7 @@ let state: UpdateState = {
   intent: "update",
   channel: selectedUpdateChannel(),
   buildId: null,
+  experimentalVersion: null,
   status: "idle",
   version: null,
   notes: null,
@@ -164,6 +166,7 @@ function revokeExperimentalAccess(): void {
     intent: "update",
     channel: selectedUpdateChannel(),
     buildId: null,
+    experimentalVersion: null,
     status: "idle",
     version: null,
     notes: null,
@@ -263,7 +266,13 @@ export async function checkForUpdate(manual = false): Promise<void> {
   const request = revision;
   const selected = selectedUpdateChannel();
   checkedChannel = selected;
-  set({ status: "checking", channel: selected, manualCheck: manual, error: null });
+  set({
+    status: "checking",
+    channel: selected,
+    experimentalVersion: null,
+    manualCheck: manual,
+    error: null,
+  });
   let candidate: UpdateHandle | null = null;
   try {
     if (selected === "experimental") {
@@ -334,6 +343,7 @@ export async function checkForUpdate(manual = false): Promise<void> {
       set({
         status: "available",
         version: release.version,
+        experimentalVersion: release.experimentalVersion,
         buildId: release.buildId,
         notes: release.notes,
         handoff: plan,
@@ -410,7 +420,14 @@ export async function prepareBetaReturn(version: string): Promise<void> {
   clearStagedUpdate();
   const request = revision;
   const selected = selectedUpdateChannel();
-  set({ intent: "return-beta", channel: "beta", status: "checking", version, manualCheck: true });
+  set({
+    intent: "return-beta",
+    channel: "beta",
+    status: "checking",
+    version,
+    experimentalVersion: null,
+    manualCheck: true,
+  });
   try {
     const [{ getVersion }, probe] = await Promise.all([
       import("@tauri-apps/api/app"),
@@ -435,7 +452,9 @@ export async function prepareBetaReturn(version: string): Promise<void> {
     if (!currentRequest(request, selected)) return;
     const release = parseExperimentalRelease(raw, context.platformKey);
     const target =
-      release?.version === context.version && release.buildId === context.buildId
+      release?.version === context.version &&
+      release.experimentalVersion === context.experimentalVersion &&
+      release.buildId === context.buildId
         ? parseBetaReturnTargets(release.returnToBeta, context.version, context.platformKey).find(
             (entry) => entry.version === version,
           )
@@ -567,6 +586,7 @@ export async function installUpdate(): Promise<void> {
             throw new Error("The update changed.");
           saveBetaReturnContext(
             experimentalRelease.version,
+            experimentalRelease.experimentalVersion,
             experimentalRelease.buildId,
             probe.platformKey,
             experimentalRelease.returnToBeta,
@@ -583,6 +603,7 @@ export async function installUpdate(): Promise<void> {
           recoverable: plan.recoveryProtocol === 1,
           channel: state.channel,
           buildId: state.buildId,
+          experimentalVersion: state.experimentalVersion,
           at: Date.now(),
         }),
       );
@@ -709,6 +730,7 @@ async function detectFailedHandoff(pending: {
   channel?: UpdateChannel;
   intent?: "update" | "return-beta";
   recoverable?: boolean;
+  experimentalVersion?: string;
   returnPreferenceUndo?: unknown;
 }): Promise<boolean> {
   if (pending.intent === "return-beta") {
@@ -728,6 +750,7 @@ async function detectFailedHandoff(pending: {
       status: "error",
       installFailed: true,
       version: pending.version ?? null,
+      experimentalVersion: pending.experimentalVersion ?? null,
       channel: selectedUpdateChannel(),
       error: t(
         "Return to beta did not finish. Your recovery files have been kept. Try again from Experimental builds.",
@@ -756,6 +779,7 @@ async function detectFailedHandoff(pending: {
     status: "error",
     installFailed: true,
     version: pending.version ?? null,
+    experimentalVersion: pending.experimentalVersion ?? null,
     handoff: plan,
     error: t("Harbor Setup did not finish updating Harbor. Check for updates to try again."),
     channel: pending.channel ?? selectedUpdateChannel(),
@@ -773,6 +797,7 @@ async function detectFailedUpdate(): Promise<boolean> {
     channel?: UpdateChannel;
     intent?: "update" | "return-beta";
     recoverable?: boolean;
+    experimentalVersion?: string;
   } | null = null;
   try {
     pending = JSON.parse(localStorage.getItem(PENDING_KEY) ?? "null");
@@ -844,6 +869,7 @@ export function clearStagedUpdate(): void {
     intent: "update",
     status: "idle",
     version: null,
+    experimentalVersion: null,
     notes: null,
     progress: 0,
     downloadedBytes: 0,

--- a/src/views/settings/advanced-panel/about-tab.tsx
+++ b/src/views/settings/advanced-panel/about-tab.tsx
@@ -4,6 +4,7 @@ import { Check, RotateCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { IS_BETA_BUILD } from "@/lib/build-info";
 import { useT } from "@/lib/i18n";
+import { readBetaReturnContext } from "@/lib/updater/beta-return";
 import { ROW_DESC, Section } from "../shared";
 import { SettingRow } from "../kit";
 import { Signature } from "../signature";
@@ -36,11 +37,16 @@ export function AboutTab() {
 
 function AboutRow() {
   const t = useT();
+  const experimental = readBetaReturnContext(__APP_VERSION__);
   return (
     <>
       <InfoLine
         label={t("Version")}
-        value={`${__APP_VERSION__}${IS_BETA_BUILD ? ` (${t("Beta")})` : ""}`}
+        value={
+          experimental
+            ? `${experimental.experimentalVersion} (${t("Experimental")})`
+            : `${__APP_VERSION__}${IS_BETA_BUILD ? ` (${t("Beta")})` : ""}`
+        }
       />
       <InfoLine label={t("Build")} value={isTauri ? t("Desktop (Tauri 2 / WebView2)") : t("Web")} />
       <InfoLine label={t("Bug reports")} value="bugs@harbor.site" />

--- a/src/views/settings/advanced-panel/update-rows.tsx
+++ b/src/views/settings/advanced-panel/update-rows.tsx
@@ -2,6 +2,7 @@ import { Download, FlaskConical, Loader2, RotateCw } from "lucide-react";
 import { useId, useState } from "react";
 import { useSettings } from "@/lib/settings";
 import { readChannelPreference, selectedUpdateChannel } from "@/lib/updater/channel";
+import { readBetaReturnContext } from "@/lib/updater/beta-return";
 import {
   checkForUpdate,
   setUpdateChannel,
@@ -76,6 +77,7 @@ export function BetaChannelRow() {
 export function UpdatesRow() {
   const t = useT();
   const u = useUpdate();
+  const installedExperimental = readBetaReturnContext(__APP_VERSION__);
   const ready = u.intent !== "return-beta" && updateAvailable(u);
   const busy = u.intent === "return-beta" || u.status === "checking" || u.status === "installing";
   const status =
@@ -112,9 +114,13 @@ export function UpdatesRow() {
       label={
         <span className="inline-flex min-w-0 flex-wrap items-center gap-2">
           <span className="min-w-0">
-            {ready && u.version
-              ? t("Harbor {version} available", { version: u.version })
-              : `Harbor ${__APP_VERSION__}`}
+            {ready && u.channel === "experimental" && u.experimentalVersion
+              ? `${t("Experimental")} ${u.experimentalVersion}`
+              : ready && u.version
+                ? t("Harbor {version} available", { version: u.version })
+                : installedExperimental
+                  ? `${t("Experimental")} ${installedExperimental.experimentalVersion}`
+                  : `Harbor ${__APP_VERSION__}`}
           </span>
           {u.channel === "experimental" ? (
             <span className={`${QUAL} bg-accent-soft text-accent`}>{t("Experimental")}</span>

--- a/src/views/settings/experimental-builds-section.tsx
+++ b/src/views/settings/experimental-builds-section.tsx
@@ -28,7 +28,8 @@ export function ExperimentalBuildsSection() {
   const trigger = useRef<HTMLButtonElement>(null);
   const confirmationId = useId();
   const access = useExperimentalAccess();
-  const experimentalInstalled = readBetaReturnContext(__APP_VERSION__) !== null;
+  const installedContext = readBetaReturnContext(__APP_VERSION__);
+  const experimentalInstalled = installedContext !== null;
   const enabled = selectedUpdateChannel() === "experimental";
   const supported = isWindowsDesktop();
   const locked = updateChannelLocked();
@@ -75,9 +76,9 @@ export function ExperimentalBuildsSection() {
             ? t("Checking experimental builds…")
             : u.status === "uptodate"
               ? t("No newer experimental build is available for this device.")
-              : ready && u.version
+              : ready && u.experimentalVersion
                 ? t("Experimental {version} · Build {buildId}", {
-                    version: u.version,
+                    version: u.experimentalVersion,
                     buildId: u.buildId ?? "—",
                   })
                 : t("Experimental updates are enabled on this device.")))
@@ -98,7 +99,9 @@ export function ExperimentalBuildsSection() {
             )}
           </p>
           <p className="text-[12px] text-ink-muted">
-            {t("Installed: Harbor {version}", { version: __APP_VERSION__ })}
+            {experimentalInstalled
+              ? `${t("Installed")}: ${t("Experimental")} ${installedContext.experimentalVersion}`
+              : t("Installed: Harbor {version}", { version: __APP_VERSION__ })}
             {" · "}
             {t("Update channel: {channel}", { channel: enabled ? t("Experimental") : normal })}
           </p>

--- a/src/views/settings/experimental-builds-section.tsx
+++ b/src/views/settings/experimental-builds-section.tsx
@@ -177,8 +177,7 @@ export function ExperimentalBuildsSection() {
           {enabled && (
             <p className="text-[12px] leading-relaxed text-ink-subtle">
               {t(
-                "Leaving returns you to {channel} updates when a newer version is available. It does not downgrade Harbor.",
-                { channel: normal },
+                "Leaving only turns off experimental checks. Use Return to beta below to replace the experimental app.",
               )}
             </p>
           )}

--- a/tests/updater-experimental.test.ts
+++ b/tests/updater-experimental.test.ts
@@ -479,6 +479,7 @@ test("manifest validation uses exact architecture, HTTPS, signatures and unchang
   wrongPayload.installer["windows-x86_64"].payloadVersion++;
   assert.equal(experimental.parseExperimentalRelease(wrongPayload, "windows-x86_64"), null);
   assert.equal(experimental.experimentalPayloadVersion("0.9.123"), 9123);
+  assert.equal(experimental.experimentalPayloadVersion("0.999.1"), 999001);
   assert.equal(experimental.experimentalChannelVersion("0.0.1"), 1);
   for (const version of ["0.1000.1", "0.9.1000", "0.09.123", "0.9.123-beta", "0.9.123.1"]) {
     assert.equal(experimental.experimentalPayloadVersion(version), null);

--- a/tests/updater-experimental.test.ts
+++ b/tests/updater-experimental.test.ts
@@ -62,6 +62,7 @@ function manifest() {
   return {
     channel: "experimental",
     version: "0.9.123",
+    experimentalVersion: "0.0.1",
     buildId: "abc1234",
     notes: "Test fixes",
     platforms: {
@@ -424,6 +425,8 @@ test("experimental rejects stable fallback, empty feed, missing platforms and ma
     { version: "0.9.123", platforms: manifest().platforms },
     { ...manifest(), channel: "beta" },
     { ...manifest(), buildId: "" },
+    { ...manifest(), experimentalVersion: "0.0.0" },
+    { ...manifest(), experimentalVersion: "1.0.0" },
     { ...manifest(), version: "0.9.123-exp.2" },
     { ...manifest(), platforms: {} },
     { ...manifest(), installer: [] },
@@ -476,6 +479,7 @@ test("manifest validation uses exact architecture, HTTPS, signatures and unchang
   wrongPayload.installer["windows-x86_64"].payloadVersion++;
   assert.equal(experimental.parseExperimentalRelease(wrongPayload, "windows-x86_64"), null);
   assert.equal(experimental.experimentalPayloadVersion("0.9.123"), 9123);
+  assert.equal(experimental.experimentalChannelVersion("0.0.1"), 1);
   for (const version of ["0.1000.1", "0.9.1000", "0.09.123", "0.9.123-beta", "0.9.123.1"]) {
     assert.equal(experimental.experimentalPayloadVersion(version), null);
   }
@@ -607,6 +611,7 @@ test("explicit return verifies the exact approved target, backs up, and does not
   h.updater.setExperimentalUpdates(true);
   h.betaReturn.saveBetaReturnContext(
     "0.9.123",
+    "0.0.1",
     "abc1234",
     "windows-x86_64",
     manifest().returnToBeta,
@@ -633,6 +638,7 @@ test("failed approval, signature, backup or launch never silently switches to be
     h.updater.setExperimentalUpdates(true);
     h.betaReturn.saveBetaReturnContext(
       "0.9.123",
+      "0.0.1",
       "abc1234",
       "windows-x86_64",
       manifest().returnToBeta,


### PR DESCRIPTION
## Why this bootstrap is required
The live beta feed already serves 0.9.123, and that package was built before PR #1381 merged. Existing 0.9.123 testers will not reinstall an equal version, so the experimental-updater bootstrap needs beta 0.9.124.

## Changes
- bump Harbor and Harbor Setup from beta 0.9.123 to beta 0.9.124
- give the experimental channel its own tester-facing sequence beginning at 0.0.1
- reserve the internal 0.999.x package line for experimental installers
- keep the public beta sequence independent and keep stable/beta feed behavior unchanged
- direct installed experimental users to the tested Return to beta action

## First rollout
- beta bootstrap: Harbor 0.9.124
- tester-facing experimental release: Experimental 0.0.1
- experimental package compatibility version: Harbor 0.999.1
- tested return target: beta 0.9.124
- next public beta remains available as 0.9.125

## Validation
- 24 experimental updater tests pass
- TypeScript project check passes
- changed-file Vite+ check passes
- application cargo check passes
- installer cargo check passes
- all eight beta version declarations agree on 0.9.124

The subtitle fix remains in draft PR #1382 until Experimental 0.0.1 passes tester validation.