### PR TITLE
fix(updater): bootstrap managed experimental handoff

### DIFF
--- a/installer/EXPERIMENTAL-UPDATES.md
+++ b/installer/EXPERIMENTAL-UPDATES.md
@@ -27,12 +27,13 @@ The app now has **Return to beta** under Experimental builds. This is separate
 from **Leave experimental builds**, which only changes the future update feed.
 Normal stable/beta update discovery remains upgrade-only.
 
-Automatic experimental installation and return are currently gated to managed
-Windows x86_64 installations. The publisher/edge can still describe macOS, but
-this app will not install an experimental build without its tested, recoverable
-return path. Older Windows/NSIS and macOS automatic return are not implemented.
-The earlier cross-platform experimental-install descriptions below predate this
-safety gate and are not release-readiness claims.
+Automatic experimental installation and return are currently gated to Windows
+x86_64 installations with a tested recovery path. A signed recoverable handoff
+can bootstrap the recovery marker for a legacy NSIS installation immediately
+before Harbor Setup starts; subsequent handoffs are managed normally. The
+publisher/edge can still describe macOS, but this app will not install an
+experimental build there. The earlier cross-platform experimental-install
+descriptions below predate this safety gate and are not release-readiness claims.
 
 See [RETURN-TO-BETA.md](RETURN-TO-BETA.md) for the new installer protocol,
 publisher approval contract, recovery paths and required packaged tests. No real
@@ -175,12 +176,14 @@ Requirements enforced by the app:
 - Each supported exact OS/architecture has an HTTPS URL with no embedded
   credentials/fragment and a nonempty signature. Do not include top-level
   dynamic `url` or `signature` fields alongside `platforms`.
-- A managed Windows installation requires the separate `installer` entry, with a
+- A Windows recoverable handoff requires the separate `installer` entry, with a
   positive integer byte size and the unchanged payload formula:
   `major * 1_000_000 + minor * 1_000 + patch`.
 - `platforms.windows-x86_64` stays the legacy Tauri/NSIS artifact. Never replace
-  it with the new Harbor Setup executable. Managed Windows uses `installer`;
-  legacy Windows and macOS use the native Tauri updater.
+  it with the new Harbor Setup executable. Normal beta updates use this artifact;
+  experimental installation and return use `installer`, including the first
+  automatic handoff from an existing NSIS installation. macOS uses the native
+  Tauri updater only after its own return path is implemented and certified.
 - Native updater metadata must match the app's preflight version, build ID,
   platform URL and signature. If publishing changes between those checks, the
   user is asked to check again. Actual bytes still require native signature

--- a/installer/RETURN-TO-BETA.md
+++ b/installer/RETURN-TO-BETA.md
@@ -2,10 +2,12 @@
 
 ## Status and scope
 
-Implemented locally; not release-certified or published. Managed Windows x86_64
-only. No signed artifact was produced, no real installer was run, and no stable,
-beta or experimental server object was changed. macOS/legacy Windows return and
-Linux builds remain release gates, not assumed successes.
+Implemented locally; not release-certified or published. Windows x86_64 only.
+A signed recoverable handoff can bootstrap an existing legacy NSIS installation;
+future experimental installs and returns then use the managed installer. No signed
+artifact was produced by this change, no real installer was run, and no stable,
+beta or experimental server object was changed. macOS and Linux builds remain
+release gates, not assumed successes.
 
 ## Tester flow
 
@@ -13,7 +15,9 @@ Linux builds remain release gates, not assumed successes.
 2. An experimental build is installable only when its manifest approves at least
    one compatible beta and declares recovery protocol 1 for Harbor Setup.
 3. Download, then approve installation. Harbor saves a local `.harbx` backup and
-   the source build's approved return choices. The installer keeps the previous
+   the source build's approved return choices. If this copy originally came from
+   NSIS, Harbor creates its recovery marker only after verifying the signed Setup
+   executable and immediately before launch. The installer keeps the previous
    application directory until the new main UI acknowledges successful startup.
 4. To finish testing, choose **Return to beta**, select an approved version,
    download/verify, then **Install beta … and restart**.
@@ -130,8 +134,9 @@ authorized:
 1. Install the proposed beta, enter experimental, select and return to that exact
    beta; confirm version, beta feed, addon order, profiles, settings, watch
    progress and latest selected subtitles. Repeat after leaving experimental.
