### PR TITLE
fix(ebook): load the full Edge TTS voice list

### DIFF
--- a/src-tauri/src/ebook_tts.rs
+++ b/src-tauri/src/ebook_tts.rs
@@ -56,9 +56,68 @@ pub struct EBookTtsVoice {
     name: String,
 }
 
+const VOICE_LIST_URL: &str =
+    "https://speech.platform.bing.com/consumer/speech/synthesize/readaloud/voices/list";
+// Public constants of the Edge read-aloud endpoint, the same ones the crate uses
+// internally. They are pub(crate) over there, so we cannot borrow them.
+const VOICE_LIST_TOKEN: &str = "6A5AA1D4EAFF4E9FB37E23D68491D6F4";
+const VOICE_LIST_GEC_VERSION: &str = "1-143.0.3650.75";
+
+#[derive(serde::Deserialize)]
+struct RemoteVoice {
+    #[serde(rename = "ShortName")]
+    short_name: String,
+    #[serde(rename = "Locale")]
+    locale: String,
+    #[serde(rename = "Gender")]
+    gender: String,
+    #[serde(rename = "FriendlyName")]
+    friendly_name: String,
+}
+
+// The crate's list_voices() reads the response until the socket closes and lets
+// the read error escape. Microsoft closes without a TLS close_notify, so rustls
+// reports UnexpectedEof and the call fails every time even though the body
+// arrived intact, which is why the reader only ever saw the built-in voices.
+// reqwest ends the body on Content-Length, so it gets all 300+ voices.
+async fn remote_voices() -> Result<Vec<EBookTtsVoice>, String> {
+    let url = format!(
+        "{VOICE_LIST_URL}?TrustedClientToken={VOICE_LIST_TOKEN}\
+         &Sec-MS-GEC={}&Sec-MS-GEC-Version={VOICE_LIST_GEC_VERSION}",
+        kothok_edge_tts::sec_ms_gec(0)
+    );
+    let client = crate::http_fetch::http_client_builder()
+        .build()
+        .map_err(|error| format!("voice list client: {error}"))?;
+    let voices = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|error| format!("voice list request: {error}"))?
+        .error_for_status()
+        .map_err(|error| format!("voice list status: {error}"))?
+        .json::<Vec<RemoteVoice>>()
+        .await
+        .map_err(|error| format!("voice list body: {error}"))?;
+    Ok(voices
+        .into_iter()
+        .map(|voice| EBookTtsVoice {
+            id: voice.short_name,
+            locale: voice.locale,
+            gender: voice.gender,
+            name: voice.friendly_name,
+        })
+        .collect())
+}
+
 #[tauri::command]
 pub async fn ebook_tts_voices() -> Result<Vec<EBookTtsVoice>, String> {
     init_tls();
+    match remote_voices().await {
+        Ok(voices) if !voices.is_empty() => return Ok(voices),
+        Ok(_) => eprintln!("[harbor::tts] voice list came back empty, trying the crate"),
+        Err(error) => eprintln!("[harbor::tts] {error}, trying the crate"),
+    }
     let voices = list_voices()
         .await
         .map_err(|error| format!("Could not load Edge TTS voices: {error}"))?;

--- a/src-tauri/src/http_fetch.rs
+++ b/src-tauri/src/http_fetch.rs
@@ -237,7 +237,7 @@ fn apply_redirect_method(
     }
 }
 
-fn http_client_builder() -> reqwest::ClientBuilder {
+pub(crate) fn http_client_builder() -> reqwest::ClientBuilder {
     reqwest::Client::builder()
         .no_proxy()
         .redirect(reqwest::redirect::Policy::none())


### PR DESCRIPTION
## Summary

The eBook reader only ever offered the 21 built-in voices, all English or Arabic, so no other language could be selected. It now loads the full, 300+ voices across 75 locales.

## Why

`kothok-edge-tts` reads the voice list response until the socket closes and lets the read error escape:

```rust
    let n = tls.read(&mut chunk).await?;    // propagates the error
    if n == 0 { break; }
```

Microsoft closes the connection without a TLS `close_notify`, so rustls reports `UnexpectedEof` rather than a clean `Ok(0)`. `list_voices()` fails every single time even though the body already arrived intact, and the reader silently keeps its built-in table.
I checked the endpoint directly with the same token and parameters: **HTTP 200, 167 KB, 322 voices across 75 locales**, italian included. So nothing is wrong with the request itself, only with how the response is read.
The fix belongs upstream, but 0.2.10 is the newest release and the crate is unchanged since July, so this works around it on our side: fetch the list with reqwest, which ends the body on `Content-length`, and keep the crate call as a fallback if the direct fetch fails or comes back empty.

Two things worth flagging for review:

- `TRUSTED_CLIENT_TOKEN` and `SEC_MS_GEC_VERSION` had to be redeclared here because the are `pub(crate)` in the crate. They are public protocol constants, identical in every edge-tts implementation, but it is duplication.
- `sec_ms_gec()` is re-exported by the crate but marked `#[doc(hidden)]`, so it works yet is not guaranteed API.

`http_client_builder` becomes `pub(crate)` so the shared timeouts and pool settings are reused instead of duplicated.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml` - clean, no new warnings (17 before and after, all pre-existing elsewhere)
- `cargo test --manifest-path src-tauri/Cargo.toml` - 180 passed, 0 failed, 2 ignored
- Ran a source build and opened the narration settings: the voice list now shows every locale

## Platform Impact

Verified on Linux (WebKitGTK). The change sits in the shared HTTP path rather than in anything platform-specific, so it should behave the same everywhere.
The crate fallback keeps the previous behaviour if the direct fetch ever fails.

## Checklist

- [X] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files. (n/a, Rust only)
- [ ] I ran `vp run typecheck` after TypeScript changes. (n/a, no TypeScript)
- [X] I ran the relevant Cargo checks after Rust changes.
- [X] I tested affected platforms when the change is platform-specific. (Linux)
- [X] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes. (depends on a live network call; verified manually)
- [X] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.
