### PR TITLE
fix(player): exact step seeks and accumulator rebase to fix frozen forward seeks

### DIFF
--- a/src/views/player/hooks/use-playback-controls.ts
+++ b/src/views/player/hooks/use-playback-controls.ts
@@ -15,6 +15,13 @@ import { cacheSelectedSubtitle } from "@/lib/subtitles/selected-subtitle-cache";
 
 const SEEK_ACCUM_WINDOW_MS = 700;
 
+// Largest gap allowed between the observed playback position and a chained
+// seek target before the chain is discarded and restarted from reality.
+// Keyframe seeks can land several seconds behind the request on sparse-GOP
+// files; without this guard each chained press compounds the gap. Well under
+// real snap-backs (3-6s seen in mpv logs), well above clock jitter (~0.2s).
+const SEEK_REBASE_TOLERANCE_SEC = 1;
+
 export function usePlaybackControls(params: {
   bridgeRef: RefObject<PlayerBridge | null>;
   snapRef: RefObject<PlayerSnapshot>;
@@ -162,39 +169,51 @@ export function usePlaybackControls(params: {
     else b.play().catch(() => {});
   };
 
-  const seekAccumRef = useRef<{ target: number; at: number } | null>(null);
+  const seekAccumRef = useRef<{ target: number; at: number; clock: number } | null>(null);
 
   const seekStep = (delta: number) => {
     const now = performance.now();
+    const observed = getPlaybackPosition();
     const acc = seekAccumRef.current;
-    const base = acc && now - acc.at < SEEK_ACCUM_WINDOW_MS ? acc.target : getPlaybackPosition();
+    // Chain rapid presses onto the previous request (the clock lags mpv by
+    // ~200ms and may not have ticked yet), but once it ticks to a value
+    // behind the chained target, restart the chain from reality.
+    let base = observed;
+    if (acc && now - acc.at < SEEK_ACCUM_WINDOW_MS) {
+      base =
+        observed !== acc.clock && observed < acc.target - SEEK_REBASE_TOLERANCE_SEC
+          ? observed
+          : acc.target;
+    }
     const dur = snapRef.current.durationSec;
     const upper = dur > 0 ? dur : Number.POSITIVE_INFINITY;
     const target = Math.min(upper, Math.max(0, base + delta));
     if (castDevice) {
-      seekAccumRef.current = { target, at: now };
+      seekAccumRef.current = { target, at: now, clock: observed };
       void seekCast(target);
       return;
     }
     if (!canControl) return;
-    seekAccumRef.current = { target, at: now };
+    seekAccumRef.current = { target, at: now, clock: observed };
     if (inRoom && !isHost) {
       sendCommand({ action: "seek", positionSeconds: target });
       return;
     }
-    bridgeRef.current?.seek(target, "keyframes");
+    // Exact: keyframe seeks snap to the previous keyframe and can land behind
+    // the request (several seconds on sparse-GOP HEVC), so forward steps stall.
+    bridgeRef.current?.seek(target, "exact");
   };
 
   const seekTo = useCallback(
     (sec: number) => {
       const target = Math.max(0, sec);
       if (castDevice) {
-        seekAccumRef.current = { target, at: performance.now() };
+        seekAccumRef.current = { target, at: performance.now(), clock: getPlaybackPosition() };
         void seekCast(target);
         return;
       }
       if (!canControl) return;
-      seekAccumRef.current = { target, at: performance.now() };
+      seekAccumRef.current = { target, at: performance.now(), clock: getPlaybackPosition() };
       if (inRoom && !isHost) {
         sendCommand({ action: "seek", positionSeconds: target });
         return;


### PR DESCRIPTION
… seeks

## Summary

Step seeks (arrow keys, seek buttons) now request exact precision instead of keyframes, and the 700ms seek accumulator records the playback clock at request time so a chained press restarts from the observed position when mpv demonstrably landed behind the previous target. Scrub-bar seeks stay on keyframes for speed. One file: src/views/player/hooks/use-playback-controls.ts.

## Why

Every step seek sent seek <target> absolute+keyframes, which snaps to the previous keyframe and stops. On sparse-GOP HEVC (3–6s gaps in the reported files) a +5s step lands at or behind the current position, so repeated forward presses hit the same keyframe forever — e.g. 2240.068 → 2236.192 three times in a row — while the UI keeps the playing icon with no spinner. The accumulator compounded it by chaining each new target onto the requested (not actual) position. Resume already used absolute+exact and always landed correctly, so steps now match that path.

## Verification

- tsc -b: clean for the changed file (single repo error in untouched WIP bp-monitor-picker.tsx, pre-existing baseline).
- mpv-log A/B on the failing SiGMA file in one session log: before — absolute+keyframes with adjust seek target snap-backs of 3–6s onto identical keyframes; after — ~60 absolute+exact seeks landing within 0.02s of target, all playback restart complete ... audio=playing, zero underruns.

## Platform Impact

None

## Checklist

- [x] This pull request is focused and contains no unrelated refactors.
- [ ] I ran `vp check` for the changed files.
- [x] I ran `vp run typecheck` after TypeScript changes.
- [ ] I ran the relevant Cargo checks after Rust changes.
- [ ] I tested affected platforms when the change is platform-specific.
- [x] I preserved playback, navigation, and configured hotkey behavior where applicable.
- [ ] I added or updated tests for behavior changes.
- [x] I removed secrets, tokens, private URLs, and personal data from logs and screenshots.