### PR TITLE
fix: select series season from watch progress

### DIFF
--- a/src/lib/episode-progress.ts
+++ b/src/lib/episode-progress.ts
@@ -1,6 +1,5 @@
 import { manualWatchedState } from "@/lib/manual-watched";
 import { lastPlayedEpisode, readResumeEntry } from "@/lib/resume";
-import { getViewedSeason } from "@/lib/season-view-pref";
 
 export type EpisodeProgress = {
   ratio: number;
@@ -9,7 +8,6 @@ export type EpisodeProgress = {
 };
 
 const WATCHED_THRESHOLD = 0.85;
-const SEASON_DONE_RATIO = 0.9;
 
 export function resumeDefaultSeason(
   seriesId: string,
@@ -22,9 +20,6 @@ export function resumeDefaultSeason(
     .sort((a, b) => a.seasonNumber - b.seasonNumber);
   const first = real[0]?.seasonNumber ?? seasons[0]?.seasonNumber ?? 1;
 
-  const viewed = getViewedSeason(seriesId);
-  if (viewed != null && seasons.some((s) => s.seasonNumber === viewed)) return viewed;
-
   if (real.length <= 1) return first;
 
   const watchedInSeason = (sn: number): number => {
@@ -35,14 +30,23 @@ export function resumeDefaultSeason(
     return n;
   };
   const seasonDone = (s: { seasonNumber: number; episodeCount: number }): boolean =>
-    s.episodeCount > 0 && watchedInSeason(s.seasonNumber) / s.episodeCount >= SEASON_DONE_RATIO;
+    s.episodeCount > 0 && watchedInSeason(s.seasonNumber) >= s.episodeCount;
 
   const nextUnwatched = real.find((s) => !seasonDone(s))?.seasonNumber ?? null;
 
+  const latestWatchedSeason =
+    real.filter((season) => watchedInSeason(season.seasonNumber) > 0).at(-1)?.seasonNumber ?? null;
+
+  const localLastPlayedSeason = lastPlayedEpisode(seriesId)?.season ?? null;
+
   const hint =
-    lastPlayedSeasonHint != null && real.some((s) => s.seasonNumber === lastPlayedSeasonHint)
+    lastPlayedSeasonHint != null &&
+    real.some((season) => season.seasonNumber === lastPlayedSeasonHint)
       ? lastPlayedSeasonHint
-      : (lastPlayedEpisode(seriesId)?.season ?? null);
+      : localLastPlayedSeason != null &&
+          real.some((season) => season.seasonNumber === localLastPlayedSeason)
+        ? localLastPlayedSeason
+        : latestWatchedSeason;
 
   if (hint != null && real.some((s) => s.seasonNumber === hint)) {
     const hintObj = real.find((s) => s.seasonNumber === hint)!;
@@ -67,8 +71,7 @@ export function getEpisodeProgress(
   traktSeason?: number,
   traktEpisode?: number,
 ): EpisodeProgress {
-  const resumeIds =
-    traktImdbId && traktImdbId !== resumeId ? [resumeId, traktImdbId] : [resumeId];
+  const resumeIds = traktImdbId && traktImdbId !== resumeId ? [resumeId, traktImdbId] : [resumeId];
   let entry: { ms: number; t: number } | null = null;
   for (const id of resumeIds) {
     const e = readResumeEntry(id, season, episode);
@@ -88,7 +91,9 @@ export function getEpisodeProgress(
   const durationMs = runtimeMin && runtimeMin > 0 ? runtimeMin * 60 * 1000 : 0;
   const ratio = durationMs > 0 && ms > 0 ? Math.min(1, ms / durationMs) : 0;
 
-  const traktKey = traktImdbId ? `imdb:${traktImdbId}:${traktSeason ?? season}:${traktEpisode ?? episode}` : null;
+  const traktKey = traktImdbId
+    ? `imdb:${traktImdbId}:${traktSeason ?? season}:${traktEpisode ?? episode}`
+    : null;
   const traktDone = traktKey ? traktWatched.has(traktKey) : false;
   const stremioDone = stremioWatched ? stremioWatched.has(`${season}:${episode}`) : false;
   const anilistDone = anilistWatched ? anilistWatched.has(`${season}:${episode}`) : false;

--- a/src/views/detail.tsx
+++ b/src/views/detail.tsx
@@ -1959,6 +1959,7 @@ export function DetailView({
                 meta={playMeta}
                 videos={cinemetaFull.videos}
                 stremioWatched={stremioWatched}
+                resumeSeason={lastPlay?.season}
               />
             </FadeInUp>
           )}

--- a/src/views/detail/cinemeta-episodes.tsx
+++ b/src/views/detail/cinemeta-episodes.tsx
@@ -4,42 +4,43 @@ import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "reac
 import { createPortal } from "react-dom";
 import type { Meta } from "@/lib/cinemeta";
 import { EpisodeWatchedMenu, type WatchedMenuTarget } from "@/components/episode-watched-menu";
-import { manualWatchedState, manualWatchedVersion, subscribeManualWatched } from "@/lib/manual-watched";
-import { getLastSeason, setLastSeason } from "@/lib/last-season";
-import { lastPlayedEpisode } from "@/lib/resume";
+import {
+  manualEpisodeKeys,
+  manualWatchedState,
+  manualWatchedVersion,
+  subscribeManualWatched,
+} from "@/lib/manual-watched";
 import { Poster } from "@/components/poster";
 import { useSettings } from "@/lib/settings";
 import { useLocalAwareSeriesPlay } from "@/lib/local-library/use-series-play";
 import { useT } from "@/lib/i18n";
 import { EpisodeDownloadButton } from "./episode-download-button";
+import { resumeDefaultSeason } from "@/lib/episode-progress";
 
 type Translator = (key: string, vars?: Record<string, string | number>) => string;
 
 type CinemetaVideo = NonNullable<Meta["videos"]>[number];
 
-function pickDefaultSeason(metaId: string, seasons: number[]): number {
-  const has = (n: number) => seasons.includes(n);
-  const saved = getLastSeason(metaId);
-  if (saved != null && has(saved)) return saved;
-  const lp = lastPlayedEpisode(metaId);
-  if (lp && has(lp.season)) return lp.season;
-  const real = seasons.filter((s) => s > 0);
-  return real[real.length - 1] ?? seasons[seasons.length - 1] ?? 1;
-}
-
 export function CinemetaEpisodes({
   meta,
   videos,
   stremioWatched,
+  resumeSeason,
 }: {
   meta: Meta;
   videos: NonNullable<Meta["videos"]>;
   stremioWatched?: Set<string>;
+  resumeSeason?: number;
 }) {
   const t = useT();
-  useSyncExternalStore(subscribeManualWatched, manualWatchedVersion);
+  const mwVersion = useSyncExternalStore(subscribeManualWatched, manualWatchedVersion);
   const [watchedMenu, setWatchedMenu] = useState<WatchedMenuTarget | null>(null);
-  const openWatchedMenu = (e: React.MouseEvent, season: number, episode: number, watched: boolean) => {
+  const openWatchedMenu = (
+    e: React.MouseEvent,
+    season: number,
+    episode: number,
+    watched: boolean,
+  ) => {
     e.preventDefault();
     setWatchedMenu({ x: e.clientX, y: e.clientY, season, episode, watched });
   };
@@ -59,7 +60,9 @@ export function CinemetaEpisodes({
       .sort(([a], [b]) => a - b)
       .map(([s, eps]) => ({
         seasonNumber: s,
-        episodes: eps.slice().sort((a, b) => ((a.episode ?? a.number) ?? 0) - ((b.episode ?? b.number) ?? 0)),
+        episodes: eps
+          .slice()
+          .sort((a, b) => (a.episode ?? a.number ?? 0) - (b.episode ?? b.number ?? 0)),
       }));
     if (flat.length > 0 && numbered.length === 0) {
       flat.sort((a, b) => (a.released ?? "").localeCompare(b.released ?? ""));
@@ -67,6 +70,23 @@ export function CinemetaEpisodes({
     }
     return numbered;
   }, [videos]);
+  const combinedWatched = useMemo(() => {
+    const watched = new Set(stremioWatched ?? []);
+    const manual = manualEpisodeKeys(meta.id);
+
+    for (const key of manual.watched) watched.add(key);
+    for (const key of manual.unwatched) watched.delete(key);
+
+    return watched;
+  }, [meta.id, stremioWatched, mwVersion]);
+  const seasonStats = useMemo(
+    () =>
+      grouped.map((group) => ({
+        seasonNumber: group.seasonNumber,
+        episodeCount: group.episodes.length,
+      })),
+    [grouped],
+  );
 
   const allEpisodesOrdered = useMemo(
     () =>
@@ -81,7 +101,7 @@ export function CinemetaEpisodes({
   );
 
   const [active, setActive] = useState<number>(() =>
-    pickDefaultSeason(meta.id, grouped.map((g) => g.seasonNumber)),
+    resumeDefaultSeason(meta.id, seasonStats, combinedWatched, resumeSeason),
   );
   const userPickedRef = useRef(false);
 
@@ -91,8 +111,8 @@ export function CinemetaEpisodes({
 
   useEffect(() => {
     if (userPickedRef.current) return;
-    setActive(pickDefaultSeason(meta.id, grouped.map((g) => g.seasonNumber)));
-  }, [meta.id, grouped.length]);
+    setActive(resumeDefaultSeason(meta.id, seasonStats, combinedWatched, resumeSeason));
+  }, [meta.id, seasonStats, combinedWatched, resumeSeason]);
 
   if (grouped.length === 0) return null;
   const activeEps = grouped.find((g) => g.seasonNumber === active)?.episodes ?? [];
@@ -107,7 +127,6 @@ export function CinemetaEpisodes({
             active={active}
             onChange={(n) => {
               userPickedRef.current = true;
-              setLastSeason(meta.id, n);
               setActive(n);
             }}
           />
@@ -143,7 +162,12 @@ export function CinemetaEpisodes({
       {watchedMenu && (
         <EpisodeWatchedMenu
           metaId={meta.id}
-          meta={{ type: "series", name: meta.name, poster: meta.poster, background: meta.background }}
+          meta={{
+            type: "series",
+            name: meta.name,
+            poster: meta.poster,
+            background: meta.background,
+          }}
           target={watchedMenu}
           allEpisodes={allEpisodesOrdered}
           onClose={() => setWatchedMenu(null)}
@@ -245,7 +269,12 @@ function SeasonDropdown({
   onChange: (n: number) => void;
 }) {
   const t = useT();
-  const [menu, setMenu] = useState<{ right: number; top?: number; bottom?: number; maxH: number } | null>(null);
+  const [menu, setMenu] = useState<{
+    right: number;
+    top?: number;
+    bottom?: number;
+    maxH: number;
+  } | null>(null);
   const btnRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const open = menu != null;


### PR DESCRIPTION
## Summary

Fix the default season selected when opening a multi-season series.
- New series open on the first season.
- In-progress series open on the latest relevant watched or played season.
- Completed seasons advance to the next unwatched season.
- Manual and Stremio watched states are both considered.

## Why

Multi-season series previously defaulted to the latest season, even when the user had not watched anything. This made users manually return to season one or locate their current progress.

## Verification

- Ran vp check for the three changed files.
- Ran pnpm run typecheck.
- Tested a completely unwatched series.
- Tested partially watched seasons.
- Tested completed seasons advancing to the next season.
- Tested manual watched and unwatched changes.
- Tested reopening a previously played series.
- Tested manually selecting a different season.