-2. Test fresh and existing managed installs, paths with spaces, limited free
-   space, locked files, non-writable directories, tampered downloads and signatures.
+2. Test fresh managed installs and legacy NSIS upgrades, paths with spaces,
+   limited free space, locked files, non-writable directories, tampered downloads
+   and signatures. Confirm a corrupt pre-existing marker is never overwritten.
 3. Inject failure during extraction, each directory rename, registration,
    relaunch and pre-ack startup. Confirm automatic recovery or the documented
    manual recovery command; never mistake a newer running app for success.

--- a/src-tauri/src/installer_handoff.rs
+++ b/src-tauri/src/installer_handoff.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -30,6 +30,69 @@ static STAGED: Mutex<Option<Staged>> = Mutex::new(None);
 #[serde(rename_all = "camelCase")]
 struct InstallMarker {
     payload_version: Option<u64>,
+}
+
+fn read_install_marker(dest: &Path) -> Option<InstallMarker> {
+    std::fs::read_to_string(dest.join(MARKER))
+        .ok()
+        .and_then(|text| serde_json::from_str::<InstallMarker>(&text).ok())
+}
+
+fn payload_version(version: &str) -> Result<u64, String> {
+    let parts: Vec<_> = version.split('.').collect();
+    if parts.len() != 3
+        || parts
+            .iter()
+            .any(|part| part.is_empty() || !part.bytes().all(|c| c.is_ascii_digit()))
+    {
+        return Err("the running Harbor version cannot be used for installer recovery".into());
+    }
+    let major = parts[0].parse::<u64>().map_err(|e| e.to_string())?;
+    let minor = parts[1].parse::<u64>().map_err(|e| e.to_string())?;
+    let patch = parts[2].parse::<u64>().map_err(|e| e.to_string())?;
+    if minor >= 1_000 || patch >= 1_000 {
+        return Err("the running Harbor version cannot be used for installer recovery".into());
+    }
+    major
+        .checked_mul(1_000_000)
+        .and_then(|value| value.checked_add(minor * 1_000))
+        .and_then(|value| value.checked_add(patch))
+        .ok_or_else(|| "the running Harbor version cannot be used for installer recovery".into())
+}
+
+fn ensure_recovery_marker(dest: &Path, version: &str) -> Result<bool, String> {
+    let marker = dest.join(MARKER);
+    if marker.exists() {
+        return read_install_marker(dest)
+            .filter(|value| value.payload_version.unwrap_or(0) > 0)
+            .map(|_| false)
+            .ok_or_else(|| "the existing Harbor install marker is invalid".into());
+    }
+    if !dest.join("harbor.exe").is_file() {
+        return Err("the Harbor installation is missing harbor.exe".into());
+    }
+    let installed_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    let body = serde_json::json!({
+        "payloadVersion": payload_version(version)?,
+        "version": version,
+        "installedAt": installed_at,
+        "installer": "harbor-bootstrap",
+    });
+    let mut file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&marker)
+        .map_err(|e| format!("cannot create the Harbor install marker: {e}"))?;
+    serde_json::to_writer_pretty(&mut file, &body)
+        .map_err(|e| format!("cannot write the Harbor install marker: {e}"))?;
+    file.write_all(b"\n")
+        .map_err(|e| format!("cannot write the Harbor install marker: {e}"))?;
+    file.sync_all()
+        .map_err(|e| format!("cannot flush the Harbor install marker: {e}"))?;
+    Ok(true)
 }
 
 #[derive(Serialize)]
