### PR TITLE
fix(rtl): improve Big Picture navigation, poster dock, and live-tv multiview

### DIFF
--- a/src/lib/poster-dock.ts
+++ b/src/lib/poster-dock.ts
@@ -82,10 +82,8 @@ export function updatePosterDock({
   const stride = cellWidth + gap;
   if (rect.width <= 0 || stride <= 0) return;
 
-  const viewportX = pointerX - rect.left;
-  const contentX = rtl
-    ? track.scrollWidth - viewportX - scrollPosition
-    : viewportX + scrollPosition;
+  const viewportX = rtl ? rect.right - pointerX : pointerX - rect.left;
+  const contentX = viewportX + scrollPosition;
 
   const activeIndex = (contentX - cellWidth / 2) / stride;
   const range = Math.ceil(DISTANCE / stride);

--- a/src/views/big-picture/bp-row-see-all.ts
+++ b/src/views/big-picture/bp-row-see-all.ts
@@ -30,8 +30,9 @@ export function isBpRowSeeAll(el: HTMLElement | null): boolean {
  * Null for every other direction and for a row with no see-all, so the caller
  * falls through to the shake exactly as it did before.
  */
-export function bpSeeAllEnter(from: HTMLElement, dir: BpDir): HTMLElement | null {
-  if (dir !== "right") return null;
+export function bpSeeAllEnter(from: HTMLElement, dir: BpDir, rtl = false): HTMLElement | null {
+  const enterDir = rtl ? "left" : "right";
+  if (dir !== enterDir) return null;
   const row = from.closest<HTMLElement>(ROW);
   if (!row) return null;
   const link = row.querySelector<HTMLElement>(LINK);
@@ -54,8 +55,9 @@ export function bpSeeAllEnter(from: HTMLElement, dir: BpDir): HTMLElement | null
  * Reversed and offered whole rather than picked, so a cell that refuses focus
  * falls through to its neighbour instead of dropping the press.
  */
-export function bpSeeAllExit(link: HTMLElement, dir: BpDir): HTMLElement | null {
-  if (dir !== "left") return null;
+export function bpSeeAllExit(link: HTMLElement, dir: BpDir, rtl = false): HTMLElement | null {
+  const exitDir = rtl ? "right" : "left";
+  if (dir !== exitDir) return null;
   const track = link.closest<HTMLElement>(ROW)?.querySelector<HTMLElement>(TRACK);
   if (!track) return null;
   const cells = measureFocusables(track).map((m) => m.el);

--- a/src/views/big-picture/bp-row.tsx
+++ b/src/views/big-picture/bp-row.tsx
@@ -118,12 +118,7 @@ export function BpRow({
   // ten however it was fed, which is also why loadMore refuses below: reaching
   // the end of a ranked row would otherwise fetch a page nothing can draw.
   const all = useMemo(
-    () =>
-      ranked
-        ? metas.slice(0, RANK_MAX)
-        : extra.length > 0
-          ? [...metas, ...extra]
-          : metas,
+    () => (ranked ? metas.slice(0, RANK_MAX) : extra.length > 0 ? [...metas, ...extra] : metas),
     [ranked, metas, extra],
   );
 
@@ -167,7 +162,9 @@ export function BpRow({
       // write, so the settling event still gets through and pages exactly once.
       if (bpTrackGliding(track)) return;
       const width = track.clientWidth;
-      const remaining = track.scrollWidth - (track.scrollLeft + width);
+      const isRtl = getComputedStyle(track).direction === "rtl";
+      const scrolled = isRtl ? -track.scrollLeft : track.scrollLeft;
+      const remaining = track.scrollWidth - (scrolled + width);
       // A collapsed track (empty:hidden, a row still resolving) reports 0 and
       // would read as "at the end" on every scroll it never has.
       const near = tv ? (width >= 2 ? width * TV_NEAR_END : -1) : NEAR_END_PX;

--- a/src/views/big-picture/bp-top-bar.tsx
+++ b/src/views/big-picture/bp-top-bar.tsx
@@ -14,10 +14,7 @@ import { BpProfileMenu } from "./bp-profile-menu";
 import { useBpT } from "./bp-i18n";
 import { HarborMark } from "@/components/icons/harbor-mark";
 import { useHarborLogo } from "@/lib/harbor-logo";
-import {
-  goBigPictureTab,
-  type BigPictureTabKind,
-} from "@/lib/big-picture";
+import { goBigPictureTab, type BigPictureTabKind } from "@/lib/big-picture";
 
 function useClock(): string {
   const [now, setNow] = useState(() => new Date());
@@ -38,7 +35,11 @@ type BpTab = {
 
 const TABS: BpTab[] = [
   { kind: "home", label: "Home", icon: (a) => <HomeIcon active={a} /> },
-  { kind: "discover", label: "Discover", icon: () => <NavGlyph name="explore" className="h-[26px] w-[26px] p-[2px]" /> },
+  {
+    kind: "discover",
+    label: "Discover",
+    icon: () => <NavGlyph name="explore" className="h-[26px] w-[26px] p-[2px]" />,
+  },
   {
     kind: "anime",
     label: "Anime",
@@ -47,12 +48,25 @@ const TABS: BpTab[] = [
     parentalKey: "anime",
   },
   { kind: "shows", label: "Shows", icon: (a) => <TvIcon active={a} />, parentalKey: "shows" },
-  { kind: "movies", label: "Movies", icon: (a) => <MoviesIcon active={a} />, parentalKey: "movies" },
+  {
+    kind: "movies",
+    label: "Movies",
+    icon: (a) => <MoviesIcon active={a} />,
+    parentalKey: "movies",
+  },
   // Deliberately not gated on hasLive. A TV-only viewer has never seen the
   // desktop app, so hiding the tab until a playlist exists hid the only route to
   // adding one. Live TV owns its own setup screen when there is nothing yet.
-  { kind: "live", label: "Live TV", icon: () => <NavGlyph name="livetv" className="h-[26px] w-[26px] p-[2px]" /> },
-  { kind: "search", label: "Search", icon: () => <NavGlyph name="search" className="h-[26px] w-[26px] p-[2px]" /> },
+  {
+    kind: "live",
+    label: "Live TV",
+    icon: () => <NavGlyph name="livetv" className="h-[26px] w-[26px] p-[2px]" />,
+  },
+  {
+    kind: "search",
+    label: "Search",
+    icon: () => <NavGlyph name="search" className="h-[26px] w-[26px] p-[2px]" />,
+  },
   {
     kind: "library",
     label: "Library",
@@ -61,7 +75,11 @@ const TABS: BpTab[] = [
   },
   // Ungated for the same reason as Live TV: it needs a TMDB key, and hiding it
   // until there is one hid the only place that explains how to add one.
-  { kind: "collections", label: "Collections", icon: () => <NavGlyph name="collections" className="h-[26px] w-[26px] p-[2px]" /> },
+  {
+    kind: "collections",
+    label: "Collections",
+    icon: () => <NavGlyph name="collections" className="h-[26px] w-[26px] p-[2px]" />,
+  },
   { kind: "settings", label: "Settings", icon: (a) => <SettingsIcon active={a} /> },
 ];
 
@@ -77,10 +95,7 @@ export function useBpTabGate(): BpTabGate {
   const { settings } = useSettings();
   const { locked, hiddenTabs } = useParental();
   const animeHidden = Boolean(settings.hideContent.anime);
-  return useMemo(
-    () => ({ animeHidden, locked, hiddenTabs }),
-    [animeHidden, locked, hiddenTabs],
-  );
+  return useMemo(() => ({ animeHidden, locked, hiddenTabs }), [animeHidden, locked, hiddenTabs]);
 }
 
 function visibleTabs(gate: BpTabGate): BpTab[] {
@@ -178,12 +193,12 @@ function BpTabButton({
       onBlur={() => onHint(null, "")}
       aria-label={title}
       className={`${TAB_BASE} justify-center ${
-        !compact && on
-          ? "gap-[clamp(6px,0.5vw,9px)] px-[clamp(11px,1vw,20px)]"
-          : "aspect-square"
+        !compact && on ? "gap-[clamp(6px,0.5vw,9px)] px-[clamp(11px,1vw,20px)]" : "aspect-square"
       } ${on ? "bg-[var(--bp-on)] text-ink" : "text-ink-subtle hover:text-ink"}`}
     >
-      <span data-bp-tab-icon className={ICON_BOX}>{tab.icon(on)}</span>
+      <span data-bp-tab-icon className={ICON_BOX}>
+        {tab.icon(on)}
+      </span>
       {!compact && on && <span>{title}</span>}
     </button>
   );
@@ -240,8 +255,11 @@ export function BpTopBar({ active }: { active: BigPictureTabKind }) {
       if (!el) return;
       const t = track.getBoundingClientRect();
       const e = el.getBoundingClientRect();
+      const isRtl = getComputedStyle(track).direction === "rtl";
+      const max = Math.max(0, track.scrollWidth - track.clientWidth);
       const left = track.scrollLeft + (e.left - t.left) - (t.width - e.width) / 2;
-      track.scrollTo({ left: Math.max(0, left), behavior: "auto" });
+      const target = isRtl ? Math.max(-max, Math.min(0, left)) : Math.max(0, Math.min(max, left));
+      track.scrollTo({ left: target, behavior: "auto" });
     };
     reveal();
     const ro = new ResizeObserver(reveal);
@@ -339,7 +357,10 @@ export function BpTopBar({ active }: { active: BigPictureTabKind }) {
 
       <div className="pointer-events-auto relative col-start-3 flex shrink-0 items-center justify-self-end gap-[clamp(9px,0.9vw,17px)] whitespace-nowrap">
         <BpStatus />
-        <span data-bp-clock className="font-mono text-[clamp(14px,1.9vh,22px)] font-semibold tabular-nums leading-none text-ink">
+        <span
+          data-bp-clock
+          className="font-mono text-[clamp(14px,1.9vh,22px)] font-semibold tabular-nums leading-none text-ink"
+        >
           {clock}
         </span>
       </div>

--- a/src/views/big-picture/bp-track-glide.ts
+++ b/src/views/big-picture/bp-track-glide.ts
@@ -70,8 +70,9 @@ function stop(g: Glide | undefined): void {
  * and no snap-to-previous-target guard is needed before the measurement.
  */
 export function glideBpTrack(track: HTMLElement, to: number, reduce: boolean): void {
+  const isRtl = getComputedStyle(track).direction === "rtl";
   const max = Math.max(0, track.scrollWidth - track.clientWidth);
-  const target = Math.max(0, Math.min(to, max));
+  const target = isRtl ? Math.max(-max, Math.min(to, 0)) : Math.max(0, Math.min(to, max));
   const now = performance.now();
   const g = live.get(track);
   const from = track.scrollLeft;

--- a/src/views/big-picture/use-bp-focus.ts
+++ b/src/views/big-picture/use-bp-focus.ts
@@ -186,10 +186,13 @@ export function useBpFocusRoot(params: {
       // reveal in moveVertically still has somewhere to look.
       let railMissed = false;
 
+      const isRtl = getComputedStyle(root).direction === "rtl";
+      const navDir = isRtl ? "right" : "left";
+
       // Apple's tvOS rule is that focus returns to the tab bar from anywhere
       // rather than by walking every row upward. Left already runs out at the
-      // start of a row, so that dead end becomes the direct path to the nav:
-      // one press from any depth instead of one per row.
+      // start of a row (Right in RTL), so that dead end becomes the direct path
+      // to the nav: one press from any depth instead of one per row.
       //
       // The row names the tab it belongs to, so Left out of a movies row lands
       // on Movies rather than on whichever tab is active. That is what replaced
@@ -199,16 +202,15 @@ export function useBpFocusRoot(params: {
       // behaviour. Read off the row rather than the cell so every card in the
       // row escapes to the same place.
       const toNav = (from: HTMLElement): HTMLElement | null => {
-        if (dir !== "left" || bpInChrome(from)) return null;
+        if (dir !== navDir || bpInChrome(from)) return null;
         const tab = from.closest<HTMLElement>("[data-bp-row]")?.dataset.bpRowTab;
         return focusBpTopBar(root, tab) ? currentBpFocus(root) : null;
       };
 
-      // Both ends of a row lead somewhere now. Left at the start reaches the
-      // nav, Right at the end reaches the row's own see-all, and Left off that
-      // see-all comes back to the cell it was pressed from rather than carrying
-      // on to the nav: the only door onto it is one press, so the reverse press
-      // has to undo exactly that one press.
+      // Both ends of a row lead somewhere now. In LTR, Left at the start reaches
+      // the nav, Right at the end reaches the row's own see-all, and Left off that
+      // see-all comes back to the cell it was pressed from. In RTL, these
+      // horizontal endpoints are mirrored.
       //
       // Shared by the fast path and the slow path because they answer
       // identically once the origin is known, and the two drifting apart is how
@@ -217,10 +219,10 @@ export function useBpFocusRoot(params: {
       // see-all branch reads it, and on the fast path building it is a
       // measureFocusables over the whole track.
       const stepAcross = (from: HTMLElement, pool: () => Measured[]): HTMLElement | null => {
-        if (isBpRowSeeAll(from)) return bpSeeAllExit(from, dir);
+        if (isBpRowSeeAll(from)) return bpSeeAllExit(from, dir, isRtl);
         return (
           focusFirstOf(candidatesFor(from, pool(), dir), { dir }) ??
-          bpSeeAllEnter(from, dir) ??
+          bpSeeAllEnter(from, dir, isRtl) ??
           toNav(from)
         );
       };
@@ -424,7 +426,10 @@ export function useBpFocusRoot(params: {
         }
       }
 
-      if (focused && (interactedRef.current || restored || focused.dataset.bpAutofocus === "true")) {
+      if (
+        focused &&
+        (interactedRef.current || restored || focused.dataset.bpAutofocus === "true")
+      ) {
         return;
       }
       const marked = root.querySelector<HTMLElement>("[data-bp-autofocus='true']");

--- a/src/views/multiview/grid.tsx
+++ b/src/views/multiview/grid.tsx
@@ -11,7 +11,7 @@ import {
   type Layout,
   type SlotChannel,
 } from "@/lib/multiview/store";
-import { useT } from "@/lib/i18n";
+import { isRtl, useT, useUiLanguage } from "@/lib/i18n";
 import { Cell } from "./cell";
 
 const HANDLE_CENTER_OFFSET = "0.875rem";
@@ -35,15 +35,19 @@ function Divider({
   split,
   min,
   max,
+  rtl = false,
   onChange,
   onDragStart,
+  onPreview,
 }: {
   axis: Axis;
   split: number;
   min: number;
   max: number;
+  rtl?: boolean;
   onChange: (pct: number) => void;
   onDragStart?: () => void;
+  onPreview?: (pct: number) => void;
 }) {
   const t = useT();
   const dragRef = useRef<DividerDrag | null>(null);
@@ -59,7 +63,7 @@ function Divider({
     const rect = parent.getBoundingClientRect();
     const size = isX ? rect.width : rect.height;
     if (size === 0) return null;
-    const position = isX ? clientX - rect.left : clientY - rect.top;
+    const position = isX ? (rtl ? rect.right - clientX : clientX - rect.left) : clientY - rect.top;
     return clamp((position / size) * 100, min, max);
   };
 
@@ -68,6 +72,7 @@ function Divider({
     if (!(panel instanceof HTMLElement)) return;
     if (isX) panel.style.width = value + "%";
     else panel.style.height = value + "%";
+    onPreview?.(value);
   };
 
   const finish = () => {
@@ -121,8 +126,14 @@ function Divider({
         if (dragRef.current?.pointerId === event.pointerId) finish();
       }}
       onKeyDown={(event) => {
-        const increase = event.key === "ArrowRight" || event.key === "ArrowDown";
-        const decrease = event.key === "ArrowLeft" || event.key === "ArrowUp";
+        const increase =
+          isX && rtl
+            ? event.key === "ArrowLeft" || event.key === "ArrowDown"
+            : event.key === "ArrowRight" || event.key === "ArrowDown";
+        const decrease =
+          isX && rtl
+            ? event.key === "ArrowRight" || event.key === "ArrowUp"
+            : event.key === "ArrowLeft" || event.key === "ArrowUp";
         if (!increase && !decrease) return;
         event.preventDefault();
         onChange(clamp(split + (increase ? 2.5 : -2.5), min, max));
@@ -143,6 +154,7 @@ function Divider({
 }
 
 function Nexus({
+  nexusRef,
   rootRef,
   leftRef,
   leftTopRef,
@@ -151,11 +163,13 @@ function Nexus({
   splitRow,
   splitRow2,
   linked,
+  rtl = false,
   onSplitChange,
   onSplitRowChange,
   onSplitRow2Change,
   onAlign,
 }: {
+  nexusRef: RefObject<HTMLDivElement | null>;
   rootRef: RefObject<HTMLDivElement | null>;
   leftRef: RefObject<HTMLDivElement | null>;
   leftTopRef: RefObject<HTMLDivElement | null>;
@@ -164,22 +178,24 @@ function Nexus({
   splitRow: number;
   splitRow2: number;
   linked: boolean;
+  rtl?: boolean;
   onSplitChange: (pct: number) => void;
   onSplitRowChange: (pct: number) => void;
   onSplitRow2Change: (pct: number) => void;
   onAlign: () => void;
 }) {
   const t = useT();
-  const handleRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<NexusDrag | null>(null);
 
   const preview = (value: NexusValue) => {
     if (leftRef.current) leftRef.current.style.width = value.split + "%";
     if (leftTopRef.current) leftTopRef.current.style.height = value.row + "%";
     if (rightTopRef.current) rightTopRef.current.style.height = value.row2 + "%";
-    if (handleRef.current) {
-      handleRef.current.style.left = "calc(" + value.split + "% + " + HANDLE_CENTER_OFFSET + ")";
-      handleRef.current.style.top =
+    if (nexusRef.current) {
+      nexusRef.current.style.left = rtl
+        ? "calc(100% - " + value.split + "% - " + HANDLE_CENTER_OFFSET + ")"
+        : "calc(" + value.split + "% + " + HANDLE_CENTER_OFFSET + ")";
+      nexusRef.current.style.top =
         "calc(" + (value.row + value.row2) / 2 + "% + " + HANDLE_CENTER_OFFSET + ")";
     }
   };
@@ -191,10 +207,13 @@ function Nexus({
     const rect = root.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) return drag.value;
 
+    const deltaX = ((clientX - drag.startX) / rect.width) * 100;
+    const deltaY = ((clientY - drag.startY) / rect.height) * 100;
+
     const value = {
-      split: clamp(drag.split + ((clientX - drag.startX) / rect.width) * 100, SPLIT_MIN, SPLIT_MAX),
-      row: clamp(drag.row + ((clientY - drag.startY) / rect.height) * 100, SPLIT_MIN, SPLIT_MAX),
-      row2: clamp(drag.row2 + ((clientY - drag.startY) / rect.height) * 100, SPLIT_MIN, SPLIT_MAX),
+      split: clamp(drag.split + (rtl ? -deltaX : deltaX), SPLIT_MIN, SPLIT_MAX),
+      row: clamp(drag.row + deltaY, SPLIT_MIN, SPLIT_MAX),
+      row2: clamp(drag.row2 + deltaY, SPLIT_MIN, SPLIT_MAX),
     };
     drag.value = value;
     return value;
@@ -218,7 +237,7 @@ function Nexus({
 
   return (
     <div
-      ref={handleRef}
+      ref={nexusRef}
       title={instruction}
       onDoubleClick={onAlign}
       onPointerDown={(event) => {
@@ -261,7 +280,9 @@ function Nexus({
           : "border-edge-soft bg-elevated/95 text-ink-muted hover:border-accent hover:bg-accent hover:text-black")
       }
       style={{
-        left: "calc(" + split + "% + " + HANDLE_CENTER_OFFSET + ")",
+        left: rtl
+          ? "calc(100% - " + split + "% - " + HANDLE_CENTER_OFFSET + ")"
+          : "calc(" + split + "% + " + HANDLE_CENTER_OFFSET + ")",
         top: "calc(" + center + "% + " + HANDLE_CENTER_OFFSET + ")",
       }}
     >
@@ -307,10 +328,14 @@ export function Grid({
   onSplit3aChange: (pct: number) => void;
   onSplit3bChange: (pct: number) => void;
 }) {
+  const lang = useUiLanguage();
+  const rtl =
+    isRtl(lang) || (typeof document !== "undefined" && document.documentElement.dir === "rtl");
   const rootRef = useRef<HTMLDivElement>(null);
   const leftRef = useRef<HTMLDivElement>(null);
   const leftTopRef = useRef<HTMLDivElement>(null);
   const rightTopRef = useRef<HTMLDivElement>(null);
+  const nexusRef = useRef<HTMLDivElement>(null);
   const [rowsLinked, setRowsLinked] = useState(false);
   const alignRows = () => {
     const avg = (splitRow + splitRow2) / 2;
@@ -339,7 +364,14 @@ export function Grid({
         <div className="flex h-full min-w-0" style={{ width: split + "%" }}>
           {renderCell(0)}
         </div>
-        <Divider axis="x" split={split} min={SPLIT_MIN} max={SPLIT_MAX} onChange={onSplitChange} />
+        <Divider
+          axis="x"
+          split={split}
+          min={SPLIT_MIN}
+          max={SPLIT_MAX}
+          rtl={rtl}
+          onChange={onSplitChange}
+        />
         <div className="flex h-full min-w-0 flex-1">{renderCell(1)}</div>
       </div>
     );
@@ -356,6 +388,7 @@ export function Grid({
           split={splitRow}
           min={SPLIT_MIN}
           max={SPLIT_MAX}
+          rtl={rtl}
           onChange={onSplitRowChange}
         />
         <div className="flex h-full min-h-0 flex-1">{renderCell(1)}</div>
@@ -374,6 +407,7 @@ export function Grid({
           split={split3a}
           min={SPLIT3A_MIN}
           max={SPLIT3A_MAX}
+          rtl={rtl}
           onChange={onSplit3aChange}
         />
         <div className="flex h-full min-w-0 flex-1 gap-2">
@@ -385,6 +419,7 @@ export function Grid({
             split={split3b}
             min={SPLIT3B_MIN}
             max={SPLIT3B_MAX}
+            rtl={rtl}
             onChange={onSplit3bChange}
           />
           <div className="flex h-full min-w-0 flex-1">{renderCell(2)}</div>
@@ -409,12 +444,33 @@ export function Grid({
             split={splitRow}
             min={SPLIT_MIN}
             max={SPLIT_MAX}
+            rtl={rtl}
             onChange={onSplitRowChange}
             onDragStart={unlinkRows}
+            onPreview={(val) => {
+              if (nexusRef.current) {
+                nexusRef.current.style.top =
+                  "calc(" + (val + splitRow2) / 2 + "% + " + HANDLE_CENTER_OFFSET + ")";
+              }
+            }}
           />
           <div className="flex h-full min-h-0 flex-1">{renderCell(1)}</div>
         </div>
-        <Divider axis="x" split={split} min={SPLIT_MIN} max={SPLIT_MAX} onChange={onSplitChange} />
+        <Divider
+          axis="x"
+          split={split}
+          min={SPLIT_MIN}
+          max={SPLIT_MAX}
+          rtl={rtl}
+          onChange={onSplitChange}
+          onPreview={(val) => {
+            if (nexusRef.current) {
+              nexusRef.current.style.left = rtl
+                ? "calc(100% - " + val + "% - " + HANDLE_CENTER_OFFSET + ")"
+                : "calc(" + val + "% + " + HANDLE_CENTER_OFFSET + ")";
+            }
+          }}
+        />
         <div className="flex h-full min-w-0 flex-1 flex-col gap-2">
           <div
             ref={rightTopRef}
@@ -428,12 +484,20 @@ export function Grid({
             split={splitRow2}
             min={SPLIT_MIN}
             max={SPLIT_MAX}
+            rtl={rtl}
             onChange={onSplitRow2Change}
             onDragStart={unlinkRows}
+            onPreview={(val) => {
+              if (nexusRef.current) {
+                nexusRef.current.style.top =
+                  "calc(" + (splitRow + val) / 2 + "% + " + HANDLE_CENTER_OFFSET + ")";
+              }
+            }}
           />
           <div className="flex h-full min-h-0 flex-1">{renderCell(3)}</div>
         </div>
         <Nexus
+          nexusRef={nexusRef}
           rootRef={rootRef}
           leftRef={leftRef}
           leftTopRef={leftTopRef}
@@ -442,6 +506,7 @@ export function Grid({
           splitRow={splitRow}
           splitRow2={splitRow2}
           linked={rowsLinked}
+          rtl={rtl}
           onSplitChange={onSplitChange}
           onSplitRowChange={onSplitRowChange}
           onSplitRow2Change={onSplitRow2Change}


### PR DESCRIPTION
### 1. Big Picture Mode
- Fixed row pagination stopping after the first batch of cards in RTL.

### 2. Poster Dock Magnification
- Fixed poster hover magnification not working properly in RTL.

### 3. Multiview Grid & Nexus Center Handle
- Fixed inverted horizontal divider dragging and 2x2 Nexus center handle alignment in RTL layouts.
- Improved RTL slider behavior across two- and three-pane multiview layouts, allowing dividers to be dragged naturally without inverted movement.
