### PR TITLE
fix(player): stop encrypted HLS stalling on every segment

### DIFF
--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -794,7 +794,11 @@ pub async fn mpv_start(
         }
         let _ = mpv.set_property("cache-on-disk", "yes");
         let _ = mpv.set_property("network-timeout", network_timeout_for(&args.url));
-        let reconnect_opts = "reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1,reconnect_on_http_error=429,reconnect_delay_max=10,reconnect_delay_total_max=60";
+        // No reconnect_streamed: on AES-128 HLS every segment ends in a normal
+        // EOF that ffmpeg then retries from offset 0, gets an empty body, and
+        // backs off 1/3/7s. Measured on a vixsrc stream: 7 segments and 55s of
+        // backoff per 100s with the flag, 94 segments and 0s without it.
+        let reconnect_opts = "reconnect=1,reconnect_on_network_error=1,reconnect_on_http_error=429,reconnect_delay_max=10,reconnect_delay_total_max=60";
         match mpv.set_property("stream-lavf-o", reconnect_opts) {
             Ok(()) => eprintln!("[harbor::mpv] stream-lavf-o set {}", reconnect_opts),
             Err(e) => eprintln!("[harbor::mpv] stream-lavf-o rejected: {:?}", e),

--- a/src-tauri/src/mpv.rs
+++ b/src-tauri/src/mpv.rs
@@ -783,7 +783,13 @@ pub async fn mpv_start(
             let dvr = base.join("mpv-cache");
             let _ = std::fs::create_dir_all(&dvr);
             if let Some(s) = dvr.to_str() {
-                let _ = mpv.set_property("cache-dir", s);
+                // mpv renamed this to demuxer-cache-dir; the old name is
+                // rejected (M_PROPERTY_UNKNOWN) on 0.41, which leaves
+                // cache-on-disk enabled with no directory and logs
+                // "Failed to create file cache" on every load.
+                if mpv.set_property("demuxer-cache-dir", s).is_err() {
+                    let _ = mpv.set_property("cache-dir", s);
+                }
             }
         }
         let _ = mpv.set_property("cache-on-disk", "yes");

--- a/src-tauri/src/multiview.rs
+++ b/src-tauri/src/multiview.rs
@@ -535,7 +535,8 @@ fn spawn_mpv(
         .arg("--cache-secs=20")
         .arg("--demuxer-readahead-secs=30")
         .arg("--network-timeout=60")
-        .arg("--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_delay_max=10")
+        // See mpv.rs: reconnect_streamed stalls AES-128 HLS segments.
+        .arg("--stream-lavf-o=reconnect=1,reconnect_delay_max=10")
         .arg("--vd-lavc-threads=2")
         .arg("--volume=100")
         .arg("--mute=yes")


### PR DESCRIPTION
- **fix(player): use demuxer-cache-dir so the disk cache gets a directory**
- **fix(player): drop reconnect_streamed to stop AES-128 HLS stalling**

## Summary

Two small mpv fixes that fell out of chasing one very annoying playback bug.

The main one: Harbor passes `reconnect_streamed=1` to ffmpeg, and on encrypted HLS that makes playback stall at the end of *every* segment. Dropping the flag is the whole fix. The second is a one-liner right next to it: `cache-dir` is no longer a valid mpv property, so the on-disk cache was running without a directory.

One commit per bug, so they can be reviewed or reverted separately.

## Why

I lost most of a day to this one, so bear with the story.

Any source that went through a proxy would play for a few seconds, freeze, spin, play again, freeze again. Getting through a 30-second stretch could take a minute. The same link played perfectly in plain mpv and perfectly in Stremio, which is exactly what made it maddening: everything pointed at my setup being the problem.

So I went through the usual suspects. GPU drivers, Wayland, the WebView, the proxy, the addon, cache settings, buffer sizes. All dead ends. The thing that finally gave it away was noticing that every reconnect in the log restarted from offset 0.

The cause is boring once you see it. On encrypted HLS each segment is its own finite file, so ffmpeg gets perfectly normal end-of-file when it finishes one. `reconnect_streamed` tells it to treat that EOF as a dropped connection, so it reopens the request from the beginning, reads zero bytes, and waits 1s, then 3s, then 7s before trying again. That wait is the freeze. Plain HLS and torrents never trigger it, which is why it only hit some sources and felt random.

Stremio never sets `stream-lavf-o` at all, which is why it was never affected.

## Verification

Measured outside Harbor with `mpv --no-config`, same stream and same cache settings Harbor uses, 100 seconds per run:

| | segments downloaded | time spent backing off |
|---|---|---|
| flags as they are today | 7 | 55s |
| `reconnect_streamed` removed | 94 | 0s|

That flag was the only variable between the two runs. Every other reconnect option stayed exactly where it was.

Then the same source inside Harbor, before and after. Before: 97 reconnects, 89 of them from offset 0, and 264 seconds of pure waiting in a single session.
After: continuous playback, no reconnect spam, and the 12 `Failed to create file cache` errors per session are gone too, which is the second commit.

`cargo check --manifest-path src-tauri/Cargo.toml` is clean, with no new warnings in the touched files.

## Platform Impact

Verified on Linux with mpv 0.41 and the system libmpv. Not tested on Windows or macOS, but this is a flag Harbor hands to ffmpeg rather than anything platform-specific, so the behavior should carry over. The cache fix tries `demuxer-cache-dir` first and falls back to `cache-dir`, so older libmpv builds keep working unchanged.

Multiview spawns mpv with the same flag on its own command line, so it gets the same removal and the two stay consistent.

## Checklist

- [X] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files. (n/a, Rust only)
- [ ] I ran `vp run typecheck` after TypeScript changes. (n/a, no TypeScript)
- [X] I ran the relevant Cargo checks after Rust changes.
- [X] I tested affected platforms when the change is platform-specific. (Linux)
- [X] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes. (option string only; verified by measurement)
- [X] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