@@ -80,17 +143,18 @@ fn platform_key() -> String {
 #[tauri::command]
 pub fn handoff_probe() -> HandoffProbe {
     let dir = install_dir();
-    let marker = dir
+    let marker = dir.as_deref().and_then(read_install_marker);
+    let payload_version = marker
         .as_ref()
-        .and_then(|d| std::fs::read_to_string(d.join(MARKER)).ok())
-        .and_then(|text| serde_json::from_str::<InstallMarker>(&text).ok());
+        .and_then(|value| value.payload_version)
+        .unwrap_or(0);
     HandoffProbe {
         supported: cfg!(target_os = "windows") && dir.is_some(),
-        managed: marker.is_some(),
+        managed: payload_version > 0,
         install_dir: dir
             .map(|d| d.to_string_lossy().to_string())
             .unwrap_or_default(),
-        payload_version: marker.and_then(|m| m.payload_version).unwrap_or(0),
+        payload_version,
         platform_key: platform_key(),
     }
 }
@@ -378,6 +442,9 @@ pub async fn handoff_launch(app: tauri::AppHandle) -> Result<(), String> {
     let pubkey = updater_pubkey(&app)?;
     tokio::task::spawn_blocking(move || {
         verify_setup(&setup, &signature, &pubkey)?;
+        if recoverable {
+            ensure_recovery_marker(&target, &from)?;
+        }
         spawn_setup(&setup, &target, &log, pid, &from, &version, recoverable)
     })
     .await
@@ -432,4 +499,48 @@ pub async fn handoff_save_backup(app: tauri::AppHandle, content: String) -> Resu
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> PathBuf {
+        std::env::temp_dir().join(format!("harbor-handoff-bootstrap-{}", uuid::Uuid::new_v4()))
+    }
+
+    #[test]
+    fn bootstraps_a_recoverable_nsis_install() {
+        let dest = fixture();
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("harbor.exe"), b"test").unwrap();
+
+        assert!(harbor_install_recovery::Transaction::begin(&dest, "0.999.1").is_err());
+        assert!(ensure_recovery_marker(&dest, "0.9.124").unwrap());
+
+        let marker: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dest.join(MARKER)).unwrap()).unwrap();
+        assert_eq!(marker["payloadVersion"], 9_124);
+        assert_eq!(marker["version"], "0.9.124");
+        assert_eq!(marker["installer"], "harbor-bootstrap");
+        assert!(!ensure_recovery_marker(&dest, "0.9.124").unwrap());
+
+        let transaction = harbor_install_recovery::Transaction::begin(&dest, "0.999.1").unwrap();
+        let recovery = transaction.root().to_path_buf();
+        drop(transaction);
+        std::fs::remove_dir_all(recovery).unwrap();
+        std::fs::remove_dir_all(dest).unwrap();
+    }
+
+    #[test]
+    fn refuses_to_replace_an_invalid_marker() {
+        let dest = fixture();
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("harbor.exe"), b"test").unwrap();
+        std::fs::write(dest.join(MARKER), b"not json").unwrap();
+
+        assert!(ensure_recovery_marker(&dest, "0.9.124").is_err());
+        assert_eq!(std::fs::read(dest.join(MARKER)).unwrap(), b"not json");
+        std::fs::remove_dir_all(dest).unwrap();
+    }
 }

