### PR TITLE
fix(anilist,mal): don't flip completed or re-watching entries on auto

### DIFF
--- a/src/lib/anilist/sync.ts
+++ b/src/lib/anilist/sync.ts
@@ -179,6 +179,11 @@ export async function syncAnimeProgress(
     const media = cur?.Media;
     if (!media) return;
 
+    // Never overwrite an entry the user deliberately moved to Completed or
+    // Re-watching; auto-sync would otherwise flip it back to CURRENT.
+    const entryStatus = media.mediaListEntry?.status;
+    if (entryStatus === "COMPLETED" || entryStatus === "REPEATING") return;
+
     const current = media.mediaListEntry?.progress ?? 0;
     const total = media.episodes ?? 0;
     let target = ep;

--- a/src/lib/mal/sync.ts
+++ b/src/lib/mal/sync.ts
@@ -54,7 +54,11 @@ function saveSent(map: SentMap): void {
 
 type EntryResponse = {
   num_episodes: number | null;
-  my_list_status: { num_episodes_watched: number; status: string } | null;
+  my_list_status: {
+    num_episodes_watched: number;
+    status: string;
+    is_rewatching: boolean;
+  } | null;
 };
 
 type SaveResponse = {
@@ -126,6 +130,11 @@ export async function syncMalProgress(
     const cur = await malRequest<EntryResponse>(
       `/anime/${malId}?fields=num_episodes,my_list_status`,
     );
+
+    // Never overwrite entries the user completed or marked as re-watching;
+    // auto-sync would otherwise flip completed/rewatching back to "watching".
+    const listStatus = cur?.my_list_status;
+    if (listStatus && (listStatus.status === "completed" || listStatus.is_rewatching)) return;
 
     const current = cur?.my_list_status?.num_episodes_watched ?? 0;
     const total = cur?.num_episodes ?? 0;


### PR DESCRIPTION
## Summary

Harbor's tracker auto-sync (syncAnimeProgress for AniList, syncMalProgress for MAL) rewrote both progress and a computed status on every episode play. When a user had deliberately set an entry to Completed or Re-watching, the next watched episode silently flipped it back to Watching. Both sync functions now bail out before any write when the stored status indicates the user finished the title or is deliberately re-watching it.

Two files changed: src/lib/anilist/sync.ts and src/lib/mal/sync.ts (+15/−1, no other files).

## Why

- On AniList, "Re-watching" is the API status REPEATING (the UI label is "Rewatching"); on MAL it is not a status at all — it is the is_rewatching flag on my_list_status, with the base status remaining watching or completed.
- Both sync functions computed status purely from progress (CURRENT/watching unless target >= total), so any sync past the stored progress overwrote the user's status.
- Completed was only incidentally protected (when stored progress already sat at the episode total); any case where target > current — e.g. the series' total episode count grew, or the rewatch reset progress — flipped COMPLETED → CURRENT / completed → watching.
- This fits Harbor's model: the tracker is the source of truth for the user's intent about status; auto-sync only reports watch progress. Completed/Re-watching entries are left untouched, and normal in-progress syncing (including auto-complete) is unchanged.
- The guard sits before the local "sent" watermark bookkeeping on purpose: skipping must not record a sync watermark, otherwise a stale watermark would suppress legitimate progress syncs after the user later moves the entry back to CURRENT/watching.

## Verification

- pnpm run typecheck (tsc -b --pretty false) — clean, zero errors.
- Code paths traced against the current my_list_status/mediaListEntry shapes; is_rewatching is already read the same way in src/lib/mal/lists.ts, and the AniList REPEATING value was confirmed against the official API docs (docs.anilist.co/reference/enum/medialiststatus).
Manual scenarios (to re-run after building):

  - AniList COMPLETED → play any episode → status stays Completed (was: could flip to Watching when target > current).
  - AniList REPEATING (Re-watching) → play episode 1 → status stays Re-watching.
  - AniList CURRENT → play → progress still syncs; last episode still auto-completes.
  - MAL completed → play → status stays completed.
  - MAL rewatch (is_rewatching: true, either base status) → play → status and is_rewatching unchanged.
  - MAL watching → play → progress still syncs; last episode still auto-completes.
  - No sync toast/event is emitted when a sync is skipped (no misleading "synced" feedback).

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files.
- [ ] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
