### PR TITLE
fix(theme): restore ElegantFin sidebar collapse and back alignment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1392,7 +1392,11 @@ function Shell({ onReady }: { onReady?: () => void }) {
   const peopleAlive = useIdleEvict(peopleTop);
 
   return (
-    <div data-kids={kidsTop || kid ? "on" : undefined} className="relative flex h-full">
+    <div
+      data-harbor-shell
+      data-kids={kidsTop || kid ? "on" : undefined}
+      className="relative flex h-full"
+    >
       {!settingsTop && !playerActive && !liveTop && !pickerTop && layout === "sidebar" && (
         <Sidebar />
       )}

--- a/src/chrome/account-menu/account-menu.tsx
+++ b/src/chrome/account-menu/account-menu.tsx
@@ -79,7 +79,11 @@ export function AccountMenu({
           }
         >
           {avatar("lg")}
-          <div className={`hidden min-w-0 flex-1 ${collapsed ? "" : "lg:block"}`}>
+          <div
+            data-harbor-sidebar-label
+            aria-hidden={collapsed || undefined}
+            className={`hidden min-w-0 flex-1 ${collapsed ? "" : "lg:block"}`}
+          >
             <div className="truncate text-[14.5px] font-medium tracking-tight text-ink">{name}</div>
             <div className="truncate text-[12px] text-ink-subtle">
               <SubtitleText active={activeProfile} profiles={ctrl.profiles} user={user} />

--- a/src/chrome/sidebar.tsx
+++ b/src/chrome/sidebar.tsx
@@ -27,6 +27,7 @@ export function Sidebar() {
 
   const { mark: customMark, wordmark: customWordmark } = useHarborLogo();
   const collapsed = settings.sidebarCollapsed;
+  const retainLabels = (settings.theme.preset as string) === "elegantfin" && !kid;
   const hybridBar =
     typeof window !== "undefined" &&
     "__TAURI_INTERNALS__" in window &&
@@ -38,6 +39,7 @@ export function Sidebar() {
       <aside
         aria-hidden={chromeHidden}
         data-harbor-sidebar
+        data-collapsed={collapsed ? "true" : "false"}
         className={`relative z-[60] flex w-[72px] shrink-0 flex-col border-e border-edge-soft bg-canvas transition-[opacity,transform,width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] ${
           collapsed ? "" : "lg:w-60"
         } ${
@@ -49,31 +51,40 @@ export function Sidebar() {
         {kid && <KidsSidebarDoodles />}
         <div
           data-tauri-drag-region
+          data-harbor-sidebar-brand
           className={`flex shrink-0 items-center justify-center gap-0.5 px-3 text-ink ${
             collapsed ? "" : "lg:justify-start lg:px-7"
           } ${hybridBar ? "h-12" : "h-20"}`}
         >
+          {!hybridBar && (
+            <span data-harbor-sidebar-mark className="inline-flex shrink-0">
+              {customMark ? (
+                <img
+                  src={customMark}
+                  alt=""
+                  draggable={false}
+                  className={`h-9 w-9 shrink-0 object-contain ${collapsed ? "" : "lg:h-10 lg:w-10"}`}
+                />
+              ) : (
+                <HarborMark className={`h-9 w-9 shrink-0 ${collapsed ? "" : "lg:h-10 lg:w-10"}`} />
+              )}
+            </span>
+          )}
           {!hybridBar &&
-            (customMark ? (
-              <img
-                src={customMark}
-                alt=""
-                draggable={false}
-                className={`h-9 w-9 shrink-0 object-contain ${collapsed ? "" : "lg:h-10 lg:w-10"}`}
-              />
-            ) : (
-              <HarborMark className={`h-9 w-9 shrink-0 ${collapsed ? "" : "lg:h-10 lg:w-10"}`} />
-            ))}
-          {!hybridBar && !collapsed &&
+            (!collapsed || retainLabels) &&
             (customWordmark ? (
               <img
                 src={customWordmark}
                 alt=""
                 draggable={false}
+                data-harbor-sidebar-label
+                aria-hidden={collapsed || undefined}
                 className="hidden h-8 w-auto object-contain lg:inline-block"
               />
             ) : kid ? (
               <span
+                data-harbor-sidebar-label
+                aria-hidden={collapsed || undefined}
                 className="hidden whitespace-nowrap text-[42px] font-bold leading-none tracking-tight lg:inline-flex lg:items-center"
                 style={{
                   fontFamily: '"Fredoka", "Baloo 2", system-ui, sans-serif',
@@ -92,6 +103,8 @@ export function Sidebar() {
               </span>
             ) : (
               <span
+                data-harbor-sidebar-label
+                aria-hidden={collapsed || undefined}
                 className="hidden whitespace-nowrap text-[44px] font-medium leading-none tracking-tight lg:inline"
                 style={{
                   fontFamily: '"Fraunces", "Iowan Old Style", "Georgia", serif',
@@ -114,13 +127,14 @@ export function Sidebar() {
           setView={setView}
           locked={locked}
           collapsed={collapsed}
+          retainLabels={retainLabels}
           hiddenTabs={hiddenTabs}
           onPinNav={(v) => setPendingPinView(v)}
         />
-        <div className={`relative p-2 ${collapsed ? "" : "lg:p-4"}`}>
+        <div data-harbor-sidebar-footer className={`relative p-2 ${collapsed ? "" : "lg:p-4"}`}>
           <div className={`flex flex-col gap-1 pb-1 ${collapsed ? "items-center" : ""}`}>
-            <SidebarBigPictureEntry collapsed={collapsed} />
-            <CollapseToggle collapsed={collapsed} />
+            <SidebarBigPictureEntry collapsed={collapsed} retainLabels={retainLabels} />
+            <CollapseToggle collapsed={collapsed} retainLabels={retainLabels} />
           </div>
           {locked ? (
             <div
@@ -131,10 +145,18 @@ export function Sidebar() {
               <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-edge-soft bg-elevated/50 text-ink-subtle">
                 <Lock size={17} />
               </div>
-              {!collapsed && (
-                <div className="hidden min-w-0 flex-1 lg:block">
-                  <div className="truncate text-[13.5px] font-medium text-ink-muted">{t("chrome.locked")}</div>
-                  <div className="truncate text-[12px] text-ink-subtle">{t("chrome.parentalOn")}</div>
+              {(!collapsed || retainLabels) && (
+                <div
+                  data-harbor-sidebar-label
+                  aria-hidden={collapsed || undefined}
+                  className="hidden min-w-0 flex-1 lg:block"
+                >
+                  <div className="truncate text-[13.5px] font-medium text-ink-muted">
+                    {t("chrome.locked")}
+                  </div>
+                  <div className="truncate text-[12px] text-ink-subtle">
+                    {t("chrome.parentalOn")}
+                  </div>
                 </div>
               )}
             </div>
@@ -166,6 +188,7 @@ function ScrollableNav({
   setView,
   locked,
   collapsed,
+  retainLabels,
   hiddenTabs,
   onPinNav,
 }: {
@@ -173,6 +196,7 @@ function ScrollableNav({
   setView: (v: View) => void;
   locked: boolean;
   collapsed: boolean;
+  retainLabels: boolean;
   hiddenTabs: Record<LockableTab, boolean>;
   onPinNav: (v: View) => void;
 }) {
@@ -241,6 +265,7 @@ function ScrollableNav({
               key={item.id}
               {...item}
               collapsed={collapsed}
+              retainLabels={retainLabels}
               big={!!kid}
               active={view === item.view}
               onClick={() => setView(item.view)}
@@ -252,6 +277,7 @@ function ScrollableNav({
               label="Play"
               big
               collapsed={collapsed}
+              retainLabels={retainLabels}
               active={false}
               onClick={() => {
                 setView("kids");
@@ -270,6 +296,7 @@ function ScrollableNav({
                 {...item}
                 gated={gated}
                 collapsed={collapsed}
+                retainLabels={retainLabels}
                 active={view === item.view}
                 onClick={() => (gated ? onPinNav(item.view) : setView(item.view))}
               />
@@ -339,6 +366,7 @@ function NavItem({
   onClick,
   gated,
   collapsed,
+  retainLabels = false,
   big,
   view,
 }: {
@@ -348,6 +376,7 @@ function NavItem({
   onClick?: () => void;
   gated?: boolean;
   collapsed?: boolean;
+  retainLabels?: boolean;
   big?: boolean;
   view?: View;
 }) {
@@ -375,7 +404,10 @@ function NavItem({
             : "text-ink-muted hover:bg-elevated/50 hover:text-ink"
       }`}
     >
-      <span className={`relative ${big ? "scale-110" : ""} ${gated ? "opacity-70" : ""}`}>
+      <span
+        data-harbor-sidebar-icon
+        className={`relative ${big ? "scale-110" : ""} ${gated ? "opacity-70" : ""}`}
+      >
         {render(Boolean(active || hovered), hovered)}
         {gated && (
           <span className="absolute -bottom-1 -end-1 flex h-4 w-4 items-center justify-center rounded-full bg-canvas text-ink-subtle ring-1 ring-edge">
@@ -383,8 +415,15 @@ function NavItem({
           </span>
         )}
       </span>
-      {!collapsed && <span className="hidden lg:inline">{text}</span>}
+      {(!collapsed || retainLabels) && (
+        <span
+          data-harbor-sidebar-label
+          aria-hidden={collapsed || undefined}
+          className="hidden lg:inline"
+        >
+          {text}
+        </span>
+      )}
     </button>
   );
 }
-

--- a/src/chrome/sidebar/big-picture-entry.tsx
+++ b/src/chrome/sidebar/big-picture-entry.tsx
@@ -6,7 +6,13 @@ import { useActiveKid } from "@/lib/profiles";
 import { SFX } from "@/lib/sfx";
 import { shouldOfferBigPicture } from "@/views/big-picture/bp-logic";
 
-export function SidebarBigPictureEntry({ collapsed }: { collapsed: boolean }) {
+export function SidebarBigPictureEntry({
+  collapsed,
+  retainLabels = false,
+}: {
+  collapsed: boolean;
+  retainLabels?: boolean;
+}) {
   const { settings } = useSettings();
   const t = useT();
   const kid = useActiveKid();
@@ -33,8 +39,18 @@ export function SidebarBigPictureEntry({ collapsed }: { collapsed: boolean }) {
         collapsed ? "w-9" : "w-full lg:justify-start lg:px-3"
       }`}
     >
-      <Monitor size={17} strokeWidth={1.8} className="shrink-0" />
-      {!collapsed && <span className="hidden text-[13px] font-medium lg:inline">{label}</span>}
+      <span data-harbor-sidebar-icon className="inline-flex shrink-0">
+        <Monitor size={17} strokeWidth={1.8} className="shrink-0" />
+      </span>
+      {(!collapsed || retainLabels) && (
+        <span
+          data-harbor-sidebar-label
+          aria-hidden={collapsed || undefined}
+          className="hidden text-[13px] font-medium lg:inline"
+        >
+          {label}
+        </span>
+      )}
     </button>
   );
 }

--- a/src/chrome/sidebar/collapse-toggle.tsx
+++ b/src/chrome/sidebar/collapse-toggle.tsx
@@ -2,13 +2,20 @@ import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useT } from "@/lib/i18n";
 import { useSettings } from "@/lib/settings";
 
-export function CollapseToggle({ collapsed }: { collapsed: boolean }) {
+export function CollapseToggle({
+  collapsed,
+  retainLabels = false,
+}: {
+  collapsed: boolean;
+  retainLabels?: boolean;
+}) {
   const { update } = useSettings();
   const t = useT();
   const label = collapsed ? t("Expand sidebar") : t("Collapse sidebar");
   return (
     <button
       type="button"
+      data-harbor-sidebar-toggle
       onClick={() => update({ sidebarCollapsed: !collapsed })}
       aria-label={label}
       aria-pressed={collapsed}
@@ -17,12 +24,22 @@ export function CollapseToggle({ collapsed }: { collapsed: boolean }) {
         collapsed ? "w-9" : "w-full lg:justify-start lg:px-3"
       }`}
     >
-      {collapsed ? (
-        <PanelLeftOpen size={17} strokeWidth={1.8} className="dir-icon" />
-      ) : (
-        <PanelLeftClose size={17} strokeWidth={1.8} className="dir-icon" />
+      <span data-harbor-sidebar-icon className="inline-flex shrink-0">
+        {collapsed ? (
+          <PanelLeftOpen size={17} strokeWidth={1.8} className="dir-icon" />
+        ) : (
+          <PanelLeftClose size={17} strokeWidth={1.8} className="dir-icon" />
+        )}
+      </span>
+      {(!collapsed || retainLabels) && (
+        <span
+          data-harbor-sidebar-label
+          aria-hidden={collapsed || undefined}
+          className="hidden text-[13px] font-medium lg:inline"
+        >
+          {t("Collapse")}
+        </span>
       )}
-      {!collapsed && <span className="hidden text-[13px] font-medium lg:inline">{t("Collapse")}</span>}
     </button>
   );
 }

--- a/src/chrome/topbar.tsx
+++ b/src/chrome/topbar.tsx
@@ -131,12 +131,14 @@ export function Topbar({ connecting = false }: { connecting?: boolean } = {}) {
       )}
       <div
           {...dragProps}
+          data-harbor-topbar-content
           className={`relative z-10 grid h-full grid-cols-[1fr_auto_1fr] items-center gap-3 px-4 sm:px-8 ${
             hybridBar ? "pt-11" : ""
           }`}
         >
           <div
             {...dragProps}
+            data-harbor-topbar-leading
             className={
               sidebarHidden
                 ? "pointer-events-auto flex h-full min-w-0 items-center justify-start gap-3"
@@ -171,6 +173,7 @@ export function Topbar({ connecting = false }: { connecting?: boolean } = {}) {
           </div>
           <div
             {...dragProps}
+            data-harbor-topbar-actions
             className="pointer-events-auto flex h-full items-center justify-end gap-2"
           >
           {!inSettings && (
@@ -427,6 +430,7 @@ function SearchPill() {
     <button
       type="button"
       data-tauri-drag-region="false"
+      data-harbor-search
       onClick={() => setOpen(true)}
       className={
         settings.liquidGlass

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -348,6 +348,10 @@ const elegantFinCss = `@import url("https://fonts.googleapis.com/css2?family=Int
   --ef-panel-glass: rgba(30, 40, 54, 0.95);
   --ef-hairline: #47505c;
   --ef-border-w: 0.06em;
+  --ef-rail-width: 72px;
+  --ef-drawer-width: 260px;
+  --ef-rail-space: 0px;
+  --ef-header-inset: 1rem;
   --ef-shine: linear-gradient(
     0deg,
     transparent 0%,
@@ -384,9 +388,14 @@ aside[data-harbor-sidebar] {
   inset-block: 0 !important;
   inset-inline-start: 0 !important;
   z-index: 120 !important;
-  width: 260px !important;
+  width: var(--ef-drawer-width) !important;
   transform: translateX(-103%);
-  transition: transform 170ms ease !important;
+  visibility: hidden;
+  pointer-events: none;
+  transition: width var(--duration-base) var(--ease-in-out),
+    transform var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out),
+    visibility 0s linear var(--duration-fast) !important;
   box-shadow: 0.5em 0 2.5em rgba(0, 0, 0, 0.5);
 }
 html[dir="rtl"] aside[data-harbor-sidebar] {
@@ -395,6 +404,104 @@ html[dir="rtl"] aside[data-harbor-sidebar] {
 html.ef-drawer-open aside[data-harbor-sidebar],
 html[dir="rtl"].ef-drawer-open aside[data-harbor-sidebar] {
   transform: translateX(0);
+  visibility: visible;
+  pointer-events: auto;
+  transition-duration: var(--duration-base), var(--duration-base), var(--duration-fast), 0s !important;
+  transition-delay: 0s !important;
+}
+aside[data-harbor-sidebar][data-collapsed="true"]:not([aria-hidden="true"]) {
+  width: var(--ef-rail-width) !important;
+  transform: translateX(0) !important;
+  visibility: visible;
+  pointer-events: auto;
+  box-shadow: none;
+  transition-delay: 0s !important;
+}
+/* The drawer stays fixed during morphing; only the pinned rail occupies page space. */
+html:has(aside[data-harbor-sidebar]:not([aria-hidden="true"])) {
+  --ef-header-inset: 4.25rem;
+}
+html:has(aside[data-harbor-sidebar][data-collapsed="true"]:not([aria-hidden="true"])) {
+  --ef-rail-space: var(--ef-rail-width);
+  --ef-header-inset: calc(var(--ef-rail-width) + 1rem);
+}
+[data-harbor-shell]::before {
+  content: "";
+  flex: none;
+  width: var(--ef-rail-space);
+  pointer-events: none;
+  transition: width var(--duration-base) var(--ease-in-out);
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-brand] {
+  justify-content: flex-start !important;
+  padding-inline: 12px !important;
+  gap: 4px !important;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-mark] {
+  flex: none;
+  width: 48px;
+  justify-content: center;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-mark] > :is(svg, img) {
+  width: 36px !important;
+  height: 36px !important;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-label] {
+  display: block !important;
+  flex-shrink: 0;
+  white-space: nowrap;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--duration-fast) var(--ease-out), visibility 0s;
+  transition-delay: calc(var(--duration-base) - var(--duration-fast)), 0s;
+}
+aside[data-harbor-sidebar][data-collapsed="true"] [data-harbor-sidebar-label] {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition-delay: 0s, var(--duration-fast);
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-brand] [data-harbor-sidebar-label] {
+  min-width: 0;
+  flex-shrink: 1;
+  overflow: hidden;
+}
+aside[data-harbor-sidebar] [data-harbor-nav] {
+  justify-content: flex-start !important;
+  padding-inline: 0 !important;
+  gap: 0 !important;
+  overflow: hidden;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-icon] {
+  display: inline-flex;
+  flex: none;
+  width: 40px;
+  justify-content: center;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-footer] {
+  padding-inline: 8px !important;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-footer] > .flex {
+  align-items: stretch !important;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-footer] > .flex > button {
+  width: 100% !important;
+  justify-content: flex-start !important;
+  padding-inline: 0 !important;
+  gap: 0 !important;
+  overflow: hidden;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-footer] [data-harbor-sidebar-icon] {
+  width: 56px;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-footer] > .relative > button {
+  justify-content: flex-start !important;
+  padding-inline: 4px !important;
+}
+aside[data-harbor-sidebar] [data-harbor-sidebar-footer] > .relative > button [data-harbor-sidebar-label] {
+  min-width: 0;
+  flex-shrink: 1;
+  overflow: hidden;
 }
 aside[data-harbor-sidebar] [data-tauri-drag-region] > span {
   font-family: "Inter", system-ui, sans-serif !important;
@@ -428,7 +535,7 @@ aside[data-harbor-sidebar] [data-tauri-drag-region] > span > span {
   background-color: color-mix(in srgb, var(--color-accent) 24%, transparent) !important;
   color: var(--color-accent) !important;
 }
-aside[data-harbor-sidebar].w-[72px] [data-harbor-nav][data-active],
+aside[data-harbor-sidebar][data-collapsed="true"] [data-harbor-nav][data-active],
 html:not(.lg) [data-harbor-nav][data-active] {
   box-shadow: inset 0 0 0 var(--ef-border-w) color-mix(in srgb, var(--color-accent) 55%, transparent) !important;
 }
@@ -449,13 +556,17 @@ aside[data-harbor-sidebar] > div:last-child .bg-elevated/50 {
 /* ==========================================================================
    TOP HEADER BAR  (glass it: blur10 + bottom hairline on the inner grid)
    ========================================================================== */
-header.fixed.inset-x-0.top-0 > div {
+[data-harbor-topbar-content] {
   background-color: transparent !important;
   background-image: none !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   border-bottom: 0 !important;
-  padding-inline-start: 4.25rem !important;
+  padding-inline-start: var(--ef-header-inset) !important;
+  transition: padding-inline-start var(--duration-base) var(--ease-in-out);
+}
+[data-harbor-topbar-leading] {
+  padding-inline-start: 0 !important;
 }
 .harbor-search-pill {
   background-color: color-mix(in srgb, var(--color-raised) 45%, transparent) !important;
@@ -779,9 +890,6 @@ textarea {
   opacity: 1;
   background-color: rgba(255, 255, 255, 0.08);
 }
-header.fixed.inset-x-0.top-0 > div > :first-child button.rounded-full {
-  display: none !important;
-}
 .harbor-search-pill {
   display: none !important;
 }
@@ -830,9 +938,11 @@ header.fixed.inset-x-0.top-0 > div > :first-child button.rounded-full {
   object-fit: cover;
   border-radius: 999px;
 }
-html.ef-drawer-open #ef-topleft {
+html.ef-drawer-open #ef-topleft,
+html:has(aside[data-harbor-sidebar][data-collapsed="true"]) #ef-topleft {
   opacity: 0;
   pointer-events: none;
+  visibility: hidden;
 }
 #ef-scrim {
   pointer-events: none;
@@ -841,18 +951,30 @@ html.ef-drawer-open #ef-topleft {
   z-index: 85;
   background: rgba(9, 13, 21, 0.5);
   opacity: 0;
-  transition: opacity 170ms ease;
+  transition: opacity var(--duration-fast) var(--ease-out);
 }
-html.ef-drawer-open #ef-scrim {
+html.ef-drawer-open:has(aside[data-harbor-sidebar][data-collapsed="false"]:not([aria-hidden="true"])) #ef-scrim {
   pointer-events: auto;
   opacity: 1;
 }
 html:not(:has(header.fixed.inset-x-0.top-0)) #ef-topleft,
 html:not(:has(aside[data-harbor-sidebar])) #ef-menu,
-html:not(:has(aside[data-harbor-sidebar])) #ef-home,
 html:not(:has(aside[data-harbor-sidebar])) #ef-profile,
 html:not(:has(aside[data-harbor-sidebar])) #ef-scrim {
   display: none !important;
+}
+@media (prefers-reduced-motion: reduce) {
+  aside[data-harbor-sidebar],
+  aside[data-harbor-sidebar] [data-harbor-sidebar-label],
+  html.ef-drawer-open aside[data-harbor-sidebar],
+  html[dir="rtl"].ef-drawer-open aside[data-harbor-sidebar],
+  [data-harbor-shell]::before,
+  [data-harbor-topbar-content],
+  #ef-topleft,
+  #ef-scrim {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+  }
 }
 
 /* ==========================================================================
@@ -966,12 +1088,6 @@ main.absolute.inset-0 .rounded-xl.border.bg-elevated\\/70 {
 
 function buildElegantFinHtml(): string {
   return `<div id="ef-topleft">
-  <button id="ef-back" type="button" aria-label="${escapeGeneratedHtml(t("Back"))}" style="display:none">
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M19 12H5m0 0l7 7m-7-7l7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-  </button>
-  <button id="ef-home" type="button" aria-label="${escapeGeneratedHtml(t("Home"))}" style="display:none">
-    <svg width="19" height="19" viewBox="0 0 24 24" fill="none"><path d="M3 10.5L12 3l9 7.5M5.5 8.5V20a1 1 0 001 1H10v-6h4v6h3.5a1 1 0 001-1V8.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-  </button>
   <button id="ef-menu" type="button" aria-label="${escapeGeneratedHtml(t("Menu"))}">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M4 6.5h16M4 12h16M4 17.5h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
   </button>
@@ -986,13 +1102,45 @@ function buildElegantFinJs(): string {
     try { w.__efChromeCleanup(); } catch (e) {}
   }
   var root = document.documentElement;
-  function setOpen(open) {
-    if (open === undefined) root.classList.toggle("ef-drawer-open");
-    else if (open) root.classList.add("ef-drawer-open");
-    else root.classList.remove("ef-drawer-open");
+  var sidebar = null;
+  var sidebarParent = null;
+  var previousCollapsed = null;
+  var originalInert = false;
+  var observer = new MutationObserver(syncSidebar);
+  function syncAccess() {
+    var open = root.classList.contains("ef-drawer-open");
+    var hidden = !sidebar || sidebar.getAttribute("aria-hidden") === "true";
+    var collapsed = sidebar && sidebar.getAttribute("data-collapsed") === "true";
+    if (sidebar) sidebar.inert = hidden || (!collapsed && !open);
+    var menu = document.getElementById("ef-menu");
+    if (menu) menu.setAttribute("aria-expanded", String(open && !hidden && !collapsed));
   }
-  function realBack() {
-    return document.querySelector("header.fixed.inset-x-0.top-0 > div > :first-child button.rounded-full");
+  function setOpen(open) {
+    if (open === undefined) open = !root.classList.contains("ef-drawer-open");
+    root.classList.toggle("ef-drawer-open", !!open && !!sidebar && sidebar.getAttribute("aria-hidden") !== "true");
+    syncAccess();
+  }
+  function syncSidebar() {
+    var next = document.querySelector("aside[data-harbor-sidebar]");
+    if (next !== sidebar) {
+      if (sidebar) sidebar.inert = originalInert;
+      observer.disconnect();
+      sidebar = next;
+      previousCollapsed = null;
+      originalInert = sidebar ? sidebar.inert : false;
+      if (sidebar) sidebarParent = sidebar.parentElement;
+      if (sidebarParent) observer.observe(sidebarParent, { childList: true });
+      if (sidebar) observer.observe(sidebar, { attributes: true, attributeFilter: ["data-collapsed", "aria-hidden"] });
+      setOpen(false);
+    }
+    if (!sidebar || sidebar.getAttribute("aria-hidden") === "true") {
+      setOpen(false);
+      return;
+    }
+    var collapsed = sidebar.getAttribute("data-collapsed") === "true";
+    if (previousCollapsed !== null && previousCollapsed !== collapsed) setOpen(!collapsed);
+    previousCollapsed = collapsed;
+    syncAccess();
   }
   function onClick(e) {
     var t = e.target;
@@ -1001,18 +1149,12 @@ function buildElegantFinJs(): string {
       setOpen();
       return;
     }
-    if (t.closest("#ef-back")) {
-      var rb = realBack();
-      if (rb) rb.click();
-      return;
-    }
-    if (t.closest("#ef-home")) {
-      var home = document.querySelector("aside[data-harbor-sidebar] [data-harbor-nav]");
-      if (home) home.click();
+    if (t.closest("[data-harbor-sidebar-toggle]")) {
+      // React owns the saved preference; the observer follows its committed state.
       return;
     }
     if (t.closest("#ef-search")) {
-      var pill = document.querySelector(".harbor-search-pill");
+      var pill = document.querySelector("[data-harbor-search]");
       if (pill) pill.click();
       return;
     }
@@ -1027,6 +1169,10 @@ function buildElegantFinJs(): string {
           opened = w.harbor.tryViewMyProfile() === true;
         }
       } catch (e) {}
+      if (!opened && sidebar && sidebar.getAttribute("data-collapsed") === "true") {
+        var expand = sidebar.querySelector("[data-harbor-sidebar-toggle]");
+        if (expand) expand.click();
+      }
       setOpen(!opened);
       return;
     }
@@ -1034,23 +1180,17 @@ function buildElegantFinJs(): string {
       setOpen(false);
       return;
     }
-    var bottom = t.closest("aside[data-harbor-sidebar] > div:last-child");
-    if (bottom && t.closest("button") && !t.closest("div.relative")) {
-      e.preventDefault();
-      e.stopPropagation();
-      setOpen(false);
-    }
   }
   function onKey(e) {
-    if (e.key === "Escape") setOpen(false);
+    if (e.key !== "Escape") return;
+    var restoreFocus = sidebar && sidebar.getAttribute("data-collapsed") !== "true" && sidebar.contains(document.activeElement);
+    setOpen(false);
+    var menu = document.getElementById("ef-menu");
+    if (restoreFocus && menu) menu.focus({ preventScroll: true });
   }
   function tick() {
-    var back = document.getElementById("ef-back");
-    var home = document.getElementById("ef-home");
-    var showNav = realBack() ? "flex" : "none";
-    if (back && back.style.display !== showNav) back.style.display = showNav;
-    if (home && home.style.display !== showNav) home.style.display = showNav;
-    var cluster = document.querySelector("header.fixed.inset-x-0.top-0 > div > :last-child");
+    syncSidebar();
+    var cluster = document.querySelector("[data-harbor-topbar-actions]");
     var prof = document.getElementById("ef-profile");
     if (!cluster) return;
     var search = document.getElementById("ef-search");
@@ -1096,6 +1236,8 @@ function buildElegantFinJs(): string {
   var iv = w.setInterval(tick, 800);
   tick();
   var cleanup = function () {
+    observer.disconnect();
+    if (sidebar) sidebar.inert = originalInert;
     root.classList.remove("ef-drawer-open");
     document.removeEventListener("click", onClick, true);
     window.removeEventListener("keydown", onKey);

--- a/tests/elegantfin-profile-navigation.test.ts
+++ b/tests/elegantfin-profile-navigation.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import ts from "typescript";
 import { requestOpenProfile, subscribeOpenProfile } from "../src/lib/social/open-profile.ts";
 import { WINDOW_HARBOR } from "../src/views/settings/theme-panel/theme-studio/cheat-sheet-data.ts";
+import { createThemeDom } from "./helpers/elegantfin-dom.ts";
 
 const appText = readFileSync(new URL("../src/App.tsx", import.meta.url), "utf8");
 const appSource = ts.createSourceFile(
@@ -183,7 +184,6 @@ test("Theme Studio documents the immediate boolean profile API", () => {
   );
 });
 
-type Listener = (event: unknown) => void;
 type ImmediateApi = { tryViewMyProfile?: () => unknown };
 
 function elegantFinScript(): string {
@@ -216,90 +216,45 @@ function elegantFinScript(): string {
   return script;
 }
 
-function mountElegantFin(api?: ImmediateApi) {
-  const tokens = new Set<string>();
-  const classList = {
-    add: (...names: string[]) => names.forEach((name) => tokens.add(name)),
-    remove: (...names: string[]) => names.forEach((name) => tokens.delete(name)),
-    contains: (name: string) => tokens.has(name),
-    toggle: (name: string) => {
-      if (tokens.has(name)) {
-        tokens.delete(name);
-        return false;
-      }
-      tokens.add(name);
-      return true;
-    },
-  };
-  const documentListeners = new Map<string, Set<Listener>>();
-  const windowListeners = new Map<string, Set<Listener>>();
-  const clearedIntervals = new Set<number>();
-  const add = (listenersByType: Map<string, Set<Listener>>, type: string, listener: Listener) => {
-    const listeners = listenersByType.get(type) ?? new Set<Listener>();
-    listeners.add(listener);
-    listenersByType.set(type, listeners);
-  };
-  const remove = (
-    listenersByType: Map<string, Set<Listener>>,
-    type: string,
-    listener: Listener,
-  ) => {
-    listenersByType.get(type)?.delete(listener);
-  };
-  const documentStub = {
-    documentElement: { classList },
-    querySelector: () => null,
-    getElementById: () => null,
-    createElement: (tag: string) => {
-      throw new Error("Unexpected createElement(" + tag + ")");
-    },
-    addEventListener: (type: string, listener: Listener) => add(documentListeners, type, listener),
-    removeEventListener: (type: string, listener: Listener) =>
-      remove(documentListeners, type, listener),
-  };
-  type ThemeWindow = {
+function mountElegantFin(api?: ImmediateApi, collapsed = false) {
+  const dom = createThemeDom(`
+    <header class="fixed inset-x-0 top-0"><div>
+      <div data-harbor-topbar-leading><button id="native-back" class="rounded-lg">Back</button></div>
+      <div><button data-harbor-search class="harbor-search-pill">Search</button></div>
+      <div data-harbor-topbar-actions><div class="ms-1"></div></div>
+    </div></header>
+    <aside data-harbor-sidebar data-collapsed="${collapsed}" aria-hidden="false">
+      <div>Harbor</div><nav><button data-harbor-nav="home">Home</button></nav>
+      <div><div><button data-harbor-sidebar-toggle><svg><path></path></svg></button></div>
+        <div class="relative"><div class="h-12 w-12 rounded-full"><img src="/avatar.png"></div></div>
+      </div>
+    </aside>
+    <div id="ef-topleft"><button id="ef-menu">Menu</button></div><div id="ef-scrim"></div>
+  `);
+  const themeWindow = dom.window as typeof dom.window & {
     harbor?: ImmediateApi;
     __efChromeCleanup?: () => void;
     __harborThemeCleanup?: () => void;
-    setInterval: (listener: () => void, delay: number) => number;
-    clearInterval: (id: number) => void;
-    addEventListener: (type: string, listener: Listener) => void;
-    removeEventListener: (type: string, listener: Listener) => void;
   };
-  const windowStub: ThemeWindow = {
-    harbor: api,
-    setInterval: () => 41,
-    clearInterval: (id) => clearedIntervals.add(id),
-    addEventListener: (type, listener) => add(windowListeners, type, listener),
-    removeEventListener: (type, listener) => remove(windowListeners, type, listener),
-  };
-
-  new Function("window", "document", elegantFinScript())(windowStub, documentStub);
-
-  const click = (selector: string) => {
-    const target = {
-      closest(candidate: string) {
-        return candidate === selector ? target : null;
-      },
-    };
-    for (const listener of documentListeners.get("click") ?? []) {
-      listener({
-        target,
-        preventDefault() {},
-        stopPropagation() {},
-      });
-    }
-  };
-
+  themeWindow.harbor = api;
+  new Function("window", "document", "MutationObserver", "Element", elegantFinScript())(
+    themeWindow,
+    dom.document,
+    dom.Observer,
+    dom.Element,
+  );
+  dom.flush();
+  const root = dom.document.documentElement;
+  const sidebar = dom.document.querySelector("[data-harbor-sidebar]")!;
   return {
-    click,
-    drawerOpen: () => classList.contains("ef-drawer-open"),
-    setDrawerOpen: (open: boolean) =>
-      open ? classList.add("ef-drawer-open") : classList.remove("ef-drawer-open"),
-    cleanup: () => windowStub.__harborThemeCleanup?.(),
-    clickListenerCount: () => documentListeners.get("click")?.size ?? 0,
-    keyListenerCount: () => windowListeners.get("keydown")?.size ?? 0,
-    intervalWasCleared: () => clearedIntervals.has(41),
+    ...dom,
+    sidebar,
+    drawerOpen: () => root.classList.contains("ef-drawer-open"),
+    setDrawerOpen: (open: boolean) => root.classList.toggle("ef-drawer-open", open),
+    cleanup: () => themeWindow.__harborThemeCleanup?.(),
+    clickListenerCount: () => dom.listeners("click"),
+    keyListenerCount: () => dom.listeners("keydown"),
+    intervalWasCleared: () => dom.pendingIntervals() === 0,
   };
 }
 
@@ -320,8 +275,131 @@ test("ElegantFin cleanup removes drawer state and listeners", () => {
   assert.equal(harness.clickListenerCount(), 0);
   assert.equal(harness.keyListenerCount(), 0);
   assert.equal(harness.intervalWasCleared(), true);
+  assert.equal(harness.activeObservers(), 0);
+  assert.equal(harness.document.querySelector("#ef-profile"), null);
+  assert.equal(harness.document.querySelector("#ef-search"), null);
   harness.click("#ef-menu");
   assert.equal(harness.drawerOpen(), false);
+});
+
+test("ElegantFin Collapse reaches the native settings handler and dismisses the drawer", () => {
+  const harness = mountElegantFin({});
+  harness.click("#ef-menu");
+  let nativeCalls = 0;
+  const event = harness.click("[data-harbor-sidebar-toggle] path", () => {
+    nativeCalls += 1;
+    harness.sidebar.setAttribute("data-collapsed", "true");
+  });
+  assert.equal(nativeCalls, 1);
+  assert.equal(event.propagationStopped, false);
+  assert.equal(event.defaultPrevented, false);
+  assert.equal(harness.drawerOpen(), false);
+  assert.equal(harness.sidebar.getAttribute("data-collapsed"), "true");
+  harness.cleanup();
+});
+
+test("ElegantFin Expand reaches the native settings handler and opens the full drawer", () => {
+  const harness = mountElegantFin({}, true);
+  let nativeCalls = 0;
+  harness.click("[data-harbor-sidebar-toggle] path", () => {
+    nativeCalls += 1;
+    harness.sidebar.setAttribute("data-collapsed", "false");
+  });
+  assert.equal(nativeCalls, 1);
+  assert.equal(harness.drawerOpen(), true);
+  assert.equal(harness.sidebar.getAttribute("data-collapsed"), "false");
+  harness.cleanup();
+});
+
+test("ElegantFin observes a collapse setting change while the drawer is open", () => {
+  const harness = mountElegantFin({});
+  harness.click("#ef-menu");
+  harness.sidebar.setAttribute("data-collapsed", "true");
+  harness.flush();
+  assert.equal(harness.drawerOpen(), false);
+  harness.cleanup();
+});
+
+test("ElegantFin releases the scrim state when navigation unmounts the sidebar", () => {
+  const harness = mountElegantFin({});
+  harness.click("#ef-menu");
+  harness.sidebar.remove();
+  harness.flush();
+  assert.equal(harness.drawerOpen(), false);
+  harness.cleanup();
+});
+
+test("ElegantFin releases the scrim state when playback hides the sidebar", () => {
+  const harness = mountElegantFin({});
+  harness.click("#ef-menu");
+  harness.sidebar.setAttribute("aria-hidden", "true");
+  harness.flush();
+  assert.equal(harness.drawerOpen(), false);
+  harness.cleanup();
+});
+
+test("ElegantFin makes only the hidden drawer inert and restores focusability on cleanup", () => {
+  const harness = mountElegantFin({});
+  assert.equal(harness.sidebar.inert, true);
+  harness.click("#ef-menu");
+  assert.equal(harness.sidebar.inert, false);
+  harness.click("#ef-scrim");
+  assert.equal(harness.sidebar.inert, true);
+  harness.cleanup();
+  assert.equal(harness.sidebar.inert, false);
+});
+
+test("ElegantFin keeps collapsed navigation focusable without an open drawer", () => {
+  const harness = mountElegantFin({}, true);
+  assert.equal(harness.sidebar.inert, false);
+  harness.key("Escape");
+  assert.equal(harness.sidebar.inert, false);
+  assert.equal(harness.drawerOpen(), false);
+  harness.cleanup();
+});
+
+test("ElegantFin Escape returns focus from the closed drawer to its menu button", () => {
+  const harness = mountElegantFin({});
+  harness.click("#ef-menu");
+  harness.document.querySelector("[data-harbor-sidebar-toggle]")!.focus();
+  harness.key("Escape");
+  assert.equal(harness.drawerOpen(), false);
+  assert.equal(harness.document.activeElement.id, "ef-menu");
+  harness.cleanup();
+});
+
+test("ElegantFin Escape preserves focus inside the pinned rail", () => {
+  const harness = mountElegantFin({}, true);
+  const toggle = harness.document.querySelector("[data-harbor-sidebar-toggle]")!;
+  toggle.focus();
+  harness.key("Escape");
+  assert.equal(harness.document.activeElement === toggle, true);
+  assert.equal(harness.sidebar.getAttribute("data-collapsed"), "true");
+  assert.equal(harness.drawerOpen(), false);
+  harness.cleanup();
+});
+
+test("ElegantFin keeps the collapsed rail setting when Escape or navigation dismisses a drawer", () => {
+  const harness = mountElegantFin({}, true);
+  harness.key("Escape");
+  harness.click("[data-harbor-nav]");
+  assert.equal(harness.sidebar.getAttribute("data-collapsed"), "true");
+  assert.equal(harness.drawerOpen(), false);
+  harness.cleanup();
+});
+
+test("ElegantFin synchronizes one profile action when the native header is remounted", () => {
+  const harness = mountElegantFin({});
+  harness.document.querySelector("[data-harbor-topbar-actions]")!.innerHTML =
+    '<div class="ms-1"></div>';
+  harness.tick();
+  assert.equal(harness.document.querySelectorAll("#ef-profile").length, 1);
+  assert.equal(harness.document.querySelectorAll("#ef-search").length, 1);
+  assert.equal(
+    harness.document.querySelector("#ef-profile img")?.getAttribute("src"),
+    "/avatar.png",
+  );
+  harness.cleanup();
 });
 
 test("ElegantFin avatar closes the drawer when immediate navigation succeeds", () => {
@@ -350,6 +428,21 @@ test("ElegantFin avatar opens the drawer when no loaded profile is available", (
   harness.click("#ef-profile");
   assert.equal(calls, 1);
   assert.equal(harness.drawerOpen(), true);
+  harness.cleanup();
+});
+
+test("ElegantFin avatar expands the pinned rail through the native handler when profile navigation fails", () => {
+  const harness = mountElegantFin({ tryViewMyProfile: () => false }, true);
+  let nativeCalls = 0;
+  harness.bindClick("[data-harbor-sidebar-toggle]", () => {
+    nativeCalls += 1;
+    harness.sidebar.setAttribute("data-collapsed", "false");
+  });
+  harness.click("#ef-profile");
+  assert.equal(nativeCalls, 1);
+  assert.equal(harness.sidebar.getAttribute("data-collapsed"), "false");
+  assert.equal(harness.drawerOpen(), true);
+  assert.equal(harness.sidebar.inert, false);
   harness.cleanup();
 });
 

--- a/tests/helpers/elegantfin-dom.ts
+++ b/tests/helpers/elegantfin-dom.ts
@@ -1,0 +1,320 @@
+import { load, type CheerioAPI } from "cheerio";
+
+type Selection = ReturnType<CheerioAPI>;
+type Listener = (event: unknown) => void;
+type Mutation = { type: "attributes" | "childList"; target: DomElement; attributeName?: string };
+
+// Cheerio provides the real HTML parser and CSS selector engine. The adapter supplies
+// the browser mutation/event boundaries used by a generated theme script; layout is
+// deliberately left to the browser regression checks.
+export function createThemeDom(html: string) {
+  const $ = load(html);
+  const elements = new WeakMap<object, DomElement>();
+  const observers = new Set<Observer>();
+  const documentListeners = new Map<string, Set<Listener>>();
+  const windowListeners = new Map<string, Set<Listener>>();
+  const nativeClicks = new WeakMap<DomElement, () => void>();
+  const intervals = new Map<number, () => void>();
+  const tasks = new Map<number, () => void>();
+  let nextTimer = 1;
+
+  function wrap(selection: Selection): DomElement | null {
+    const node = selection.get(0);
+    if (!node) return null;
+    let element = elements.get(node);
+    if (!element) {
+      element = new DomElement(selection.first());
+      elements.set(node, element);
+    }
+    return element;
+  }
+
+  function notify(mutation: Mutation) {
+    for (const observer of observers) observer.receive(mutation);
+  }
+
+  class DomElement {
+    readonly style: Record<string, string> = {};
+    readonly selection: Selection;
+    constructor(selection: Selection) {
+      this.selection = selection;
+    }
+    get id() {
+      return this.getAttribute("id") ?? "";
+    }
+    set id(value: string) {
+      this.setAttribute("id", value);
+    }
+    get type() {
+      return this.getAttribute("type") ?? "";
+    }
+    set type(value: string) {
+      this.setAttribute("type", value);
+    }
+    get inert() {
+      return this.hasAttribute("inert");
+    }
+    set inert(value: boolean) {
+      if (value) {
+        this.setAttribute("inert", "");
+        if (this.contains(document.activeElement)) document.activeElement = document.body;
+      } else this.removeAttribute("inert");
+    }
+    get parentElement() {
+      return wrap(this.selection.parent());
+    }
+    get nextElementSibling() {
+      return wrap(this.selection.next());
+    }
+    get firstChild() {
+      return wrap(this.selection.children().first());
+    }
+    get isConnected() {
+      return this === document.documentElement || document.documentElement.contains(this);
+    }
+    get innerHTML() {
+      return this.selection.html() ?? "";
+    }
+    set innerHTML(value: string) {
+      this.selection.html(value);
+      notify({ type: "childList", target: this });
+    }
+    get textContent() {
+      return this.selection.text();
+    }
+    set textContent(value: string) {
+      this.selection.text(value);
+      notify({ type: "childList", target: this });
+    }
+    get classList() {
+      const change = (names: string[], add: boolean) => {
+        const old = this.getAttribute("class");
+        if (add) this.selection.addClass(names.join(" "));
+        else this.selection.removeClass(names.join(" "));
+        if (old !== this.getAttribute("class"))
+          notify({ type: "attributes", target: this, attributeName: "class" });
+      };
+      return {
+        contains: (name: string) => this.selection.hasClass(name),
+        add: (...names: string[]) => change(names, true),
+        remove: (...names: string[]) => change(names, false),
+        toggle: (name: string, force?: boolean) => {
+          const add = force ?? !this.selection.hasClass(name);
+          change([name], add);
+          return add;
+        },
+      };
+    }
+    getAttribute(name: string) {
+      return this.selection.attr(name) ?? null;
+    }
+    hasAttribute(name: string) {
+      return this.getAttribute(name) !== null;
+    }
+    setAttribute(name: string, value: string) {
+      if (this.getAttribute(name) === String(value)) return;
+      this.selection.attr(name, String(value));
+      notify({ type: "attributes", target: this, attributeName: name });
+    }
+    removeAttribute(name: string) {
+      if (!this.hasAttribute(name)) return;
+      this.selection.removeAttr(name);
+      notify({ type: "attributes", target: this, attributeName: name });
+    }
+    querySelector(selector: string) {
+      return wrap(
+        selector.startsWith(":scope > ")
+          ? this.selection.children(selector.slice(9))
+          : this.selection.find(selector),
+      );
+    }
+    querySelectorAll(selector: string) {
+      return this.selection
+        .find(selector)
+        .toArray()
+        .map((node) => wrap($(node))!);
+    }
+    closest(selector: string) {
+      return wrap(this.selection.closest(selector));
+    }
+    matches(selector: string) {
+      return this.selection.is(selector);
+    }
+    contains(element: DomElement) {
+      return (
+        this === element ||
+        this.selection
+          .find("*")
+          .toArray()
+          .some((node) => node === element.selection.get(0))
+      );
+    }
+    appendChild(element: DomElement) {
+      this.selection.append(element.selection);
+      notify({ type: "childList", target: this });
+      return element;
+    }
+    insertBefore(element: DomElement, anchor: DomElement | null) {
+      if (anchor) anchor.selection.before(element.selection);
+      else this.selection.append(element.selection);
+      notify({ type: "childList", target: this });
+      return element;
+    }
+    removeChild(element: DomElement) {
+      element.selection.remove();
+      notify({ type: "childList", target: this });
+      return element;
+    }
+    remove() {
+      this.parentElement?.removeChild(this);
+    }
+    click() {
+      dispatchClick(this);
+    }
+    focus(_options?: FocusOptions) {
+      if (this.isConnected && !this.closest("[inert]")) document.activeElement = this;
+    }
+  }
+
+  class Observer {
+    private targets: { element: DomElement; options: MutationObserverInit }[] = [];
+    private pending: Mutation[] = [];
+    private readonly callback: (mutations: Mutation[]) => void;
+    constructor(callback: (mutations: Mutation[]) => void) {
+      this.callback = callback;
+    }
+    observe(element: DomElement, options: MutationObserverInit) {
+      this.targets.push({ element, options });
+      observers.add(this);
+    }
+    disconnect() {
+      this.targets = [];
+      this.pending = [];
+      observers.delete(this);
+    }
+    receive(mutation: Mutation) {
+      if (
+        this.targets.some(
+          ({ element, options }) =>
+            (element === mutation.target ||
+              (options.subtree && element.contains(mutation.target))) &&
+            (mutation.type === "childList"
+              ? options.childList
+              : options.attributes &&
+                (!options.attributeFilter ||
+                  options.attributeFilter.includes(mutation.attributeName!))),
+        )
+      ) {
+        this.pending.push(mutation);
+      }
+    }
+    deliver() {
+      const pending = this.pending;
+      this.pending = [];
+      if (pending.length) this.callback(pending);
+      return pending.length > 0;
+    }
+  }
+
+  const add = (listeners: Map<string, Set<Listener>>, type: string, listener: Listener) => {
+    const bucket = listeners.get(type) ?? new Set<Listener>();
+    bucket.add(listener);
+    listeners.set(type, bucket);
+  };
+  const document = {
+    documentElement: wrap($("html"))!,
+    body: wrap($("body"))!,
+    activeElement: wrap($("body"))!,
+    querySelector: (selector: string) => wrap($(selector)),
+    querySelectorAll: (selector: string) =>
+      $(selector)
+        .toArray()
+        .map((node) => wrap($(node))!),
+    getElementById: (id: string) => wrap($("#" + id)),
+    createElement: (tag: string) => wrap($("<" + tag + "></" + tag + ">"))!,
+    addEventListener: (type: string, listener: Listener) => add(documentListeners, type, listener),
+    removeEventListener: (type: string, listener: Listener) =>
+      documentListeners.get(type)?.delete(listener),
+  };
+  const schedule = (queue: Map<number, () => void>, fn: () => void) => {
+    const id = nextTimer++;
+    queue.set(id, fn);
+    return id;
+  };
+  const window = {
+    MutationObserver: Observer,
+    setInterval: (fn: () => void) => schedule(intervals, fn),
+    clearInterval: (id: number) => intervals.delete(id),
+    setTimeout: (fn: () => void) => schedule(tasks, fn),
+    clearTimeout: (id: number) => tasks.delete(id),
+    requestAnimationFrame: (fn: () => void) => schedule(tasks, fn),
+    cancelAnimationFrame: (id: number) => tasks.delete(id),
+    addEventListener: (type: string, listener: Listener) => add(windowListeners, type, listener),
+    removeEventListener: (type: string, listener: Listener) =>
+      windowListeners.get(type)?.delete(listener),
+  };
+  function flush() {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const delivered = Array.from(observers, (observer) => observer.deliver()).some(Boolean);
+      const pending = Array.from(tasks.values());
+      tasks.clear();
+      for (const task of pending) task();
+      if (!delivered && pending.length === 0) return;
+    }
+    throw new Error("Theme mutation observer did not settle");
+  }
+  function dispatchClick(target: DomElement, nativeHandler?: () => void) {
+    let propagationStopped = false;
+    let defaultPrevented = false;
+    const event = {
+      target,
+      preventDefault: () => {
+        defaultPrevented = true;
+      },
+      stopPropagation: () => {
+        propagationStopped = true;
+      },
+    };
+    for (const listener of documentListeners.get("click") ?? []) listener(event);
+    if (!propagationStopped) {
+      const handler = nativeHandler ?? nativeClicks.get(target.closest("button") ?? target);
+      handler?.();
+    }
+    flush();
+    return { defaultPrevented, propagationStopped };
+  }
+
+  return {
+    document,
+    window,
+    Observer,
+    Element: DomElement,
+    flush,
+    click: (selector: string, nativeHandler?: () => void) => {
+      const target = document.querySelector(selector);
+      if (!target) throw new Error("Missing click target: " + selector);
+      return dispatchClick(target, nativeHandler);
+    },
+    bindClick: (selector: string, handler: () => void) => {
+      const target = document.querySelector(selector);
+      if (!target) throw new Error("Missing handler target: " + selector);
+      nativeClicks.set(target, handler);
+    },
+    key: (key: string) => {
+      for (const listener of windowListeners.get("keydown") ?? []) listener({ key });
+      flush();
+    },
+    tick: () => {
+      for (const interval of intervals.values()) interval();
+      flush();
+    },
+    pendingIntervals: () => intervals.size,
+    activeObservers: () => observers.size,
+    listeners: (type: string) =>
+      (documentListeners.get(type)?.size ?? 0) + (windowListeners.get(type)?.size ?? 0),
+  };
+}
+
+type DomElement = NonNullable<
+  ReturnType<ReturnType<typeof createThemeDom>["document"]["querySelector"]>
+>;


### PR DESCRIPTION
## Summary

Fix ElegantFin's navigation chrome so Collapse produces a persistent 72px icon rail, Expand restores the 260px drawer, and the native Back action stays aligned in LTR and RTL.

- Coordinate sidebar width, content reservation, labels, and header spacing with Harbor's existing motion tokens and reduced-motion preference.
- Preserve the single profile action, including its account fallback from the collapsed rail.
- Restore keyboard focus when Escape closes the drawer and clean up transient state when the sidebar disappears or the theme changes.
- Add DOM-based regressions for native event propagation, state synchronization, profile fallback, and focus handling.

## Why

ElegantFin forced the sidebar to remain 260px wide while React hid its labels. Dismissing the drawer then hid the intended icon rail too. The theme now follows the existing `sidebarCollapsed` setting through explicit DOM hooks; the native React handler remains responsible for persistence. Retaining labels during the transition avoids abrupt text removal. Back uses Harbor's native navigation instead of the theme's old proxy buttons.

The shared-component changes supply the hooks and label retention needed by ElegantFin. This diff does not change Settings pages, defaults, Rust, dependencies, or release configuration. The duplicate native profile action was already removed upstream; this preserves that behavior.

## Verification

- Passed: `node --experimental-loader ./scripts/node-test-loader.mjs --test tests/elegantfin-profile-navigation.test.ts` — 26/26.
- Passed: `pnpm run typecheck` and the production frontend build.
- Passed: Windows x64 release and NSIS packaging. Archive integrity passed; the extracted executable matched the built executable and contained the final frontend asset.
- Browser checks covered English/Arabic alignment, open/close/collapse/expand, navigation with the rail visible, Escape focus, account popovers, routes without the sidebar, and switching back to Harbor default.
- Ran `pnpm run check` against all nine changed/new files: six passed; `account-menu.tsx`, `sidebar.tsx`, and `topbar.tsx` retain formatting failures reproduced on their unchanged base versions.
- Broader theme/navigation checks: 48/50 passed. Both failures in `tests/theme-author-navigation.test.ts` were reproduced on clean base `e123e2b8`: they reference the already missing `store-top-charts.tsx`.

## Platform Impact

Windows x64 installer built and verified. Linux build was attempted with `pnpm run tauri:build:linux-system --target x86_64-unknown-linux-gnu`; this Windows host lacks that Rust target and WSL. Linux, macOS, and native TV/remote runtime behavior were not verified. Keyboard behavior was exercised in the production frontend; configured hotkeys are unchanged.

## UI Changes

| Action | Before | After |
| --- | --- | --- |
| Collapse | Labels disappear inside a full-width drawer | Drawer narrows to a persistent icon rail and reserves matching content space |
| Navigate or dismiss | Collapsed sidebar disappears | Icon rail remains visible |
| Expand | Full-width state is disconnected from drawer visibility | Full drawer opens with coordinated motion |
| Back | Theme proxy and header spacing move the action inward | Single native Back follows the navigation edge in LTR/RTL |

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [x] I ran `vp check` for the changed files; baseline formatting failures are recorded above.
- [x] I ran the project's TypeScript check after TypeScript changes.
- [x] Cargo checks after Rust changes: not applicable; no Rust source changed.
- [x] Platform validation and its limits are recorded above.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [x] I added tests for the behavior changes.
- [x] The published diff and description contain no credentials, private URLs, or personal test data.