--- a/src/lib/updater/beta-return.ts
+++ b/src/lib/updater/beta-return.ts
@@ -69,7 +69,10 @@ export function parseBetaReturnTargets(
 }
 
 export function betaReturnSupported(probe: HandoffProbe | null): boolean {
-  return !!probe?.supported && probe.managed && probe.platformKey === "windows-x86_64";
+  // A signed recoverable experimental handoff can bootstrap the marker for a
+  // Windows installation that arrived through NSIS. Harbor Setup writes the
+  // normal managed marker before the experimental app is allowed to remain.
+  return !!probe?.supported && probe.platformKey === "windows-x86_64";
 }
 
 export function readBetaReturnContext(installed?: string): BetaReturnContext | null {

--- a/src/lib/updater/experimental.ts
+++ b/src/lib/updater/experimental.ts
@@ -113,12 +113,7 @@ export function experimentalHandoff(
   probe: HandoffProbe,
 ): HandoffPlan | null {
   const entry = release.installer;
-  if (
-    !probe.supported ||
-    !probe.managed ||
-    !entry ||
-    entry.payloadVersion <= probe.payloadVersion
-  ) {
+  if (!probe.supported || !entry || entry.payloadVersion <= probe.payloadVersion) {
     return null;
   }
   return {

--- a/src/lib/updater/use-update.ts
+++ b/src/lib/updater/use-update.ts
@@ -295,18 +295,19 @@ export async function checkForUpdate(manual = false): Promise<void> {
         return;
       }
       const plan = experimentalHandoff(release, probe);
-      if (
-        !betaReturnSupported(probe) ||
-        plan?.recoveryProtocol !== 1 ||
-        !parseBetaReturnTargets(release.returnToBeta, release.version, probe.platformKey).length
-      ) {
+      const returnTargets = parseBetaReturnTargets(
+        release.returnToBeta,
+        release.version,
+        probe.platformKey,
+      );
+      if (!betaReturnSupported(probe) || !returnTargets.length) {
         set({
           status: "unavailable",
           error: t("No tested return to beta is available for this build."),
         });
         return;
       }
-      if (probe.supported && probe.managed && !plan) {
+      if (!plan || plan.recoveryProtocol !== 1) {
         set({
           status: "unavailable",
           error: t("No verified experimental build is available for this device yet."),

--- a/tests/updater-experimental.test.ts
+++ b/tests/updater-experimental.test.ts
@@ -486,20 +486,31 @@ test("manifest validation uses exact architecture, HTTPS, signatures and unchang
   }
 });
 
-test("unmanaged Windows and macOS cannot install without a supported recoverable return path", async () => {
-  for (const platform of ["windows-x86_64", "darwin-aarch64"]) {
-    const h = harness({ platform, managed: false });
-    h.updater.setExperimentalUpdates(true);
-    await h.updater.checkForUpdate(true);
-    assert.equal(h.updater.useUpdate().status, "unavailable");
-    assert.deepEqual(h.calls.headers, []);
-    assert.deepEqual(h.calls.fetchHeaders, [undefined]);
-    assert.ok(h.calls.fetchUrls[0].endsWith("/updates/latest-experimental.json"));
-    assert.equal(h.calls.download + h.calls.install, 0);
-    await h.updater.downloadUpdate();
-    await h.updater.installUpdate();
-    assert.equal(h.calls.install + h.calls.launch, 0);
-  }
+test("legacy NSIS Windows bootstraps through only the verified recoverable installer", async () => {
+  const h = harness({ managed: false });
+  h.updater.setExperimentalUpdates(true);
+  await h.updater.checkForUpdate(true);
+  assert.ok(h.updater.useUpdate().handoff?.verifiable);
+  assert.deepEqual(h.calls.headers, []);
+  assert.deepEqual(h.calls.fetchHeaders, [undefined]);
+  assert.ok(h.calls.fetchUrls[0].endsWith("/updates/latest-experimental.json"));
+  await h.updater.downloadUpdate();
+  await h.updater.installUpdate();
+  assert.equal(h.calls.stage, 1);
+  assert.equal(h.calls.backup, 1);
+  assert.equal(h.calls.launch, 1);
+  assert.equal(h.calls.download + h.calls.install, 0);
+});
+
+test("unsupported platforms and missing return approval cannot install experimental", async () => {
+  const mac = harness({ platform: "darwin-aarch64", managed: false });
+  mac.updater.setExperimentalUpdates(true);
+  await mac.updater.checkForUpdate(true);
+  assert.equal(mac.updater.useUpdate().status, "unavailable");
+  await mac.updater.downloadUpdate();
+  await mac.updater.installUpdate();
+  assert.equal(mac.calls.install + mac.calls.launch, 0);
+
   const h = harness();
   h.updater.setExperimentalUpdates(true);
   h.config.raw = { ...manifest(), returnToBeta: [] };
@@ -534,7 +545,7 @@ test("signature rejection and unsupported paths never permit an experimental ins
     await h.updater.checkForUpdate();
     h.config.signatureFailure = true;
     await h.updater.downloadUpdate();
-    assert.equal(h.updater.useUpdate().status, managed ? "error" : "unavailable");
+    assert.equal(h.updater.useUpdate().status, "error");
     await h.updater.installUpdate();
     await h.updater.openManualDownload();
     await h.updater.openHandoffDownload();


### PR DESCRIPTION
## Summary
- allow legacy Windows NSIS installs to use the signed recoverable Experimental handoff
- create and flush the recovery marker only after re-verifying Harbor Setup, immediately before launch
- fail closed for corrupt existing markers and keep macOS/unsupported paths blocked
- document the automatic NSIS-to-managed flow

## Tests
- pnpm run check -- installer/EXPERIMENTAL-UPDATES.md installer/RETURN-TO-BETA.md src-tauri/src/installer_handoff.rs src/lib/updater/beta-return.ts src/lib/updater/experimental.ts src/lib/updater/use-update.ts tests/updater-experimental.test.ts
- pnpm run typecheck
- node --experimental-loader ./scripts/node-test-loader.mjs --test tests/updater-experimental.test.ts (25 passed)
- cargo test --manifest-path src-tauri/Cargo.toml installer_handoff::tests (2 passed)
- cargo test --manifest-path harbor-install-recovery/Cargo.toml (5 passed)
- cargo check --manifest-path src-tauri/Cargo.toml